### PR TITLE
feat(ui): Add Convert and Convert&Send buttons (#656)

### DIFF
--- a/apps/e2e/playwright-e2e-helpers.ts
+++ b/apps/e2e/playwright-e2e-helpers.ts
@@ -93,5 +93,7 @@ export async function openConverterForE2e(page: Page): Promise<void> {
 
 export async function convertManualMetar(page: Page, metar: string): Promise<void> {
   await page.getByLabel(/Enter METAR data manually/i).fill(metar);
-  await page.getByRole('button', { name: /Convert METAR files to IWXXM XML/i }).click();
+  await page
+    .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
+    .click();
 }

--- a/apps/e2e/playwright-e2e-helpers.ts
+++ b/apps/e2e/playwright-e2e-helpers.ts
@@ -93,7 +93,5 @@ export async function openConverterForE2e(page: Page): Promise<void> {
 
 export async function convertManualMetar(page: Page, metar: string): Promise<void> {
   await page.getByLabel(/Enter METAR data manually/i).fill(metar);
-  await page
-    .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
-    .click();
+  await page.getByTestId('convert-button').click();
 }

--- a/apps/e2e/tac-file-upload-database.e2e.spec.ts
+++ b/apps/e2e/tac-file-upload-database.e2e.spec.ts
@@ -78,6 +78,43 @@ test.describe('TAC File Upload to Database', () => {
     ).toBeDisabled();
   });
 
+  test('single TAC file can be converted and sent with one click', async ({ page }) => {
+    const tacFiles = getTacFiles();
+    test.skip(
+      tacFiles.length === 0,
+      'No TAC fixture files available for upload E2E coverage.',
+    );
+
+    const testFile = tacFiles[0];
+    await loginAndOpenConverter(page);
+
+    await page.route('**/functions/v1/**/database/upload', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'Files converted and sent successfully',
+          results: [{ recordId: 'playwright-convert-send-id' }],
+        }),
+      });
+    });
+
+    await page.locator('input[type="file"]').setInputFiles(testFile.path);
+    await page
+      .getByRole('button', {
+        name: /Convert METAR files to IWXXM XML and send to database/i,
+      })
+      .click();
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
+      { timeout: 10000 },
+    );
+    await expect(page.locator('pre').first()).toContainText(/iwxxm|metar:/i);
+    await expect(page.getByText(/Files converted and sent successfully/i)).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
   test('single TAC file can be converted and uploaded', async ({ page }) => {
     const tacFiles = getTacFiles();
     test.skip(
@@ -105,7 +142,7 @@ test.describe('TAC File Upload to Database', () => {
 
     await page.locator('input[type="file"]').setInputFiles(testFile.path);
     await page
-      .getByRole('button', { name: /Convert METAR files to IWXXM XML/i })
+      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
       .click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
@@ -137,7 +174,7 @@ test.describe('TAC File Upload to Database', () => {
       .locator('input[type="file"]')
       .setInputFiles(tacFiles.slice(0, 2).map((file) => file.path));
     await page
-      .getByRole('button', { name: /Convert METAR files to IWXXM XML/i })
+      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
       .click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
@@ -154,7 +191,7 @@ test.describe('TAC File Upload to Database', () => {
 
     await page.getByLabel(/Enter METAR data manually/i).fill('INVALID TAC FORMAT');
     await page
-      .getByRole('button', { name: /Convert METAR files to IWXXM XML/i })
+      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
       .click();
 
     await expect(page.getByText(/Conversion Error/i).first()).toBeVisible({

--- a/apps/e2e/tac-file-upload-database.e2e.spec.ts
+++ b/apps/e2e/tac-file-upload-database.e2e.spec.ts
@@ -100,11 +100,7 @@ test.describe('TAC File Upload to Database', () => {
     });
 
     await page.locator('input[type="file"]').setInputFiles(testFile.path);
-    await page
-      .getByRole('button', {
-        name: /Convert METAR files to IWXXM XML and send to database/i,
-      })
-      .click();
+    await page.getByTestId('convert-and-send-button').click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
       { timeout: 10000 },
@@ -141,9 +137,7 @@ test.describe('TAC File Upload to Database', () => {
     });
 
     await page.locator('input[type="file"]').setInputFiles(testFile.path);
-    await page
-      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
-      .click();
+    await page.getByTestId('convert-button').click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
       { timeout: 10000 },
@@ -173,9 +167,7 @@ test.describe('TAC File Upload to Database', () => {
     await page
       .locator('input[type="file"]')
       .setInputFiles(tacFiles.slice(0, 2).map((file) => file.path));
-    await page
-      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
-      .click();
+    await page.getByTestId('convert-button').click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
       { timeout: 10000 },
@@ -190,9 +182,7 @@ test.describe('TAC File Upload to Database', () => {
     await loginAndOpenConverter(page);
 
     await page.getByLabel(/Enter METAR data manually/i).fill('INVALID TAC FORMAT');
-    await page
-      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
-      .click();
+    await page.getByTestId('convert-button').click();
 
     await expect(page.getByText(/Conversion Error/i).first()).toBeVisible({
       timeout: 10000,

--- a/apps/e2e/workflow-narrative-full-journey.e2e.spec.ts
+++ b/apps/e2e/workflow-narrative-full-journey.e2e.spec.ts
@@ -52,7 +52,7 @@ test.describe('Workflow: Narrative Full Journey', () => {
       .getByLabel(/Enter METAR data manually/i)
       .fill('METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990');
     await page
-      .getByRole('button', { name: /Convert METAR files to IWXXM XML/i })
+      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
       .click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(

--- a/apps/e2e/workflow-narrative-full-journey.e2e.spec.ts
+++ b/apps/e2e/workflow-narrative-full-journey.e2e.spec.ts
@@ -51,9 +51,7 @@ test.describe('Workflow: Narrative Full Journey', () => {
     await page
       .getByLabel(/Enter METAR data manually/i)
       .fill('METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990');
-    await page
-      .getByRole('button', { name: /^Convert METAR files to IWXXM XML$/i })
-      .click();
+    await page.getByTestId('convert-button').click();
 
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
       { timeout: 15000 },

--- a/apps/frontend/src/app/components/DatabaseUploadDialog.test.tsx
+++ b/apps/frontend/src/app/components/DatabaseUploadDialog.test.tsx
@@ -16,6 +16,8 @@ vi.mock('sonner', () => ({
 
 vi.mock('/utils/supabase/info', () => ({
   projectId: 'test-project',
+  edgeFunctionUrl: (subpath: string) =>
+    `https://test-project.supabase.co/functions/v1/make-server-2e3cda33/${subpath}`,
 }));
 
 const sampleFiles = [
@@ -89,6 +91,7 @@ describe('DatabaseUploadDialog', () => {
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ message: 'Uploaded 1 file' }),
+      text: async () => JSON.stringify({ message: 'Uploaded 1 file' }),
     } as Response);
 
     render(<DatabaseUploadDialog {...defaultProps} onClose={onClose} />);
@@ -130,6 +133,7 @@ describe('DatabaseUploadDialog', () => {
     vi.mocked(global.fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ error: 'Database unavailable' }),
+      text: async () => JSON.stringify({ error: 'Database unavailable' }),
     } as Response);
 
     render(<DatabaseUploadDialog {...defaultProps} />);
@@ -161,6 +165,7 @@ describe('DatabaseUploadDialog', () => {
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ message: 'Uploaded 1 file' }),
+      text: async () => JSON.stringify({ message: 'Uploaded 1 file' }),
     } as Response);
 
     render(<DatabaseUploadDialog {...defaultProps} />);

--- a/apps/frontend/src/app/components/DatabaseUploadDialog.tsx
+++ b/apps/frontend/src/app/components/DatabaseUploadDialog.tsx
@@ -4,23 +4,19 @@ import { Label } from './ui/label';
 import { Card } from './ui/card';
 import { Database, Upload, Loader2, CheckCircle, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
-import { projectId } from '/utils/supabase/info';
+import {
+  uploadConvertedFiles,
+  type ConvertedFileUpload,
+  type DatabaseFormat,
+  type UploadDestination,
+} from '/utils/databaseUpload';
 
 interface DatabaseUploadDialogProps {
-  convertedFiles: Array<{
-    id: string;
-    originalName: string;
-    originalContent: string;
-    convertedContent: string;
-    timestamp: number;
-  }>;
+  convertedFiles: ConvertedFileUpload[];
   isOpen: boolean;
   onClose: () => void;
   accessToken?: string;
 }
-
-type DatabaseFormat = 'iwxxm' | 'json' | 'both';
-type UploadDestination = 'primary' | 'archive' | 'both';
 
 export function DatabaseUploadDialog({
   convertedFiles,
@@ -48,30 +44,15 @@ export function DatabaseUploadDialog({
     setUploadStatus('idle');
 
     try {
-      const response = await fetch(
-        `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/database/upload`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${accessToken}`,
-          },
-          body: JSON.stringify({
-            files: convertedFiles,
-            options: {
-              format,
-              destination,
-              includeOriginal,
-            },
-          }),
+      const data = await uploadConvertedFiles({
+        files: convertedFiles,
+        accessToken,
+        options: {
+          format,
+          destination,
+          includeOriginal,
         },
-      );
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to upload to database');
-      }
+      });
 
       setUploadStatus('success');
       toast.success(data.message || 'Files uploaded successfully');

--- a/apps/frontend/src/app/components/FileConverter.test.tsx
+++ b/apps/frontend/src/app/components/FileConverter.test.tsx
@@ -8,6 +8,9 @@ const mockSignOutWithScope = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 const mockConvertMetarToIwxxm = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ success: true, data: '<iwxxm>test</iwxxm>' }),
 );
+const mockUploadConvertedFiles = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ message: 'Files uploaded successfully' }),
+);
 const mockToast = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
@@ -35,6 +38,15 @@ vi.mock('/utils/api', () => ({
   fetchAirportRegion: vi
     .fn()
     .mockResolvedValue({ airport_code: 'KJFK', icao_region: 'NAM' }),
+}));
+
+vi.mock('/utils/databaseUpload', () => ({
+  uploadConvertedFiles: mockUploadConvertedFiles,
+  CONVERT_AND_SEND_UPLOAD_OPTIONS: {
+    format: 'iwxxm',
+    destination: 'primary',
+    includeOriginal: false,
+  },
 }));
 
 vi.mock('sonner', () => ({
@@ -609,7 +621,9 @@ describe('FileConverter Component', () => {
       const user = userEvent.setup();
       render(<FileConverter {...defaultProps} />);
 
-      const convertBtn = await screen.findByText(/convert/i, { selector: 'button' });
+      const convertBtn = screen.getByRole('button', {
+        name: /^convert metar files to iwxxm xml$/i,
+      });
       await user.click(convertBtn);
 
       // Should show error or validation message
@@ -629,7 +643,7 @@ describe('FileConverter Component', () => {
       render(<FileConverter {...defaultProps} />);
 
       const convertBtn = screen.getByRole('button', {
-        name: /convert metar files to iwxxm xml/i,
+        name: /^convert metar files to iwxxm xml$/i,
       });
       expect(convertBtn).toBeDisabled();
 
@@ -667,7 +681,7 @@ describe('FileConverter Component', () => {
 
       const { container } = render(<FileConverter {...defaultProps} />);
       const convertBtn = screen.getByRole('button', {
-        name: /convert metar files to iwxxm xml/i,
+        name: /^convert metar files to iwxxm xml$/i,
       });
       expect(convertBtn).toBeDisabled();
 
@@ -702,7 +716,7 @@ describe('FileConverter Component', () => {
       await user.type(textarea, 'METAR EGLL 121650Z 22008KT 9999 BKN025 18/12 Q1016');
 
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -722,7 +736,7 @@ describe('FileConverter Component', () => {
       await user.type(textarea, 'METAR KDEN 121653Z 02006KT 10SM SCT050 21/08 A3010');
 
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -826,7 +840,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLIPBOARD SUCCESS');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -884,7 +898,7 @@ describe('FileConverter Component', () => {
       const manualInput = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(manualInput, 'METAR CONVERT FOR REMOVE');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -909,7 +923,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR UPLOAD BUTTON');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       const uploadButton = await screen.findByRole('button', {
@@ -960,7 +974,7 @@ describe('FileConverter Component', () => {
       });
 
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -983,7 +997,7 @@ describe('FileConverter Component', () => {
       await user.type(textarea, 'METAR EMPTY RESULTS CASE');
 
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1012,7 +1026,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR COPY TEST');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1050,7 +1064,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR COPY FAIL TEST');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1090,7 +1104,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR DOWNLOAD SINGLE');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1120,7 +1134,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR GENERIC ERROR');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1156,7 +1170,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR XML FALLBACK');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1176,7 +1190,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CONTENT FALLBACK');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1196,7 +1210,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLEAR TEST');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1235,7 +1249,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR DOWNLOAD ALL ZIP');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       const downloadZipBtn = await screen.findByLabelText(
@@ -1279,7 +1293,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLIPBOARD CATCH PATH');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1321,7 +1335,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR EXEC THROW PATH');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       await waitFor(() => {
@@ -1428,7 +1442,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLOSE DIALOG TEST');
       await user.click(
-        screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
       );
 
       const uploadButton = await screen.findByRole('button', {
@@ -1447,6 +1461,85 @@ describe('FileConverter Component', () => {
       await waitFor(() => {
         expect(screen.getByTestId('database-upload-dialog').style.display).toBe('none');
       });
+    });
+
+    it('displays Convert&Send button and chains convert with upload', async () => {
+      const user = userEvent.setup();
+      mockConvertMetarToIwxxm.mockResolvedValueOnce({
+        results: [{ iwxxm_xml: '<iwxxm>send-test</iwxxm>' }],
+      });
+
+      const { container } = render(<FileConverter {...defaultProps} />);
+      const convertAndSendBtn = screen.getByRole('button', {
+        name: /convert metar files to iwxxm xml and send to database/i,
+      });
+      expect(convertAndSendBtn).toBeDisabled();
+
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      await user.type(textarea, 'METAR CONVERT AND SEND');
+      expect(convertAndSendBtn).toBeEnabled();
+
+      await user.click(convertAndSendBtn);
+
+      await waitFor(() => {
+        expect(mockConvertMetarToIwxxm).toHaveBeenCalledTimes(1);
+        expect(mockUploadConvertedFiles).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockUploadConvertedFiles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'test-token',
+          options: {
+            format: 'iwxxm',
+            destination: 'primary',
+            includeOriginal: false,
+          },
+        }),
+      );
+      expect(mockToast.success).toHaveBeenCalledWith('Files uploaded successfully');
+    });
+
+    it('shows send failure when convert succeeds but upload fails', async () => {
+      const user = userEvent.setup();
+      mockConvertMetarToIwxxm.mockResolvedValueOnce({
+        results: [{ iwxxm_xml: '<iwxxm>send-fail</iwxxm>' }],
+      });
+      mockUploadConvertedFiles.mockRejectedValueOnce(new Error('Upload rejected'));
+
+      const { container } = render(<FileConverter {...defaultProps} />);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      await user.type(textarea, 'METAR SEND FAIL');
+      await user.click(
+        screen.getByRole('button', {
+          name: /convert metar files to iwxxm xml and send to database/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith(
+          'Conversion succeeded but send failed: Upload rejected',
+        );
+      });
+      expect(screen.getByText(/send failed: upload rejected/i)).toBeInTheDocument();
+    });
+
+    it('requires auth token for Convert&Send', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <FileConverter {...defaultProps} accessToken={undefined} />,
+      );
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      await user.type(textarea, 'METAR NO TOKEN');
+      await user.click(
+        screen.getByRole('button', {
+          name: /convert metar files to iwxxm xml and send to database/i,
+        }),
+      );
+
+      expect(mockToast.error).toHaveBeenCalledWith(
+        'Authentication required. Please log in again.',
+      );
+      expect(mockConvertMetarToIwxxm).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/src/app/components/FileConverter.test.tsx
+++ b/apps/frontend/src/app/components/FileConverter.test.tsx
@@ -621,9 +621,7 @@ describe('FileConverter Component', () => {
       const user = userEvent.setup();
       render(<FileConverter {...defaultProps} />);
 
-      const convertBtn = screen.getByRole('button', {
-        name: /^convert metar files to iwxxm xml$/i,
-      });
+      const convertBtn = screen.getByTestId('convert-button');
       await user.click(convertBtn);
 
       // Should show error or validation message
@@ -642,9 +640,7 @@ describe('FileConverter Component', () => {
       const user = userEvent.setup();
       render(<FileConverter {...defaultProps} />);
 
-      const convertBtn = screen.getByRole('button', {
-        name: /^convert metar files to iwxxm xml$/i,
-      });
+      const convertBtn = screen.getByTestId('convert-button');
       expect(convertBtn).toBeDisabled();
 
       await user.click(convertBtn);
@@ -680,9 +676,7 @@ describe('FileConverter Component', () => {
       });
 
       const { container } = render(<FileConverter {...defaultProps} />);
-      const convertBtn = screen.getByRole('button', {
-        name: /^convert metar files to iwxxm xml$/i,
-      });
+      const convertBtn = screen.getByTestId('convert-button');
       expect(convertBtn).toBeDisabled();
 
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
@@ -715,9 +709,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR EGLL 121650Z 22008KT 9999 BKN025 18/12 Q1016');
 
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText(/backend may be unreachable/i)).toBeInTheDocument();
@@ -735,9 +727,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR KDEN 121653Z 02006KT 10SM SCT050 21/08 A3010');
 
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText(/authentication failed/i)).toBeInTheDocument();
@@ -839,9 +829,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLIPBOARD SUCCESS');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -897,9 +885,7 @@ describe('FileConverter Component', () => {
 
       const manualInput = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(manualInput, 'METAR CONVERT FOR REMOVE');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -922,9 +908,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR UPLOAD BUTTON');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       const uploadButton = await screen.findByRole('button', {
         name: /upload 1 converted files to database/i,
@@ -973,9 +957,7 @@ describe('FileConverter Component', () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(
@@ -996,9 +978,7 @@ describe('FileConverter Component', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR EMPTY RESULTS CASE');
 
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText(/no files were converted/i)).toBeInTheDocument();
@@ -1025,9 +1005,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR COPY TEST');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -1063,9 +1041,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR COPY FAIL TEST');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -1103,9 +1079,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR DOWNLOAD SINGLE');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -1133,9 +1107,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR GENERIC ERROR');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('Conversion Error')).toBeInTheDocument();
@@ -1169,9 +1141,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR XML FALLBACK');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(mockToast.success).toHaveBeenCalledWith(
@@ -1189,9 +1159,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CONTENT FALLBACK');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(mockToast.success).toHaveBeenCalledWith(
@@ -1209,9 +1177,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLEAR TEST');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(mockToast.success).toHaveBeenCalledWith(
@@ -1248,9 +1214,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR DOWNLOAD ALL ZIP');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       const downloadZipBtn = await screen.findByLabelText(
         /download all 1 converted files as zip/i,
@@ -1292,9 +1256,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLIPBOARD CATCH PATH');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -1334,9 +1296,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR EXEC THROW PATH');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
         expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
@@ -1441,9 +1401,7 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR CLOSE DIALOG TEST');
-      await user.click(
-        screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-      );
+      await user.click(screen.getByTestId('convert-button'));
 
       const uploadButton = await screen.findByRole('button', {
         name: /upload 1 converted files to database/i,
@@ -1470,9 +1428,7 @@ describe('FileConverter Component', () => {
       });
 
       const { container } = render(<FileConverter {...defaultProps} />);
-      const convertAndSendBtn = screen.getByRole('button', {
-        name: /convert metar files to iwxxm xml and send to database/i,
-      });
+      const convertAndSendBtn = screen.getByTestId('convert-and-send-button');
       expect(convertAndSendBtn).toBeDisabled();
 
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
@@ -1509,17 +1465,14 @@ describe('FileConverter Component', () => {
       const { container } = render(<FileConverter {...defaultProps} />);
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR SEND FAIL');
-      await user.click(
-        screen.getByRole('button', {
-          name: /convert metar files to iwxxm xml and send to database/i,
-        }),
-      );
+      await user.click(screen.getByTestId('convert-and-send-button'));
 
       await waitFor(() => {
         expect(mockToast.error).toHaveBeenCalledWith(
           'Conversion succeeded but send failed: Upload rejected',
         );
       });
+      expect(screen.getByText('Send Error')).toBeInTheDocument();
       expect(screen.getByText(/send failed: upload rejected/i)).toBeInTheDocument();
     });
 
@@ -1530,11 +1483,7 @@ describe('FileConverter Component', () => {
       );
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       await user.type(textarea, 'METAR NO TOKEN');
-      await user.click(
-        screen.getByRole('button', {
-          name: /convert metar files to iwxxm xml and send to database/i,
-        }),
-      );
+      await user.click(screen.getByTestId('convert-and-send-button'));
 
       expect(mockToast.error).toHaveBeenCalledWith(
         'Authentication required. Please log in again.',

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -82,7 +82,7 @@ export function FileConverter({
   const [isConverting, setIsConverting] = useState(false);
   const [isConvertAndSending, setIsConvertAndSending] = useState(false);
   const [conversionStatus, setConversionStatus] = useState<{
-    type: 'idle' | 'loading' | 'timeout' | 'error';
+    type: 'idle' | 'loading' | 'timeout' | 'error' | 'send_error';
     message?: string;
   }>({ type: 'idle' });
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
@@ -350,7 +350,7 @@ export function FileConverter({
         const uploadMessage =
           error instanceof Error ? error.message : 'Failed to upload to database';
         setConversionStatus({
-          type: 'error',
+          type: 'send_error',
           message: `Send failed: ${uploadMessage}`,
         });
         toast.error(`Conversion succeeded but send failed: ${uploadMessage}`);
@@ -451,6 +451,10 @@ export function FileConverter({
     setConversionStatus({ type: 'idle' });
     toast.info('Queue cleared');
   };
+
+  const isBusy = isConverting || isConvertAndSending;
+  const hasInput = pendingFiles.length > 0 || !!manualInput.trim();
+  const hasConverted = convertedFiles.length > 0;
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8 px-4 transition-colors">
@@ -819,12 +823,9 @@ export function FileConverter({
         {/* Action Buttons */}
         <div className="flex flex-wrap gap-3 mb-8 bg-[rgba(0,0,0,0)]">
           <Button
+            data-testid="convert-button"
             onClick={handleConvert}
-            disabled={
-              isConverting ||
-              isConvertAndSending ||
-              (pendingFiles.length === 0 && !manualInput.trim())
-            }
+            disabled={isBusy || !hasInput}
             className="bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             aria-label={
               isConverting
@@ -842,12 +843,9 @@ export function FileConverter({
             )}
           </Button>
           <Button
+            data-testid="convert-and-send-button"
             onClick={handleConvertAndSend}
-            disabled={
-              isConverting ||
-              isConvertAndSending ||
-              (pendingFiles.length === 0 && !manualInput.trim())
-            }
+            disabled={isBusy || !hasInput}
             className="bg-indigo-500 hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700 text-white text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             aria-label={
               isConvertAndSending
@@ -866,9 +864,7 @@ export function FileConverter({
           </Button>
           <Button
             onClick={() => setIsUploadDialogOpen(true)}
-            disabled={
-              convertedFiles.length === 0 || isConverting || isConvertAndSending
-            }
+            disabled={isBusy || !hasConverted}
             variant="outline"
             className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
             aria-label={`Upload ${convertedFiles.length} converted files to database`}
@@ -879,9 +875,7 @@ export function FileConverter({
           </Button>
           <Button
             onClick={handleDownloadAll}
-            disabled={
-              convertedFiles.length === 0 || isConverting || isConvertAndSending
-            }
+            disabled={isBusy || !hasConverted}
             variant="outline"
             className="bg-gray-600 text-white hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
             aria-label={`Download all ${convertedFiles.length} converted files as ZIP`}
@@ -937,7 +931,11 @@ export function FileConverter({
               >
                 {conversionStatus.type === 'loading'
                   ? 'Converting...'
-                  : 'Conversion Error'}
+                  : conversionStatus.type === 'timeout'
+                    ? 'Conversion Timeout'
+                    : conversionStatus.type === 'send_error'
+                      ? 'Send Error'
+                      : 'Conversion Error'}
               </p>
               {conversionStatus.message && (
                 <p

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -29,6 +29,10 @@ import { IcaoAutocomplete } from './IcaoAutocomplete';
 import { AirportDetailsCard } from './AirportDetailsCard';
 import { signOutWithScope } from '/utils/supabase/logout';
 import { convertMetarToIwxxm as callBackendConversion } from '/utils/api';
+import {
+  CONVERT_AND_SEND_UPLOAD_OPTIONS,
+  uploadConvertedFiles,
+} from '/utils/databaseUpload';
 
 interface ConvertedFile {
   id: string;
@@ -76,6 +80,7 @@ export function FileConverter({
   const [manualInput, setManualInput] = useState('');
   const [isDragging, setIsDragging] = useState(false);
   const [isConverting, setIsConverting] = useState(false);
+  const [isConvertAndSending, setIsConvertAndSending] = useState(false);
   const [conversionStatus, setConversionStatus] = useState<{
     type: 'idle' | 'loading' | 'timeout' | 'error';
     message?: string;
@@ -209,19 +214,17 @@ export function FileConverter({
     setIsDragging(false);
   };
 
-  const handleConvert = async () => {
+  const performConversion = async (): Promise<ConvertedFile[] | null> => {
     if (pendingFiles.length === 0 && !manualInput.trim()) {
       toast.error('Please add files or enter manual input');
-      return;
+      return null;
     }
 
-    setIsConverting(true);
     setConversionStatus({ type: 'loading', message: 'Converting...' });
 
     try {
       const newConvertedFiles: ConvertedFile[] = [];
 
-      // Prepare files for conversion
       const filesToConvert: File[] = pendingFiles.map((file) => {
         return new File([file.content], file.name, { type: 'text/plain' });
       });
@@ -232,7 +235,6 @@ export function FileConverter({
         accessToken: accessToken ? `${accessToken.substring(0, 20)}...` : 'MISSING',
       });
 
-      // Call backend API for conversion with timeout and token
       const response = await callBackendConversion({
         manualText: manualInput.trim() || undefined,
         files: filesToConvert.length > 0 ? filesToConvert : undefined,
@@ -243,7 +245,6 @@ export function FileConverter({
 
       console.log('[FileConverter] Conversion response:', response);
 
-      // Process response and create converted file entries
       if (response.results && Array.isArray(response.results)) {
         response.results.forEach(
           (
@@ -269,15 +270,14 @@ export function FileConverter({
       if (newConvertedFiles.length === 0) {
         toast.error('No files were converted');
         setConversionStatus({ type: 'error', message: 'No files were converted' });
-        setIsConverting(false);
-        return;
+        return null;
       }
 
       setConvertedFiles((prev) => [...newConvertedFiles, ...prev]);
       setPendingFiles([]);
       setManualInput('');
       setConversionStatus({ type: 'idle' });
-      toast.success(`Successfully converted ${newConvertedFiles.length} file(s)`);
+      return newConvertedFiles;
     } catch (error) {
       console.error('[FileConverter] Conversion error:', error);
 
@@ -305,8 +305,58 @@ export function FileConverter({
         setConversionStatus({ type: 'error', message: errorMessage });
         toast.error(errorMessage);
       }
+      return null;
+    }
+  };
+
+  const handleConvert = async () => {
+    setIsConverting(true);
+    try {
+      const newConvertedFiles = await performConversion();
+      if (newConvertedFiles) {
+        toast.success(`Successfully converted ${newConvertedFiles.length} file(s)`);
+      }
     } finally {
       setIsConverting(false);
+    }
+  };
+
+  const handleConvertAndSend = async () => {
+    if (!accessToken) {
+      toast.error('Authentication required. Please log in again.');
+      return;
+    }
+
+    setIsConvertAndSending(true);
+    try {
+      const newConvertedFiles = await performConversion();
+      if (!newConvertedFiles) {
+        return;
+      }
+
+      toast.success(`Successfully converted ${newConvertedFiles.length} file(s)`);
+      setConversionStatus({ type: 'loading', message: 'Sending to database...' });
+
+      try {
+        const data = await uploadConvertedFiles({
+          files: newConvertedFiles,
+          accessToken,
+          options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+        });
+        setConversionStatus({ type: 'idle' });
+        toast.success(data.message || 'Files converted and sent successfully');
+      } catch (error) {
+        console.error('[FileConverter] Convert&Send upload error:', error);
+        const uploadMessage =
+          error instanceof Error ? error.message : 'Failed to upload to database';
+        setConversionStatus({
+          type: 'error',
+          message: `Send failed: ${uploadMessage}`,
+        });
+        toast.error(`Conversion succeeded but send failed: ${uploadMessage}`);
+      }
+    } finally {
+      setIsConvertAndSending(false);
     }
   };
 
@@ -771,7 +821,9 @@ export function FileConverter({
           <Button
             onClick={handleConvert}
             disabled={
-              isConverting || (pendingFiles.length === 0 && !manualInput.trim())
+              isConverting ||
+              isConvertAndSending ||
+              (pendingFiles.length === 0 && !manualInput.trim())
             }
             className="bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             aria-label={
@@ -790,8 +842,33 @@ export function FileConverter({
             )}
           </Button>
           <Button
+            onClick={handleConvertAndSend}
+            disabled={
+              isConverting ||
+              isConvertAndSending ||
+              (pendingFiles.length === 0 && !manualInput.trim())
+            }
+            className="bg-indigo-500 hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700 text-white text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            aria-label={
+              isConvertAndSending
+                ? 'Converting and sending files, please wait'
+                : 'Convert METAR files to IWXXM XML and send to database'
+            }
+          >
+            {isConvertAndSending ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />
+                Converting & Sending...
+              </>
+            ) : (
+              'Convert&Send'
+            )}
+          </Button>
+          <Button
             onClick={() => setIsUploadDialogOpen(true)}
-            disabled={convertedFiles.length === 0}
+            disabled={
+              convertedFiles.length === 0 || isConverting || isConvertAndSending
+            }
             variant="outline"
             className="bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
             aria-label={`Upload ${convertedFiles.length} converted files to database`}
@@ -802,7 +879,9 @@ export function FileConverter({
           </Button>
           <Button
             onClick={handleDownloadAll}
-            disabled={convertedFiles.length === 0}
+            disabled={
+              convertedFiles.length === 0 || isConverting || isConvertAndSending
+            }
             variant="outline"
             className="bg-gray-600 text-white hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 text-base disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
             aria-label={`Download all ${convertedFiles.length} converted files as ZIP`}

--- a/apps/frontend/src/test/conversion-parameters-mapping.workflow.test.tsx
+++ b/apps/frontend/src/test/conversion-parameters-mapping.workflow.test.tsx
@@ -89,9 +89,7 @@ describe('UI Workflow: Conversion Parameter Mapping', () => {
       },
     });
 
-    await user.click(
-      screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-    );
+    await user.click(screen.getByTestId('convert-button'));
 
     await waitFor(() => {
       expect(mockConvertMetarToIwxxm).toHaveBeenCalledTimes(1);
@@ -173,9 +171,7 @@ describe('UI Workflow: Conversion Parameter Mapping', () => {
       target: { value: 'METAR KDEN 121653Z 02006KT 10SM SCT050 21/08 A3010' },
     });
 
-    await user.click(
-      screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
-    );
+    await user.click(screen.getByTestId('convert-button'));
 
     await waitFor(() => {
       expect(mockConvertMetarToIwxxm).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/test/conversion-parameters-mapping.workflow.test.tsx
+++ b/apps/frontend/src/test/conversion-parameters-mapping.workflow.test.tsx
@@ -90,7 +90,7 @@ describe('UI Workflow: Conversion Parameter Mapping', () => {
     });
 
     await user.click(
-      screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+      screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
     );
 
     await waitFor(() => {
@@ -174,7 +174,7 @@ describe('UI Workflow: Conversion Parameter Mapping', () => {
     });
 
     await user.click(
-      screen.getByRole('button', { name: /convert metar files to iwxxm xml/i }),
+      screen.getByRole('button', { name: /^convert metar files to iwxxm xml$/i }),
     );
 
     await waitFor(() => {

--- a/apps/frontend/src/utils/databaseUpload.test.ts
+++ b/apps/frontend/src/utils/databaseUpload.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CONVERT_AND_SEND_UPLOAD_OPTIONS,
+  uploadConvertedFiles,
+} from './databaseUpload';
+
+vi.mock('/utils/supabase/info', () => ({
+  projectId: 'test-project',
+}));
+
+const mockFetch = vi.fn();
+
+describe('databaseUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('exports fixed defaults for Convert&Send', () => {
+    expect(CONVERT_AND_SEND_UPLOAD_OPTIONS).toEqual({
+      format: 'iwxxm',
+      destination: 'primary',
+      includeOriginal: false,
+    });
+  });
+
+  it('uploads converted files with bearer token', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Files uploaded successfully' }),
+    });
+
+    const files = [
+      {
+        id: '1',
+        originalName: 'test.tac',
+        originalContent: 'METAR',
+        convertedContent: '<iwxxm/>',
+        timestamp: 1,
+      },
+    ];
+
+    const result = await uploadConvertedFiles({
+      files,
+      accessToken: 'test-token',
+      options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+    });
+
+    expect(result.message).toBe('Files uploaded successfully');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://test-project.supabase.co/functions/v1/make-server-2e3cda33/database/upload',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({
+          files,
+          options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+        }),
+      }),
+    );
+  });
+
+  it('throws when upload response is not ok', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Upload rejected' }),
+    });
+
+    await expect(
+      uploadConvertedFiles({
+        files: [],
+        accessToken: 'test-token',
+        options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+      }),
+    ).rejects.toThrow('Upload rejected');
+  });
+});

--- a/apps/frontend/src/utils/databaseUpload.test.ts
+++ b/apps/frontend/src/utils/databaseUpload.test.ts
@@ -6,6 +6,8 @@ import {
 
 vi.mock('/utils/supabase/info', () => ({
   projectId: 'test-project',
+  edgeFunctionUrl: (subpath: string) =>
+    `https://test-project.supabase.co/functions/v1/make-server-2e3cda33/${subpath}`,
 }));
 
 const mockFetch = vi.fn();
@@ -27,7 +29,7 @@ describe('databaseUpload', () => {
   it('uploads converted files with bearer token', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ message: 'Files uploaded successfully' }),
+      text: async () => JSON.stringify({ message: 'Files uploaded successfully' }),
     });
 
     const files = [
@@ -66,7 +68,8 @@ describe('databaseUpload', () => {
   it('throws when upload response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ error: 'Upload rejected' }),
+      status: 400,
+      text: async () => JSON.stringify({ error: 'Upload rejected' }),
     });
 
     await expect(
@@ -76,5 +79,37 @@ describe('databaseUpload', () => {
         options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
       }),
     ).rejects.toThrow('Upload rejected');
+  });
+
+  it('throws with response text when error body is not JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => 'Bad Gateway',
+    });
+
+    await expect(
+      uploadConvertedFiles({
+        files: [],
+        accessToken: 'test-token',
+        options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+      }),
+    ).rejects.toThrow('Bad Gateway');
+  });
+
+  it('falls back to message field when error field is absent', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ message: 'Server unavailable' }),
+    });
+
+    await expect(
+      uploadConvertedFiles({
+        files: [],
+        accessToken: 'test-token',
+        options: CONVERT_AND_SEND_UPLOAD_OPTIONS,
+      }),
+    ).rejects.toThrow('Server unavailable');
   });
 });

--- a/apps/frontend/src/utils/databaseUpload.ts
+++ b/apps/frontend/src/utils/databaseUpload.ts
@@ -1,4 +1,4 @@
-import { projectId } from '/utils/supabase/info';
+import { edgeFunctionUrl } from './supabase/info';
 
 export type DatabaseFormat = 'iwxxm' | 'json' | 'both';
 export type UploadDestination = 'primary' | 'archive' | 'both';
@@ -30,6 +30,39 @@ export interface UploadConvertedFilesParams {
   options: DatabaseUploadOptions;
 }
 
+export const DATABASE_UPLOAD_SUBPATH = 'database/upload';
+
+function parseUploadResponseBody(raw: string): Record<string, unknown> {
+  if (!raw) {
+    return {};
+  }
+  try {
+    const data = JSON.parse(raw) as unknown;
+    return typeof data === 'object' && data !== null
+      ? (data as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function uploadErrorMessage(
+  raw: string,
+  data: Record<string, unknown>,
+  status: number,
+): string {
+  if (typeof data.error === 'string' && data.error) {
+    return data.error;
+  }
+  if (typeof data.message === 'string' && data.message) {
+    return data.message;
+  }
+  if (raw) {
+    return raw;
+  }
+  return `Failed to upload to database (${status})`;
+}
+
 /**
  * Upload converted METAR/IWXXM files to the Supabase database edge function.
  *
@@ -44,26 +77,24 @@ export async function uploadConvertedFiles({
   accessToken,
   options,
 }: UploadConvertedFilesParams): Promise<{ message?: string }> {
-  const response = await fetch(
-    `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/database/upload`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({
-        files,
-        options,
-      }),
+  const response = await fetch(edgeFunctionUrl(DATABASE_UPLOAD_SUBPATH), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
     },
-  );
+    body: JSON.stringify({
+      files,
+      options,
+    }),
+  });
 
-  const data = await response.json();
+  const raw = await response.text();
+  const data = parseUploadResponseBody(raw);
 
   if (!response.ok) {
-    throw new Error(data.error || 'Failed to upload to database');
+    throw new Error(uploadErrorMessage(raw, data, response.status));
   }
 
-  return data;
+  return data as { message?: string };
 }

--- a/apps/frontend/src/utils/databaseUpload.ts
+++ b/apps/frontend/src/utils/databaseUpload.ts
@@ -1,0 +1,69 @@
+import { projectId } from '/utils/supabase/info';
+
+export type DatabaseFormat = 'iwxxm' | 'json' | 'both';
+export type UploadDestination = 'primary' | 'archive' | 'both';
+
+export interface ConvertedFileUpload {
+  id: string;
+  originalName: string;
+  originalContent: string;
+  convertedContent: string;
+  timestamp: number;
+}
+
+export interface DatabaseUploadOptions {
+  format: DatabaseFormat;
+  destination: UploadDestination;
+  includeOriginal: boolean;
+}
+
+/** Defaults for one-click Convert&Send (evolve EV-001 / GitHub #656). */
+export const CONVERT_AND_SEND_UPLOAD_OPTIONS: DatabaseUploadOptions = {
+  format: 'iwxxm',
+  destination: 'primary',
+  includeOriginal: false,
+};
+
+export interface UploadConvertedFilesParams {
+  files: ConvertedFileUpload[];
+  accessToken: string;
+  options: DatabaseUploadOptions;
+}
+
+/**
+ * Upload converted METAR/IWXXM files to the Supabase database edge function.
+ *
+ * @param params.files - Converted file payloads from the converter UI
+ * @param params.accessToken - Supabase JWT for authorization
+ * @param params.options - Storage format, destination, and include-original flag
+ * @returns Parsed JSON response from the upload endpoint
+ * @throws Error when the request fails or the server returns a non-OK status
+ */
+export async function uploadConvertedFiles({
+  files,
+  accessToken,
+  options,
+}: UploadConvertedFilesParams): Promise<{ message?: string }> {
+  const response = await fetch(
+    `https://${projectId}.supabase.co/functions/v1/make-server-2e3cda33/database/upload`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        files,
+        options,
+      }),
+    },
+  );
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to upload to database');
+  }
+
+  return data;
+}

--- a/apps/frontend/src/utils/supabase/info.ts
+++ b/apps/frontend/src/utils/supabase/info.ts
@@ -32,3 +32,16 @@ if (!publicAnonKey) {
  * Supabase URL for API calls
  */
 export const supabaseApiUrl = supabaseUrl;
+
+/** Edge function deployment slug for the bundled Hono server. */
+export const edgeServerSlug = 'make-server-2e3cda33';
+
+/**
+ * Build the full HTTPS URL for a Supabase edge function subpath.
+ *
+ * @param subpath - Path after the deployment slug (e.g. ``database/upload``)
+ * @returns Edge function URL for the current project
+ */
+export function edgeFunctionUrl(subpath: string): string {
+  return `https://${projectId}.supabase.co/functions/v1/${edgeServerSlug}/${subpath}`;
+}

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -8,6 +8,7 @@ part of an active pipeline session. See [sessions/README.md](../sessions/README.
 
 | Slug | Topic | Status | Created | Linked features |
 |------|-------|--------|---------|-----------------|
+| [convert-send-buttons](convert-send-buttons.md) | Convert & Convert&Send UI (GitHub #656) | active | 2026-06-22 | F1, UJ-001 |
 | [live-e2e-integration](live-e2e-integration.md) | Live E2E and integration tests for Render | requirements-complete | 2026-06-22 | test-plan H3–H6, UJ-001–003 |
 
 **Convention**: One brief per topic at `docs/context/<slug>.md`. Reference downstream as

--- a/docs/context/convert-send-buttons.md
+++ b/docs/context/convert-send-buttons.md
@@ -5,7 +5,7 @@
 
 ## Executive Summary
 
-Issue #656 requests two explicit actions in the main converter: **Convert** (format conversion only) and **Convert&Send** (convert then immediately send output). The codebase already implements **Convert** and a separate **Upload to Database** flow that requires a prior conversion and opens a configuration dialog. **Convert&Send is not implemented** — matching issue #555's note that it was "under development." Implementation is primarily frontend work in `FileConverter.tsx`, reusing the existing Supabase upload endpoint. Several behavioral details (upload defaults, button layout, scope of sibling #555 asks) need product decisions before build.
+Issue #656 requests two explicit actions in the main converter: **Convert** (format conversion only) and **Convert&Send** (convert then immediately send output). This evolve cycle (S001 / EV-001) delivers all three actions in the main UI: **Convert**, **Convert&Send** (fixed upload defaults, no dialog), and **Upload to Database** (post-conversion dialog with configurable options). Shared upload logic lives in `databaseUpload.ts`; button state and send feedback are wired in `FileConverter.tsx`.
 
 ## Resolution Log
 

--- a/docs/context/convert-send-buttons.md
+++ b/docs/context/convert-send-buttons.md
@@ -1,0 +1,98 @@
+# Context — Convert & Convert&Send Buttons
+
+> **Mode**: scoped | **Slug**: convert-send-buttons | **Generated**: 2026-06-22  
+> **Feature / workflow**: GitHub [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656) — dual convert/send UI | **Status**: active
+
+## Executive Summary
+
+Issue #656 requests two explicit actions in the main converter: **Convert** (format conversion only) and **Convert&Send** (convert then immediately send output). The codebase already implements **Convert** and a separate **Upload to Database** flow that requires a prior conversion and opens a configuration dialog. **Convert&Send is not implemented** — matching issue #555's note that it was "under development." Implementation is primarily frontend work in `FileConverter.tsx`, reusing the existing Supabase upload endpoint. Several behavioral details (upload defaults, button layout, scope of sibling #555 asks) need product decisions before build.
+
+## Resolution Log
+
+| ID | Category | Decision |
+|----|----------|----------|
+| R1 | Ambiguity | **Convert&Send uses fixed defaults** — `format: iwxxm`, `destination: primary`, `includeOriginal: false`; no upload dialog |
+| R2 | Decision | **Keep all three buttons** — Convert, Convert&Send, Upload to Database |
+| R3 | Scope | **#656 only** — buttons + send feedback; exclude #555 auto-clear and log preview |
+
+## Scope & Constraints
+
+**In scope (#656)**
+
+- Convert-only button (may already satisfy requirement — verify UX/label placement).
+- Convert&Send: chained convert → upload ("send").
+- Send success/failure confirmation (toast and/or inline status).
+
+**Linked features**
+
+- **F1** — METAR → IWXXM conversion UI.
+- Upload path is ancillary to F1 (Supabase edge function, not documented as separate Fn).
+
+**Out of scope unless R3 expands**
+
+- REQ-016 / migration non-goals: no unrelated rewrites.
+- Backend `/api/v1/convert` unchanged unless evolve adds upload-prefs API (unlikely).
+
+## Environment / Topology
+
+| Surface | Role | Notes |
+|---------|------|-------|
+| `apps/frontend` | Static UI | Vite; calls backend for convert |
+| Backend API | `POST /api/v1/convert` | Bearer auth; used by `convertMetarToIwxxm` |
+| Supabase edge fn | `POST .../make-server-2e3cda33/database/upload` | "Send" destination; Bearer auth |
+
+Browser wiring: frontend → API for convert; frontend → Supabase functions for upload (cross-origin). No CORS change expected for convert-only work; upload already used in production path.
+
+## Existing Infrastructure
+
+| Asset | Path | Relevance |
+|-------|------|-----------|
+| Convert handler | `apps/frontend/src/app/components/FileConverter.tsx` (`handleConvert`) | Core convert logic |
+| Action buttons row | `FileConverter.tsx` ~L770–820 | Convert, Upload to Database, Download |
+| Upload dialog | `apps/frontend/src/app/components/DatabaseUploadDialog.tsx` | Format/destination options; `handleUpload` |
+| Upload API (client) | `DatabaseUploadDialog.tsx` L51–68 | POST with `{ files, options }` |
+| Upload API (server) | `apps/frontend/supabase/functions/server/index.ts` L242–289 | Validates auth + options |
+| User preferences | `UserPreferencesDialog.tsx` | Conversion params only — **no upload defaults** |
+| Unit tests | `FileConverter.test.tsx`, `DatabaseUploadDialog.test.tsx` | Button states, upload mock |
+| E2E | `apps/e2e/tac-file-upload-database.e2e.spec.ts` | Convert → open dialog → upload |
+| Parent issue | GitHub #555 | Original tester feedback |
+
+## Cross-Reference Matrix
+
+| Source | Convert button | Convert&Send | Send = DB upload | Upload dialog required |
+|--------|----------------|--------------|------------------|------------------------|
+| Issue #656 | Required | Required | Implied ("send output") | Not specified |
+| Issue #555 | Requested (under dev) | Requested (under dev) | Implied | Not specified |
+| Current UI | **Present** ("Convert") | **Absent** | **Yes** (Upload to Database) | **Yes** (2-step) |
+| E2E tests | Covered | Not covered | Covered (mocked upload) | Assumes dialog flow |
+
+## Implementation Backlog
+
+1. **Extract upload client** — Move fetch logic from `DatabaseUploadDialog` to shared util (e.g. `uploadConvertedFiles`) callable from Convert&Send and dialog.
+2. **Add `handleConvertAndSend`** — After successful `handleConvert`, invoke upload with agreed defaults (R1).
+3. **UI** — Add "Convert&Send" button next to Convert; disabled rules match Convert; loading states for combined operation.
+4. **Feedback** — Surface send success/failure (#555 ask); distinguish convert failure vs send failure.
+5. **Tests** — Unit: chained flow, error paths; E2E: optional one-click path with route mock.
+6. **Docs delta (16-evolve)** — Extend UJ-001 steps; add test-plan tier note; optional feature-list bullet under F1.
+
+## Data & Credentials
+
+- Upload requires `accessToken` (Supabase JWT) — already passed to `FileConverter`.
+- Default upload options today in dialog: `format: 'iwxxm'`, `destination: 'primary'`, `includeOriginal: false`.
+
+## Unresolved Gaps
+
+- **R1**: Without saved upload preferences, Convert&Send must pick defaults or still open the dialog (defeats "immediately sends").
+- **R2**: Three buttons (Convert, Convert&Send, Upload) may clutter UI — product choice.
+- **R3**: #555 also asks auto-clear inputs and error log preview — separate stories or same session?
+- **Feature registry**: Database upload/send not listed as standalone feature in `feature-list.md`; evolve should document under F1 or new sub-capability.
+- **No project `context-brief.md`** — scoped brief only; project-level brief unchanged.
+
+## Sources
+
+- [GitHub #656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656)
+- [GitHub #555](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/555) — `gh issue view 555`
+- [Repo: apps/frontend/src/app/components/FileConverter.tsx]
+- [Repo: apps/frontend/src/app/components/DatabaseUploadDialog.tsx]
+- [Repo: apps/e2e/tac-file-upload-database.e2e.spec.ts]
+- [Docs: user-journeys.md §UJ-001]

--- a/docs/evolve-decisions.md
+++ b/docs/evolve-decisions.md
@@ -1,0 +1,41 @@
+# Evolve Decisions
+
+> Standing log of approved evolve-cycle scope and product decisions.
+> Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
+
+## Cycle EV-001 — Convert & Convert&Send UI (S001)
+
+**GitHub**: [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656)  
+**Session**: S001-convert-send-buttons  
+**Feature**: F1 (conversion UI + database send)  
+**Approved**: 2026-06-22
+
+### Scope
+
+**In scope**
+
+- **Convert** button — conversion only (already present; verify UX).
+- **Convert&Send** button — convert then immediately upload with fixed defaults.
+- Success/failure toast feedback for the send step.
+
+**Out of scope**
+
+- Auto-clear input panel (#555 sibling).
+- In-app error log preview (#555 sibling).
+- Backend API changes.
+
+### Decisions
+
+| ID | Category | Decision |
+|----|----------|----------|
+| R1 | Ambiguity | Convert&Send uses fixed defaults: `format: iwxxm`, `destination: primary`, `includeOriginal: false`; no upload dialog |
+| R2 | Decision | Keep all three actions: Convert, Convert&Send, Upload to Database |
+| R3 | Scope | #656 only — exclude #555 auto-clear and log preview |
+
+### Artifacts updated
+
+- `docs/feature-list.md` — F1 UI actions
+- `docs/user-journeys.md` — UJ-001 steps
+- `docs/test-plan.md` — E2E module for convert-and-send
+- `apps/frontend/` — `FileConverter`, shared `databaseUpload` util
+- `apps/e2e/tac-file-upload-database.e2e.spec.ts` — one-click path

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/joseph-c-mcguire/metar-to-IWXXM
-> **Last updated**: 2026-06-14
+> **Last updated**: 2026-06-22
 
 ## Summary
 
@@ -27,7 +27,11 @@
 
 - **What it does**: Converts METAR/SPECI TAC text (file upload or manual input) to IWXXM XML via GIFTs.
 - **Inputs**: `.tac` / `.txt` files, manual TAC strings, optional conversion parameters.
-- **Outputs**: IWXXM XML per input; batch ZIP download.
+- **Outputs**: IWXXM XML per input; batch ZIP download; optional database upload ("send").
+- **UI actions** (main converter):
+  - **Convert** — TAC → IWXXM only.
+  - **Convert&Send** — TAC → IWXXM then upload to primary database with IWXXM format (fixed defaults; no dialog).
+  - **Upload to Database** — upload previously converted files with configurable format/destination (dialog).
 - **Limitations**: Depends on GIFTs and vendored IWXXM schemas for target version.
 - **Source**: README, `backend/src/utilities/conversion.py`
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,11 +25,11 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| — | — | — | — | — | — | — |
+| [S001-convert-send-buttons](S001-convert-send-buttons/session-brief.md) | feature | in_progress | Convert & Convert&Send UI (#656) | feat/S001-convert-send-buttons | 2026-06-22 | — |
 
 ## Active session
 
-None — see `workflow-state.yaml` §`active_session`.
+**S001-convert-send-buttons** — see `workflow-state.yaml` §`active_session`.
 
 ## Folder layout
 

--- a/docs/sessions/S001-convert-send-buttons/reports/build-report.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/build-report.md
@@ -1,0 +1,48 @@
+# Build report — S001 convert-send-buttons (07-build)
+
+**Cycle**: EV-001 | **GitHub**: [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656)  
+**Branch**: `feat/S001-convert-send-buttons`  
+**Date**: 2026-06-22
+
+## Execution state
+
+| Item | Value |
+|------|-------|
+| Phase | EV-001 — Convert & Convert&Send UI |
+| Feature | F1 |
+| Tasks | All backlog items from `docs/context/convert-send-buttons.md` §Implementation Backlog |
+
+## Delivered
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Shared upload client | done | `apps/frontend/src/utils/databaseUpload.ts` |
+| Convert&Send handler | done | `handleConvertAndSend` in `FileConverter.tsx` |
+| UI buttons | done | Convert, Convert&Send, Upload to Database retained |
+| Send feedback | done | Success/error toasts; inline send-failure status |
+| Unit tests | done | `FileConverter.test.tsx`, `databaseUpload.test.ts` |
+| E2E one-click path | done | `tac-file-upload-database.e2e.spec.ts` |
+| Doc deltas | done | feature-list, user-journeys, test-plan, evolve-decisions |
+
+## Fix applied (this session)
+
+Convert&Send shares an aria-label prefix with Convert (`Convert METAR files to IWXXM XML…`).
+Tests and E2E helpers that used an unanchored regex matched both buttons. Updated locators to
+`^Convert METAR files to IWXXM XML$` in:
+
+- `apps/frontend/src/test/conversion-parameters-mapping.workflow.test.tsx`
+- `apps/e2e/playwright-e2e-helpers.ts`
+- `apps/e2e/tac-file-upload-database.e2e.spec.ts`
+- `apps/e2e/workflow-narrative-full-journey.e2e.spec.ts`
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `pnpm exec vitest run` (frontend) | 422 passed |
+| `make lint-frontend` | pass |
+
+## Outstanding
+
+- Changes are **uncommitted** on `feat/S001-convert-send-buttons` (awaiting user commit request).
+- Next pipeline stage: **09-qa** (per session routing plan).

--- a/docs/sessions/S001-convert-send-buttons/reports/e2e-report.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/e2e-report.md
@@ -1,0 +1,139 @@
+# E2E Behavior Report — S001 / EV-001 (Convert & Convert&Send UI)
+
+> Generated: 2026-06-22  
+> Mechanism: mixed (Vitest T0 + Playwright T2 browser)  
+> Scope: Delta E2E for GitHub [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656)  
+> Branch: `feat/S001-convert-send-buttons` | Session: S001-convert-send-buttons | Feature: F1 (UJ-001)
+
+## Summary
+
+| # | Journey | Mechanism | Steps | Passed | Failed | Skipped | T0 | T2 | T3 | Status |
+|---|---------|-----------|-------|--------|--------|---------|----|----|-----|--------|
+| 1 | UJ-001 Convert METAR via UI (Convert only) | browser | 5 | 5 | 0 | 0 | — | ✓ | — | **PASS** |
+| 2 | UJ-001 Convert&Send one-click | browser | 4 | 4 | 0 | 0 | ✓ | ✓ | — | **PASS** |
+| 3 | UJ-001 Upload to Database (dialog) | browser | 5 | 5 | 0 | 0 | — | ✓ | — | **PASS** |
+| 4 | UJ-003 Auth (login for upload tests) | browser | 3 | 3 | 0 | 0 | — | ✓ | — | **PASS** |
+
+**Overall: PASS (T0 + T2)** — Issue #656 acceptance verified locally. **T3 deferred** until feature branch merges and Render redeploys.
+
+```text
+E2E Results (S001 delta):
+  T0 (Vitest Convert&Send):  PASS — 2/2 tests
+  T2 (Playwright UJ-001):    PASS — 11/11 executed (3 skipped without fixtures; 11/11 with fixtures)
+  T2 connectivity:           PASS — CORS preflight 200 on POST /api/v1/convert during runs
+  T3 (Render live):          DEFERRED — production not yet on feat/S001-convert-send-buttons
+  T3 browser:                NOT RUN
+```
+
+---
+
+## Issue #656 journey mapping
+
+| Requirement | Journey step | Evidence |
+|-------------|--------------|----------|
+| **Convert** button (conversion only) | Paste/drop TAC → click **Convert** → view IWXXM | `tac-file-conversion.e2e.spec.ts` (6 tests); manual METAR convert PASS |
+| **Convert&Send** (convert + immediate send) | Drop TAC → click **Convert&Send** → toast success | `tac-file-upload-database.e2e.spec.ts` — "converted and sent with one click" |
+| Send success/failure feedback | Mock upload 200 → toast; mock failure covered in unit tests | Playwright: `Files converted and sent successfully`; Vitest: send-failure path |
+| Retain **Upload to Database** (R2) | Convert → open dialog → upload | `tac-file-upload-database.e2e.spec.ts` — dialog flow PASS |
+
+---
+
+## Commands run
+
+```bash
+# T0 — Convert&Send unit coverage (Vitest)
+cd apps/frontend && pnpm test -- --run FileConverter.test.tsx -t "Convert&Send"
+
+# T2 — UJ-001 Playwright (default fixture path; 3 upload tests skipped without .tac dir)
+cd apps/e2e && pnpm exec playwright test \
+  tac-file-conversion.e2e.spec.ts \
+  tac-file-upload-database.e2e.spec.ts
+
+# T2 — full upload suite with golden fixtures
+cd apps/e2e && PLAYWRIGHT_TAC_FIXTURES_DIR=/root/metar-to-IWXXM/test-data/golden/cases \
+  pnpm exec playwright test tac-file-upload-database.e2e.spec.ts
+```
+
+**Environment**: Local dev stack via Playwright `webServer` (`DISABLE_AUTH=true`, API `:8001`, frontend `:5173`). Upload send step mocked via `page.route('**/functions/v1/**/database/upload')`.
+
+---
+
+## Journey details
+
+### Journey 1: UJ-001 — Convert only (T2)
+
+- **Feature**: F1
+- **Mechanism**: Playwright browser (mock session + real API convert)
+- **Test module**: `apps/e2e/tac-file-conversion.e2e.spec.ts`
+- **Steps**:
+  1. Open converter with mock session — **PASS**
+  2. Enter manual METAR — **PASS**
+  3. Click **Convert** (`^Convert METAR files to IWXXM XML$`) — **PASS**
+  4. Conversion results region visible — **PASS**
+  5. IWXXM XML in `<pre>` output — **PASS**
+- **Additional cases**: COR METAR, clear input, mocked success/empty/401 — all **PASS** (6/6)
+
+### Journey 2: UJ-001 — Convert&Send one-click (T0 + T2)
+
+- **Feature**: F1 / EV-001
+- **Mechanism**: Vitest (T0) + Playwright (T2, mocked upload endpoint)
+- **Test modules**: `FileConverter.test.tsx`, `tac-file-upload-database.e2e.spec.ts`
+- **T0 steps**:
+  1. **Convert&Send** button visible, disabled until input — **PASS**
+  2. Click chains `convertMetarToIwxxm` + `uploadConvertedFiles` with fixed defaults — **PASS**
+  3. Auth required when no token — **PASS**
+- **T2 steps** (fixture: `test-data/golden/cases/kjfk_basic.tac`):
+  1. Login via Supabase (UJ-003) — **PASS**
+  2. Attach TAC file — **PASS**
+  3. Click **Convert&Send** (`Convert METAR files to IWXXM XML and send to database`) — **PASS**
+  4. Results region + IWXXM output + success toast — **PASS**
+
+### Journey 3: UJ-001 — Upload to Database dialog (T2)
+
+- **Feature**: F1 (R2 retained)
+- **Mechanism**: Playwright browser
+- **Test module**: `apps/e2e/tac-file-upload-database.e2e.spec.ts`
+- **Steps**:
+  1. Upload button disabled before conversion — **PASS**
+  2. Convert via **Convert** only — **PASS**
+  3. Open upload dialog, select IWXXM format — **PASS**
+  4. Mock upload → success toast — **PASS**
+  5. Multi-file queue (2 TAC files) — **PASS**
+
+### Journey 4: UJ-003 — Auth for protected flows (T2)
+
+- **Feature**: F1 (auth)
+- **Mechanism**: Playwright browser (real Supabase login in upload tests)
+- **Steps**:
+  1. Navigate to login — **PASS**
+  2. `POST /auth/login` → 200 — **PASS**
+  3. Open converter from admin dashboard — **PASS**
+
+---
+
+## Connectivity
+
+| Tier | Check | Result |
+|------|-------|--------|
+| T2 | `OPTIONS /api/v1/convert` preflight during Playwright | 200 |
+| T2 | `POST /api/v1/convert` from browser origin `http://localhost:5173` | 200 (valid TAC) / 400 (invalid) |
+| T3 | H4–H5 live CORS + bundle wiring | **NOT RUN** — feature not deployed |
+| T3 | `make test-live-e2e` against Render | **DEFERRED** — run post-merge per UJ-OPS-001 |
+
+---
+
+## Findings for 11-verify-impl
+
+| ID | Severity | Finding | Suggested action |
+|----|----------|---------|------------------|
+| E2E-001 | Advisory | Default Playwright run skips 3 upload tests when `data/iwxxm-translation/.../metar` absent | CI sets `PLAYWRIGHT_TAC_FIXTURES_DIR` or documents `test-data/golden/cases` fallback |
+| E2E-002 | Advisory | T3 live Convert&Send not exercised against Render | After merge to `main` + frontend redeploy, run `make test-live-e2e` or manual UJ-001 step 4 (Convert&Send) |
+| E2E-003 | Info | Live upload path uses real Supabase edge function; T2 mocks upload only | T3 send verification requires staging credentials + live deploy |
+
+---
+
+## Handoff
+
+- **Blocking failures**: none
+- **Next stage**: **11-verify-impl** — present PASS summary; defer E2E-002 until deploy
+- **GitHub #656**: Local E2E acceptance **PASS** for Convert, Convert&Send, and retained Upload dialog

--- a/docs/sessions/S001-convert-send-buttons/reports/evolve-summary.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/evolve-summary.md
@@ -1,0 +1,25 @@
+# Evolve summary — S001 convert-send-buttons
+
+**Cycle**: EV-001  
+**GitHub**: [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656)  
+**Status**: implementation complete (pending deploy verify)
+
+## Delivered
+
+- **Convert** — existing convert-only action retained.
+- **Convert&Send** — one-click convert then upload with fixed defaults (`iwxxm` / `primary` / no original).
+- **Upload to Database** — manual two-step flow with dialog retained.
+- Shared `uploadConvertedFiles` client in `apps/frontend/src/utils/databaseUpload.ts`.
+- Unit tests (`FileConverter`, `databaseUpload`) and E2E one-click path in `tac-file-upload-database.e2e.spec.ts`.
+
+## Spec deltas
+
+- `docs/evolve-decisions.md` — scope and R1–R3
+- `docs/feature-list.md` — F1 UI actions
+- `docs/user-journeys.md` — UJ-001 steps
+- `docs/test-plan.md` — E2E module reference
+
+## Out of scope (deferred)
+
+- Auto-clear input (#555)
+- In-app error log preview (#555)

--- a/docs/sessions/S001-convert-send-buttons/reports/pr-remediation.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/pr-remediation.md
@@ -1,0 +1,36 @@
+# PR Remediation — S001 / PR #683
+
+**Cycle:** PRM-003 | **Linked review:** PRR-003 | **Branch:** `feat/S001-convert-send-buttons`  
+**Completed:** 2026-06-22 | **Head:** `8f7545d` | **CI:** success
+
+## Summary
+
+| Metric | Count |
+|--------|------:|
+| Fixed | 6 |
+| Deferred | 0 |
+| Won't fix | 0 |
+
+All advisory findings from PRR-003 and Sourcery review were addressed. Three inline threads resolved on GitHub.
+
+## Commits
+
+| SHA | Description |
+|-----|-------------|
+| `fa6d5c5` | Derived button flags, `send_error` status, `data-testid` on action buttons |
+| `a47eaf4` | `edgeFunctionUrl()` + hardened upload error parsing |
+| `22741dd` | Test/E2E locators + context doc executive summary |
+| `8f7545d` | `DatabaseUploadDialog.test.tsx` mock parity (CI fix) |
+
+## Findings
+
+1. **F-001** — Sourcery complexity: `isBusy` / `hasInput` / `hasConverted` derived flags.
+2. **F-002** — Send failures use `send_error` type; panel heading **Send Error**.
+3. **F-003** — Context brief executive summary reflects delivered Convert&Send.
+4. **F-004** — Stable `data-testid` locators in unit/workflow/E2E tests.
+5. **F-005** — Centralized Supabase upload URL; safe non-JSON error handling.
+6. **F-006** — Dialog upload tests updated after upload client change.
+
+## Follow-up
+
+- Re-run **18-pr-review** offered to user after remediation.

--- a/docs/sessions/S001-convert-send-buttons/reports/pr-review.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/pr-review.md
@@ -1,0 +1,66 @@
+# PR Review — S001 / EV-001 (Stage 18)
+
+> Generated: 2026-06-22  
+> PR: [#683](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/683) — feat(ui): Add Convert and Convert&Send buttons (#656)  
+> Branch: `feat/S001-convert-send-buttons` → `main`  
+> Reviewer: 18-pr-review (full checklist)
+
+## Verdict
+
+**APPROVE** — 0 blockers, 3 advisories, 4 praise items.
+
+## Summary
+
+Well-scoped frontend evolve cycle (EV-001) delivering GitHub #656: shared `databaseUpload.ts` client, Convert&Send one-click flow with fixed defaults, retained Upload dialog, unit + E2E coverage, and anchored Playwright selectors. Remote CI green on HEAD `4af5bb2`.
+
+## Checklist
+
+| Section | Result | Notes |
+|---------|--------|-------|
+| A Intake | pass | Clear PR body; Closes #656; feature type; docs updated |
+| B Code quality | pass | Clean refactor; ruff/eslint CI green |
+| C Tests | pass | Unit + E2E for happy/error/auth paths |
+| D CI | pass | All 14 checks pass on PR HEAD |
+| E Hygiene | pass | No secrets/cruft; scope matches EV-001 |
+| F Connectivity | pass (N/A delta) | Frontend-only; no API/CORS contract changes |
+| G Subagents | manual | Bugbot/Security failed diff; triaged manually |
+| H Delivery | pass | Inline comments + review posted |
+
+## Findings
+
+### Blockers (0)
+
+None.
+
+### Advisories (3)
+
+| ID | Severity | Location | Finding |
+|----|----------|----------|---------|
+| PRR683-001 | 🟡 | `FileConverter.tsx:940` | Send failure shown under "Conversion Error" heading |
+| PRR683-002 | 🟡 | `docs/context/convert-send-buttons.md:8` | Executive summary says Convert&Send not implemented |
+| PRR683-003 | 🟡 | PR test plan | T3 live Convert&Send deferred post-merge (expected) |
+
+### Praise (4)
+
+| ID | Location | Note |
+|----|----------|------|
+| PRR683-P1 | `databaseUpload.ts` | Shared upload client with typed options and TSDoc |
+| PRR683-P2 | E2E/helpers | Anchored `^Convert…$` regex prevents Convert&Send mis-clicks |
+| PRR683-P3 | `FileConverter.test.tsx` | Convert&Send chain, auth gate, send-failure paths covered |
+| PRR683-P4 | PR description | Thorough spec refs, test plan, evolve traceability |
+
+## CI
+
+- `ci.yml`: all jobs pass (Quality Gates, Frontend, Backend, Integration Matrix, gitleaks)
+- HEAD: `4af5bb220b7bb94003b6c147bb8c203371082f5e`
+
+## Subagents
+
+- **Bugbot:** failed_diff — manual triage, no confirmed bugs
+- **Security:** failed_diff — manual triage; auth token handling unchanged from dialog path; gitleaks CI pass
+
+## Manual security notes
+
+- Bearer JWT required before Convert&Send; no token logging beyond pre-existing prefix debug
+- Upload payload same shape as existing dialog flow
+- No new secrets or operator specs in diff

--- a/docs/sessions/S001-convert-send-buttons/reports/qa-report.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/qa-report.md
@@ -1,0 +1,188 @@
+# QA Report — S001 / EV-001 (Convert & Convert&Send UI)
+
+> Generated: 2026-06-22  
+> Scope: Delta QA for GitHub [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656) — Convert & Convert&Send buttons  
+> Branch: `feat/S001-convert-send-buttons`  
+> Session: S001-convert-send-buttons | Evolve cycle: EV-001 | Feature: F1
+
+```text
+QA Results (S001 delta + blocking connectivity):
+  Lint:           PASS — 0 issues (make lint)
+  Format:         PASS — 388 Python + Prettier clean
+  Typecheck:      PASS — 0 errors (basedpyright + tsc)
+  Tests (Python): PASS — 1009 passed, 1 skipped (make test-unit)
+  Tests (H0c):    PASS — 6/6 (tests/unit/test_cors_policy.py)
+  Tests (H0i):    PASS — 82/82 (integration pytest, in-process)
+  Tests (FE):     PASS — 422 passed (vitest); S001 delta 76/76
+  Security:       PASS — 0 CVEs; 0 tree leaks (gitleaks --no-git)
+  Cross-file:     1 F841 advisory (backend script, outside lint scope)
+  Dependencies:   PASS — pip-audit clean; workspace pkgs skipped (expected)
+  Template:       PASS — static+api monorepo layout
+  Connectivity:   H0c/H0i PASS; H4–H5 SKIPPED (no LIVE_* env this run)
+  Config guard:   PASS — 2/2 placeholder tests
+  Badge audit:    PASS
+```
+
+**Overall: pass_with_advisories** — all blocking checks green; advisories below for **11-verify-impl**.
+
+---
+
+## Executive summary
+
+| Category | Status | Blocking |
+|----------|--------|----------|
+| Lint / format / typecheck | PASS | — |
+| Unit tests (Python + frontend) | PASS | — |
+| H0c CORS policy | PASS | Yes — green |
+| H0i integration (in-process) | PASS | Yes — green |
+| pip-audit | PASS | — |
+| gitleaks (working tree) | PASS | — |
+| Issue #656 acceptance | PASS | — |
+| Uncommitted S001 work | Advisory | QA-010 |
+| `make test-integration` local Makefile | Advisory | QA-011 |
+| H4–H5 live connectivity | SKIPPED | QA-012 (advisory) |
+| Pre-existing F841 in backend script | Advisory | QA-013 |
+| Pre-existing eval/exec in GIFTs tpg | Advisory | QA-014 |
+
+### Issue #656 acceptance (F1)
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| **Convert** button (conversion only) | Implemented | `FileConverter.tsx` — aria-label `Convert METAR files to IWXXM XML` |
+| **Convert&Send** button (convert + send) | Implemented | `handleConvertAndSend`, shared `databaseUpload.ts` |
+| Send success/failure feedback | Implemented | Toasts + inline send-failure status in `FileConverter.tsx` |
+| Retain Upload to Database (R2) | Implemented | Dialog flow unchanged |
+| Unit tests | PASS | `FileConverter.test.tsx`, `databaseUpload.test.ts` |
+| E2E one-click path | Present | `tac-file-upload-database.e2e.spec.ts` — "converted and sent with one click" |
+
+---
+
+## Commands run
+
+```bash
+# Quality gates (CI parity)
+make lint
+make format-check
+make typecheck
+
+# Blocking connectivity
+uv run pytest tests/unit/test_cors_policy.py -v
+uv run pytest tests/test_backend_auth_integration.py \
+  tests/test_backend_frontend_integration.py \
+  tests/test_auth_frontend_integration.py \
+  tests/test_gifts_backend_integration.py \
+  tests/test_integration.py -v
+
+# Full unit suite
+make test-unit
+
+# S001 delta frontend tests
+pnpm --filter @metar/frontend exec vitest run \
+  src/app/components/FileConverter.test.tsx \
+  src/utils/databaseUpload.test.ts \
+  src/test/conversion-parameters-mapping.workflow.test.tsx
+pnpm --filter @metar/frontend exec vitest run
+
+# Security
+uv run pip-audit
+gitleaks detect --no-git --config .gitleaks.toml
+
+# Cross-file / config
+uv run ruff check --select F401,F841 apps packages tests
+uv run pytest tests/test_config_placeholders.py -v
+python3 .github/scripts/badge_audit.py
+```
+
+**Not run (env-gated — advisory):**
+
+```bash
+LIVE_API_URL=... LIVE_FRONTEND_URL=... bash scripts/deploy/verify_connectivity.sh  # H4–H5
+make test-integration  # docker compose + smoke subset (see QA-011)
+```
+
+---
+
+## Per-check details
+
+### Lint / format / typecheck
+
+All green. Matches `.github/workflows/ci-cd.yml` quality-gates job paths.
+
+### Tests
+
+| Suite | Result | Notes |
+|-------|--------|-------|
+| `make test-unit` | 1009 passed, 1 skipped | gifts coverage 98.79% |
+| H0c | 6 passed | Blocking — green |
+| H0i (direct pytest) | 82 passed | Blocking — green; 45 deprecation warnings (pre-existing) |
+| Frontend full | 422 passed | 34 files |
+| S001 delta | 76 passed | 3 files |
+| Config placeholders | 2 passed | CI config-guard parity |
+
+### Security
+
+- **pip-audit**: No known vulnerabilities. Workspace packages (`gifts`, `metar-*`) skipped — expected.
+- **gitleaks** (`--no-git`): No leaks in working tree (~1.08 GB scanned).
+- **Dangerous patterns** (`eval`/`exec` in `apps/`): None.
+- **packages/gifts/gifts/common/tpg.py**: Pre-existing parser-generator `eval`/`exec` (upstream GIFTs); not introduced by S001.
+
+### Cross-file
+
+- **F401/F841**: 1 hit — `F841` unused `test_cases` in `apps/backend/scripts/generate_test_data.py:210`. File is outside `PY_LINT` scope in Makefile; not caught by `make lint`.
+
+### Template conformance (`static+api`)
+
+| Check | Result |
+|-------|--------|
+| `apps/backend/` API | OK |
+| `apps/frontend/` static | OK — S001 changes confined here + `apps/e2e/` |
+| `packages/auth/` library | OK — no changes |
+| `packages/gifts/` | OK — no changes |
+| `vendor/schemas/*` read-only | OK — untouched |
+| `.github/workflows/ci-cd.yml` | OK |
+
+### Connectivity (stage 09)
+
+| Tier | Status | Notes |
+|------|--------|-------|
+| H0c | PASS | 6/6 unit CORS tests |
+| H0i | PASS | 82/82 integration tests (in-process, no docker required for pytest subset) |
+| H4–H5 live | SKIPPED | `LIVE_*` / `STAGING_*` unset in this environment |
+| Artifacts present | OK | `scripts/deploy/verify_connectivity.sh`, `tests/smoke/test_staging_connectivity.py` |
+
+Prior full-repo live QA (2026-06-22, `docs/qa-report.md`) verified H3–H6 green against Render URLs. S001 is frontend-only; no CORS or API contract changes expected.
+
+---
+
+## Findings for 11-verify-impl
+
+| ID | Severity | Finding | Suggested action |
+|----|----------|---------|------------------|
+| QA-010 | Advisory | S001 implementation **uncommitted** on `feat/S001-convert-send-buttons` (~447 LOC delta) | User commit + PR before merge |
+| QA-011 | Advisory | `make test-integration` exits 1 locally: backend smoke subset hits **28% coverage** vs 98% gate after main integration tests pass | Use alt ports (`METAR_BACKEND_HOST_PORT=18010`) if 18000/18001 busy; or run integration pytest directly (82 passed). CI job uses separate coverage targets — unaffected |
+| QA-012 | Advisory | H4–H5 live connectivity not re-run this session | Run `make test-live-connectivity` before deploy signoff; see `docs/qa-report.md` for prior green run |
+| QA-013 | Advisory | F841 in `apps/backend/scripts/generate_test_data.py` | Fix or exclude scripts from F841 sweep (pre-existing) |
+| QA-014 | Advisory | `eval`/`exec` in `packages/gifts/gifts/common/tpg.py` | Document as upstream; no S001 action |
+| QA-015 | Advisory | `docs/context/convert-send-buttons.md` §Executive Summary still says "Convert&Send is not implemented" | Update context doc status post-build (doc drift only) |
+
+---
+
+## Phase / execution-plan alignment
+
+- **EV-001 scope**: F1 UI only — matches issue #656 and evolve decisions R1–R3.
+- **Out of scope confirmed**: #555 auto-clear and error log preview — not in diff.
+- **Next pipeline stage**: **10-e2e** (delta Playwright for Convert&Send journey).
+- **Deploy gate**: Pending — requires commit, PR, and live H4–H5 on staging/production per `docs/deploy.md`.
+
+---
+
+## Handoff
+
+**11-verify-impl** should:
+
+1. Confirm QA-010 (commit/PR) with user.
+2. Walk through issue #656 acceptance table above.
+3. Defer or run QA-012 live connectivity before deploy.
+4. Optionally refresh context doc (QA-015).
+
+Do not re-run full 09 unless codebase changes materially after this report date.

--- a/docs/sessions/S001-convert-send-buttons/reports/verification-report.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/verification-report.md
@@ -1,0 +1,79 @@
+# Verification Report
+
+> Generated: 2026-06-22  
+> Scope: S001 / EV-001 — GitHub [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656) (Convert & Convert&Send UI)  
+> Branch: `feat/S001-convert-send-buttons`
+
+## Summary
+
+| Check | Status | Findings | Auto-Fixed | Tool |
+|-------|--------|----------|------------|------|
+| Lint | PASS | 0 | 0 | `make lint` (ruff + eslint) |
+| Format | PASS | 1 (Prettier) | 1 | `make format-check` |
+| Typecheck | PASS | 0 | — | `make typecheck` (basedpyright + tsc) |
+| Tests (unit) | PASS | 0 failed | — | `make test-unit-*` |
+| Tests (H0c CORS) | PASS | 6 passed | — | `pytest tests/unit/test_cors_policy.py` |
+| Tests (integration) | PASS* | 0 failed | — | `pytest tests/test_*_integration.py` + smoke subset |
+| Security | PASS | 0 CVEs | — | `pip-audit` |
+| Connectivity artifacts | PASS | Present | — | manual |
+| Template conformance | PASS | 0 deviations | — | `static+api` monorepo |
+| Performance | SKIPPED | — | — | — |
+| Data integrity | SKIPPED | — | — | — |
+| Badge audit | PASS | 0 | — | `make badge-audit` |
+
+**Overall: PASS** (with environment advisory below)
+
+\* `make test-integration` fails on default host ports **18000/18001** because another Docker stack (`vecinita-*`) already binds them. Integration was re-run on **18010/18011**; all **82** integration tests and **6** CORS/conversion smoke tests passed. CI on GitHub Actions is unaffected.
+
+## Auto-corrections applied
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `apps/e2e/playwright-e2e-helpers.ts` | Prettier format | `prettier --write` |
+
+Not committed (awaiting user commit request).
+
+## Connectivity (stage 08)
+
+| Artifact | Status |
+|----------|--------|
+| `tests/unit/test_cors_policy.py` | 6/6 passed |
+| `tests/integration/` | 6 passed, 6 skipped (no `LIVE_*` URLs) |
+| `tests/smoke/test_staging_connectivity.py` | Present (H4 live; skipped without env) |
+| `scripts/deploy/verify_connectivity.sh` | Present |
+| `apps/backend/src/api.py` `CORSMiddleware` | Configured |
+
+## Security detail
+
+- **pip-audit**: No known vulnerabilities on PyPI packages. Workspace packages (`gifts`, `metar-*`) skipped (local path deps).
+- **Secret scan**: Hits limited to test fixtures and archived scripts — no production secrets.
+- **Advisory**: `packages/gifts/gifts/common/tpg.py` uses `eval`/`exec` (upstream parser generator); pre-existing, not introduced by S001.
+
+## S001 delta scope (changed modules)
+
+| Area | Tests | Result |
+|------|-------|--------|
+| `FileConverter.tsx` / tests | vitest | pass |
+| `databaseUpload.ts` / tests | vitest | pass |
+| `conversion-parameters-mapping.workflow.test.tsx` | vitest | pass |
+| Full frontend suite | 422 passed | pass |
+
+## Template conformance (`static+api`)
+
+| Check | Result |
+|-------|--------|
+| `apps/backend/` API deployable | OK |
+| `apps/frontend/` static deployable | OK |
+| `packages/auth/` library (no separate service) | OK |
+| `packages/gifts/` conversion library | OK |
+| `vendor/schemas/*` read-only | OK |
+| `.github/workflows/ci-cd.yml` | OK |
+
+## Blockers / advisories
+
+1. **Local integration port conflict** — use `METAR_BACKEND_HOST_PORT` / `METAR_FRONTEND_HOST_PORT` when 18000/18001 are taken, or stop conflicting containers.
+2. **Uncommitted work** — S001 implementation and format fix remain on `feat/S001-convert-send-buttons`.
+
+## Next stage
+
+Per routing plan: **09-qa**.

--- a/docs/sessions/S001-convert-send-buttons/reports/verify-impl.md
+++ b/docs/sessions/S001-convert-send-buttons/reports/verify-impl.md
@@ -1,0 +1,127 @@
+# Implementation Verification — S001 / EV-001 (Stage 11)
+
+> Generated: 2026-06-22  
+> GitHub: [#656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656) — Add Convert and Convert&Send buttons to UI  
+> Branch: `feat/S001-convert-send-buttons`  
+> Session: S001-convert-send-buttons | Evolve cycle: EV-001 | Feature: F1 (delta)
+
+## Summary
+
+| Category | Status |
+|----------|--------|
+| Build verification (08) | **PASS** |
+| QA (09) | **pass_with_advisories** |
+| E2E (10) | **PASS** (T0 + T2) |
+| User journey signoff | **3 / 3 approved** |
+| Feature approval | **F1 delta approved** |
+| T3 live (Render) | **Deferred** — post-merge deploy |
+
+**Overall: APPROVED** — ready for commit, PR, and **12-verify-deploy** (when user routes there).
+
+---
+
+## Issue #656 acceptance
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| **Convert** button (conversion only) | ✓ Approved | `FileConverter.tsx` — aria-label `Convert METAR files to IWXXM XML` |
+| **Convert&Send** button (convert + send) | ✓ Approved | `handleConvertAndSend`, `CONVERT_AND_SEND_UPLOAD_OPTIONS` in `databaseUpload.ts` |
+| Send success/failure feedback | ✓ Approved | Toasts + inline send-failure status |
+| Retain Upload to Database (R2) | ✓ Approved | Dialog flow unchanged; three-button layout |
+| Unit tests | ✓ | `FileConverter.test.tsx`, `databaseUpload.test.ts` |
+| E2E one-click path | ✓ | `tac-file-upload-database.e2e.spec.ts` — "converted and sent with one click" |
+
+---
+
+## User signoff
+
+### Journeys (UJ-001)
+
+| Path | Decision | T0 | T2 | T3 |
+|------|----------|----|----|-----|
+| A — Convert only | **Approved** | — | ✓ 6/6 | Deferred |
+| B — Convert&Send one-click | **Approved** | ✓ 2/2 | ✓ | Deferred |
+| C — Upload to Database dialog | **Approved** | — | ✓ | Deferred |
+
+### Features
+
+| Feature | Decision |
+|---------|----------|
+| F1 — Convert & Convert&Send UI (#656) | **Approved** |
+
+---
+
+## Verification evidence
+
+### 08-verify-build
+
+- Lint, format, typecheck: PASS
+- Unit tests: 1009 Python + 422 Vitest PASS
+- H0c CORS: 6/6 PASS
+- H0i integration: 82/82 PASS
+- Template conformance: static+api PASS
+
+### 09-qa
+
+- Blocking checks: all green
+- Advisories: QA-010 (uncommitted), QA-011 (local port conflict), QA-012 (H4–H5 skipped), QA-013–015 (pre-existing / doc drift)
+
+### 10-e2e
+
+- T0 Vitest Convert&Send: 2/2 PASS
+- T2 Playwright UJ-001: 11/11 with golden fixtures
+- T3 Render live: NOT RUN (feature branch not deployed)
+
+---
+
+## Scope analysis
+
+| Metric | Count |
+|--------|-------|
+| Features in EV-001 scope | 1 (F1 delta) |
+| Features implemented | 1 |
+| Features with passing E2E (T0+T2) | 1 |
+| User-approved | 1 |
+| Scope creep | 0 — #555 siblings excluded per R3 |
+| Scope gaps | 0 |
+
+---
+
+## Open advisories (non-blocking)
+
+| ID | Item | Action |
+|----|------|--------|
+| QA-010 | Uncommitted S001 work on branch | User commit + PR before merge |
+| E2E-002 | T3 live Convert&Send not on Render | Run after merge + frontend redeploy |
+| QA-012 | H4–H5 not re-run this session | Run `make test-live-connectivity` at deploy signoff |
+| QA-015 | Context doc says Convert&Send not implemented | Update `docs/context/convert-send-buttons.md` status |
+
+---
+
+## Deploy gate (partial)
+
+- ✓ QA blocking checks green
+- ✓ E2E behaviors verified locally (T0 + T2)
+- ✓ Implementation verified by user
+- ○ Commit + PR pending (QA-010)
+- ○ T3 live verification pending post-deploy
+- ○ Deploy strategy — next: **12-verify-deploy**
+
+---
+
+## Artifacts
+
+| Report | Path |
+|--------|------|
+| Verification (08) | `docs/sessions/S001-convert-send-buttons/reports/verification-report.md` |
+| QA (09) | `docs/sessions/S001-convert-send-buttons/reports/qa-report.md` |
+| E2E (10) | `docs/sessions/S001-convert-send-buttons/reports/e2e-report.md` |
+| Verify-impl (11) | `docs/sessions/S001-convert-send-buttons/reports/verify-impl.md` |
+
+---
+
+## Next step
+
+1. Commit S001 changes on `feat/S001-convert-send-buttons`
+2. Open PR referencing #656
+3. Proceed to **12-verify-deploy** after merge approval (or user-directed hotfix path)

--- a/docs/sessions/S001-convert-send-buttons/routing-plan.md
+++ b/docs/sessions/S001-convert-send-buttons/routing-plan.md
@@ -1,0 +1,32 @@
+# Routing plan — S001-convert-send-buttons
+
+**Session type:** `feature`  
+**Orchestrator:** [16-evolve](../../.cursor/skills/16-evolve/SKILL.md)  
+**Proposed branch:** `feat/S001-convert-send-buttons`
+
+| Stage | Required | Mode | Skip rationale |
+|-------|----------|------|----------------|
+| 00-context | yes | scoped | This session — `docs/context/convert-send-buttons.md` |
+| 16-evolve | yes | delta | Register UI capability; update feature-list / user-journey / test-plan deltas |
+| 07-build | yes | full | Implement Convert&Send in `FileConverter` + shared upload helper |
+| 08-verify-build | yes | full | Lint, typecheck, unit tests |
+| 09-qa | yes | full | Manual QA checklist for dual-button workflow |
+| 10-e2e | yes | delta | Extend Playwright upload/convert specs |
+| 11-verify-impl | yes | full | Implementation verification vs evolve artifact |
+| 01-requirements | skip | — | Standing requirements exist; delta via 16-evolve |
+| 02-verify-plan | skip | — | No product-plan change beyond evolve delta |
+| 03-plan-tooling | skip | — | No new tooling |
+| 04-tech-plan | skip | — | No new architecture; frontend-only |
+| 05-verify-tech | skip | — | N/A for UI-only delta |
+| 06-tech-tooling | skip | — | N/A |
+| 12-verify-deploy | skip | — | Defer until PR merge / user requests deploy verify |
+| 13-deploy-smoke | skip | — | Defer until deploy |
+
+## Approved
+
+User approval recorded: 2026-06-22
+
+- Routing: approved as proposed
+- R1: fixed upload defaults, one-click send
+- R2: keep Convert + Convert&Send + Upload to Database
+- R3: #656 scope only

--- a/docs/sessions/S001-convert-send-buttons/session-brief.md
+++ b/docs/sessions/S001-convert-send-buttons/session-brief.md
@@ -1,0 +1,60 @@
+---
+session_id: S001-convert-send-buttons
+type: feature
+status: in_progress
+branch: feat/S001-convert-send-buttons
+started_at: 2026-06-22
+intent: "Add Convert and Convert&Send buttons to the converter UI (GitHub #656)"
+orchestrator: 16-evolve
+evolve_cycle_id: null
+context_briefs:
+  - docs/context/convert-send-buttons.md
+standing_docs_touched: []
+github_issue: https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656
+---
+
+# Session S001 — convert-send-buttons
+
+## Intent
+
+Implement clearer convert vs convert-and-send workflow in the main converter UI per
+[GitHub issue #656](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/656),
+following initial user feedback in [issue #555](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/555).
+
+## Scope
+
+**In scope (issue #656)**
+
+- Explicit **Convert** action (conversion only).
+- **Convert&Send** action (convert then immediately upload/send output).
+- Success/failure feedback for the send step (partially exists via upload dialog toasts).
+
+**Likely out of scope (issue #555 siblings — confirm via routing/decisions)**
+
+- Auto-clear / overwrite previous METAR input panel without manual close.
+- In-app error log preview.
+
+**Constraints**
+
+- Maps to **F1** (conversion UI) + existing Supabase database upload path.
+- No backend API changes expected unless evolve adds upload defaults endpoint.
+- Monorepo targets: `apps/frontend/`, `apps/e2e/`.
+
+## Current state (discovery)
+
+| Capability | Status | Location |
+|------------|--------|----------|
+| Convert button | **Exists** | `apps/frontend/src/app/components/FileConverter.tsx` |
+| Upload to Database (manual 2-step) | **Exists** | `FileConverter.tsx` → `DatabaseUploadDialog.tsx` |
+| Convert&Send (one-click) | **Missing** | — |
+| Upload API | **Exists** | Supabase `POST .../database/upload` |
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).
+
+## Links
+
+- Scoped context: [convert-send-buttons.md](../../context/convert-send-buttons.md)
+- Standing: [feature-list.md](../../feature-list.md), [user-journeys.md](../../user-journeys.md), [test-plan.md](../../test-plan.md)
+- Parent feedback: GitHub #555

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -34,7 +34,7 @@ Unified manual live test harness against Render staging:
 
 | Journey | Feature | Local E2E module | Live E2E | Test plan TC |
 |---------|---------|------------------|----------|--------------|
-| UJ-001 | F1 | `apps/e2e/tac-file-conversion.e2e.spec.ts` | `make test-live-e2e` (H6) | TC-001, TC-LIVE-001 |
+| UJ-001 | F1 | `apps/e2e/tac-file-conversion.e2e.spec.ts`, `apps/e2e/tac-file-upload-database.e2e.spec.ts` (Convert&Send one-click) | `make test-live-e2e` (H6) | TC-001, TC-LIVE-001 |
 | UJ-002 | F2 | backend validation tests + UI if exposed | H3 validate + H6 where exposed | TC-002, TC-LIVE-002 |
 | UJ-003 | F1 | `apps/e2e/auth.e2e.spec.ts` | `make test-live-e2e` (H6) | TC-003, TC-LIVE-003 |
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -52,8 +52,11 @@ Run live E2E: `make test-live` (requires `.env` with `ADMIN_EMAIL` / `ADMIN_PASS
 1. Open frontend in browser.
 2. Log in (UJ-003).
 3. Drag-drop `.tac` file or paste manual text.
-4. Submit conversion.
-5. View, copy, or download IWXXM result.
+4. Choose an action:
+   - **Convert** — conversion only; view, copy, or download IWXXM result.
+   - **Convert&Send** — conversion then immediate upload to primary database (IWXXM format, fixed defaults).
+   - **Upload to Database** — upload already-converted files with format/destination options (dialog).
+5. View conversion output; for send actions, confirm success/failure via toast.
 
 **Acceptance**: At least one METAR converts without error; output passes schema/Schematron validation for the selected IWXXM version.
 

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -336,15 +336,15 @@ stages:
 
   18-pr-review:
     status: completed
-    started: "2026-06-21"
+    started: "2026-06-22"
     completed: "2026-06-22"
-    last_cycle: PRR-002
+    last_cycle: PRR-003
 
   19-address-pr-review:
     status: completed
     started: "2026-06-22"
     completed: "2026-06-22"
-    last_cycle: PRM-002
+    last_cycle: PRM-003
 
 stages_pending: []
 
@@ -911,6 +911,34 @@ pr_review_cycles:
         note: checklist source
     gh_review_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/681#pullrequestreview-4540604664
 
+  - id: PRR-003
+    pr_number: 683
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/683
+    title: "feat(ui): Add Convert and Convert&Send buttons (#656)"
+    status: completed
+    started: "2026-06-22"
+    completed: "2026-06-22"
+    head_ref: feat/S001-convert-send-buttons
+    base_ref: main
+    verdict: APPROVE
+    blockers: 0
+    advisories: 3
+    praise: 4
+    ci_status: success
+    session_id: S001-convert-send-buttons
+    subagents:
+      bugbot: failed_diff
+      security_review: failed_diff
+    artifacts:
+      - path: docs/sessions/S001-convert-send-buttons/reports/pr-review.md
+        note: session report
+      - path: .cursor/skills/18-pr-review/checklist.md
+        note: checklist source
+    gh_review_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/683#pullrequestreview-4548622093
+    linked_issue: 656
+    notes:
+      - "Self-approval blocked by GitHub; posted COMMENT with APPROVE recommendation"
+
 pr_remediation_cycles:
   - id: PRM-001
     pr_number: 679
@@ -1091,5 +1119,78 @@ pr_remediation_cycles:
         status: fixed
         commit: 7b9f5a9
         note: named migrator before patch
+    follow_up:
+      pr_review_rerun: offered
+
+  - id: PRM-003
+    pr_number: 683
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/683
+    linked_review_cycle_id: PRR-003
+    title: "feat(ui): Add Convert and Convert&Send buttons (#656)"
+    status: completed
+    started: "2026-06-22"
+    completed: "2026-06-22"
+    head_ref: feat/S001-convert-send-buttons
+    base_ref: main
+    ci_status: success
+    counts:
+      fixed: 6
+      deferred: 0
+      wont_fix: 0
+    findings:
+      - id: F-001
+        source: inline
+        severity: advisory
+        path: apps/frontend/src/app/components/FileConverter.tsx
+        line: 821
+        thread_id: PRRT_kwDOQW-3CM6LaWYM
+        status: fixed
+        commit: fa6d5c5
+        note: derived isBusy/hasInput/hasConverted flags
+      - id: F-002
+        source: inline
+        severity: advisory
+        path: apps/frontend/src/app/components/FileConverter.tsx
+        line: 352
+        thread_id: PRRT_kwDOQW-3CM6Lap-T
+        status: fixed
+        commit: fa6d5c5
+        note: send_error status heading
+      - id: F-003
+        source: inline
+        severity: advisory
+        path: docs/context/convert-send-buttons.md
+        line: 8
+        thread_id: PRRT_kwDOQW-3CM6Lap_V
+        status: fixed
+        commit: 22741dd
+        note: executive summary delivered state
+      - id: F-004
+        source: review_body
+        severity: advisory
+        path: apps/frontend/src/app/components/FileConverter.tsx
+        line: null
+        thread_id: null
+        status: fixed
+        commit: 22741dd
+        note: data-testid convert button locators
+      - id: F-005
+        source: review_body
+        severity: advisory
+        path: apps/frontend/src/utils/databaseUpload.ts
+        line: null
+        thread_id: null
+        status: fixed
+        commit: a47eaf4
+        note: edgeFunctionUrl + hardened error parsing
+      - id: F-006
+        source: inline
+        severity: advisory
+        path: apps/frontend/src/app/components/DatabaseUploadDialog.test.tsx
+        line: null
+        thread_id: null
+        status: fixed
+        commit: 8f7545d
+        note: CI mock parity after upload client change
     follow_up:
       pr_review_rerun: offered

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -4,8 +4,51 @@ project:
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 0
-active_session: null
+session_counter: 1
+active_session:
+  id: S001-convert-send-buttons
+  type: feature
+  intent: "Add Convert and Convert&Send buttons to the converter UI (GitHub #656)"
+  status: completed
+  branch: feat/S001-convert-send-buttons
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-001
+  artifacts_dir: docs/sessions/S001-convert-send-buttons/
+  routing_plan:
+    - stage: 00-context
+      mode: scoped
+      required: true
+      status: completed
+      skip_rationale: null
+    - stage: 16-evolve
+      required: true
+      status: completed
+      skip_rationale: null
+    - stage: 07-build
+      required: true
+      status: completed
+      skip_rationale: null
+    - stage: 08-verify-build
+      required: true
+      status: completed
+      skip_rationale: null
+    - stage: 09-qa
+      required: true
+      status: completed
+      skip_rationale: null
+    - stage: 10-e2e
+      required: true
+      mode: delta
+      status: completed
+      skip_rationale: null
+    - stage: 11-verify-impl
+      required: true
+      status: completed
+      skip_rationale: null
+  current_stage: 11-verify-impl
+  started_at: "2026-06-22"
+  context_briefs:
+    - docs/context/convert-send-buttons.md
 sessions: []
 
 template:
@@ -14,6 +57,26 @@ template:
   confirmed_at: "2026-06-14"
 
 stages:
+  00-context:
+    status: completed
+    mode: scoped
+    scoped_slug: convert-send-buttons
+    started_at: "2026-06-22T00:00:00Z"
+    completed_at: "2026-06-22T00:00:00Z"
+    substeps:
+      phase0_session: completed
+      phase1a: completed
+      phase1b: skipped
+      phase1c: skipped
+      phase2: completed
+      phase3: completed
+      phase4: completed
+    artifacts:
+      - docs/context/convert-send-buttons.md
+      - docs/sessions/S001-convert-send-buttons/session-brief.md
+      - docs/sessions/S001-convert-send-buttons/routing-plan.md
+    notes:
+      - "GitHub #656; parent feedback #555; session S001 opened"
   01-requirements:
     status: completed
     started_at: "2026-06-14T00:00:00Z"
@@ -190,9 +253,10 @@ stages:
     overall: fail
 
   11-verify-impl:
-    status: in_progress
-    started_at: "2026-06-20T23:59:00Z"
-    completed_at: null
+    status: completed
+    started_at: "2026-06-22T22:00:00Z"
+    completed_at: "2026-06-22T22:30:00Z"
+    session_id: S001-convert-send-buttons
     substeps:
       collect_results:
         status: completed
@@ -200,28 +264,25 @@ stages:
         status: completed
       journey_signoff:
         status: completed
-        approved: 2
-        flagged: 5
-        total: 7
+        approved: 3
+        flagged: 0
+        total: 3
       feature_approval:
         status: completed
-        approved: 4
-        flagged: 6
-        total: 10
+        approved: 1
+        flagged: 0
+        total: 1
       fixes_applied:
         status: completed
-        notes: "E2E-001 schema path, QA-004 msgpack, QA-002 legacy dirs, F3 UI, E2E-003 skip condition"
-      deploy_staging:
-        status: blocked
-        notes: "Render MCP requires workspace selection; push + redeploy pending user"
+        notes: "None required — user approved as-is"
       scope_analysis:
         status: completed
       summary:
         status: completed
-    report: docs/implementation-verification.md
+    report: docs/sessions/S001-convert-send-buttons/reports/verify-impl.md
     notes:
-      - "User flagged UJ-001/002/003/DEV-001/OPS-001; approved UJ-DEV-002/003"
-      - "Fixes applied locally; staging auth redeploy blocked on Render workspace"
+      - "S001 / EV-001 / GitHub #656 — user approved UJ-001 paths A/B/C and F1 delta"
+      - "T3 live deferred; QA-010 uncommitted work remains"
 
   10-e2e:
     status: completed
@@ -250,10 +311,10 @@ stages:
 
   08-verify-build:
     status: completed
-    started_at: "2026-06-20T00:00:00Z"
-    completed_at: "2026-06-20T23:59:00Z"
-    overall: fail
-    report: docs/verification-report.md
+    started_at: "2026-06-22T17:27:00Z"
+    completed_at: "2026-06-22T17:52:00Z"
+    overall: pass
+    report: docs/sessions/S001-convert-send-buttons/reports/verification-report.md
     substeps:
       lint:
         status: completed
@@ -268,8 +329,10 @@ stages:
       report:
         status: completed
     notes:
-      - "Overall FAIL — blocking: format (291 files), typecheck (313+ errors), pydantic-settings CVE, Makefile lint-frontend points to removed frontend/"
-      - "H0c + H0i tests pass; migration gates pass on main; make test-unit green"
+      - "S001 / EV-001 / GitHub #656 — overall PASS on feat/S001-convert-send-buttons"
+      - "Auto-fixed Prettier on apps/e2e/playwright-e2e-helpers.ts (uncommitted)"
+      - "make test-integration blocked on default ports 18000/18001 (vecinita stack); 82+6 tests pass on alternate ports"
+      - "H0c CORS 6/6 pass; connectivity artifacts present"
 
   18-pr-review:
     status: completed
@@ -560,9 +623,139 @@ artifacts:
   - path: docs/qa-report.md
     stage: 09-qa
     status: complete
+  - path: docs/context/convert-send-buttons.md
+    kind: context-scoped
+    slug: convert-send-buttons
+    topic: "Convert & Convert&Send UI (GitHub #656)"
+    session_id: S001-convert-send-buttons
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/evolve-decisions.md
+    kind: evolve-decisions
+    session_id: S001-convert-send-buttons
+    evolve_cycle_id: EV-001
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/sessions/S001-convert-send-buttons/reports/evolve-summary.md
+    kind: evolve-summary
+    session_id: S001-convert-send-buttons
+    evolve_cycle_id: EV-001
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/sessions/S001-convert-send-buttons/reports/verification-report.md
+    kind: verification-report
+    session_id: S001-convert-send-buttons
+    stage: 08-verify-build
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/sessions/S001-convert-send-buttons/reports/qa-report.md
+    kind: qa-report
+    session_id: S001-convert-send-buttons
+    stage: 09-qa
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/sessions/S001-convert-send-buttons/reports/e2e-report.md
+    kind: e2e-report
+    session_id: S001-convert-send-buttons
+    stage: 10-e2e
+    created_at: "2026-06-22"
+    status: active
+  - path: docs/sessions/S001-convert-send-buttons/reports/verify-impl.md
+    kind: verify-impl-report
+    session_id: S001-convert-send-buttons
+    stage: 11-verify-impl
+    created_at: "2026-06-22"
+    status: active
+
+evolve_cycles:
+  - id: EV-001
+    session_id: S001-convert-send-buttons
+    cycle_type: feature
+    feature_ids: [F1]
+    title: "Add Convert and Convert&Send buttons to UI"
+    status: completed
+    started: "2026-06-22"
+    completed: "2026-06-22"
+    scope_summary: |
+      GitHub #656 — explicit Convert (conversion only) and Convert&Send (convert + immediate
+      database upload with fixed defaults). Retain Upload to Database dialog. Exclude #555 siblings.
+    routing_plan:
+      required_stages:
+        - 16-evolve
+        - 07-build
+        - 08-verify-build
+        - 09-qa
+        - 10-e2e
+        - 11-verify-impl
+      skipped_stages:
+        - 01-requirements
+        - 02-verify-plan
+        - 03-plan-tooling
+        - 04-tech-plan
+        - 05-verify-tech
+        - 06-tech-tooling
+        - 12-verify-deploy
+        - 13-deploy-smoke
+    current_stage: 12-verify-deploy
+    stages:
+      16-evolve:
+        status: completed
+        started: "2026-06-22"
+        completed: "2026-06-22"
+        artifacts_updated:
+          - docs/evolve-decisions.md
+          - docs/feature-list.md
+          - docs/user-journeys.md
+          - docs/test-plan.md
+      07-build:
+        status: completed
+        started: "2026-06-22"
+        completed: "2026-06-22"
+      08-verify-build:
+        status: completed
+        started: "2026-06-22"
+        completed: "2026-06-22"
+        report: docs/sessions/S001-convert-send-buttons/reports/verification-report.md
+      09-qa:
+        status: completed
+        started: "2026-06-22T18:00:00Z"
+        completed: "2026-06-22T18:12:00Z"
+        report: docs/sessions/S001-convert-send-buttons/reports/qa-report.md
+        overall: pass_with_advisories
+      10-e2e:
+        status: completed
+        started: "2026-06-22T21:18:00Z"
+        completed: "2026-06-22T21:21:00Z"
+        report: docs/sessions/S001-convert-send-buttons/reports/e2e-report.md
+        overall: pass
+        notes: "S001 delta UJ-001 — T0 2/2 Vitest; T2 Playwright 11/11 with golden fixtures; T3 deferred pre-deploy"
+      11-verify-impl:
+        status: completed
+        started: "2026-06-22T22:00:00Z"
+        completed: "2026-06-22T22:30:00Z"
+        report: docs/sessions/S001-convert-send-buttons/reports/verify-impl.md
+        overall: approved
+        notes: "User approved UJ-001 paths A/B/C and F1 delta; T3 deferred"
+    gates:
+      a_to_b: passed
+      b_to_c: passed
+      c_to_d: passed
+      deploy: pending
+    checkpoints:
+      phase_a: passed
+      phase_b: passed
+      phase_c: passed
+      phase_d: pending
+      deploy: pending
+    artifacts:
+      - path: docs/evolve-decisions.md
+        status: completed
+      - path: docs/sessions/S001-convert-send-buttons/reports/evolve-summary.md
+        status: completed
+    issues: []
 
 git_history:
-  current_branch: feat/M11-big-bang-finalize
+  current_branch: feat/S001-convert-send-buttons
   branches:
     - name: phase/1-monorepo-scaffold
       base: main


### PR DESCRIPTION
## Summary

- Adds **Convert&Send** button to the converter UI — one-click convert then upload to primary database with fixed defaults (`iwxxm` / `primary` / no original)
- Extracts shared `databaseUpload.ts` client used by Convert&Send and the existing Upload to Database dialog
- Retains all three actions per evolve decision R2: **Convert** | **Convert&Send** | **Upload to Database**
- Adds success/failure toast and inline send-failure feedback for the send step

Closes #656

## Spec references

- EV-001 evolve cycle / session S001
- `docs/evolve-decisions.md` — R1–R3
- `docs/user-journeys.md` — UJ-001 steps updated
- `docs/feature-list.md` — F1 UI actions

## Test plan

- [x] `make lint` / `make format-check` / `make typecheck` — pass
- [x] Vitest S001 delta — 76/76 pass (`FileConverter.test.tsx`, `databaseUpload.test.ts`, workflow test)
- [x] Playwright UJ-001 — Convert only (6/6), Convert&Send one-click, Upload dialog (11/11 with golden fixtures)
- [x] Stage 11 verify-impl — user approved UJ-001 paths A/B/C and F1 delta
- [ ] T3 live Convert&Send on Render — run after merge + frontend redeploy (`make test-live-e2e`)


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add a one-click Convert&Send flow to the METAR converter UI and document/verify the new dual convert/send behavior within the evolve workflow.

New Features:
- Introduce a Convert&Send button that chains TAC-to-IWXXM conversion with an immediate upload to the primary database using fixed defaults.
- Expose a shared database upload client utility for frontend components to send converted files to the Supabase-backed database.

Enhancements:
- Refine converter action button states and accessibility labels to distinguish Convert-only from Convert&Send behavior and coordinate loading/disabled states across actions.
- Centralize database upload logic in a reusable helper and update the Upload to Database dialog to consume it.
- Capture the new UI behavior and evolve decisions in project workflow metadata, including evolve cycles, session records, and routing plans.

CI:
- Record new QA, build verification, E2E, and implementation verification reports in the workflow-state and session artifacts to reflect the completed EV-001 evolve cycle.

Documentation:
- Update feature, user-journey, and test-plan documentation to describe the Convert, Convert&Send, and Upload to Database actions and their test coverage.
- Add evolve-cycle, session, and context documents summarizing the scope, decisions, and verification for the Convert&Send UI feature.

Tests:
- Extend unit tests for the FileConverter component and new database upload utility to cover Convert&Send flows, auth handling, and error paths.
- Expand Playwright E2E coverage to exercise one-click Convert&Send, existing upload dialog behavior, and ensure selectors remain stable with the new button.