### PR TITLE
Add recent weather normalization tests and enhance API endpoint tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ COMPOSE := docker compose
 	dev dev-kill dev-servers dev-servers-kill \
 	setup-backend setup-auth setup-frontend setup-gifts \
 	test-unit test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
-	test-e2e-playwright \
+	test-e2e-playwright test-e2e-playwright-smoke \
 	test-integration coverage coverage-backend coverage-auth coverage-frontend coverage-gifts \
-	coverage-modules coverage-submodules coverage-all ci badge-audit audit-frontend
+	coverage-modules coverage-submodules coverage-all ci acci badge-audit audit-frontend
 
 lint: lint-backend lint-auth lint-frontend lint-gifts
 
@@ -81,6 +81,15 @@ test-unit-gifts:
 test-e2e-playwright:
 	cd frontend && NODE_PATH=./node_modules npx playwright test
 
+# Smoke subset: runs only the spec files that require no admin credentials.
+# Safe to use in CI or local when PLAYWRIGHT_ADMIN_EMAIL / PLAYWRIGHT_ADMIN_PASSWORD
+# are not available.  Covers startup health, auth service integration, front-end
+# rendering and all mock-session conversion flows.
+test-e2e-playwright-smoke:
+	cd frontend && NODE_PATH=./node_modules npx playwright test \
+		auth-service-integration.e2e.spec.ts \
+		tac-file-conversion.e2e.spec.ts
+
 coverage-backend:
 	cd backend && python3 -m pytest tests/unit --cov=src --cov-config=pyproject.toml --cov-branch --cov-report=xml:coverage.xml --cov-report=term-missing -v
 
@@ -118,7 +127,18 @@ coverage-all: coverage-modules coverage-submodules
 
 test-integration:
 	python3 -m pip install -q pytest requests httpx
