### PR TITLE
[hotfix] Fix production logout — send Bearer token on scoped sign-out

### DIFF
--- a/apps/frontend/src/utils/supabase/logout.test.ts
+++ b/apps/frontend/src/utils/supabase/logout.test.ts
@@ -5,14 +5,26 @@ import { signOutWithScope } from './logout';
 describe('signOutWithScope', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
   });
 
-  it('returns true on successful sign out', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+  it('returns true when no access token is stored', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    await expect(signOutWithScope('local')).resolves.toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns true on successful sign out with bearer token', async () => {
+    localStorage.setItem('access_token', 'test-access-token');
+    localStorage.setItem('expires_at', String(Math.floor(Date.now() / 1000) + 3600));
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       statusText: 'OK',
     } as Response);
@@ -20,18 +32,25 @@ describe('signOutWithScope', () => {
     const result = await signOutWithScope('global');
 
     expect(result).toBe(true);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('/logout'),
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-access-token',
+        }),
       }),
     );
   });
 
   it('returns false on non-ok response', async () => {
+    localStorage.setItem('access_token', 'test-access-token');
+    localStorage.setItem('expires_at', String(Math.floor(Date.now() / 1000) + 3600));
+
     vi.spyOn(global, 'fetch').mockResolvedValue({
       ok: false,
+      status: 401,
       statusText: 'Unauthorized',
     } as Response);
 
@@ -39,6 +58,9 @@ describe('signOutWithScope', () => {
   });
 
   it('returns false when fetch throws', async () => {
+    localStorage.setItem('access_token', 'test-access-token');
+    localStorage.setItem('expires_at', String(Math.floor(Date.now() / 1000) + 3600));
+
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
 
     await expect(signOutWithScope('local')).resolves.toBe(false);

--- a/apps/frontend/src/utils/supabase/logout.ts
+++ b/apps/frontend/src/utils/supabase/logout.ts
@@ -1,4 +1,5 @@
 import { authUrl } from '../apiBase';
+import { getAccessToken } from '../authService';
 
 /**
  * Sign out user with specified scope
@@ -8,18 +9,24 @@ import { authUrl } from '../apiBase';
 export async function signOutWithScope(
   scope: 'global' | 'local' | 'others',
 ): Promise<boolean> {
+  const token = getAccessToken();
+  if (!token) {
+    return true;
+  }
+
   try {
     const response = await fetch(authUrl('/logout'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ scope }),
       credentials: 'include',
     });
 
     if (!response.ok) {
-      console.error('Logout failed:', response.statusText);
+      console.error('Logout failed:', response.status, response.statusText);
       return false;
     }
 

--- a/docs/bug-reports/BUG-2026-06-21-logout-failed-production.md
+++ b/docs/bug-reports/BUG-2026-06-21-logout-failed-production.md
@@ -1,0 +1,133 @@
+# BUG-2026-06-21-logout-failed-production
+
+| Field | Value |
+|-------|-------|
+| **Status** | verifying |
+| **Feature** | M4 (auth merged into backend API) |
+| **Severity** | critical (user report) |
+| **Classification** | code bug (implementation drift) |
+| **Remediation path** | local-first — deploy after user approval |
+
+## Error description
+
+Production logout fails every time when user clicks logout. Browser console shows:
+
+```
+[Auth Service] Initialized with URL: https://metar-to-iwxxm-api.onrender.com
+Logout failed:
+```
+
+Stack trace points at `signOutWithScope` → `fetch(authUrl('/logout'))` in bundled frontend (`index-CvXTTHz_.js`).
+
+## Error logs
+
+```
+index-CvXTTHz_.js:217 [Auth Service] Initialized with URL: https://metar-to-iwxxm-api.onrender.com
+installHook.js:1 Logout failed: 
+overrideMethod @ installHook.js:1
+Vp @ index-CvXTTHz_.js:216
+await in Vp
+ke @ index-CvXTTHz_.js:216
+onClick @ index-CvXTTHz_.js:216
+```
+
+## Symptoms & reproduction
+
+| Field | User answer |
+|-------|-------------|
+| Symptom | Error / crash — Logout failed in console |
+| Where | Production Render |
+| When | After last deploy |
+| Frequency | Every time |
+| Repro env | Neither yet — user has not re-tested locally |
+| Severity | Critical — cannot log out |
+| Evidence | Console stack trace only (no Network tab) |
+| Tried | Nothing |
+
+## Investigation
+
+### Timeline
+
+| When | Event |
+|------|-------|
+| 2026-06-21 | User reports logout failure in production via hotfix intake |
+| 2026-06-21 | Preliminary code read: `signOutWithScope` POSTs without `Authorization` header; API requires Bearer token |
+
+### Hypotheses
+
+| # | Hypothesis | Result |
+|---|------------|--------|
+| H1 | `signOutWithScope` missing `Authorization: Bearer` header → API 401 | **Confirmed** — live POST returns 401; repro test RED |
+| H2 | CORS blocks logout POST (similar to prior login bug) | **Open** — needs Network tab or curl probe |
+| H3 | Expired/invalid token causes 401 | **Open** |
+| H4 | Wrong logout URL path | **Unlikely** — `authUrl('/logout')` → `/auth/logout` per `apiBase.ts` |
+
+### Root cause
+
+`signOutWithScope` (`apps/frontend/src/utils/supabase/logout.ts`) POSTs to `/auth/logout` with `{ scope }` body but **no `Authorization: Bearer` header**. Backend requires token via `get_token_from_header` → 401 → frontend logs `Logout failed:` with empty `statusText`. Used by FileConverter and AdminDashboard scoped logout menus. `authService.logout()` correctly sends Bearer but is a separate code path (App.tsx simple logout).
+
+## Spec conformance
+
+| Spec | Section | Result |
+|------|---------|--------|
+| docs/api-contract.md | POST /auth/logout — Bearer on protected routes | pass (API enforces; client drift) |
+| packages/auth/src/api_supabase.py | get_token_from_header on logout | pass |
+| apps/frontend/src/utils/authService.ts | logout() sends Bearer | pass (reference impl) |
+| apps/frontend/src/utils/supabase/logout.ts | signOutWithScope | **implementation drift** — no Authorization header |
+
+No blocking spec contradiction.
+
+## Repro test
+
+| Path | Status |
+|------|--------|
+| `tests/bugs/test_bug_2026_06_21_logout_missing_auth_header.py` | GREEN (2026-06-21) |
+
+## Fix
+
+**Branch:** uncommitted (local working tree)
+
+**Change:** `apps/frontend/src/utils/supabase/logout.ts` — import `getAccessToken`, send `Authorization: Bearer` on POST `/auth/logout`; early-return true when no token stored.
+
+**Tests updated:** `apps/frontend/src/utils/supabase/logout.test.ts` — asserts Bearer header sent when token present.
+
+### TDD iteration log
+
+| # | Action | Result |
+|---|--------|--------|
+| 1 | `test_sign_out_with_scope_sends_bearer_token` — source lacks Authorization | FAIL (expected) |
+| 1 | `test_auth_logout_requires_bearer_token` — API contract | PASS |
+| 1 | Live probe: POST /auth/logout no auth → 401 | Confirms H1 |
+
+## Verification plan
+
+| Field | Choice |
+|-------|--------|
+| Success criterion | New repro/regression test passes in CI |
+| Checks | Full main CI parity (local) + gh on main after merge |
+| Monitoring | User watches production after deploy |
+
+## Verification
+
+### Layer 1 — Automated
+
+- [x] Repro test red → green (2026-06-21)
+- [x] `logout.test.ts` — 4 passed
+- [x] FileConverter + AdminDashboard tests — 74 passed
+- [ ] Full CI parity (local) — pending before PR
+
+### Layer 2 — Reproduction
+
+- [ ] User logout flow succeeds
+
+### Layer 3 — Pre-deploy smoke
+
+- [ ] pending
+
+### Layer 4 — Production
+
+- [ ] pending
+
+## Interview record
+
+Phase 0 intake completed 2026-06-21.

--- a/tests/bugs/test_bug_2026_06_21_logout_missing_auth_header.py
+++ b/tests/bugs/test_bug_2026_06_21_logout_missing_auth_header.py
@@ -1,0 +1,42 @@
+"""BUG-2026-06-21 — production logout fails: signOutWithScope omits Bearer token.
+
+User report: console "Logout failed:" (empty statusText) on every logout click in
+production. POST /auth/logout requires Authorization: Bearer per api-contract.md;
+signOutWithScope in apps/frontend must send the stored access token.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "apps" / "backend"
+FRONTEND_LOGOUT = REPO_ROOT / "apps" / "frontend" / "src" / "utils" / "supabase" / "logout.ts"
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from src.api import app  # noqa: E402
+
+
+def test_auth_logout_requires_bearer_token() -> None:
+    """POST /auth/logout without Authorization returns 401 (api-contract)."""
+    client = TestClient(app)
+    response = client.post("/auth/logout", json={"scope": "local"})
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing authorization header"
+
+
+def test_sign_out_with_scope_sends_bearer_token() -> None:
+    """Frontend scoped logout must attach Authorization like authService.logout()."""
+    source = FRONTEND_LOGOUT.read_text(encoding="utf-8")
+    assert "Authorization" in source, (
+        "signOutWithScope must send Authorization: Bearer <access_token> — "
+        "POST /auth/logout rejects unauthenticated requests (401)"
+    )
+    assert "getAccessToken" in source or "access_token" in source, (
+        "signOutWithScope must read the stored access token before calling /auth/logout"
+    )


### PR DESCRIPTION
## Summary

- **Issue:** Production logout fails every time with console `Logout failed:` when using scoped logout (FileConverter / AdminDashboard menus).
- **Root cause:** `signOutWithScope` POSTed `/auth/logout` without `Authorization: Bearer` header; API returns 401 per `api-contract.md`.
- **Fix:** Read stored access token via `getAccessToken()` and send Bearer header (same pattern as `authService.logout()`).

## Bug report

[docs/bug-reports/BUG-2026-06-21-logout-failed-production.md](docs/bug-reports/BUG-2026-06-21-logout-failed-production.md)

## Spec

- `docs/api-contract.md` — Bearer required on protected auth routes
- No spec change required (client drift fix)

## Tests

- `tests/bugs/test_bug_2026_06_21_logout_missing_auth_header.py` (red → green)
- `apps/frontend/src/utils/supabase/logout.test.ts` — asserts Bearer header

## Blast radius

- **Files:** `apps/frontend/src/utils/supabase/logout.ts`, tests only
- **Risk:** Low — mirrors existing `authService.logout` behavior

## Test plan

- [x] Bug repro test passes locally
- [x] Frontend logout unit tests pass
- [x] FileConverter + AdminDashboard logout tests pass
- [ ] CI green on PR branch
- [ ] Production logout verified after frontend redeploy


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ensure scoped frontend logout calls the backend /auth/logout endpoint with the required Bearer token and add regression coverage for the production logout failure.

Bug Fixes:
- Fix scoped logout to include the stored access token as an Authorization: Bearer header when calling /auth/logout.
- Avoid calling the logout endpoint when no access token is present, treating this as a successful no-op logout.
- Improve logout error logging by including the HTTP status code alongside the status text.

Documentation:
- Document the production logout failure, root cause, and verification plan in a new bug report file.

Tests:
- Extend frontend logout unit tests to cover bearer header behavior, missing-token behavior, and error cases.
- Add a backend regression test to enforce that /auth/logout requires a Bearer token and that the frontend scoped logout implementation reads and sends the access token.