### PR TITLE
fix(admin): route Settings and Monitoring panels to merged API host

### DIFF
--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -484,12 +484,14 @@ except Exception as e:
     logger.error(f"DEBUG: Failed to include ICAO OPMET router: {e}", exc_info=True)
 
 try:
+    from auth.admin_api import router as admin_router
     from auth.api_supabase import legacy_router as auth_legacy_router
     from auth.api_supabase import router as auth_router
 
     app.include_router(auth_router)
     app.include_router(auth_legacy_router)
-    logger.info("DEBUG: included auth routers at /auth/* successfully")
+    app.include_router(admin_router)
+    logger.info("DEBUG: included auth routers at /auth/* and /admin/* successfully")
 except Exception as e:
     logger.error(f"DEBUG: Failed to include auth routers: {e}", exc_info=True)
 

--- a/apps/frontend/src/app/components/admin/MonitoringPanel.tsx
+++ b/apps/frontend/src/app/components/admin/MonitoringPanel.tsx
@@ -12,7 +12,7 @@ import {
   Shield,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { projectId } from '/utils/supabase/info';
+import { adminUrl } from '@/utils/apiBase';
 
 interface UserInfo {
   user_id: string;
@@ -52,22 +52,16 @@ export function MonitoringPanel({ accessToken }: MonitoringPanelProps) {
     setIsLoading(true);
     try {
       const [usersResponse, statsResponse] = await Promise.all([
-        fetch(
-          `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/all-users`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
+        fetch(adminUrl('/all-users'), {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
           },
-        ),
-        fetch(
-          `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/stats`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
+        }),
+        fetch(adminUrl('/stats'), {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
           },
-        ),
+        }),
       ]);
 
       if (!usersResponse.ok || !statsResponse.ok) {
@@ -94,17 +88,14 @@ export function MonitoringPanel({ accessToken }: MonitoringPanelProps) {
 
   const toggleAdminStatus = async (userId: string, currentStatus: boolean) => {
     try {
-      const response = await fetch(
-        `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/toggle-admin`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ userId, isAdmin: !currentStatus }),
+      const response = await fetch(adminUrl('/toggle-admin'), {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
         },
-      );
+        body: JSON.stringify({ userId, isAdmin: !currentStatus }),
+      });
 
       if (!response.ok) {
         throw new Error('Failed to toggle admin status');

--- a/apps/frontend/src/app/components/admin/SystemSettingsPanel.tsx
+++ b/apps/frontend/src/app/components/admin/SystemSettingsPanel.tsx
@@ -6,7 +6,7 @@ import { Label } from '../ui/label';
 import { Loader2, Save, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import { IcaoAutocomplete } from '../IcaoAutocomplete';
-import { projectId } from '/utils/supabase/info';
+import { adminUrl } from '@/utils/apiBase';
 
 type IWXXMVersion = '2025-2' | '2023-1';
 type OnErrorBehavior = 'skip' | 'fail' | 'warn';
@@ -46,14 +46,11 @@ export function SystemSettingsPanel({ accessToken }: SystemSettingsPanelProps) {
   const loadSettings = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(
-        `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/settings`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
+      const response = await fetch(adminUrl('/settings'), {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
         },
-      );
+      });
 
       if (!response.ok) {
         throw new Error('Failed to load settings');
@@ -78,17 +75,14 @@ export function SystemSettingsPanel({ accessToken }: SystemSettingsPanelProps) {
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      const response = await fetch(
-        `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/settings`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ settings }),
+      const response = await fetch(adminUrl('/settings'), {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
         },
-      );
+        body: JSON.stringify({ settings }),
+      });
 
       if (!response.ok) {
         throw new Error('Failed to save settings');

--- a/apps/frontend/src/test/vite-api-base-url.client.test.ts
+++ b/apps/frontend/src/test/vite-api-base-url.client.test.ts
@@ -4,7 +4,13 @@
  * RED until T6.3 implements ../utils/apiBase and migrates api.ts / authService.ts.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getApiBaseUrl, apiUrl, authUrl, adminUrl, requireApiBaseUrl } from '../utils/apiBase';
+import {
+  getApiBaseUrl,
+  apiUrl,
+  authUrl,
+  adminUrl,
+  requireApiBaseUrl,
+} from '../utils/apiBase';
 
 const DEFAULT_DEV_API = 'http://localhost:18001';
 
@@ -80,7 +86,9 @@ describe('VITE_API_BASE_URL client', () => {
   describe('adminUrl', () => {
     it('builds admin routes on the same host as auth and API calls', () => {
       vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
-      expect(adminUrl('/settings')).toBe('https://api.example.onrender.com/admin/settings');
+      expect(adminUrl('/settings')).toBe(
+        'https://api.example.onrender.com/admin/settings',
+      );
       expect(adminUrl('/all-users')).toBe(
         'https://api.example.onrender.com/admin/all-users',
       );

--- a/apps/frontend/src/test/vite-api-base-url.client.test.ts
+++ b/apps/frontend/src/test/vite-api-base-url.client.test.ts
@@ -4,7 +4,7 @@
  * RED until T6.3 implements ../utils/apiBase and migrates api.ts / authService.ts.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getApiBaseUrl, apiUrl, authUrl, requireApiBaseUrl } from '../utils/apiBase';
+import { getApiBaseUrl, apiUrl, authUrl, adminUrl, requireApiBaseUrl } from '../utils/apiBase';
 
 const DEFAULT_DEV_API = 'http://localhost:18001';
 
@@ -74,6 +74,21 @@ describe('VITE_API_BASE_URL client', () => {
     it('normalizes auth paths without a leading slash', () => {
       vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
       expect(authUrl('refresh')).toBe('https://api.example.onrender.com/auth/refresh');
+    });
+  });
+
+  describe('adminUrl', () => {
+    it('builds admin routes on the same host as auth and API calls', () => {
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
+      expect(adminUrl('/settings')).toBe('https://api.example.onrender.com/admin/settings');
+      expect(adminUrl('/all-users')).toBe(
+        'https://api.example.onrender.com/admin/all-users',
+      );
+    });
+
+    it('normalizes admin paths without a leading slash', () => {
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
+      expect(adminUrl('stats')).toBe('https://api.example.onrender.com/admin/stats');
     });
   });
 

--- a/apps/frontend/src/test/vite-api-base-url.client.test.ts
+++ b/apps/frontend/src/test/vite-api-base-url.client.test.ts
@@ -103,6 +103,13 @@ describe('VITE_API_BASE_URL client', () => {
       vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com/');
       expect(adminUrl('/stats')).toBe('https://api.example.onrender.com/admin/stats');
     });
+
+    it('accepts paths that already include /admin', () => {
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
+      expect(adminUrl('/admin/settings')).toBe(
+        'https://api.example.onrender.com/admin/settings',
+      );
+    });
   });
 
   describe('requireApiBaseUrl', () => {

--- a/apps/frontend/src/test/vite-api-base-url.client.test.ts
+++ b/apps/frontend/src/test/vite-api-base-url.client.test.ts
@@ -90,6 +90,11 @@ describe('VITE_API_BASE_URL client', () => {
       vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com');
       expect(adminUrl('stats')).toBe('https://api.example.onrender.com/admin/stats');
     });
+
+    it('avoids double slashes when VITE_API_BASE_URL has a trailing slash', () => {
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.onrender.com/');
+      expect(adminUrl('/stats')).toBe('https://api.example.onrender.com/admin/stats');
+    });
   });
 
   describe('requireApiBaseUrl', () => {

--- a/apps/frontend/src/utils/apiBase.ts
+++ b/apps/frontend/src/utils/apiBase.ts
@@ -41,3 +41,11 @@ export function authUrl(path: string): string {
     : `/auth${path.startsWith('/') ? path : `/${path}`}`;
   return `${base}${normalized}`;
 }
+
+export function adminUrl(path: string): string {
+  const base = getApiBaseUrl();
+  const normalized = path.startsWith('/admin')
+    ? path
+    : `/admin${path.startsWith('/') ? path : `/${path}`}`;
+  return `${base}${normalized}`;
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -12,7 +12,7 @@
 | Render | `https://<frontend-host>` | `https://<api-host>` |
 
 **Post-migration change**: Auth endpoints move from separate `:8003` service to same host as backend.
-Frontend uses single `VITE_API_BASE_URL` for both `/api/v1/*` and `/auth/*`.
+Frontend uses single `VITE_API_BASE_URL` for `/api/v1/*`, `/auth/*`, and `/admin/*`.
 
 ## Services
 
@@ -53,6 +53,21 @@ GET  /auth/health
 
 **Migration note**: Paths preserved for frontend compatibility; proxy config simplified.
 
+### Admin (packages/auth — same host post-migration)
+
+```
+GET  /admin/settings
+POST /admin/settings
+GET  /admin/all-users
+GET  /admin/stats
+POST /admin/toggle-admin
+```
+
+**Auth**: Supabase JWT; Bearer token required. Caller must have `user_profiles.is_admin = true`.
+Server uses `SUPABASE_SERVICE_ROLE_KEY` for profile lookups and admin mutations.
+
+**Note**: Settings are stored in-process (not durable across deploys); see PR #679.
+
 ### Conversion
 
 ```
@@ -83,7 +98,7 @@ POST /api/v1/validate
 | `Access-Control-Allow-Methods` | GET, POST, OPTIONS |
 | `Access-Control-Allow-Headers` | Authorization, Content-Type |
 
-Preflight: `OPTIONS` on `/api/v1/*` and `/auth/*`.
+Preflight: `OPTIONS` on `/api/v1/*`, `/auth/*`, and `/admin/*`.
 
 ## Error Format
 

--- a/docs/bug-reports/BUG-2026-06-21-admin-panels-wrong-api-host.md
+++ b/docs/bug-reports/BUG-2026-06-21-admin-panels-wrong-api-host.md
@@ -1,4 +1,4 @@
-# BUG-2026-06-21 — Admin panels fail loading settings/monitoring
+# BUG-2026-06-21 — Admin panels fail to load settings/monitoring
 
 | Field | Value |
 |-------|-------|

--- a/docs/bug-reports/BUG-2026-06-21-admin-panels-wrong-api-host.md
+++ b/docs/bug-reports/BUG-2026-06-21-admin-panels-wrong-api-host.md
@@ -1,0 +1,84 @@
+# BUG-2026-06-21 — Admin panels fail loading settings/monitoring
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixing |
+| **Feature** | M4 (auth merged into backend API) |
+| **Severity** | high |
+| **Classification** | connectivity / implementation drift |
+| **Remediation path** | local-first — deploy after user approval |
+
+## Error description
+
+After successful admin login on production, **System Settings** and **System Monitoring**
+panels fail to load. Console shows:
+
+```
+Error loading settings: Error: Failed to load settings
+Error loading monitoring data: Error: Failed to load monitoring data
+```
+
+Login via `https://metar-to-iwxxm-api.onrender.com/auth/login` succeeds (200).
+
+## Error logs
+
+```
+[Auth Service] Initialized with URL: https://metar-to-iwxxm-api.onrender.com
+[Auth Service] Login response status: 200
+🔐 AdminDashboard mounted for user: admin@metar.local {hasAccessToken: true, ...}
+Error loading settings: Error: Failed to load settings
+Error loading monitoring data: Error: Failed to load monitoring data
+```
+
+## Symptoms & reproduction
+
+| Field | User answer |
+|-------|-------------|
+| Symptom | Error / crash — fetch fails |
+| Where | Production Render |
+| When | After last deploy / CORS fix |
+| Frequency | Every time |
+| Repro env | Production only (panels call wrong host) |
+| Severity | High — admin config/monitoring unavailable |
+| Evidence | Console logs |
+| Tried | Nothing |
+
+## Investigation
+
+### Root cause
+
+M4 migrated `/auth/*` to the merged API host (`VITE_API_BASE_URL`), but
+`SystemSettingsPanel` and `MonitoringPanel` still fetch Supabase Edge Function
+URLs:
+
+`https://{projectId}.supabase.co/functions/v1/make-server-2e3cda33/admin/*`
+
+Those functions are not the active auth/admin path post-migration; requests fail
+(non-OK response) while login uses the backend correctly.
+
+### Fix
+
+1. Add `/admin/*` routes to `packages/auth/src/admin_api.py` on the merged API.
+2. Add `adminUrl()` helper in `apps/frontend/src/utils/apiBase.ts`.
+3. Point admin panels at `VITE_API_BASE_URL/admin/*`.
+
+## Spec conformance
+
+| Spec | Section | Result |
+|------|---------|--------|
+| docs/spec.md | M4 auth on backend host | implementation drift (admin panels) |
+| docs/api-contract.md | — | no prior `/admin/*` contract; added with fix |
+
+## Repro test
+
+- `tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py`
+- `packages/auth/tests/test_admin_api_unit.py`
+
+## Verification plan
+
+| Layer | Check | Status |
+|-------|-------|--------|
+| L1 | pytest + frontend unit tests | pending |
+| L2 | User repro — panels load on merged API | pending |
+| L3 | Pre-deploy smoke | pending |
+| L4 | Production after deploy | pending |

--- a/packages/auth/src/admin_api.py
+++ b/packages/auth/src/admin_api.py
@@ -86,7 +86,7 @@ def require_admin(
     client = _get_service_client()
     result = client.table("user_profiles").select("is_admin").eq("id", user_id).maybe_single().execute()
 
-    if not result.data or not result.data.get("is_admin"):
+    if result is None or not result.data or not result.data.get("is_admin"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
@@ -108,7 +108,20 @@ def save_settings(
 ) -> dict[str, Any]:
     """Persist system settings for the current process."""
     global _system_settings
-    _system_settings = copy.deepcopy(payload.settings)
+    if not payload.settings:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Settings payload must not be empty",
+        )
+    unknown_keys = set(payload.settings) - set(DEFAULT_SETTINGS)
+    if unknown_keys:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown settings keys: {sorted(unknown_keys)}",
+        )
+    merged = copy.deepcopy(DEFAULT_SETTINGS)
+    merged.update(payload.settings)
+    _system_settings = merged
     logger.info("[ADMIN] System settings updated")
     return {"message": "Settings saved successfully", "settings": copy.deepcopy(_system_settings)}
 
@@ -148,12 +161,7 @@ def toggle_admin(
 ) -> dict[str, Any]:
     """Grant or revoke admin status on a user profile."""
     client = _get_service_client()
-    update = (
-        client.table("user_profiles")
-        .update({"is_admin": payload.isAdmin})
-        .eq("id", payload.userId)
-        .execute()
-    )
+    update = client.table("user_profiles").update({"is_admin": payload.isAdmin}).eq("id", payload.userId).execute()
 
     if not update.data:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")

--- a/packages/auth/src/admin_api.py
+++ b/packages/auth/src/admin_api.py
@@ -1,0 +1,170 @@
+"""Admin API routes — settings, user monitoring, and admin role management.
+
+Served on the merged API host at ``/admin/*`` (M4). Replaces Supabase Edge
+Function URLs previously hard-coded in admin dashboard panels.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from supabase import Client, create_client
+
+from api_supabase import get_token_from_header
+from supabase_proxy import SupabaseAuthProxy, get_supabase_proxy
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+DEFAULT_SETTINGS: dict[str, Any] = {
+    "defaultBulletinId": "SAAA00",
+    "defaultIssuingCenter": "KWBC",
+    "defaultIwxxmVersion": "2025-2",
+    "defaultStrictValidation": True,
+    "defaultIncludeNilReasons": True,
+    "defaultOnError": "warn",
+    "defaultLogLevel": "INFO",
+    "allowedIcaoCodes": [],
+}
+
+_system_settings: dict[str, Any] = copy.deepcopy(DEFAULT_SETTINGS)
+
+
+class ToggleAdminRequest(BaseModel):
+    """Request body for granting or revoking admin status."""
+
+    userId: str = Field(min_length=1)
+    isAdmin: bool
+
+
+class SystemSettingsPayload(BaseModel):
+    """Wrapper for system settings POST body."""
+
+    settings: dict[str, Any]
+
+
+def _get_service_client() -> Client:
+    """Return a Supabase client authenticated with the service role key."""
+    url = os.getenv("SUPABASE_URL", "").strip()
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    if not url or not key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin service unavailable — missing Supabase service configuration",
+        )
+    return create_client(url, key)
+
+
+def _profile_to_user_info(row: dict[str, Any]) -> dict[str, Any]:
+    """Map a ``user_profiles`` row to the frontend monitoring panel shape."""
+    return {
+        "user_id": row.get("id") or row.get("user_id"),
+        "email": row.get("email", ""),
+        "username": row.get("username", ""),
+        "approval_status": row.get("approval_status", "pending"),
+        "is_admin": bool(row.get("is_admin")),
+        "created_at": row.get("created_at"),
+        "approved_at": row.get("approved_at"),
+        "last_login": row.get("last_login"),
+    }
+
+
+def require_admin(
+    token: str = Depends(get_token_from_header),
+    proxy: SupabaseAuthProxy = Depends(get_supabase_proxy),
+) -> dict[str, Any]:
+    """Validate bearer token and ensure the caller has admin privileges."""
+    user = proxy.get_user(token)
+    user_id = user["id"]
+
+    client = _get_service_client()
+    result = client.table("user_profiles").select("is_admin").eq("id", user_id).maybe_single().execute()
+
+    if not result.data or not result.data.get("is_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+    return user
+
+
+@router.get("/settings")
+def get_settings(_admin: dict[str, Any] = Depends(require_admin)) -> dict[str, Any]:
+    """Return current system settings (defaults when none saved yet)."""
+    return {"settings": copy.deepcopy(_system_settings)}
+
+
+@router.post("/settings")
+def save_settings(
+    payload: SystemSettingsPayload,
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Persist system settings for the current process."""
+    global _system_settings
+    _system_settings = copy.deepcopy(payload.settings)
+    logger.info("[ADMIN] System settings updated")
+    return {"message": "Settings saved successfully", "settings": copy.deepcopy(_system_settings)}
+
+
+@router.get("/all-users")
+def list_all_users(_admin: dict[str, Any] = Depends(require_admin)) -> dict[str, Any]:
+    """List all user profiles for the monitoring panel."""
+    client = _get_service_client()
+    result = client.table("user_profiles").select("*").order("created_at", desc=True).execute()
+    users = [_profile_to_user_info(row) for row in (result.data or [])]
+    return {"users": users}
+
+
+@router.get("/stats")
+def get_stats(_admin: dict[str, Any] = Depends(require_admin)) -> dict[str, Any]:
+    """Return aggregate user statistics for the monitoring dashboard."""
+    client = _get_service_client()
+    result = client.table("user_profiles").select("*").execute()
+    rows = result.data or []
+
+    stats = {
+        "totalUsers": len(rows),
+        "pendingUsers": sum(1 for r in rows if r.get("approval_status") == "pending"),
+        "approvedUsers": sum(1 for r in rows if r.get("approval_status") == "approved"),
+        "rejectedUsers": sum(1 for r in rows if r.get("approval_status") == "rejected"),
+        "adminUsers": sum(1 for r in rows if r.get("is_admin")),
+        "totalConversions": 0,
+        "totalStorageUsed": "0 MB",
+    }
+    return {"stats": stats}
+
+
+@router.post("/toggle-admin")
+def toggle_admin(
+    payload: ToggleAdminRequest,
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Grant or revoke admin status on a user profile."""
+    client = _get_service_client()
+    update = (
+        client.table("user_profiles")
+        .update({"is_admin": payload.isAdmin})
+        .eq("id", payload.userId)
+        .execute()
+    )
+
+    if not update.data:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    row = update.data[0]
+    logger.info(
+        "[ADMIN] Admin status %s for user %s",
+        "granted" if payload.isAdmin else "revoked",
+        payload.userId,
+    )
+    return {
+        "message": f"Admin status {'granted' if payload.isAdmin else 'revoked'}",
+        "profile": _profile_to_user_info(row),
+    }

--- a/packages/auth/src/admin_api.py
+++ b/packages/auth/src/admin_api.py
@@ -61,6 +61,18 @@ def _get_service_client() -> Client:
     return create_client(url, key)
 
 
+def _profile_row(data: object) -> dict[str, Any] | None:
+    """Return a profile row dict when Supabase JSON is a mapping."""
+    return data if isinstance(data, dict) else None
+
+
+def _profile_rows(data: object) -> list[dict[str, Any]]:
+    """Return profile row dicts from a Supabase list response."""
+    if not isinstance(data, list):
+        return []
+    return [row for row in data if isinstance(row, dict)]
+
+
 def _profile_to_user_info(row: dict[str, Any]) -> dict[str, Any]:
     """Map a ``user_profiles`` row to the frontend monitoring panel shape."""
     return {
@@ -86,7 +98,8 @@ def require_admin(
     client = _get_service_client()
     result = client.table("user_profiles").select("is_admin").eq("id", user_id).maybe_single().execute()
 
-    if result is None or not result.data or not result.data.get("is_admin"):
+    profile = None if result is None else _profile_row(result.data)
+    if profile is None or not profile.get("is_admin"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
@@ -131,7 +144,7 @@ def list_all_users(_admin: dict[str, Any] = Depends(require_admin)) -> dict[str,
     """List all user profiles for the monitoring panel."""
     client = _get_service_client()
     result = client.table("user_profiles").select("*").order("created_at", desc=True).execute()
-    users = [_profile_to_user_info(row) for row in (result.data or [])]
+    users = [_profile_to_user_info(row) for row in _profile_rows(result.data)]
     return {"users": users}
 
 
@@ -140,7 +153,7 @@ def get_stats(_admin: dict[str, Any] = Depends(require_admin)) -> dict[str, Any]
     """Return aggregate user statistics for the monitoring dashboard."""
     client = _get_service_client()
     result = client.table("user_profiles").select("*").execute()
-    rows = result.data or []
+    rows = _profile_rows(result.data)
 
     stats = {
         "totalUsers": len(rows),
@@ -166,7 +179,9 @@ def toggle_admin(
     if not update.data:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    row = update.data[0]
+    row = _profile_row(update.data[0])
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     logger.info(
         "[ADMIN] Admin status %s for user %s",
         "granted" if payload.isAdmin else "revoked",

--- a/packages/auth/src/admin_api.py
+++ b/packages/auth/src/admin_api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import copy
 import logging
 import os
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -63,14 +63,21 @@ def _get_service_client() -> Client:
 
 def _profile_row(data: object) -> dict[str, Any] | None:
     """Return a profile row dict when Supabase JSON is a mapping."""
-    return data if isinstance(data, dict) else None
+    if isinstance(data, dict):
+        return cast(dict[str, Any], data)
+    return None
 
 
 def _profile_rows(data: object) -> list[dict[str, Any]]:
     """Return profile row dicts from a Supabase list response."""
     if not isinstance(data, list):
         return []
-    return [row for row in data if isinstance(row, dict)]
+    rows: list[dict[str, Any]] = []
+    for item in cast(list[object], data):
+        row = _profile_row(item)
+        if row is not None:
+            rows.append(row)
+    return rows
 
 
 def _profile_to_user_info(row: dict[str, Any]) -> dict[str, Any]:

--- a/packages/auth/src/auth/__init__.py
+++ b/packages/auth/src/auth/__init__.py
@@ -1,6 +1,7 @@
 """Compatibility package exposing auth modules from the flat src layout."""
 
+from admin_api import router as admin_router  # noqa: F401
 from api_supabase import router  # noqa: F401
 from supabase_proxy import get_supabase_proxy  # noqa: F401
 
-__all__ = ["router", "get_supabase_proxy"]
+__all__ = ["router", "admin_router", "get_supabase_proxy"]

--- a/packages/auth/src/auth/admin_api.py
+++ b/packages/auth/src/auth/admin_api.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for admin_api imports."""
+
+from admin_api import *  # noqa: F401,F403

--- a/packages/auth/tests/test_admin_api_unit.py
+++ b/packages/auth/tests/test_admin_api_unit.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 from admin_api import require_admin, router
@@ -57,3 +57,56 @@ def test_non_admin_receives_403(admin_client: TestClient) -> None:
         admin_client.app.dependency_overrides.clear()
 
     assert response.status_code == 403
+
+
+def test_require_admin_returns_403_when_profile_missing() -> None:
+    """Missing user_profiles row returns 403 instead of 500."""
+    mock_proxy = MagicMock()
+    mock_proxy.get_user.return_value = {"id": "orphan-user", "email": "orphan@example.com"}
+    mock_client = MagicMock()
+    mock_client.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = None
+
+    with patch("admin_api._get_service_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(token="test-token", proxy=mock_proxy)
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_save_settings_rejects_empty_payload(admin_client: TestClient) -> None:
+    """Empty settings object must not wipe stored configuration."""
+    admin_client.app.dependency_overrides[require_admin] = lambda: {
+        "id": "admin-id",
+        "email": "admin@metar.local",
+    }
+    try:
+        response = admin_client.post(
+            "/admin/settings",
+            headers={"Authorization": "Bearer test-token"},
+            json={"settings": {}},
+        )
+    finally:
+        admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_save_settings_merges_with_defaults(admin_client: TestClient) -> None:
+    """Partial settings update preserves default keys."""
+    admin_client.app.dependency_overrides[require_admin] = lambda: {
+        "id": "admin-id",
+        "email": "admin@metar.local",
+    }
+    try:
+        response = admin_client.post(
+            "/admin/settings",
+            headers={"Authorization": "Bearer test-token"},
+            json={"settings": {"defaultLogLevel": "DEBUG"}},
+        )
+    finally:
+        admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    settings = response.json()["settings"]
+    assert settings["defaultLogLevel"] == "DEBUG"
+    assert settings["defaultBulletinId"] == "SAAA00"

--- a/packages/auth/tests/test_admin_api_unit.py
+++ b/packages/auth/tests/test_admin_api_unit.py
@@ -8,7 +8,34 @@ import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
-from admin_api import require_admin, router
+from admin_api import _get_service_client, require_admin, router
+
+
+def _admin_override() -> dict[str, str]:
+    return {"id": "admin-id", "email": "admin@metar.local"}
+
+
+def _mock_profile_table(
+    *,
+    maybe_single_data: object = None,
+    select_data: list[dict[str, object]] | None = None,
+    update_data: list[dict[str, object]] | None = None,
+) -> MagicMock:
+    """Build a chained Supabase table mock for admin route tests."""
+    mock_client = MagicMock()
+    table = mock_client.table.return_value
+
+    maybe_single = table.select.return_value.eq.return_value.maybe_single.return_value
+    maybe_single.execute.return_value = MagicMock(data=maybe_single_data)
+
+    select_chain = table.select.return_value
+    select_chain.order.return_value.execute.return_value = MagicMock(data=select_data or [])
+    select_chain.execute.return_value = MagicMock(data=select_data or [])
+
+    update_chain = table.update.return_value.eq.return_value
+    update_chain.execute.return_value = MagicMock(data=update_data)
+
+    return mock_client
 
 
 @pytest.fixture
@@ -110,3 +137,130 @@ def test_save_settings_merges_with_defaults(admin_client: TestClient) -> None:
     settings = response.json()["settings"]
     assert settings["defaultLogLevel"] == "DEBUG"
     assert settings["defaultBulletinId"] == "SAAA00"
+
+
+def test_save_settings_rejects_unknown_keys(admin_client: TestClient) -> None:
+    """Unknown settings keys are rejected."""
+    admin_client.app.dependency_overrides[require_admin] = _admin_override
+    try:
+        response = admin_client.post(
+            "/admin/settings",
+            headers={"Authorization": "Bearer test-token"},
+            json={"settings": {"notARealKey": True}},
+        )
+    finally:
+        admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_get_service_client_requires_supabase_env() -> None:
+    """Missing Supabase service configuration returns 503."""
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(HTTPException) as exc_info:
+            _get_service_client()
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+def test_require_admin_allows_admin_profile() -> None:
+    """Valid admin profile passes require_admin."""
+    mock_proxy = MagicMock()
+    mock_proxy.get_user.return_value = {"id": "admin-id", "email": "admin@metar.local"}
+    mock_client = _mock_profile_table(maybe_single_data={"is_admin": True})
+
+    with patch("admin_api._get_service_client", return_value=mock_client):
+        user = require_admin(token="test-token", proxy=mock_proxy)
+
+    assert user["id"] == "admin-id"
+
+
+def test_require_admin_rejects_non_admin_profile() -> None:
+    """Profile without admin flag is forbidden."""
+    mock_proxy = MagicMock()
+    mock_proxy.get_user.return_value = {"id": "user-id", "email": "user@example.com"}
+    mock_client = _mock_profile_table(maybe_single_data={"is_admin": False})
+
+    with patch("admin_api._get_service_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(token="test-token", proxy=mock_proxy)
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_list_all_users_returns_profiles(admin_client: TestClient) -> None:
+    """Monitoring panel receives mapped user profiles."""
+    rows = [
+        {
+            "id": "user-1",
+            "email": "user@example.com",
+            "username": "user1",
+            "approval_status": "approved",
+            "is_admin": False,
+        }
+    ]
+    admin_client.app.dependency_overrides[require_admin] = _admin_override
+    with patch("admin_api._get_service_client", return_value=_mock_profile_table(select_data=rows)):
+        response = admin_client.get(
+            "/admin/all-users",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    users = response.json()["users"]
+    assert users[0]["email"] == "user@example.com"
+    assert users[0]["is_admin"] is False
+
+
+def test_get_stats_aggregates_user_counts(admin_client: TestClient) -> None:
+    """Stats endpoint aggregates approval and admin counts."""
+    rows = [
+        {"approval_status": "pending", "is_admin": False},
+        {"approval_status": "approved", "is_admin": True},
+        {"approval_status": "rejected", "is_admin": False},
+    ]
+    admin_client.app.dependency_overrides[require_admin] = _admin_override
+    with patch("admin_api._get_service_client", return_value=_mock_profile_table(select_data=rows)):
+        response = admin_client.get(
+            "/admin/stats",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    admin_client.app.dependency_overrides.clear()
+
+    stats = response.json()["stats"]
+    assert stats["totalUsers"] == 3
+    assert stats["pendingUsers"] == 1
+    assert stats["approvedUsers"] == 1
+    assert stats["rejectedUsers"] == 1
+    assert stats["adminUsers"] == 1
+
+
+def test_toggle_admin_updates_profile(admin_client: TestClient) -> None:
+    """Admin can grant admin status to another user."""
+    updated = [{"id": "user-2", "email": "user2@example.com", "is_admin": True}]
+    admin_client.app.dependency_overrides[require_admin] = _admin_override
+    with patch("admin_api._get_service_client", return_value=_mock_profile_table(update_data=updated)):
+        response = admin_client.post(
+            "/admin/toggle-admin",
+            headers={"Authorization": "Bearer test-token"},
+            json={"userId": "user-2", "isAdmin": True},
+        )
+    admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["profile"]["is_admin"] is True
+
+
+def test_toggle_admin_returns_404_when_user_missing(admin_client: TestClient) -> None:
+    """Unknown user id returns 404."""
+    admin_client.app.dependency_overrides[require_admin] = _admin_override
+    with patch("admin_api._get_service_client", return_value=_mock_profile_table(update_data=[])):
+        response = admin_client.post(
+            "/admin/toggle-admin",
+            headers={"Authorization": "Bearer test-token"},
+            json={"userId": "missing-user", "isAdmin": True},
+        )
+    admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 404

--- a/packages/auth/tests/test_admin_api_unit.py
+++ b/packages/auth/tests/test_admin_api_unit.py
@@ -1,0 +1,59 @@
+"""Unit tests for merged API admin routes."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from admin_api import require_admin, router
+
+
+@pytest.fixture
+def admin_client() -> TestClient:
+    """Minimal app exposing only the admin router."""
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_get_settings_returns_defaults_for_admin(admin_client: TestClient) -> None:
+    """Admin user receives default system settings."""
+    admin_client.app.dependency_overrides[require_admin] = lambda: {
+        "id": "admin-id",
+        "email": "admin@metar.local",
+    }
+    try:
+        response = admin_client.get(
+            "/admin/settings",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    finally:
+        admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["settings"]["defaultBulletinId"] == "SAAA00"
+    assert body["settings"]["defaultIwxxmVersion"] == "2025-2"
+
+
+def test_non_admin_receives_403(admin_client: TestClient) -> None:
+    """Non-admin user is forbidden from admin settings."""
+
+    def _deny_admin() -> None:
+        from fastapi import HTTPException, status
+
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+    admin_client.app.dependency_overrides[require_admin] = _deny_admin
+    try:
+        response = admin_client.get(
+            "/admin/settings",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    finally:
+        admin_client.app.dependency_overrides.clear()
+
+    assert response.status_code == 403

--- a/render.yaml
+++ b/render.yaml
@@ -37,6 +37,8 @@ services:
         sync: false
       - key: SUPABASE_ANON_KEY
         sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
       # REQUIRED in Render dashboard:
       # DATABASE_URL
 

--- a/tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py
+++ b/tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py
@@ -22,8 +22,17 @@ from src.api import app  # noqa: E402
 def test_admin_routes_registered_on_merged_api() -> None:
     """Admin router must be mounted at /admin/* on the backend app."""
     client = TestClient(app)
-    for path in ("/admin/settings", "/admin/all-users", "/admin/stats", "/admin/toggle-admin"):
-        response = client.get(path) if path != "/admin/toggle-admin" else client.post(path, json={})
+    for path in (
+        "/admin/settings",
+        "/admin/all-users",
+        "/admin/stats",
+        "/admin/toggle-admin",
+    ):
+        response = (
+            client.get(path)
+            if path != "/admin/toggle-admin"
+            else client.post(path, json={})
+        )
         assert response.status_code in (401, 403, 422), (
             f"Expected admin route {path} on merged API, got {response.status_code}"
         )

--- a/tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py
+++ b/tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py
@@ -1,0 +1,47 @@
+"""BUG-2026-06-21 — admin panels call Supabase Edge Functions instead of merged API.
+
+Repro: SystemSettingsPanel / MonitoringPanel must use VITE_API_BASE_URL/admin/*
+not supabase.co/functions/v1/make-server-2e3cda33/admin/*.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "apps" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from src.api import app  # noqa: E402
+
+
+def test_admin_routes_registered_on_merged_api() -> None:
+    """Admin router must be mounted at /admin/* on the backend app."""
+    client = TestClient(app)
+    for path in ("/admin/settings", "/admin/all-users", "/admin/stats", "/admin/toggle-admin"):
+        response = client.get(path) if path != "/admin/toggle-admin" else client.post(path, json={})
+        assert response.status_code in (401, 403, 422), (
+            f"Expected admin route {path} on merged API, got {response.status_code}"
+        )
+
+
+def test_admin_settings_requires_authorization() -> None:
+    """Unauthenticated GET /admin/settings returns 401."""
+    from src.api import app
+
+    client = TestClient(app)
+    response = client.get("/admin/settings")
+    assert response.status_code == 401
+
+
+def test_admin_settings_rejects_missing_bearer_prefix() -> None:
+    """Malformed Authorization header returns 401."""
+    from src.api import app
+
+    client = TestClient(app)
+    response = client.get("/admin/settings", headers={"Authorization": "Token abc"})
+    assert response.status_code == 401

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -274,9 +274,9 @@ stages:
     last_cycle: PRR-001
 
   19-address-pr-review:
-    status: in_progress
+    status: completed
     started: "2026-06-21"
-    completed: null
+    completed: "2026-06-21"
     last_cycle: PRM-001
 
 stages_pending: []
@@ -698,15 +698,15 @@ pr_remediation_cycles:
     pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/679
     linked_review_cycle_id: PRR-001
     title: "fix(admin): route Settings and Monitoring panels to merged API host"
-    status: in_progress
+    status: completed
     started: "2026-06-21"
-    completed: null
+    completed: "2026-06-21"
     head_ref: fix/admin-panels-merged-api
     base_ref: main
-    ci_status: not_pushed
+    ci_status: success
     counts:
-      fixed: 0
-      deferred: 0
+      fixed: 6
+      deferred: 1
       wont_fix: 0
     findings:
       - id: F-001
@@ -716,7 +716,7 @@ pr_remediation_cycles:
         line: 151
         thread_id: PRRT_kwDOQW-3CM6LGoyV
         status: fixed
-        commit: null
+        commit: 2843ec8
         note: ruff format CI
       - id: F-002
         source: inline
@@ -725,7 +725,7 @@ pr_remediation_cycles:
         line: 87
         thread_id: PRRT_kwDOQW-3CM6LGoyz
         status: fixed
-        commit: null
+        commit: 2843ec8
         note: maybe_single None guard
       - id: F-003
         source: inline
@@ -734,7 +734,7 @@ pr_remediation_cycles:
         line: 49
         thread_id: PRRT_kwDOQW-3CM6LGozC
         status: fixed
-        commit: null
+        commit: 2843ec8
         note: settings validation merge-with-defaults
       - id: F-004
         source: inline
@@ -743,7 +743,7 @@ pr_remediation_cycles:
         line: 93
         thread_id: PRRT_kwDOQW-3CM6LGkra
         status: fixed
-        commit: null
+        commit: cf80c23
         note: adminUrl trailing slash test
       - id: F-005
         source: inline
@@ -752,7 +752,7 @@ pr_remediation_cycles:
         line: 1
         thread_id: PRRT_kwDOQW-3CM6LGkrf
         status: fixed
-        commit: null
+        commit: cf80c23
         note: typo fail to load
       - id: F-006
         source: review_body
@@ -761,7 +761,7 @@ pr_remediation_cycles:
         line: null
         thread_id: null
         status: fixed
-        commit: null
+        commit: cf80c23
         note: document /admin/* routes
       - id: F-007
         source: inline

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -267,6 +267,18 @@ stages:
       - "Overall FAIL — blocking: format (291 files), typecheck (313+ errors), pydantic-settings CVE, Makefile lint-frontend points to removed frontend/"
       - "H0c + H0i tests pass; migration gates pass on main; make test-unit green"
 
+  18-pr-review:
+    status: completed
+    started: "2026-06-21"
+    completed: "2026-06-21"
+    last_cycle: PRR-001
+
+  19-address-pr-review:
+    status: in_progress
+    started: "2026-06-21"
+    completed: null
+    last_cycle: PRM-001
+
 stages_pending: []
 
 deployment:
@@ -655,3 +667,110 @@ git_history:
       stage: "07-build"
       files_changed: 15
       timestamp: "2026-06-20T15:59:00Z"
+
+pr_review_cycles:
+  - id: PRR-001
+    pr_number: 679
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/679
+    title: "fix(admin): route Settings and Monitoring panels to merged API host"
+    status: completed
+    started: "2026-06-21"
+    completed: "2026-06-21"
+    head_ref: fix/admin-panels-merged-api
+    base_ref: main
+    verdict: REQUEST_CHANGES
+    blockers: 1
+    advisories: 4
+    praise: 3
+    ci_status: failure
+    subagents:
+      bugbot: completed
+      security_review: failed_diff
+    artifacts:
+      - path: .cursor/skills/18-pr-review/checklist.md
+        note: checklist source
+    gh_review_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/679#pullrequestreview-4539991693
+    linked_issue: 678
+
+pr_remediation_cycles:
+  - id: PRM-001
+    pr_number: 679
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/679
+    linked_review_cycle_id: PRR-001
+    title: "fix(admin): route Settings and Monitoring panels to merged API host"
+    status: in_progress
+    started: "2026-06-21"
+    completed: null
+    head_ref: fix/admin-panels-merged-api
+    base_ref: main
+    ci_status: not_pushed
+    counts:
+      fixed: 0
+      deferred: 0
+      wont_fix: 0
+    findings:
+      - id: F-001
+        source: inline
+        severity: blocker
+        path: packages/auth/src/admin_api.py
+        line: 151
+        thread_id: PRRT_kwDOQW-3CM6LGoyV
+        status: fixed
+        commit: null
+        note: ruff format CI
+      - id: F-002
+        source: inline
+        severity: advisory
+        path: packages/auth/src/admin_api.py
+        line: 87
+        thread_id: PRRT_kwDOQW-3CM6LGoyz
+        status: fixed
+        commit: null
+        note: maybe_single None guard
+      - id: F-003
+        source: inline
+        severity: advisory
+        path: packages/auth/src/admin_api.py
+        line: 49
+        thread_id: PRRT_kwDOQW-3CM6LGozC
+        status: fixed
+        commit: null
+        note: settings validation merge-with-defaults
+      - id: F-004
+        source: inline
+        severity: advisory
+        path: apps/frontend/src/test/vite-api-base-url.client.test.ts
+        line: 93
+        thread_id: PRRT_kwDOQW-3CM6LGkra
+        status: fixed
+        commit: null
+        note: adminUrl trailing slash test
+      - id: F-005
+        source: inline
+        severity: advisory
+        path: docs/bug-reports/BUG-2026-06-21-admin-panels-wrong-api-host.md
+        line: 1
+        thread_id: PRRT_kwDOQW-3CM6LGkrf
+        status: fixed
+        commit: null
+        note: typo fail to load
+      - id: F-006
+        source: review_body
+        severity: advisory
+        path: docs/api-contract.md
+        line: null
+        thread_id: null
+        status: fixed
+        commit: null
+        note: document /admin/* routes
+      - id: F-007
+        source: inline
+        severity: advisory
+        path: packages/auth/src/admin_api.py
+        line: 36
+        thread_id: PRRT_kwDOQW-3CM6LGoyn
+        status: deferred
+        commit: null
+        note: in-memory settings documented; durable storage follow-up
+    follow_up:
+      pr_review_rerun: offered


### PR DESCRIPTION
Fixes #678

## Summary

- Adds `/admin/settings`, `/admin/all-users`, `/admin/stats`, and `/admin/toggle-admin` routes on the merged API (`packages/auth/src/admin_api.py`)
- Updates `SystemSettingsPanel` and `MonitoringPanel` to use `adminUrl()` → `VITE_API_BASE_URL/admin/*` instead of Supabase Edge Function URLs
- Adds `adminUrl()` helper alongside existing `authUrl()` / `apiUrl()` in `apiBase.ts`
- Documents `SUPABASE_SERVICE_ROLE_KEY` on the Render API service in `render.yaml`

## Root cause

M4 merged auth onto the backend API host, but admin dashboard panels still fetched legacy Edge Function endpoints (`make-server-2e3cda33/admin/*`), causing every Settings/Monitoring load to fail in production.

## Milestone

Monorepo refactor (M4 auth-on-backend follow-up)

## Test plan

- [x] `pytest tests/bugs/test_bug_2026_06_21_admin_panels_wrong_api_host.py`
- [x] `pytest packages/auth/tests/test_admin_api_unit.py`
- [x] Frontend: `SystemSettingsPanel.test.tsx`, `MonitoringPanel.test.tsx`, `vite-api-base-url.client.test.ts`
- [ ] After deploy: log in as admin, open Settings and Monitoring — no console errors, data loads
- [ ] Confirm `SUPABASE_SERVICE_ROLE_KEY` is set on `metar-to-iwxxm-api` Render service

## Deploy notes

Redeploy **API first**, then **frontend**. Settings are in-memory per API process (reset on restart); durable storage can be a follow-up if needed.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Route admin settings and monitoring panels through new /admin endpoints on the merged API host and ensure they are wired into both backend and frontend.

New Features:
- Introduce an /admin API router providing settings, user monitoring, stats, and admin role management endpoints on the merged backend host.
- Add a frontend adminUrl helper that builds /admin routes from VITE_API_BASE_URL and reuse it in admin panels.

Bug Fixes:
- Redirect SystemSettingsPanel and MonitoringPanel away from legacy Supabase Edge Function URLs to the merged backend API admin routes.
- Ensure admin routes are registered on the backend app and enforce auth requirements for admin settings access.

Enhancements:
- Expose the admin router via the auth package and mount it alongside existing auth routers in the backend.
- Add an internal bug report document describing the admin panel wrong-host issue and its remediation.

Documentation:
- Document SUPABASE_SERVICE_ROLE_KEY as a required environment variable for the API service in render.yaml.

Tests:
- Add unit tests for the admin API router and bug-regression tests verifying /admin routes are mounted and secured on the merged backend API.
- Extend VITE_API_BASE_URL client tests to cover the new adminUrl helper.