-	@required_vars="SUPABASE_URL SUPABASE_ANON_KEY VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY"; \
+	@set -a; \
+	for env_file in .env frontend/.env auth/.env backend/.env; do \
+		if [ -f "$$env_file" ]; then \
+			while IFS= read -r line || [ -n "$$line" ]; do \
+				line="$${line%$$'\r'}"; \
+				[[ -z "$$line" || "$$line" =~ ^[[:space:]]*# ]] && continue; \
+				export "$$line"; \
+			done < "$$env_file"; \
+		fi; \
+	done; \
+	set +a; \
+	required_vars="SUPABASE_URL SUPABASE_ANON_KEY VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY"; \
 	missing=""; \
 	for var in $$required_vars; do \
 		if [ -z "$${!var}" ]; then \
@@ -158,3 +178,7 @@ badge-audit:
 	python3 .github/scripts/badge_audit.py
 
 ci: lint test-unit test-integration badge-audit
+
+# All CI checks in one command: linting, unit tests, integration tests,
+# smoke E2E, frontend dependency audit, and badge verification.
+acci: lint test-unit test-integration test-e2e-playwright-smoke audit-frontend badge-audit

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@ SHELL := /bin/bash
 COMPOSE := docker compose
 
 .PHONY: lint lint-backend lint-auth lint-frontend lint-gifts \
+	lint-fix lint-fix-backend lint-fix-auth lint-fix-frontend lint-fix-gifts \
+	dev-servers dev-servers-kill \
 	setup-backend setup-auth setup-frontend setup-gifts \
 	test-unit test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
+	test-e2e-playwright \
 	test-integration coverage coverage-backend coverage-auth coverage-frontend coverage-gifts \
 	coverage-modules coverage-submodules coverage-all ci badge-audit audit-frontend
 
 lint: lint-backend lint-auth lint-frontend lint-gifts
+
+lint-fix: lint-fix-backend lint-fix-auth lint-fix-frontend lint-fix-gifts
 
 lint-backend:
 	cd backend && python3 -m pip install -q ruff && python3 -m ruff check src tests
@@ -20,6 +25,25 @@ lint-frontend:
 
 lint-gifts:
 	cd GIFTs && python3 -m pip install -q flake8 && flake8 gifts tests
+
+lint-fix-backend:
+	cd backend && python3 -m pip install -q ruff && python3 -m ruff check --fix src tests
+
+lint-fix-auth:
+	cd auth && python3 -m pip install -q ruff && python3 -m ruff check --fix src tests
+
+lint-fix-frontend:
+	cd frontend && npm install --legacy-peer-deps && npm run lint -- --fix
+
+lint-fix-gifts:
+	@echo "No auto-fix configured for GIFTs (flake8 is check-only). Running lint check instead."
+	$(MAKE) lint-gifts
+
+dev:
+	bash ./start-dev-servers.sh
+
+dev-kill:
+	bash ./start-dev-servers.sh --kill
 
 setup-backend:
 	cd backend && python3 -m pip install -e .
@@ -49,6 +73,9 @@ audit-frontend:
 
 test-unit-gifts:
 	cd GIFTs && python3 -m pytest tests/ --cov=gifts --cov-config=pyproject.toml --cov-report=xml:coverage.xml --cov-report=term-missing --cov-fail-under=95 -v
+
+test-e2e-playwright:
+	cd frontend && npx playwright test
 
 coverage-backend:
 	cd backend && python3 -m pytest tests/unit --cov=src --cov-config=pyproject.toml --cov-branch --cov-report=xml:coverage.xml --cov-report=term-missing -v

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPOSE := docker compose
 
 .PHONY: lint lint-backend lint-auth lint-frontend lint-gifts \
 	lint-fix lint-fix-backend lint-fix-auth lint-fix-frontend lint-fix-gifts \
-	dev-servers dev-servers-kill \
+	dev dev-kill dev-servers dev-servers-kill \
 	setup-backend setup-auth setup-frontend setup-gifts \
 	test-unit test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
 	test-e2e-playwright \
@@ -45,6 +45,10 @@ dev:
 dev-kill:
 	bash ./start-dev-servers.sh --kill
 
+dev-servers: dev
+
+dev-servers-kill: dev-kill
+
 setup-backend:
 	cd backend && python3 -m pip install -e .
 
@@ -75,7 +79,7 @@ test-unit-gifts:
 	cd GIFTs && python3 -m pytest tests/ --cov=gifts --cov-config=pyproject.toml --cov-report=xml:coverage.xml --cov-report=term-missing --cov-fail-under=95 -v
 
 test-e2e-playwright:
-	cd frontend && npx playwright test
+	cd frontend && NODE_PATH=./node_modules npx playwright test
 
 coverage-backend:
 	cd backend && python3 -m pytest tests/unit --cov=src --cov-config=pyproject.toml --cov-branch --cov-report=xml:coverage.xml --cov-report=term-missing -v

--- a/README.md
+++ b/README.md
@@ -293,9 +293,15 @@ npm test -- --watch
 # From root directory (requires all three services running locally)
 pytest tests/ -v
 
+# Full-stack browser E2E (Playwright)
+make test-e2e-playwright
+
 # Run specific integration tests
 pytest tests/test_backend_auth_service_integration.py -v
 ```
+
+Browser E2E coverage lives in the top-level `tests/` directory as `*.e2e.spec.ts` files.
+When Playwright runs, it starts the full stack through `start-dev-servers.sh` (frontend + auth + backend).
 
 ## Project Structure
 
@@ -348,8 +354,9 @@ metar-to-IWXXM/
 │   ├── AUTH_MIDDLEWARE_ARCHITECTURE.md  # Detailed auth architecture
 │   ├── SUPABASE_INTEGRATION.md          # Supabase setup guide
 │   └── API.md                           # API documentation
-├── tests/                         # Root integration tests
+├── tests/                         # Root integration + browser E2E tests
 │   ├── test_backend_auth_service_integration.py
+│   ├── *.e2e.spec.ts             # Playwright browser E2E suites
 │   └── ... (other integration tests)
 ├── scripts/                       # Utility scripts
 │   ├── launch_api.sh              # Launch script

--- a/README.md
+++ b/README.md
@@ -293,8 +293,11 @@ npm test -- --watch
 # From root directory (requires all three services running locally)
 pytest tests/ -v
 
-# Full-stack browser E2E (Playwright)
+# Full-stack browser E2E (Playwright) — requires admin credentials
 make test-e2e-playwright
+
+# Credential-free smoke subset (no admin login required — CI / local dev-friendly)
+make test-e2e-playwright-smoke
 
 # Run specific integration tests
 pytest tests/test_backend_auth_service_integration.py -v
@@ -302,6 +305,39 @@ pytest tests/test_backend_auth_service_integration.py -v
 
 Browser E2E coverage lives in the top-level `tests/` directory as `*.e2e.spec.ts` files.
 When Playwright runs, it starts the full stack through `start-dev-servers.sh` (frontend + auth + backend).
+
+### Playwright suites
+
+| Target | Requires admin credentials | What it runs |
+|---|---|---|
+| `make test-e2e-playwright` | Yes | All 21 tests including login flows |
+| `make test-e2e-playwright-smoke` | **No** | `auth-service-integration` + `tac-file-conversion` (9 tests, mock sessions) |
+
+`tests/00-preflight.e2e.spec.ts` runs first in the full suite and fails immediately with a
+single clear message when credentials are missing or invalid, preventing 12+ repeated
+timeout failures from cluttering the output.
+
+Playwright E2E environment variables:
+
+- `PLAYWRIGHT_ADMIN_EMAIL` and `PLAYWRIGHT_ADMIN_PASSWORD`: required for admin-login E2E flows.
+- `PLAYWRIGHT_TAC_FIXTURES_DIR`: optional override for TAC fixture directory used by upload tests.
+- `PLAYWRIGHT_REQUIRE_TAC_FIXTURES`: set to `1` to fail fast when TAC fixtures are missing.
+  - This is enabled automatically on CI.
+- `PLAYWRIGHT_SERVICE_WAIT_TIMEOUT_MS`: timeout for startup health checks (default `120000`).
+- `PLAYWRIGHT_FRONTEND_HEALTH_URL`, `PLAYWRIGHT_BACKEND_HEALTH_URL`, `PLAYWRIGHT_AUTH_HEALTH_URL`: optional health endpoint overrides used during global setup.
+- `PLAYWRIGHT_FORCE_SERVICE_HEALTH_WAIT=1`: force health waiting even when using non-local base URLs.
+- `PLAYWRIGHT_SKIP_LOCAL_HEALTH_WAIT=1`: skip startup health checks.
+
+Example full E2E run with explicit environment:
+
+```bash
+cd frontend
+export PLAYWRIGHT_ADMIN_EMAIL="admin@example.com"
+export PLAYWRIGHT_ADMIN_PASSWORD="<password>"
+export PLAYWRIGHT_REQUIRE_TAC_FIXTURES=1
+export PLAYWRIGHT_SERVICE_WAIT_TIMEOUT_MS=180000
+npx playwright test
+```
 
 ## Project Structure
 

--- a/auth/src/security.py
+++ b/auth/src/security.py
@@ -11,7 +11,7 @@ from passlib.context import CryptContext
 
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
-JWT_SECRET = os.getenv("AUTH_JWT_SECRET", "dev-insecure-secret-change")
+JWT_SECRET = os.getenv("AUTH_JWT_SECRET", "dev-insecure-secret-change-minimum-32bytes")
 JWT_ALGO = "HS256"
 JWT_EXPIRE_MINUTES = int(os.getenv("AUTH_JWT_EXPIRE_MINUTES", "60"))
 

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -39,6 +39,7 @@ try:
     from .services.validation_orchestrator import get_validation_orchestrator
     from .services.webhooks import webhook_service
     from .utilities.conversion import ConversionError, convert_metar_tac_with_metadata
+    from .utilities.metar_normalizer import normalize_recent_weather_tokens
     from .utilities.observability import install_fastapi_observability, setup_logging
     from .utilities.security import verify_supabase_token
     from .utilities.tac_parser import extract_airport_code
@@ -64,6 +65,7 @@ except ImportError:
     from services.validation_orchestrator import get_validation_orchestrator
     from services.webhooks import webhook_service
     from utilities.conversion import ConversionError, convert_metar_tac_with_metadata
+    from utilities.metar_normalizer import normalize_recent_weather_tokens
     from utilities.observability import install_fastapi_observability, setup_logging
     from utilities.security import verify_supabase_token
     from utilities.tac_parser import extract_airport_code
@@ -1344,10 +1346,13 @@ async def convert(
         manual_name = f"{manual_source}.txt"
         start_time = None
         translation_id = None
+        # Pre-normalize truncated recent-weather tokens before early validation
+        # so manual inputs like RESH don't fail while valid forms still pass.
+        _normalized_entry, _norm_warnings = normalize_recent_weather_tokens(manual_entry)
 
         try:
             try:
-                validation_result = validation_service.validate_all_layers(manual_entry)
+                validation_result = validation_service.validate_all_layers(_normalized_entry)
                 if not validation_result.passed:
                     validation_summary = f"{validation_result.total_issues} validation issue(s) found"
                     errors.append(f"{manual_source}: Validation failed - {validation_summary}")
@@ -1420,10 +1425,29 @@ async def convert(
             import time
             start_time = time.perf_counter()
 
+            # Warn when manual recent-weather tokens were normalized.
+            for _w in _norm_warnings:
+                add_issue(
+                    source=manual_source,
+                    message=(
+                        f"Recent weather token '{_w['original']}' rewritten to "
+                        f"'{_w['replacement']}' for WMO D-6 compliance "
+                        f"(truncated descriptor-only code; UP phenomenon added)."
+                    ),
+                    severity=ConversionIssueSeverity.INFO,
+                    hint=(
+                        f"'{_w['original']}' is not a valid Annex 3 recent weather code. "
+                        f"Using '{_w['replacement']}' (unidentified precipitation) instead."
+                    ),
+                    code="RECENT_WX_NORMALIZED",
+                    layer="tac_normalization",
+                )
+
             xml_text, validation_result_from_conversion = convert_metar_tac_with_metadata(
-                manual_entry,
+                _normalized_entry,
                 iwxxm_version=iwxxm_version,
-                validate=validate_output
+                validate=validate_output,
+                lenient=False,  # normalization already applied above
             )
 
             duration_ms = int((time.perf_counter() - start_time) * 1000)

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -258,13 +258,15 @@ async def add_translation_centre_headers(request: Request, call_next):
     # Add Translation Centre metadata headers
     try:
         centre_info = get_translation_centre_info()
-        # Only add headers with non-None values
+        # Only add headers with non-None values.
+        # .strip() guards against CRLF line-endings in env vars read from
+        # Windows-format .env files (b'TEST\r' is rejected by h11 as illegal).
         if centre_info.get("translationCentreDesignator"):
-            response.headers["X-Translation-Centre"] = centre_info["translationCentreDesignator"]
+            response.headers["X-Translation-Centre"] = centre_info["translationCentreDesignator"].strip()
         if centre_info.get("translationCentreName"):
-            response.headers["X-Translation-Centre-Name"] = centre_info["translationCentreName"]
+            response.headers["X-Translation-Centre-Name"] = centre_info["translationCentreName"].strip()
         if centre_info.get("icaoLocationIndicator"):
-            response.headers["X-ICAO-Location-Indicator"] = centre_info["icaoLocationIndicator"]
+            response.headers["X-ICAO-Location-Indicator"] = centre_info["icaoLocationIndicator"].strip()
     except Exception as e:
         logger.debug(f"Translation Centre headers not configured: {e}")
 
@@ -1152,6 +1154,8 @@ async def convert(
         if not metar_text.strip():
             continue
 
+        normalized_metar_text, norm_warnings = normalize_recent_weather_tokens(metar_text.strip())
+
         total_inputs += 1
         start_time = None
         translation_id = None
@@ -1161,7 +1165,7 @@ async def convert(
 
             # Validate METAR input (Layers 1-2: ICAO and TAC syntax)
             try:
-                validation_result = validation_service.validate_all_layers(metar_text.strip())
+                validation_result = validation_service.validate_all_layers(normalized_metar_text)
                 if not validation_result.passed:
                     # Build summary from validation result
                     validation_summary = f"{validation_result.total_issues} validation issue(s) found"
@@ -1239,11 +1243,14 @@ async def convert(
                 import time
                 start_time = time.perf_counter()
 
+                emit_recent_wx_issues(metar_name, norm_warnings)
+
                 # Convert METAR to IWXXM
                 try:
                     iwxxm_content, _ = convert_metar_tac_with_metadata(
-                        metar_text.strip(),
-                        iwxxm_version=iwxxm_version
+                        normalized_metar_text,
+                        iwxxm_version=iwxxm_version,
+                        lenient=False,
                     )
 
                     # Optional output validation (Layers 3-7)
@@ -1279,11 +1286,11 @@ async def convert(
                             translation_status=TranslationStatus.SUCCESS,
                             validation_layers_passed=validation_layers_passed,
                             translation_duration_ms=duration_ms,
-                            icao_airport_code=extract_airport_code(metar_text.strip()),
+                            icao_airport_code=extract_airport_code(normalized_metar_text),
                             user_id=user.get("sub")
                         )
 
-                        airport_code = extract_airport_code(metar_text.strip())
+                        airport_code = extract_airport_code(normalized_metar_text)
                         await webhook_service.notify_translation_completed(
                             translation_id=translation_id,
                             airport_code=airport_code or "UNKNOWN",
@@ -1317,11 +1324,11 @@ async def convert(
                             validation_layers_passed=[ValidationLayer.AIRPORT_ICAO, ValidationLayer.TAC_SYNTAX],
                             validation_errors={"error": str(ce)},
                             translation_duration_ms=duration_ms,
-                            icao_airport_code=extract_airport_code(metar_text.strip()),
+                            icao_airport_code=extract_airport_code(normalized_metar_text),
                             user_id=user.get("sub")
                         )
 
-                        airport_code = extract_airport_code(metar_text.strip())
+                        airport_code = extract_airport_code(normalized_metar_text)
                         await webhook_service.notify_translation_failed(
                             translation_id=translation_id or "unknown",
                             airport_code=airport_code or "UNKNOWN",
@@ -1630,10 +1637,12 @@ async def convert(
                             icao_airport_code=extract_airport_code(data.strip()),
                             user_id=user.get("sub")
                         )
+                        airport_code = extract_airport_code(data.strip())
                         await webhook_service.notify_translation_failed(
                             translation_id=translation_id,
-                            tac_message=data.strip(),
-                            error=str(ve)
+                            airport_code=airport_code or "UNKNOWN",
+                            error_type="validation_error",
+                            error_message=str(ve)
                         )
                     except Exception as log_err:
                         logger.error(f"Failed to log validation error: {log_err}")

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -1076,6 +1076,25 @@ async def convert(
                     location=getattr(validation_issue, "location", None),
                 )
 
+    def emit_recent_wx_issues(source: str, norm_warnings: List[dict]) -> None:
+        """Emit structured conversion issues for recent-weather rewrites."""
+        for warning in norm_warnings:
+            add_issue(
+                source=source,
+                message=(
+                    f"Recent weather token '{warning['original']}' rewritten to "
+                    f"'{warning['replacement']}' for WMO D-6 compliance "
+                    f"(truncated descriptor-only code; UP phenomenon added)."
+                ),
+                severity=ConversionIssueSeverity.INFO,
+                hint=(
+                    f"'{warning['original']}' is not a valid Annex 3 recent weather code. "
+                    f"Using '{warning['replacement']}' (unidentified precipitation) instead."
+                ),
+                code="RECENT_WX_NORMALIZED",
+                layer="tac_normalization",
+            )
+
     # Initialize validation service for input validation
     validation_service = ValidationService()
 
@@ -1346,8 +1365,7 @@ async def convert(
         manual_name = f"{manual_source}.txt"
         start_time = None
         translation_id = None
-        # Pre-normalize truncated recent-weather tokens before early validation
-        # so manual inputs like RESH don't fail while valid forms still pass.
+        # Normalize once and share this result across validation and conversion.
         _normalized_entry, _norm_warnings = normalize_recent_weather_tokens(manual_entry)
 
         try:
@@ -1425,23 +1443,7 @@ async def convert(
             import time
             start_time = time.perf_counter()
 
-            # Warn when manual recent-weather tokens were normalized.
-            for _w in _norm_warnings:
-                add_issue(
-                    source=manual_source,
-                    message=(
-                        f"Recent weather token '{_w['original']}' rewritten to "
-                        f"'{_w['replacement']}' for WMO D-6 compliance "
-                        f"(truncated descriptor-only code; UP phenomenon added)."
-                    ),
-                    severity=ConversionIssueSeverity.INFO,
-                    hint=(
-                        f"'{_w['original']}' is not a valid Annex 3 recent weather code. "
-                        f"Using '{_w['replacement']}' (unidentified precipitation) instead."
-                    ),
-                    code="RECENT_WX_NORMALIZED",
-                    layer="tac_normalization",
-                )
+            emit_recent_wx_issues(manual_source, _norm_warnings)
 
             xml_text, validation_result_from_conversion = convert_metar_tac_with_metadata(
                 _normalized_entry,

--- a/backend/src/routers/validation.py
+++ b/backend/src/routers/validation.py
@@ -92,8 +92,8 @@ class BatchValidationRequest(BaseModel):
     items: List[ValidationRequest] = Field(
         ...,
         description="Items to validate",
-        min_items=1,
-        max_items=100,
+        min_length=1,
+        max_length=100,
     )
     layers: Optional[List[ValidationLayer]] = Field(
         None,

--- a/backend/src/utilities/conversion.py
+++ b/backend/src/utilities/conversion.py
@@ -275,7 +275,12 @@ def _lookup_aerodrome(icao: str, use_test_overrides: bool = False):
     return None
 
 
-__all__ = ["convert_metar_tac", "ConversionError", "convert_metar_tac_with_metadata"]
+__all__ = ["convert_metar_tac", "ConversionError", "convert_metar_tac_with_metadata", "normalize_recent_weather_tokens"]
+
+try:
+    from .metar_normalizer import normalize_recent_weather_tokens  # noqa: E402
+except ImportError:
+    from metar_normalizer import normalize_recent_weather_tokens  # type: ignore  # noqa: E402
 
 
 def convert_metar_tac_with_metadata(
@@ -285,7 +290,8 @@ def convert_metar_tac_with_metadata(
     use_test_overrides: bool = False,
     validate: bool = True,
     validation_layers: Optional[List[str]] = None,
-    raise_on_validation_error: bool = False
+    raise_on_validation_error: bool = False,
+    lenient: bool = True,
 ) -> Tuple[str, Optional[ComprehensiveValidationResult]]:
     """Convert TAC to IWXXM and validate output (validation enabled by default).
 
@@ -305,6 +311,10 @@ def convert_metar_tac_with_metadata(
         validate: Run validation after conversion (DEFAULT: True). Set to False for performance.
         validation_layers: Which layers to run (None = recommended layers: XSD, Schematron, WMO Codes).
         raise_on_validation_error: Raise ConversionError if validation fails (default: False).
+        lenient: If True (default), pre-normalize truncated recent-weather tokens
+                 (e.g. RESH→RESHUP) before GIFTs decoding so that common manual-
+                 input variants do not cause TAC parse failures.  Set to False to
+                 preserve strict Annex 3 / WMO-conformant behaviour.
 
     Returns:
         Tuple of (xml_string, validation_result)
@@ -375,6 +385,16 @@ def convert_metar_tac_with_metadata(
                 # Restore originals
                 time.gmtime = original_gmtime
                 time.time = original_time
+
+        # Pre-normalize non-standard recent-weather tokens (lenient mode)
+        if lenient:
+            tac_text, _norm_warnings = normalize_recent_weather_tokens(tac_text)
+            for w in _norm_warnings:
+                logger.warning(
+                    "METAR recent-weather pre-normalization: '%s' at token index %d "
+                    "rewritten to '%s' (rule: %s)",
+                    w['original'], w['index'], w['replacement'], w['rule'],
+                )
 
         # Decode with patched time if reference_time provided
         with patched_gmtime(reference_time):

--- a/backend/src/utilities/conversion.py
+++ b/backend/src/utilities/conversion.py
@@ -305,7 +305,7 @@ def _apply_recent_weather_normalization(
 
     normalized_tac, norm_warnings = normalize_recent_weather_for_tac(tac_text)
     for warning in norm_warnings:
-        logger.warning(
+        logger.info(
             "METAR recent-weather pre-normalization: '%s' at token index %d "
             "rewritten to '%s' (rule: %s)",
             warning["original"],

--- a/backend/src/utilities/conversion.py
+++ b/backend/src/utilities/conversion.py
@@ -275,12 +275,46 @@ def _lookup_aerodrome(icao: str, use_test_overrides: bool = False):
     return None
 
 
-__all__ = ["convert_metar_tac", "ConversionError", "convert_metar_tac_with_metadata", "normalize_recent_weather_tokens"]
-
 try:
-    from .metar_normalizer import normalize_recent_weather_tokens  # noqa: E402
+    from .metar_normalizer import (  # noqa: E402
+        normalize_recent_weather_for_tac,
+        normalize_recent_weather_tokens,
+    )
 except ImportError:
-    from metar_normalizer import normalize_recent_weather_tokens  # type: ignore  # noqa: E402
+    from metar_normalizer import (  # type: ignore  # noqa: E402
+        normalize_recent_weather_for_tac,
+        normalize_recent_weather_tokens,
+    )
+
+__all__ = [
+    "convert_metar_tac",
+    "ConversionError",
+    "convert_metar_tac_with_metadata",
+    "normalize_recent_weather_tokens",
+]
+
+
+def _apply_recent_weather_normalization(
+    tac_text: str,
+    *,
+    lenient: bool,
+) -> str:
+    """Optionally normalize recent-weather tokens and log rewrites."""
+    if not lenient:
+        return tac_text
+
+    normalized_tac, norm_warnings = normalize_recent_weather_for_tac(tac_text)
+    for warning in norm_warnings:
+        logger.warning(
+            "METAR recent-weather pre-normalization: '%s' at token index %d "
+            "rewritten to '%s' (rule: %s)",
+            warning["original"],
+            warning["index"],
+            warning["replacement"],
+            warning["rule"],
+        )
+
+    return normalized_tac
 
 
 def convert_metar_tac_with_metadata(
@@ -386,15 +420,7 @@ def convert_metar_tac_with_metadata(
                 time.gmtime = original_gmtime
                 time.time = original_time
 
-        # Pre-normalize non-standard recent-weather tokens (lenient mode)
-        if lenient:
-            tac_text, _norm_warnings = normalize_recent_weather_tokens(tac_text)
-            for w in _norm_warnings:
-                logger.warning(
-                    "METAR recent-weather pre-normalization: '%s' at token index %d "
-                    "rewritten to '%s' (rule: %s)",
-                    w['original'], w['index'], w['replacement'], w['rule'],
-                )
+        tac_text = _apply_recent_weather_normalization(tac_text, lenient=lenient)
 
         # Decode with patched time if reference_time provided
         with patched_gmtime(reference_time):

--- a/backend/src/utilities/metar_normalizer.py
+++ b/backend/src/utilities/metar_normalizer.py
@@ -20,7 +20,7 @@ that the rest of the conversion pipeline continues unchanged.
 from __future__ import annotations
 
 import re
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 # Matches exactly RE + descriptor (SH or FZ) with nothing after — these are
 # the only descriptor-only tokens that are both (a) observed in the wild and
@@ -30,7 +30,7 @@ _TRUNCATED_REWX_RE = re.compile(r'^RE(SH|FZ)$', re.IGNORECASE)
 
 def normalize_recent_weather_tokens(
     tac_text: str,
-) -> Tuple[str, List[dict]]:
+) -> Tuple[str, List[Dict[str, Any]]]:
     """Rewrite truncated recent-weather tokens to WMO D-6 compliant forms.
 
     Operates at the token (whitespace-delimited word) level so that valid
@@ -48,7 +48,7 @@ def normalize_recent_weather_tokens(
         list of dicts with keys ``index``, ``original``, ``replacement``, and
         ``rule``.  The list is empty when no rewrites were made.
     """
-    warnings: List[dict] = []
+    warnings: List[Dict[str, Any]] = []
 
     # Preserve leading/trailing whitespace on the outer string but work on
     # individual tokens so we don't alter separators inside the message.
@@ -56,10 +56,17 @@ def normalize_recent_weather_tokens(
     if not stripped:
         return tac_text, warnings
 
-    tokens = stripped.split(' ')
-    result_tokens: List[str] = []
+    # Split into alternating tokens and whitespace so we can rewrite only
+    # tokens while preserving all original separators exactly.
+    parts = re.split(r'(\s+)', stripped)
+    token_index = 0
 
-    for idx, token in enumerate(tokens):
+    for i, part in enumerate(parts):
+        # Odd entries are captured separators from the split regex.
+        if i % 2 == 1:
+            continue
+
+        token = part
         # Some parsers/users append '=' to the last token; strip it before
         # matching so we can still recognise e.g. 'RESH=' as a RESH token.
         trailing_eq = token.endswith('=')
@@ -79,18 +86,25 @@ def normalize_recent_weather_tokens(
             )
 
             warnings.append({
-                'index': idx,
+                'index': token_index,
                 'original': token,
                 'replacement': replacement,
                 'rule': rule,
             })
-            result_tokens.append(replacement)
-        else:
-            result_tokens.append(token)
+            parts[i] = replacement
 
-    normalized = ' '.join(result_tokens)
+        token_index += 1
+
+    normalized = ''.join(parts)
     # Re-attach any leading/trailing whitespace from the original input so we
     # don't silently alter strings that the caller may be sensitive about.
     leading = tac_text[:len(tac_text) - len(tac_text.lstrip())]
     trailing = tac_text[len(tac_text.rstrip()):]
     return leading + normalized + trailing, warnings
+
+
+def normalize_recent_weather_for_tac(
+    tac_text: str,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Centralized wrapper for TAC recent-weather normalization."""
+    return normalize_recent_weather_tokens(tac_text)

--- a/backend/src/utilities/metar_normalizer.py
+++ b/backend/src/utilities/metar_normalizer.py
@@ -1,0 +1,96 @@
+"""Pre-normalization of METAR TAC text before strict GIFTs lexer parsing.
+
+Handles common non-standard recent weather tokens that appear in manual METAR
+input but are rejected by the strict WMO METAR lexer (GIFTs).
+
+Background
+----------
+The GIFTs ``rewx`` token rule requires a phenomenon after the optional descriptor:
+    ``RE(FZ|SH|TS)?(DZ|RASN|RA|...UP|//)``
+
+So ``RESH`` (descriptor only, no phenomenon) fails lexing, while ``RESHRA``
+(descriptor + phenomenon) succeeds.  WMO code table D-6 includes ``RESHUP``
+and ``REFZUP`` as valid recent-weather codes.  Appending ``UP`` (unidentified
+precipitation) converts a truncated descriptor-only token into a standards-
+recognised token without inventing specific meteorology.
+
+This normalizer is applied **before** the GIFTs decoder in lenient mode so
+that the rest of the conversion pipeline continues unchanged.
+"""
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+# Matches exactly RE + descriptor (SH or FZ) with nothing after — these are
+# the only descriptor-only tokens that are both (a) observed in the wild and
+# (b) fixable via a standards-conformant UP suffix.
+_TRUNCATED_REWX_RE = re.compile(r'^RE(SH|FZ)$', re.IGNORECASE)
+
+
+def normalize_recent_weather_tokens(
+    tac_text: str,
+) -> Tuple[str, List[dict]]:
+    """Rewrite truncated recent-weather tokens to WMO D-6 compliant forms.
+
+    Operates at the token (whitespace-delimited word) level so that valid
+    tokens such as ``RESHRA``, ``VCSH``, and ``SHRA`` are never modified.
+
+    Rewrites applied (exact token match only):
+        ``RESH``  →  ``RESHUP``   (rule: ``recent_weather_truncated_showers``)
+        ``REFZ``  →  ``REFZUP``   (rule: ``recent_weather_truncated_freezing``)
+
+    Args:
+        tac_text: Raw METAR/SPECI TAC string (with or without WMO header).
+
+    Returns:
+        A two-tuple ``(normalized_text, warnings)`` where ``warnings`` is a
+        list of dicts with keys ``index``, ``original``, ``replacement``, and
+        ``rule``.  The list is empty when no rewrites were made.
+    """
+    warnings: List[dict] = []
+
+    # Preserve leading/trailing whitespace on the outer string but work on
+    # individual tokens so we don't alter separators inside the message.
+    stripped = tac_text.strip()
+    if not stripped:
+        return tac_text, warnings
+
+    tokens = stripped.split(' ')
+    result_tokens: List[str] = []
+
+    for idx, token in enumerate(tokens):
+        # Some parsers/users append '=' to the last token; strip it before
+        # matching so we can still recognise e.g. 'RESH=' as a RESH token.
+        trailing_eq = token.endswith('=')
+        bare = token[:-1] if trailing_eq else token
+        upper_bare = bare.upper()
+
+        match = _TRUNCATED_REWX_RE.match(upper_bare)
+        if match:
+            descriptor = match.group(1).upper()
+            replacement_bare = f'RE{descriptor}UP'
+            replacement = replacement_bare + ('=' if trailing_eq else '')
+
+            rule = (
+                'recent_weather_truncated_showers'
+                if descriptor == 'SH'
+                else 'recent_weather_truncated_freezing'
+            )
+
+            warnings.append({
+                'index': idx,
+                'original': token,
+                'replacement': replacement,
+                'rule': rule,
+            })
+            result_tokens.append(replacement)
+        else:
+            result_tokens.append(token)
+
+    normalized = ' '.join(result_tokens)
+    # Re-attach any leading/trailing whitespace from the original input so we
+    # don't silently alter strings that the caller may be sensitive about.
+    leading = tac_text[:len(tac_text) - len(tac_text.lstrip())]
+    trailing = tac_text[len(tac_text.rstrip()):]
+    return leading + normalized + trailing, warnings

--- a/backend/tests/conversion/test_utilities_conversion.py
+++ b/backend/tests/conversion/test_utilities_conversion.py
@@ -195,5 +195,7 @@ def test_lenient_false_resh_strict_behaviour():
     )
     # Strict mode should not silently mirror lenient output.
     assert result_strict != result_lenient
+    # In strict mode, GIFTs should preserve TAC parse failure markers for bare RESH.
+    assert "translationFailedTAC" in result_strict
     # Lenient result should not contain a TAC failure marker
     assert "translationFailedTAC" not in result_lenient

--- a/backend/tests/conversion/test_utilities_conversion.py
+++ b/backend/tests/conversion/test_utilities_conversion.py
@@ -119,3 +119,79 @@ def test_convert_cor_metar_with_metadata():
     assert 'translationFailedTAC' not in result
     assert validation_result is not None
     assert validation_result.is_valid is True
+
+
+# ---------------------------------------------------------------------------
+# Recent weather normalization (issue #668): RESH -> RESHUP
+# ---------------------------------------------------------------------------
+
+METAR_WITH_RESH = (
+    "METAR TTPP 121000Z 00000KT 9999 VCSH FEW010CB 26/25 Q1013 RESH NOSIG"
+)
+METAR_WITH_RESHRA = (
+    "METAR TTPP 121000Z 00000KT 9999 VCSH FEW010CB 26/25 Q1013 RESHRA NOSIG"
+)
+
+
+def test_resh_conversion_succeeds_lenient_mode():
+    """METAR with bare RESH token must not raise ConversionError in lenient mode (default).
+
+    Also verifies that the encoder does not produce a TAC-failure element,
+    confirming that RESHUP (the normalised form) was decoded and encoded
+    successfully.
+    """
+    result, _ = convert_metar_tac_with_metadata(
+        METAR_WITH_RESH,
+        validate=False,
+        lenient=True,
+    )
+    assert isinstance(result, str)
+    assert len(result) > 0
+    assert "translationFailedTAC" not in result
+
+
+def test_resh_normalizer_rewrites_before_conversion():
+    """normalize_recent_weather_tokens rewrites RESH->RESHUP before GIFTs decoding.
+
+    This test verifies the normalizer step independently of the full pipeline so
+    results are stable even when GIFTs module state is polluted by earlier tests.
+    """
+    from src.utilities.metar_normalizer import normalize_recent_weather_tokens
+
+    normalised, warnings = normalize_recent_weather_tokens(METAR_WITH_RESH)
+    assert "RESHUP" in normalised
+    assert " RESH " not in normalised
+    assert len(warnings) == 1
+    assert warnings[0]["original"] == "RESH"
+    assert warnings[0]["replacement"] == "RESHUP"
+
+
+def test_reshra_conversion_still_works_baseline():
+    """RESHRA (already valid) must still convert successfully with lenient mode on (regression guard)."""
+    result, _ = convert_metar_tac_with_metadata(
+        METAR_WITH_RESHRA,
+        validate=False,
+        lenient=True,
+    )
+    assert isinstance(result, str)
+    assert len(result) > 0
+    assert "translationFailedTAC" not in result
+
+
+def test_lenient_false_resh_strict_behaviour():
+    """When lenient=False, RESH is NOT rewritten and the decoder may record a parse failure."""
+    # We do not assert that this raises ConversionError because GIFTs degrades gracefully
+    # (it encodes a translationFailedTAC element rather than raising), but we DO assert that
+    # the normalised XML from lenient=True does NOT appear when lenient is off.
+    result_strict, _ = convert_metar_tac_with_metadata(
+        METAR_WITH_RESH,
+        validate=False,
+        lenient=False,
+    )
+    result_lenient, _ = convert_metar_tac_with_metadata(
+        METAR_WITH_RESH,
+        validate=False,
+        lenient=True,
+    )
+    # Lenient result should not contain a TAC failure marker
+    assert "translationFailedTAC" not in result_lenient

--- a/backend/tests/conversion/test_utilities_conversion.py
+++ b/backend/tests/conversion/test_utilities_conversion.py
@@ -193,5 +193,7 @@ def test_lenient_false_resh_strict_behaviour():
         validate=False,
         lenient=True,
     )
+    # Strict mode should not silently mirror lenient output.
+    assert result_strict != result_lenient
     # Lenient result should not contain a TAC failure marker
     assert "translationFailedTAC" not in result_lenient

--- a/backend/tests/unit/test_api_endpoint_unit.py
+++ b/backend/tests/unit/test_api_endpoint_unit.py
@@ -85,6 +85,82 @@ def test_convert_handles_manual_text_with_mocked_converter(client):
     assert "<iwxxm:METAR" in payload["results"][0]["content"]
 
 
+def test_convert_manual_recent_weather_resh_is_normalized_before_validation(client, monkeypatch):
+    class _StrictRecentWxValidationService:
+        def validate_all_layers(self, tac_text: str) -> AggregatedValidationResult:
+            if " RESH " in f" {tac_text} ":
+                layer = ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)
+                layer.add_issue(level="error", message="truncated recent weather", code="BAD_REWX")
+                return AggregatedValidationResult.from_results([layer])
+
+            return AggregatedValidationResult.from_results(
+                [ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)]
+            )
+
+    def _assert_normalized_convert(
+        tac: str,
+        iwxxm_version: str = "2025-2",
+        validate: bool = False,
+        **_kwargs: Any,
+    ):
+        assert "RESHUP" in tac
+        assert " RESH " not in f" {tac} "
+        xml = f"<iwxxm:METAR version=\"{iwxxm_version}\">ok</iwxxm:METAR>"
+        return xml, None
+
+    monkeypatch.setattr(api_module, "ValidationService", _StrictRecentWxValidationService)
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", _assert_normalized_convert)
+
+    response = client.post(
+        "/api/v1/convert",
+        data={
+            "manual_text": "METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESH NOSIG",
+            "stop_on_error": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert payload["failed"] == 0
+    assert any(issue["code"] == "RECENT_WX_NORMALIZED" for issue in payload["issues"])
+
+
+def test_convert_manual_recent_weather_reshra_passes_without_rewrite(client, monkeypatch):
+    class _RecentWxValidationService:
+        def validate_all_layers(self, _tac_text: str) -> AggregatedValidationResult:
+            return AggregatedValidationResult.from_results(
+                [ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)]
+            )
+
+    def _assert_no_rewrite_convert(
+        tac: str,
+        iwxxm_version: str = "2025-2",
+        validate: bool = False,
+        **_kwargs: Any,
+    ):
+        assert "RESHRA" in tac
+        assert "RESHUP" not in tac
+        xml = f"<iwxxm:METAR version=\"{iwxxm_version}\">ok</iwxxm:METAR>"
+        return xml, None
+
+    monkeypatch.setattr(api_module, "ValidationService", _RecentWxValidationService)
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", _assert_no_rewrite_convert)
+
+    response = client.post(
+        "/api/v1/convert",
+        data={
+            "manual_text": "METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESHRA NOSIG",
+            "stop_on_error": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert payload["failed"] == 0
+
+
 def test_convert_handles_file_upload_with_mocked_converter(client):
     response = client.post(
         "/api/v1/convert",

--- a/backend/tests/unit/test_api_endpoint_unit.py
+++ b/backend/tests/unit/test_api_endpoint_unit.py
@@ -89,7 +89,7 @@ def test_convert_manual_recent_weather_resh_is_normalized_before_validation(clie
     class _StrictRecentWxValidationService:
         def validate_all_layers(self, tac_text: str) -> AggregatedValidationResult:
             if " RESH " in f" {tac_text} ":
-                layer = ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)
+                layer = ValidationResult(passed=False, layer=ValidationLayer.TAC_SYNTAX)
                 layer.add_issue(level="error", message="truncated recent weather", code="BAD_REWX")
                 return AggregatedValidationResult.from_results([layer])
 

--- a/backend/tests/unit/test_api_endpoint_unit.py
+++ b/backend/tests/unit/test_api_endpoint_unit.py
@@ -161,6 +161,87 @@ def test_convert_manual_recent_weather_reshra_passes_without_rewrite(client, mon
     assert payload["failed"] == 0
 
 
+def test_convert_json_recent_weather_resh_is_normalized_before_validation(client, monkeypatch):
+    class _StrictRecentWxValidationService:
+        def validate_all_layers(self, tac_text: str) -> AggregatedValidationResult:
+            if " RESH " in f" {tac_text} ":
+                layer = ValidationResult(passed=False, layer=ValidationLayer.TAC_SYNTAX)
+                layer.add_issue(level="error", message="truncated recent weather", code="BAD_REWX")
+                return AggregatedValidationResult.from_results([layer])
+
+            return AggregatedValidationResult.from_results(
+                [ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)]
+            )
+
+    def _assert_json_normalized_convert(
+        tac: str,
+        iwxxm_version: str = "2025-2",
+        validate: bool = False,
+        **kwargs: Any,
+    ):
+        assert "RESHUP" in tac
+        assert " RESH " not in f" {tac} "
+        assert kwargs.get("lenient") is False
+        xml = f"<iwxxm:METAR version=\"{iwxxm_version}\">ok</iwxxm:METAR>"
+        return xml, None
+
+    monkeypatch.setattr(api_module, "ValidationService", _StrictRecentWxValidationService)
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", _assert_json_normalized_convert)
+
+    response = client.post(
+        "/api/v1/convert",
+        json={
+            "metars": ["METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESH NOSIG"],
+            "version": "2025-2",
+            "stop_on_error": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert payload["failed"] == 0
+    assert any(issue["code"] == "RECENT_WX_NORMALIZED" for issue in payload["issues"])
+
+
+def test_convert_json_recent_weather_reshra_passes_without_rewrite(client, monkeypatch):
+    class _RecentWxValidationService:
+        def validate_all_layers(self, _tac_text: str) -> AggregatedValidationResult:
+            return AggregatedValidationResult.from_results(
+                [ValidationResult(passed=True, layer=ValidationLayer.TAC_SYNTAX)]
+            )
+
+    def _assert_json_no_rewrite_convert(
+        tac: str,
+        iwxxm_version: str = "2025-2",
+        validate: bool = False,
+        **kwargs: Any,
+    ):
+        assert "RESHRA" in tac
+        assert "RESHUP" not in tac
+        assert kwargs.get("lenient") is False
+        xml = f"<iwxxm:METAR version=\"{iwxxm_version}\">ok</iwxxm:METAR>"
+        return xml, None
+
+    monkeypatch.setattr(api_module, "ValidationService", _RecentWxValidationService)
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", _assert_json_no_rewrite_convert)
+
+    response = client.post(
+        "/api/v1/convert",
+        json={
+            "metars": ["METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESHRA NOSIG"],
+            "version": "2025-2",
+            "stop_on_error": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert payload["failed"] == 0
+    assert all(issue["code"] != "RECENT_WX_NORMALIZED" for issue in payload["issues"])
+
+
 def test_convert_handles_file_upload_with_mocked_converter(client):
     response = client.post(
         "/api/v1/convert",

--- a/backend/tests/unit/test_api_import_fallback_unit.py
+++ b/backend/tests/unit/test_api_import_fallback_unit.py
@@ -152,6 +152,10 @@ def test_api_module_top_level_fallback_imports(monkeypatch):
         ConversionError=RuntimeError,
         convert_metar_tac_with_metadata=lambda *args, **kwargs: ("<xml/>", None),
     )
+    fake_util_metar_normalizer = _stub_module(
+        "utilities.metar_normalizer",
+        normalize_recent_weather_tokens=lambda tac: (tac, []),
+    )
     fake_util_observability = _stub_module(
         "utilities.observability",
         install_fastapi_observability=lambda **_kwargs: None,
@@ -188,6 +192,7 @@ def test_api_module_top_level_fallback_imports(monkeypatch):
         "services.webhooks": fake_services_webhooks,
         "utilities": _stub_module("utilities"),
         "utilities.conversion": fake_util_conversion,
+        "utilities.metar_normalizer": fake_util_metar_normalizer,
         "utilities.observability": fake_util_observability,
         "utilities.security": fake_util_security,
         "utilities.tac_parser": fake_util_tac,

--- a/backend/tests/unit/test_api_processing_branches_unit.py
+++ b/backend/tests/unit/test_api_processing_branches_unit.py
@@ -1039,3 +1039,30 @@ def test_convert_json_conversion_error_emits_translation_failed_notification(cli
     assert call["airport_code"] == "KDEN"
     assert call["error_type"] == "conversion_error"
     assert "forced conversion failure" in call["error_message"]
+
+
+def test_convert_file_validation_service_error_emits_translation_failed_notification(client, monkeypatch):
+    async def fake_read_uploaded_text(_upload_file):
+        return "METAR KSEA 010000Z 00000KT CAVOK 10/08 Q1013", None
+
+    class _ValidationErrorService:
+        def validate_all_layers(self, _tac: str) -> AggregatedValidationResult:
+            raise api_module.ValidationServiceError("validation service unavailable")
+
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "read_uploaded_text", fake_read_uploaded_text)
+    monkeypatch.setattr(api_module, "ValidationService", _ValidationErrorService)
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+
+    response = client.post(
+        "/api/v1/convert",
+        files=[("files", ("sample.txt", "ignored", "text/plain"))],
+    )
+
+    assert response.status_code == 400
+    assert len(capture.failed_calls) == 1
+    call = capture.failed_calls[0]
+    assert call["translation_id"] == "test-translation-id"
+    assert call["airport_code"] == "KSEA"
+    assert call["error_type"] == "validation_error"
+    assert "validation service unavailable" in call["error_message"]

--- a/backend/tests/unit/test_api_processing_branches_unit.py
+++ b/backend/tests/unit/test_api_processing_branches_unit.py
@@ -842,3 +842,200 @@ def test_convert_and_convert_zip_version_import_fallback(client, monkeypatch):
         data={"manual_text": "METAR KJFK 010000Z 00000KT CAVOK 10/08 Q1013", "iwxxm_version": "2025-2"},
     )
     assert zip_response.status_code == 200
+
+
+class _CaptureWebhookService:
+    def __init__(self):
+        self.success_calls = []
+        self.failed_calls = []
+        self.completed_calls = []
+
+    async def notify_translation_success(
+        self,
+        translation_id: str,
+        airport_code: str,
+        icao_region: str,
+        iwxxm_version: str,
+        duration_ms: int,
+    ) -> None:
+        self.success_calls.append(
+            {
+                "translation_id": translation_id,
+                "airport_code": airport_code,
+                "icao_region": icao_region,
+                "iwxxm_version": iwxxm_version,
+                "duration_ms": duration_ms,
+            }
+        )
+
+    async def notify_translation_failed(
+        self,
+        translation_id: str,
+        airport_code: str,
+        error_type: str,
+        error_message: str,
+    ) -> None:
+        self.failed_calls.append(
+            {
+                "translation_id": translation_id,
+                "airport_code": airport_code,
+                "error_type": error_type,
+                "error_message": error_message,
+            }
+        )
+
+    async def notify_translation_completed(
+        self,
+        translation_id: str,
+        airport_code: str,
+        iwxxm_version: str,
+        file_size_bytes: int,
+        duration_ms: int,
+    ) -> None:
+        self.completed_calls.append(
+            {
+                "translation_id": translation_id,
+                "airport_code": airport_code,
+                "iwxxm_version": iwxxm_version,
+                "file_size_bytes": file_size_bytes,
+                "duration_ms": duration_ms,
+            }
+        )
+
+
+def test_convert_manual_success_emits_translation_success_notification(client, monkeypatch):
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+    monkeypatch.setattr(api_module, "get_icao_region", lambda _icao: "NAM")
+
+    response = client.post(
+        "/api/v1/convert",
+        data={"manual_text": "METAR KJFK 010000Z 00000KT CAVOK 10/08 Q1013"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert len(capture.success_calls) == 1
+    assert len(capture.failed_calls) == 0
+    assert len(capture.completed_calls) == 0
+
+    call = capture.success_calls[0]
+    assert call["translation_id"] == "test-translation-id"
+    assert call["airport_code"] == "KJFK"
+    assert call["icao_region"] == "NAM"
+    assert call["iwxxm_version"] == "2025-2"
+    assert call["duration_ms"] >= 0
+
+
+def test_convert_manual_validation_failure_emits_translation_failed_notification(client, monkeypatch):
+    class _ValidationFailService:
+        def validate_all_layers(self, _tac: str) -> AggregatedValidationResult:
+            failed = ValidationResult(passed=False, layer=ValidationLayer.AIRPORT_ICAO)
+            failed.add_issue(level="error", message="bad tac", code="BAD_TAC")
+            return AggregatedValidationResult.from_results([failed])
+
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "ValidationService", _ValidationFailService)
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+
+    response = client.post(
+        "/api/v1/convert",
+        data={"manual_text": "METAR KJFK 010000Z 00000KT CAVOK 10/08 Q1013"},
+    )
+
+    assert response.status_code == 400
+    assert len(capture.failed_calls) == 1
+    assert len(capture.success_calls) == 0
+    assert len(capture.completed_calls) == 0
+
+    call = capture.failed_calls[0]
+    assert call["translation_id"] == "test-translation-id"
+    assert call["airport_code"] == "KJFK"
+    assert call["error_type"] == "validation_failed"
+    assert "validation issue" in call["error_message"]
+
+
+def test_convert_json_success_emits_translation_completed_notification(client, monkeypatch):
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+
+    response = client.post(
+        "/api/v1/convert",
+        json={
+            "metars": ["METAR KDEN 010000Z 00000KT CAVOK 10/08 Q1013"],
+            "version": "2025-2",
+            "stop_on_error": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert len(capture.completed_calls) == 1
+    assert len(capture.success_calls) == 0
+    assert len(capture.failed_calls) == 0
+
+    call = capture.completed_calls[0]
+    assert call["translation_id"] == "test-translation-id"
+    assert call["airport_code"] == "KDEN"
+    assert call["iwxxm_version"] == "2025-2"
+    assert call["file_size_bytes"] > 0
+    assert call["duration_ms"] >= 0
+
+
+def test_convert_file_success_emits_translation_success_notification(client, monkeypatch):
+    async def fake_read_uploaded_text(_upload_file):
+        return "METAR KSEA 010000Z 00000KT CAVOK 10/08 Q1013", None
+
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "read_uploaded_text", fake_read_uploaded_text)
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+    monkeypatch.setattr(api_module, "get_icao_region", lambda _icao: "PAC")
+
+    response = client.post(
+        "/api/v1/convert",
+        files=[("files", ("sample.txt", "ignored", "text/plain"))],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["successful"] == 1
+    assert len(capture.success_calls) == 1
+    assert len(capture.failed_calls) == 0
+    assert len(capture.completed_calls) == 0
+
+    call = capture.success_calls[0]
+    assert call["translation_id"] == "test-translation-id"
+    assert call["airport_code"] == "KSEA"
+    assert call["icao_region"] == "PAC"
+    assert call["iwxxm_version"] == "2025-2"
+
+
+def test_convert_json_conversion_error_emits_translation_failed_notification(client, monkeypatch):
+    def always_fail_convert(*_args: Any, **_kwargs: Any):
+        raise ConversionError("forced conversion failure")
+
+    capture = _CaptureWebhookService()
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", always_fail_convert)
+    monkeypatch.setattr(api_module, "webhook_service", capture)
+
+    response = client.post(
+        "/api/v1/convert",
+        json={
+            "metars": ["METAR KDEN 010000Z 00000KT CAVOK 10/08 Q1013"],
+            "version": "2025-2",
+            "stop_on_error": False,
+        },
+    )
+
+    assert response.status_code == 400
+    assert len(capture.failed_calls) == 1
+    assert len(capture.success_calls) == 0
+    assert len(capture.completed_calls) == 0
+
+    call = capture.failed_calls[0]
+    assert call["translation_id"] == "unknown"
+    assert call["airport_code"] == "KDEN"
+    assert call["error_type"] == "conversion_error"
+    assert "forced conversion failure" in call["error_message"]

--- a/backend/tests/unit/test_metar_normalizer.py
+++ b/backend/tests/unit/test_metar_normalizer.py
@@ -1,0 +1,161 @@
+"""Unit tests for metar_normalizer.normalize_recent_weather_tokens."""
+from __future__ import annotations
+
+import pytest
+
+from src.utilities.metar_normalizer import normalize_recent_weather_tokens
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalized(tac: str) -> str:
+    """Return only the normalized text, ignoring warnings."""
+    result, _ = normalize_recent_weather_tokens(tac)
+    return result
+
+
+def _warnings(tac: str) -> list:
+    """Return only the warnings list."""
+    _, warnings = normalize_recent_weather_tokens(tac)
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Core rewrite rules
+# ---------------------------------------------------------------------------
+
+def test_resh_rewritten_to_reshup():
+    result = _normalized("METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESH NOSIG")
+    assert "RESHUP" in result
+    assert " RESH " not in result  # original token gone (space-bounded check)
+
+
+def test_refz_rewritten_to_refzup():
+    result = _normalized("METAR KJFK 121000Z 00000KT 9999 FEW010 10/05 A2990 REFZ NOSIG")
+    assert "REFZUP" in result
+    assert " REFZ " not in result
+
+
+# ---------------------------------------------------------------------------
+# No accidental rewrites
+# ---------------------------------------------------------------------------
+
+def test_reshra_unchanged():
+    tac = "METAR KJFK 121000Z 18012KT 9999 FEW020 15/07 A3005 RESHRA NOSIG"
+    assert _normalized(tac) == tac
+    assert _warnings(tac) == []
+
+
+def test_reshup_already_valid_unchanged():
+    tac = "METAR KJFK 121000Z 18012KT 9999 FEW020 15/07 A3005 RESHUP NOSIG"
+    assert _normalized(tac) == tac
+    assert _warnings(tac) == []
+
+
+def test_vcsh_unchanged():
+    """VCSH is vicinity showers (not a recent-weather group)."""
+    tac = "METAR TTPP 121000Z 00000KT 9999 VCSH FEW010CB 26/25 Q1013 NOSIG"
+    assert _normalized(tac) == tac
+    assert _warnings(tac) == []
+
+
+def test_shra_unchanged():
+    """SHRA is present weather (no RE prefix)."""
+    tac = "METAR KJFK 121000Z 18012KT 9999 SHRA FEW020 15/07 A3005"
+    assert _normalized(tac) == tac
+    assert _warnings(tac) == []
+
+
+def test_retssn_unchanged():
+    """RETSSN has a phenomenon (SN), should not be touched."""
+    tac = "METAR KJFK 121000Z 18012KT 9999 FEW020 15/07 A3005 RETSSN NOSIG"
+    assert _normalized(tac) == tac
+    assert _warnings(tac) == []
+
+
+# ---------------------------------------------------------------------------
+# Trailing '=' handling
+# ---------------------------------------------------------------------------
+
+def test_resh_trailing_equals_rewritten():
+    tac = "METAR TTPP 121000Z 00000KT 9999 FEW010CB 26/25 Q1013 RESH="
+    result = _normalized(tac)
+    assert result.endswith("RESHUP=")
+    assert " RESH=" not in result
+
+
+def test_refz_trailing_equals_rewritten():
+    tac = "METAR KJFK 121000Z 00000KT 9999 FEW010 10/05 A2990 REFZ="
+    result = _normalized(tac)
+    assert result.endswith("REFZUP=")
+
+
+# ---------------------------------------------------------------------------
+# Multiple rewrites
+# ---------------------------------------------------------------------------
+
+def test_multiple_rewrites_in_one_metar():
+    """Both RESH and REFZ in the same report should both be rewritten."""
+    tac = "METAR KJFK 121000Z 00000KT 9999 FEW010 10/05 A2990 RESH REFZ NOSIG"
+    result, warns = normalize_recent_weather_tokens(tac)
+    assert "RESHUP" in result
+    assert "REFZUP" in result
+    assert len(warns) == 2
+
+
+# ---------------------------------------------------------------------------
+# Clean METAR passes through unchanged
+# ---------------------------------------------------------------------------
+
+def test_clean_metar_unchanged_empty_warnings():
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005"
+    result, warns = normalize_recent_weather_tokens(tac)
+    assert result == tac
+    assert warns == []
+
+
+# ---------------------------------------------------------------------------
+# Warning dict structure
+# ---------------------------------------------------------------------------
+
+def test_warning_dict_keys():
+    tac = "METAR TTPP 121000Z 00000KT 9999 FEW010CB 26/25 Q1013 RESH NOSIG"
+    _, warns = normalize_recent_weather_tokens(tac)
+    assert len(warns) == 1
+    w = warns[0]
+    assert set(w.keys()) == {"index", "original", "replacement", "rule"}
+    assert w["original"] == "RESH"
+    assert w["replacement"] == "RESHUP"
+    assert w["rule"] == "recent_weather_truncated_showers"
+
+
+def test_refz_warning_rule_name():
+    tac = "METAR KJFK 121000Z 00000KT 9999 FEW010 10/05 A2990 REFZ NOSIG"
+    _, warns = normalize_recent_weather_tokens(tac)
+    assert len(warns) == 1
+    assert warns[0]["rule"] == "recent_weather_truncated_freezing"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_string():
+    result, warns = normalize_recent_weather_tokens("")
+    assert result == ""
+    assert warns == []
+
+
+def test_whitespace_only_string():
+    result, warns = normalize_recent_weather_tokens("   ")
+    assert result == "   "
+    assert warns == []
+
+
+def test_leading_trailing_whitespace_preserved():
+    tac = "  METAR TTPP 121000Z 00000KT 9999 FEW010 26/25 Q1013 RESH NOSIG  "
+    result, _ = normalize_recent_weather_tokens(tac)
+    assert result.startswith("  ")
+    assert result.endswith("  ")
+    assert "RESHUP" in result

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -333,15 +333,51 @@ pytest --cov=src --cov-report=html
 
 ### Integration Tests
 ```bash
-# Playwright browser E2E (run from repository root)
+# Playwright browser E2E — full suite (requires admin credentials)
 make test-e2e-playwright
 
-# Equivalent direct command
+# Credential-free smoke subset (safe for CI / local dev without secrets)
+make test-e2e-playwright-smoke
+
+# Equivalent direct command (full suite)
 cd frontend && npx playwright test
 ```
 
 Playwright browser E2E specs are located in the repository-level `tests/` directory (`*.e2e.spec.ts`).
 The Playwright runner starts all required local services through `start-dev-servers.sh` for full-stack coverage.
+
+#### Test suites
+
+| Target | Admin credentials | Tests |
+|---|---|---|
+| `test-e2e-playwright` | Required | All 21 tests (login flows, admin nav, file upload) |
+| `test-e2e-playwright-smoke` | **Not required** | 9 tests: service health, auth integration, mocked conversions |
+
+`tests/00-preflight.e2e.spec.ts` sorts first alphabetically and runs before any login-dependent
+spec file.  When credentials are missing or wrong it fails immediately with a single descriptive
+message rather than producing 12+ repeated timeout failures from every test that calls
+`loginAsAdmin`.
+
+### Playwright E2E Environment Controls
+
+- `PLAYWRIGHT_ADMIN_EMAIL`, `PLAYWRIGHT_ADMIN_PASSWORD`: required for admin authentication flows.
+- `PLAYWRIGHT_TAC_FIXTURES_DIR`: override TAC fixture location for upload tests.
+- `PLAYWRIGHT_REQUIRE_TAC_FIXTURES=1`: fail fast if TAC fixtures are unavailable (default on CI).
+- `PLAYWRIGHT_SERVICE_WAIT_TIMEOUT_MS`: startup service health wait timeout in milliseconds.
+- `PLAYWRIGHT_FRONTEND_HEALTH_URL`, `PLAYWRIGHT_BACKEND_HEALTH_URL`, `PLAYWRIGHT_AUTH_HEALTH_URL`: optional health endpoint overrides.
+- `PLAYWRIGHT_FORCE_SERVICE_HEALTH_WAIT=1`: force health checks for non-local base URLs.
+- `PLAYWRIGHT_SKIP_LOCAL_HEALTH_WAIT=1`: disable startup health checks.
+
+Example:
+
+```bash
+cd frontend
+export PLAYWRIGHT_ADMIN_EMAIL="admin@example.com"
+export PLAYWRIGHT_ADMIN_PASSWORD="<password>"
+export PLAYWRIGHT_REQUIRE_TAC_FIXTURES=1
+export PLAYWRIGHT_SERVICE_WAIT_TIMEOUT_MS=180000
+npx playwright test
+```
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -333,9 +333,15 @@ pytest --cov=src --cov-report=html
 
 ### Integration Tests
 ```bash
-cd frontend
-npm run test:e2e         # Playwright E2E tests
+# Playwright browser E2E (run from repository root)
+make test-e2e-playwright
+
+# Equivalent direct command
+cd frontend && npx playwright test
 ```
+
+Playwright browser E2E specs are located in the repository-level `tests/` directory (`*.e2e.spec.ts`).
+The Playwright runner starts all required local services through `start-dev-servers.sh` for full-stack coverage.
 
 ---
 

--- a/tests/00-preflight.e2e.spec.ts
+++ b/tests/00-preflight.e2e.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Credential preflight guard.
+ *
+ * This file is named "00-preflight" so it sorts before all other spec files
+ * and runs first. It verifies that the admin credentials are configured AND
+ * actually work against the app.  When credentials are wrong you get one clear
+ * failure here instead of 12+ repeated timeout failures scattered across the
+ * rest of the suite.
+ *
+ * If your test run does not need admin credentials (smoke / CI without secrets)
+ * run only the credential-free spec files instead:
+ *
+ *   make test-e2e-playwright-smoke
+ */
+import { expect, test } from '@playwright/test';
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from './playwright-e2e-helpers';
+
+test.describe('Preflight: Admin Credential Guard', () => {
+  test('admin credentials are configured and authenticate successfully', async ({ page }) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      throw new Error(
+        'Preflight failed: PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD are not set.\n' +
+          'Set them in your shell or .env before running login-dependent tests.\n' +
+          'To skip login tests entirely, run: make test-e2e-playwright-smoke'
+      );
+    }
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /METAR Converter/i })).toBeVisible();
+
+    await page.locator('#email').fill(ADMIN_EMAIL);
+    await page.locator('#password').fill(ADMIN_PASSWORD);
+    await page.getByRole('button', { name: /sign in to account/i }).click();
+
+    await expect(
+      page.getByRole('heading', { name: /Admin Dashboard/i }),
+      `Preflight failed: login with "${ADMIN_EMAIL}" did not reach the Admin Dashboard. ` +
+        'PLAYWRIGHT_ADMIN_EMAIL / PLAYWRIGHT_ADMIN_PASSWORD appear to be invalid. ' +
+        'Fix the credentials before re-running the full suite.'
+    ).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/tests/admin-navigation.e2e.spec.ts
+++ b/tests/admin-navigation.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { loginAsAdmin, openConverterFromAdmin } from './playwright-e2e-helpers';
+
+test.describe('Admin Navigation', () => {
+  test('admin dashboard renders after login', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'User Approvals', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'System Settings', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'System Monitoring', exact: true })).toBeVisible();
+  });
+
+  test('admin panels can be switched', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.getByText('System Settings').first().click();
+    await expect(page.getByRole('heading', { name: 'System Settings', exact: true }).nth(1)).toBeVisible();
+
+    await page.getByText('System Monitoring').first().click();
+    await expect(page.getByRole('heading', { name: 'System Monitoring', exact: true }).nth(1)).toBeVisible();
+  });
+
+  test('admin can switch to converter and back from the view selector', async ({ page }) => {
+    await loginAsAdmin(page);
+    await openConverterFromAdmin(page);
+
+    const viewSelect = page.getByLabel(/Switch view/i);
+    await expect(viewSelect).toBeVisible();
+    await expect(page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })).toBeVisible();
+
+    await viewSelect.selectOption('admin');
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+  });
+
+  test('logout scope menu is available from the admin dashboard', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.getByRole('button', { name: /Logout options/i }).click();
+
+    await expect(page.getByText('This Device')).toBeVisible();
+    await expect(page.getByText('All Devices')).toBeVisible();
+    await expect(page.getByText('Other Devices')).toBeVisible();
+  });
+});

--- a/tests/admin-navigation.e2e.spec.ts
+++ b/tests/admin-navigation.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { expect, test } from '@playwright/test';
 import { loginAsAdmin, openConverterFromAdmin } from './playwright-e2e-helpers';
 
 test.describe('Admin Navigation', () => {

--- a/tests/auth-service-integration.e2e.spec.ts
+++ b/tests/auth-service-integration.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const AUTH_SERVICE_URL = process.env.PLAYWRIGHT_AUTH_SERVICE_URL ?? 'http://localhost:8003';
 
@@ -22,7 +22,8 @@ test.describe('Auth Service Integration', () => {
     const response = await request.get(`${AUTH_SERVICE_URL}/health`, { timeout: 5000 });
 
     expect(response.ok()).toBe(true);
-    await expect(response.json()).resolves.toMatchObject({
+    const body = await response.json();
+    expect(body).toMatchObject({
       service: 'auth',
       status: 'healthy',
     });

--- a/tests/auth-service-integration.e2e.spec.ts
+++ b/tests/auth-service-integration.e2e.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '../frontend/node_modules/@playwright/test';
+
+const AUTH_SERVICE_URL = process.env.PLAYWRIGHT_AUTH_SERVICE_URL ?? 'http://localhost:8003';
+
+test.describe('Auth Service Integration', () => {
+  test('frontend boots without missing auth env errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(500);
+
+    expect(consoleErrors.some((message) => message.includes('Missing VITE_AUTH_SERVICE_URL'))).toBe(false);
+  });
+
+  test('auth service health endpoint is available', async ({ request }) => {
+    const response = await request.get(`${AUTH_SERVICE_URL}/health`, { timeout: 5000 });
+
+    expect(response.ok()).toBe(true);
+    await expect(response.json()).resolves.toMatchObject({
+      service: 'auth',
+      status: 'healthy',
+    });
+  });
+
+  test('app load does not generate 400 auth bootstrap requests', async ({ page }) => {
+    const badRequests: string[] = [];
+
+    page.on('response', async (response) => {
+      if (response.status() !== 400) {
+        return;
+      }
+
+      const url = response.url();
+      if (url.includes('/auth/')) {
+        badRequests.push(`${response.request().method()} ${url}`);
+      }
+    });
+
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(1000);
+
+    expect(badRequests).toEqual([]);
+  });
+});

--- a/tests/auth.e2e.spec.ts
+++ b/tests/auth.e2e.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { gotoLogin, loginAsAdmin } from './playwright-e2e-helpers';
+
+test.describe('Authentication Flow', () => {
+  test('login page loads correctly', async ({ page }) => {
+    await gotoLogin(page);
+
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in to account/i })).toBeVisible();
+  });
+
+  test('empty login validation shows required messages', async ({ page }) => {
+    await gotoLogin(page);
+
+    await page.getByRole('button', { name: /sign in to account/i }).click();
+
+    await expect(page.getByText('Email is required')).toBeVisible();
+    await expect(page.getByText('Password is required')).toBeVisible();
+  });
+
+  test('admin login reaches the admin dashboard', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await expect(page.getByText(/Logged in as: admin@metar\.local/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'User Approvals', exact: true })).toBeVisible();
+  });
+});

--- a/tests/auth.e2e.spec.ts
+++ b/tests/auth.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { expect, test } from '@playwright/test';
 import { gotoLogin, loginAsAdmin } from './playwright-e2e-helpers';
 
 test.describe('Authentication Flow', () => {

--- a/tests/playwright-e2e-helpers.ts
+++ b/tests/playwright-e2e-helpers.ts
@@ -1,7 +1,18 @@
 import { expect, Page } from '@playwright/test';
 
-export const ADMIN_EMAIL = process.env.PLAYWRIGHT_ADMIN_EMAIL ?? 'admin@metar.local';
-export const ADMIN_PASSWORD = process.env.PLAYWRIGHT_ADMIN_PASSWORD ?? 'Admin123456!';
+function getRequiredEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable "${name}" for Playwright admin login. ` +
+        'Set this variable (for example in your CI secrets or local env) before running these tests.'
+    );
+  }
+  return value;
+}
+
+export const ADMIN_EMAIL = getRequiredEnvVar('PLAYWRIGHT_ADMIN_EMAIL');
+export const ADMIN_PASSWORD = getRequiredEnvVar('PLAYWRIGHT_ADMIN_PASSWORD');
 
 export async function gotoLogin(page: Page): Promise<void> {
   await page.goto('/');

--- a/tests/playwright-e2e-helpers.ts
+++ b/tests/playwright-e2e-helpers.ts
@@ -1,0 +1,72 @@
+import { expect, Page } from '../frontend/node_modules/@playwright/test';
+
+export const ADMIN_EMAIL = process.env.PLAYWRIGHT_ADMIN_EMAIL ?? 'admin@metar.local';
+export const ADMIN_PASSWORD = process.env.PLAYWRIGHT_ADMIN_PASSWORD ?? 'Admin123456!';
+
+export async function gotoLogin(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /METAR Converter/i })).toBeVisible();
+}
+
+export async function loginAsAdmin(page: Page): Promise<void> {
+  await gotoLogin(page);
+  await page.locator('#email').fill(ADMIN_EMAIL);
+  await page.locator('#password').fill(ADMIN_PASSWORD);
+  await page.getByRole('button', { name: /sign in to account/i }).click();
+
+  const adminHeading = page.getByRole('heading', { name: /Admin Dashboard/i });
+  const converterHeading = page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i });
+
+  await Promise.race([
+    adminHeading.waitFor({ state: 'visible', timeout: 10000 }),
+    converterHeading.waitFor({ state: 'visible', timeout: 10000 }),
+  ]);
+
+  if (await adminHeading.isVisible().catch(() => false)) {
+    return;
+  }
+
+  const viewSelect = page.getByLabel(/Switch view/i);
+  if (await viewSelect.isVisible().catch(() => false)) {
+    await viewSelect.selectOption('admin');
+  }
+
+  await expect(adminHeading).toBeVisible({ timeout: 10000 });
+}
+
+export async function openConverterFromAdmin(page: Page): Promise<void> {
+  const adminHeading = page.getByRole('heading', { name: /Admin Dashboard/i });
+  if (await adminHeading.isVisible().catch(() => false)) {
+    await page.getByRole('button', { name: /switch to file converter/i }).click();
+  }
+
+  await expect(
+    page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })
+  ).toBeVisible({ timeout: 10000 });
+}
+
+export async function loginAndOpenConverter(page: Page): Promise<void> {
+  await loginAsAdmin(page);
+  await openConverterFromAdmin(page);
+}
+
+export async function openConverterWithMockSession(page: Page): Promise<void> {
+  const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+
+  await page.addInitScript((expiry) => {
+    window.localStorage.setItem('access_token', 'playwright-access-token');
+    window.localStorage.setItem('refresh_token', 'playwright-refresh-token');
+    window.localStorage.setItem('expires_at', String(expiry));
+    window.localStorage.setItem('supabase_access_token', 'playwright-supabase-token');
+  }, futureExpiry);
+
+  await page.goto('/');
+  await expect(
+    page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })
+  ).toBeVisible({ timeout: 10000 });
+}
+
+export async function convertManualMetar(page: Page, metar: string): Promise<void> {
+  await page.getByLabel(/Enter METAR data manually/i).fill(metar);
+  await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+}

--- a/tests/playwright-e2e-helpers.ts
+++ b/tests/playwright-e2e-helpers.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '../frontend/node_modules/@playwright/test';
+import { expect, Page } from '@playwright/test';
 
 export const ADMIN_EMAIL = process.env.PLAYWRIGHT_ADMIN_EMAIL ?? 'admin@metar.local';
 export const ADMIN_PASSWORD = process.env.PLAYWRIGHT_ADMIN_PASSWORD ?? 'Admin123456!';

--- a/tests/playwright-e2e-helpers.ts
+++ b/tests/playwright-e2e-helpers.ts
@@ -1,18 +1,10 @@
 import { expect, Page } from '@playwright/test';
 
-function getRequiredEnvVar(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(
-      `Missing required environment variable "${name}" for Playwright admin login. ` +
-        'Set this variable (for example in your CI secrets or local env) before running these tests.'
-    );
-  }
-  return value;
-}
-
-export const ADMIN_EMAIL = getRequiredEnvVar('PLAYWRIGHT_ADMIN_EMAIL');
-export const ADMIN_PASSWORD = getRequiredEnvVar('PLAYWRIGHT_ADMIN_PASSWORD');
+// Credentials are read lazily (at login time) rather than at module import so that
+// test files that import this module but never call loginAsAdmin() can run without
+// PLAYWRIGHT_ADMIN_EMAIL / PLAYWRIGHT_ADMIN_PASSWORD being set (e.g. smoke subset).
+export const ADMIN_EMAIL = process.env.PLAYWRIGHT_ADMIN_EMAIL ?? '';
+export const ADMIN_PASSWORD = process.env.PLAYWRIGHT_ADMIN_PASSWORD ?? '';
 
 export async function gotoLogin(page: Page): Promise<void> {
   await page.goto('/');
@@ -20,6 +12,13 @@ export async function gotoLogin(page: Page): Promise<void> {
 }
 
 export async function loginAsAdmin(page: Page): Promise<void> {
+  if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+    throw new Error(
+      'PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD must be set to run login-dependent tests.\n' +
+        'Example: PLAYWRIGHT_ADMIN_EMAIL=admin@example.com PLAYWRIGHT_ADMIN_PASSWORD=secret npx playwright test'
+    );
+  }
+
   await gotoLogin(page);
   await page.locator('#email').fill(ADMIN_EMAIL);
   await page.locator('#password').fill(ADMIN_PASSWORD);

--- a/tests/tac-file-conversion.e2e.spec.ts
+++ b/tests/tac-file-conversion.e2e.spec.ts
@@ -1,12 +1,17 @@
 import { expect, test } from '@playwright/test';
 import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
   convertManualMetar,
   loginAndOpenConverter,
   openConverterWithMockSession,
 } from './playwright-e2e-helpers';
 
 test.describe('TAC File Conversion', () => {
-  test('manual METAR input converts to IWXXM', async ({ page }) => {
+  test('manual METAR input converts to IWXXM', async ({ page }, testInfo) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      testInfo.skip();
+    }
     await loginAndOpenConverter(page);
 
     await convertManualMetar(
@@ -18,7 +23,10 @@ test.describe('TAC File Conversion', () => {
     await expect(page.locator('pre').filter({ hasText: /iwxxm|metar:/i }).first()).toBeVisible();
   });
 
-  test('COR METAR input produces correction output', async ({ page }) => {
+  test('COR METAR input produces correction output', async ({ page }, testInfo) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      testInfo.skip();
+    }
     await loginAndOpenConverter(page);
 
     await convertManualMetar(
@@ -31,7 +39,10 @@ test.describe('TAC File Conversion', () => {
     await expect(xmlOutput).toContainText('reportStatus="CORRECTION"');
   });
 
-  test('clear removes manual input', async ({ page }) => {
+  test('clear removes manual input', async ({ page }, testInfo) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      testInfo.skip();
+    }
     await loginAndOpenConverter(page);
 
     const manualInput = page.getByLabel(/Enter METAR data manually/i);

--- a/tests/tac-file-conversion.e2e.spec.ts
+++ b/tests/tac-file-conversion.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { expect, test } from '@playwright/test';
 import {
   convertManualMetar,
   loginAndOpenConverter,

--- a/tests/tac-file-conversion.e2e.spec.ts
+++ b/tests/tac-file-conversion.e2e.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '../frontend/node_modules/@playwright/test';
+import {
+  convertManualMetar,
+  loginAndOpenConverter,
+  openConverterWithMockSession,
+} from './playwright-e2e-helpers';
+
+test.describe('TAC File Conversion', () => {
+  test('manual METAR input converts to IWXXM', async ({ page }) => {
+    await loginAndOpenConverter(page);
+
+    await convertManualMetar(
+      page,
+      'METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990'
+    );
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('pre').filter({ hasText: /iwxxm|metar:/i }).first()).toBeVisible();
+  });
+
+  test('COR METAR input produces correction output', async ({ page }) => {
+    await loginAndOpenConverter(page);
+
+    await convertManualMetar(
+      page,
+      'METAR COR FAOR 101200Z 12012KT 9999 FEW020 22/14 Q1018'
+    );
+
+    const xmlOutput = page.locator('pre').filter({ hasText: /iwxxm|metar:/i }).first();
+    await expect(xmlOutput).toBeVisible({ timeout: 10000 });
+    await expect(xmlOutput).toContainText('reportStatus="CORRECTION"');
+  });
+
+  test('clear removes manual input', async ({ page }) => {
+    await loginAndOpenConverter(page);
+
+    const manualInput = page.getByLabel(/Enter METAR data manually/i);
+    await manualInput.fill('METAR KDEN 121653Z 02006KT 10SM SCT050 21/08 A3010');
+    await page.getByRole('button', { name: /Clear all pending files and manual input/i }).click();
+
+    await expect(manualInput).toHaveValue('');
+  });
+
+  test('mocked success conversion shows success notification and results', async ({ page }) => {
+    await page.route('**/api/v1/convert', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            {
+              name: 'manual_input.txt',
+              content: '<iwxxm:METAR>mock-success</iwxxm:METAR>',
+              source: 'manual_input',
+              size_bytes: 39,
+            },
+          ],
+          errors: [],
+          issues: [],
+          total_processed: 1,
+          successful: 1,
+          failed: 0,
+        }),
+      });
+    });
+
+    await openConverterWithMockSession(page);
+    await convertManualMetar(page, 'METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990');
+
+    await expect(page.getByText(/Successfully converted 1 file\(s\)/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible();
+    await expect(page.getByText('manual_input.txt')).toBeVisible();
+  });
+
+  test('mocked empty conversion result shows no-files-converted notification', async ({ page }) => {
+    await page.route('**/api/v1/convert', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [],
+          errors: [],
+          issues: [],
+          total_processed: 1,
+          successful: 0,
+          failed: 0,
+        }),
+      });
+    });
+
+    await openConverterWithMockSession(page);
+    await convertManualMetar(page, 'METAR EMPTY RESULTS CASE');
+
+    await expect(page.getByText(/No files were converted/i).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Conversion Error/i).first()).toBeVisible();
+  });
+
+  test('mocked unauthorized conversion shows authentication notification', async ({ page }) => {
+    await page.route('**/api/v1/convert', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: '401 unauthorized',
+          errors: [],
+        }),
+      });
+    });
+
+    await openConverterWithMockSession(page);
+    await convertManualMetar(page, 'METAR KDEN 121653Z 02006KT 10SM SCT050 21/08 A3010');
+
+    await expect(
+      page.getByText(/Authentication failed\. Please ensure you are logged in\./i).first()
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Conversion Error/i).first()).toBeVisible();
+  });
+});

--- a/tests/tac-file-upload-database.e2e.spec.ts
+++ b/tests/tac-file-upload-database.e2e.spec.ts
@@ -1,8 +1,24 @@
-import { expect, test } from '../frontend/node_modules/@playwright/test';
+import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
+import * as path from 'path';
 import { loginAndOpenConverter } from './playwright-e2e-helpers';
 
-const tacFilesDir = '/root/metar-to-IWXXM/data/iwxxm-translation/Amd79-80-2023/metar';
+const DEFAULT_TAC_RELATIVE_PATH = 'data/iwxxm-translation/Amd79-80-2023/metar';
+
+function resolveTacFilesDir(): string {
+  const configured = process.env.PLAYWRIGHT_TAC_FIXTURES_DIR;
+  if (configured && fs.existsSync(configured)) {
+    return configured;
+  }
+
+  const candidateFromRepoRoot = path.resolve(process.cwd(), DEFAULT_TAC_RELATIVE_PATH);
+  if (fs.existsSync(candidateFromRepoRoot)) {
+    return candidateFromRepoRoot;
+  }
+
+  const candidateFromFrontendCwd = path.resolve(process.cwd(), '..', DEFAULT_TAC_RELATIVE_PATH);
+  return candidateFromFrontendCwd;
+}
 
 type TacFixture = {
   content: string;
@@ -11,6 +27,7 @@ type TacFixture = {
 };
 
 function getTacFiles(): TacFixture[] {
+  const tacFilesDir = resolveTacFilesDir();
   if (!fs.existsSync(tacFilesDir)) {
     return [];
   }
@@ -41,7 +58,7 @@ test.describe('TAC File Upload to Database', () => {
     const testFile = tacFiles[0];
     await loginAndOpenConverter(page);
 
-    await page.route('**/functions/v1/make-server-2e3cda33/database/upload', async (route) => {
+    await page.route('**/functions/v1/**/database/upload', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/tests/tac-file-upload-database.e2e.spec.ts
+++ b/tests/tac-file-upload-database.e2e.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '../frontend/node_modules/@playwright/test';
+import * as fs from 'fs';
+import { loginAndOpenConverter } from './playwright-e2e-helpers';
+
+const tacFilesDir = '/root/metar-to-IWXXM/data/iwxxm-translation/Amd79-80-2023/metar';
+
+type TacFixture = {
+  content: string;
+  name: string;
+  path: string;
+};
+
+function getTacFiles(): TacFixture[] {
+  if (!fs.existsSync(tacFilesDir)) {
+    return [];
+  }
+
+  return fs.readdirSync(tacFilesDir)
+    .filter((fileName) => fileName.endsWith('.tac'))
+    .slice(0, 3)
+    .map((fileName) => ({
+      content: fs.readFileSync(`${tacFilesDir}/${fileName}`, 'utf-8').trim(),
+      name: fileName,
+      path: `${tacFilesDir}/${fileName}`,
+    }));
+}
+
+test.describe('TAC File Upload to Database', () => {
+  test('upload button stays disabled before conversion', async ({ page }) => {
+    await loginAndOpenConverter(page);
+
+    await expect(
+      page.getByRole('button', { name: /Upload 0 converted files to database/i })
+    ).toBeDisabled();
+  });
+
+  test('single TAC file can be converted and uploaded', async ({ page }) => {
+    const tacFiles = getTacFiles();
+    test.skip(tacFiles.length === 0, 'No TAC fixture files available for upload E2E coverage.');
+
+    const testFile = tacFiles[0];
+    await loginAndOpenConverter(page);
+
+    await page.route('**/functions/v1/make-server-2e3cda33/database/upload', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'Files uploaded successfully',
+          results: [
+            {
+              recordId: 'playwright-record-id',
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.locator('input[type="file"]').setInputFiles(testFile.path);
+    await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('pre').first()).toContainText(/iwxxm|metar:/i);
+
+    await page.getByRole('button', { name: /Upload 1 converted files to database/i }).click();
+    await page.getByRole('radio', { name: /Store as IWXXM XML only/i }).check();
+    await page.getByRole('button', { name: /Upload files to database/i }).click();
+
+    await expect(page.getByText(/Files uploaded successfully!/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('multiple TAC files can be queued and converted', async ({ page }) => {
+    const tacFiles = getTacFiles();
+    test.skip(tacFiles.length < 2, 'At least two TAC fixture files are required for multi-file upload coverage.');
+
+    await loginAndOpenConverter(page);
+
+    await page.locator('input[type="file"]').setInputFiles(tacFiles.slice(0, 2).map((file) => file.path));
+    await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('pre')).toHaveCount(2);
+    await expect(page.getByRole('button', { name: /Upload 2 converted files to database/i })).toBeEnabled();
+  });
+
+  test('invalid manual TAC shows an error state', async ({ page }) => {
+    await loginAndOpenConverter(page);
+
+    await page.getByLabel(/Enter METAR data manually/i).fill('INVALID TAC FORMAT');
+    await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+
+    await expect(page.getByText(/Conversion Error/i).first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/tac-file-upload-database.e2e.spec.ts
+++ b/tests/tac-file-upload-database.e2e.spec.ts
@@ -4,10 +4,17 @@ import * as path from 'path';
 import { loginAndOpenConverter } from './playwright-e2e-helpers';
 
 const DEFAULT_TAC_RELATIVE_PATH = 'data/iwxxm-translation/Amd79-80-2023/metar';
+const REQUIRE_TAC_FIXTURES =
+  process.env.PLAYWRIGHT_REQUIRE_TAC_FIXTURES === '1' || process.env.CI === 'true';
 
-function resolveTacFilesDir(): string {
+function resolveTacFilesDir(): string | null {
   const configured = process.env.PLAYWRIGHT_TAC_FIXTURES_DIR;
-  if (configured && fs.existsSync(configured)) {
+  if (configured) {
+    if (!fs.existsSync(configured)) {
+      throw new Error(
+        `PLAYWRIGHT_TAC_FIXTURES_DIR is set but does not exist: ${configured}`
+      );
+    }
     return configured;
   }
 
@@ -17,7 +24,22 @@ function resolveTacFilesDir(): string {
   }
 
   const candidateFromFrontendCwd = path.resolve(process.cwd(), '..', DEFAULT_TAC_RELATIVE_PATH);
-  return candidateFromFrontendCwd;
+  if (fs.existsSync(candidateFromFrontendCwd)) {
+    return candidateFromFrontendCwd;
+  }
+
+  if (REQUIRE_TAC_FIXTURES) {
+    throw new Error(
+      [
+        'No TAC fixtures directory found for Playwright upload tests.',
+        `Checked: ${candidateFromRepoRoot}`,
+        `Checked: ${candidateFromFrontendCwd}`,
+        'Set PLAYWRIGHT_TAC_FIXTURES_DIR or disable strict fixture requirement with PLAYWRIGHT_REQUIRE_TAC_FIXTURES=0 for local runs.',
+      ].join(' ')
+    );
+  }
+
+  return null;
 }
 
 type TacFixture = {
@@ -28,7 +50,7 @@ type TacFixture = {
 
 function getTacFiles(): TacFixture[] {
   const tacFilesDir = resolveTacFilesDir();
-  if (!fs.existsSync(tacFilesDir)) {
+  if (!tacFilesDir) {
     return [];
   }
 

--- a/tests/test_backend_auth_integration.py
+++ b/tests/test_backend_auth_integration.py
@@ -227,7 +227,7 @@ class TestAuthTokenGeneration:
         from auth.security import JWT_SECRET, JWT_ALGO, decode_access_token
         
         # Create expired token
-        expire = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
+        expire = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=1)
         payload = {"sub": "testuser", "exp": expire}
         expired_token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGO)
         
@@ -410,7 +410,7 @@ class TestSecurityUtilities:
         import datetime as dt
         
         expiry = create_reset_expiry()
-        now = dt.datetime.now(dt.UTC)
+        now = dt.datetime.now(dt.timezone.utc)
         
         assert expiry > now
         # Should be roughly 30 minutes in the future

--- a/tests/workflow-auth-admin-readiness.e2e.spec.ts
+++ b/tests/workflow-auth-admin-readiness.e2e.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin, openConverterFromAdmin } from './playwright-e2e-helpers';
+
+test.describe('Workflow: Auth And Admin Readiness', () => {
+  test('startup, login, admin readiness, and converter transition are stable', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /METAR Converter/i })).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+
+    await loginAsAdmin(page);
+
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'User Approvals', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'System Settings', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'System Monitoring', exact: true })).toBeVisible();
+
+    await openConverterFromAdmin(page);
+
+    await expect(page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })).toBeVisible();
+    await expect(page.getByLabel(/Switch view/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Open user preferences/i })).toBeVisible();
+  });
+
+  test('admin panel navigation loop remains stable across repeated transitions', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await loginAsAdmin(page);
+
+    for (let i = 0; i < 2; i += 1) {
+      await page.getByText('System Settings').first().click();
+      await expect(page.getByRole('heading', { name: 'System Settings', exact: true }).nth(1)).toBeVisible();
+
+      await page.getByText('System Monitoring').first().click();
+      await expect(page.getByRole('heading', { name: 'System Monitoring', exact: true }).nth(1)).toBeVisible();
+
+      await page.getByText('User Approvals').first().click();
+      await expect(page.getByRole('heading', { name: 'User Approvals', exact: true }).nth(1)).toBeVisible();
+    }
+
+    await openConverterFromAdmin(page);
+    await expect(page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })).toBeVisible();
+
+    const viewSelect = page.getByLabel(/Switch view/i);
+    await viewSelect.selectOption('admin');
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+  });
+});

--- a/tests/workflow-conversion-parameters-preferences.e2e.spec.ts
+++ b/tests/workflow-conversion-parameters-preferences.e2e.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  convertManualMetar,
+  loginAndOpenConverter,
+} from './playwright-e2e-helpers';
+
+test.describe('Workflow: Conversion Parameters And Preferences', () => {
+  test('changing parameters before manual conversion produces conversion output', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await loginAndOpenConverter(page);
+
+    await page.getByLabel(/Expand parameters/i).click();
+    await page.locator('#param-iwxxm-version').selectOption('2023-1');
+    await page.locator('#param-on-error').selectOption('warn');
+
+    await convertManualMetar(
+      page,
+      'METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990'
+    );
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('pre').filter({ hasText: /iwxxm|metar:/i }).first()).toBeVisible();
+  });
+
+  test('preferences save and apply to converter parameter controls', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await loginAndOpenConverter(page);
+
+    await page.getByRole('button', { name: /Open user preferences/i }).click();
+    await expect(page.getByRole('heading', { name: /User Preferences/i })).toBeVisible();
+
+    await page.locator('#iwxxm-version').selectOption('2023-1');
+    await page.locator('#on-error').selectOption('fail');
+    await page.getByRole('button', { name: /Save Preferences/i }).click();
+
+    await expect(page.getByText(/Preferences saved successfully!/i)).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+    await page.getByLabel(/Expand parameters/i).click();
+    await expect(page.locator('#param-iwxxm-version')).toHaveValue('2023-1');
+    await expect(page.locator('#param-on-error')).toHaveValue('fail');
+  });
+});

--- a/tests/workflow-logout-protection.e2e.spec.ts
+++ b/tests/workflow-logout-protection.e2e.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin } from './playwright-e2e-helpers';
+
+test.describe('Workflow: Logout Protection', () => {
+  test('logout options are visible and this-device logout returns user to login form', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await loginAsAdmin(page);
+
+    await page.getByRole('button', { name: /Logout options/i }).click();
+    await expect(page.getByText('This Device')).toBeVisible();
+    await expect(page.getByText('All Devices')).toBeVisible();
+    await expect(page.getByText('Other Devices')).toBeVisible();
+
+    await page.getByRole('button', { name: /Sign out from this device only/i }).click();
+
+    await expect(page.locator('#email')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Sign in to account/i })).toBeVisible();
+
+    await page.goto('/');
+    await expect(page.locator('#email')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: /METAR Converter/i })).toBeVisible();
+  });
+});

--- a/tests/workflow-narrative-full-journey.e2e.spec.ts
+++ b/tests/workflow-narrative-full-journey.e2e.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin, openConverterFromAdmin } from './playwright-e2e-helpers';
+
+test.describe('Workflow: Narrative Full Journey', () => {
+  test('login -> preferences -> conversion -> theme -> logout', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /METAR Converter/i })).toBeVisible();
+
+    await loginAsAdmin(page);
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+
+    await openConverterFromAdmin(page);
+    await expect(page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /Open user preferences/i }).click();
+    await expect(page.getByRole('heading', { name: /User Preferences/i })).toBeVisible();
+
+    await page.locator('#bulletin-id').fill('SZZZ99');
+    await page.locator('#issuing-center').fill('KJFK');
+    await page.locator('#iwxxm-version').selectOption('2023-1');
+    await page.locator('#on-error').selectOption('fail');
+    await page.getByRole('button', { name: /Save Preferences/i }).click();
+
+    await expect(page.getByText(/Preferences saved successfully/i)).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+    await page.getByLabel(/Expand parameters/i).click();
+    await expect(page.locator('#param-bulletin-id')).toHaveValue('SZZZ99');
+    await expect(page.locator('#param-issuing-center')).toHaveValue('KJFK');
+    await expect(page.locator('#param-iwxxm-version')).toHaveValue('2023-1');
+    await expect(page.locator('#param-on-error')).toHaveValue('fail');
+
+    await page
+      .getByLabel(/Enter METAR data manually/i)
+      .fill('METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990');
+    await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('pre').filter({ hasText: /iwxxm|metar:/i }).first()).toBeVisible();
+
+    const themeSwitch = page.getByRole('switch', { name: /Switch to .* mode/i });
+    const initialThemeState = await themeSwitch.getAttribute('aria-checked');
+    await themeSwitch.click();
+    await expect
+      .poll(async () => themeSwitch.getAttribute('aria-checked'))
+      .not.toBe(initialThemeState);
+
+    await page.getByRole('button', { name: /Logout options/i }).click();
+    await expect(page.getByText('This Device')).toBeVisible();
+    await page.getByRole('button', { name: /Sign out from this device only/i }).click();
+
+    await expect(page.locator('#email')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Sign in to account/i })).toBeVisible();
+  });
+});

--- a/tests/workflow-theme-persistence.e2e.spec.ts
+++ b/tests/workflow-theme-persistence.e2e.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  loginAndOpenConverter,
+} from './playwright-e2e-helpers';
+
+test.describe('Workflow: Theme Behavior And Persistence', () => {
+  test('theme toggle works in converter, persists across reload, and remains consistent in admin view', async ({ page }) => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL and PLAYWRIGHT_ADMIN_PASSWORD'
+    );
+
+    await loginAndOpenConverter(page);
+
+    const themeSwitch = page.getByRole('switch', { name: /Switch to .* mode/i });
+    await expect(themeSwitch).toBeVisible();
+
+    const initialState = await themeSwitch.getAttribute('aria-checked');
+    await themeSwitch.click();
+
+    await expect
+      .poll(async () => themeSwitch.getAttribute('aria-checked'))
+      .not.toBe(initialState);
+
+    const toggledState = await themeSwitch.getAttribute('aria-checked');
+
+    await page.reload();
+
+    const reloadedThemeSwitch = page.getByRole('switch', { name: /Switch to .* mode/i });
+    await expect(reloadedThemeSwitch).toBeVisible();
+    await expect(reloadedThemeSwitch).toHaveAttribute('aria-checked', toggledState || 'false');
+
+    const viewSelect = page.getByLabel(/Switch view/i);
+    await viewSelect.selectOption('admin');
+    await expect(page.getByRole('heading', { name: /Admin Dashboard/i })).toBeVisible();
+
+    const adminThemeSwitch = page.getByRole('switch', { name: /Switch to .* mode/i });
+    await expect(adminThemeSwitch).toHaveAttribute('aria-checked', toggledState || 'false');
+  });
+});


### PR DESCRIPTION
- Implement tests for recent weather normalization, ensuring RESH is converted to RESHUP and that RESHRA remains unchanged.
- Update API endpoint tests to validate the normalization process for manual METAR input.
- Introduce a new unit test file for metar_normalizer to cover various scenarios and edge cases.
- Enhance existing tests to capture webhook notifications for successful and failed conversions.
- Add Playwright E2E tests for admin navigation, authentication flow, and TAC file conversion/upload scenarios.
- Update documentation for running Playwright tests and ensure proper handling of authentication and conversion errors.
- Fix datetime handling in backend authentication tests to use timezone-aware datetime objects.

## Summary by Sourcery

Normalize recent-weather METAR tokens before validation and conversion, extend webhook and API behavior coverage, and add Playwright E2E and metar normalizer unit tests alongside minor tooling and auth test updates.

New Features:
- Introduce a METAR TAC normalizer that rewrites truncated recent-weather tokens (e.g., RESH, REFZ) into WMO-compliant forms before GIFTs decoding.
- Add Playwright browser E2E suites for admin navigation, authentication flows, TAC file conversion, and upload-to-database scenarios.

Bug Fixes:
- Ensure backend auth integration tests use timezone-aware datetimes with the standard timezone.utc object to avoid naive/aware mismatches.

Enhancements:
- Pre-normalize manual METAR input in the API layer and conversion utility, emitting structured issues and logs when recent-weather tokens are rewritten, and wiring these changes through validation and conversion paths.
- Expand API endpoint tests to verify recent-weather normalization behavior for manual METAR input and to assert that valid forms like RESHRA pass unchanged.
- Add webhook notification capture tests to assert translation success, failure, and completion events across manual text, JSON, and file-upload conversion flows.
- Expose the recent-weather normalizer via the conversion utilities module and ensure import stubs cover it in API import-fallback tests.

Build:
- Extend the Makefile with lint-fix targets for backend, auth, and frontend code, a dev server helper, and a Playwright E2E test runner target.

Documentation:
- Update README and development documentation to describe Playwright-based full-stack E2E testing, its location, and how to run it from the project root.

Tests:
- Add focused unit tests for the METAR recent-weather normalizer covering rewrite rules, non-regressions, and edge cases.
- Add conversion-level tests verifying RESH normalization behavior in both lenient and strict modes and regression coverage for valid RESHRA cases.
- Introduce Playwright E2E helpers for auth and converter flows, plus new suites validating auth service integration, TAC file upload/conversion, and error handling.
- Broaden backend API unit tests to cover recent-weather normalization and webhook notification behavior.