### PR TITLE
[M1] Workspace scaffold + iwxxm-us pin

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,7 +70,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [shared, backend, auth, gifts, frontend, integration, bugs]
+        package:
+          [
+            shared,
+            backend,
+            auth,
+            gifts,
+            frontend,
+            tac2iwxxm,
+            iwxxm-validate,
+            tac-validate,
+            integration,
+            bugs,
+          ]
 
     steps:
       - uses: actions/checkout@v5
@@ -147,6 +159,27 @@ jobs:
             --cov=gifts --cov=validation --cov-config=pyproject.toml --cov-branch \
             --cov-report=xml:coverage.xml --cov-report=term-missing \
             --cov-fail-under=98 -v
+
+      - name: Run tac2iwxxm unit tests with coverage
+        if: matrix.package == 'tac2iwxxm'
+        run: |
+          uv run pytest packages/tac2iwxxm/tests --cov=tac2iwxxm \
+            --cov-config=packages/tac2iwxxm/pyproject.toml --cov-branch \
+            --cov-report=term-missing --cov-fail-under=95 -v
+
+      - name: Run iwxxm-validate unit tests with coverage
+        if: matrix.package == 'iwxxm-validate'
+        run: |
+          uv run pytest packages/iwxxm-validate/tests --cov=iwxxm_validate \
+            --cov-config=packages/iwxxm-validate/pyproject.toml --cov-branch \
+            --cov-report=term-missing --cov-fail-under=95 -v
+
+      - name: Run tac-validate unit tests with coverage
+        if: matrix.package == 'tac-validate'
+        run: |
+          uv run pytest packages/tac-validate/tests --cov=tac_validate \
+            --cov-config=packages/tac-validate/pyproject.toml --cov-branch \
+            --cov-report=term-missing --cov-fail-under=95 -v
 
       - name: Run frontend tests with coverage
         if: matrix.package == 'frontend'

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,18 @@ PY_LINT := apps/backend/src apps/backend/tests \
 	packages/auth/src packages/auth/tests \
 	packages/gifts/gifts packages/gifts/tests \
 	packages/shared packages/shared/tests \
+	packages/tac2iwxxm/src packages/tac2iwxxm/tests \
+	packages/iwxxm-validate/src packages/iwxxm-validate/tests \
+	packages/tac-validate/src packages/tac-validate/tests \
 	tests
 
 .PHONY: install test test-unit vendor-sync \
 	test-unit-workspace test-unit-workspace-py test-unit-shared-py test-unit-shared-js test-unit-workspace-js \
-	test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts test-bugs \
+	test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
+	test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate test-bugs \
 	format format-check typecheck typecheck-py typecheck-js \
 	lint lint-py lint-js lint-backend lint-auth lint-frontend lint-gifts lint-shared \
+	lint-tac2iwxxm lint-iwxxm-validate lint-tac-validate \
 	lint-fix lint-fix-py lint-fix-backend lint-fix-auth lint-fix-frontend lint-fix-gifts \
 	dev dev-kill dev-servers dev-servers-kill \
 	test-e2e-playwright test-e2e-playwright-smoke test-e2e-t2-product \
@@ -54,6 +59,9 @@ typecheck: typecheck-py typecheck-js
 
 typecheck-py:
 	$(UV) run basedpyright packages/shared/src
+	$(UV) run basedpyright packages/tac2iwxxm/src
+	$(UV) run basedpyright packages/iwxxm-validate/src
+	$(UV) run basedpyright packages/tac-validate/src
 	cd packages/auth && $(UV) run basedpyright
 	cd apps/backend && $(UV) run basedpyright
 
@@ -81,6 +89,15 @@ lint-gifts:
 
 lint-shared:
 	$(UV) run ruff check packages/shared packages/shared/tests
+
+lint-tac2iwxxm:
+	$(UV) run ruff check packages/tac2iwxxm/src packages/tac2iwxxm/tests
+
+lint-iwxxm-validate:
+	$(UV) run ruff check packages/iwxxm-validate/src packages/iwxxm-validate/tests
+
+lint-tac-validate:
+	$(UV) run ruff check packages/tac-validate/src packages/tac-validate/tests
 
 lint-frontend:
 	$(PNPM) --filter @metar/frontend run lint
@@ -140,10 +157,26 @@ test-unit-gifts:
 		--cov-report=xml:coverage.xml --cov-report=term-missing \
 		--cov-fail-under=98 -v
 
+test-unit-tac2iwxxm:
+	$(UV) run pytest packages/tac2iwxxm/tests --cov=tac2iwxxm \
+		--cov-config=packages/tac2iwxxm/pyproject.toml --cov-branch \
+		--cov-report=term-missing --cov-fail-under=95 -v
+
+test-unit-iwxxm-validate:
+	$(UV) run pytest packages/iwxxm-validate/tests --cov=iwxxm_validate \
+		--cov-config=packages/iwxxm-validate/pyproject.toml --cov-branch \
+		--cov-report=term-missing --cov-fail-under=95 -v
+
+test-unit-tac-validate:
+	$(UV) run pytest packages/tac-validate/tests --cov=tac_validate \
+		--cov-config=packages/tac-validate/pyproject.toml --cov-branch \
+		--cov-report=term-missing --cov-fail-under=95 -v
+
 test-bugs:
 	$(UV) run pytest tests/bugs -m "not live and not live_api" --no-cov -v
 
-test-unit: test-unit-workspace test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts test-bugs
+test-unit: test-unit-workspace test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
+	test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate test-bugs
 
 test: test-unit
 
@@ -351,6 +384,7 @@ supabase-pull:
 
 validate-ci: validate-fast config-guard env-check audit-frontend
 
-ci: format-check typecheck lint test-unit-workspace test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts test-bugs test-integration badge-audit
+ci: format-check typecheck lint test-unit-workspace test-unit-backend test-unit-auth test-unit-frontend test-unit-gifts \
+	test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate test-bugs test-integration badge-audit
 
 acci: ci test-e2e-playwright-smoke audit-frontend

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -26,7 +26,7 @@
 | Package | Purpose | License | Source |
 |---------|---------|---------|--------|
 | lxml | XML encode/validate support | BSD | PyPI |
-| IR library | Versioned IR models | Apache-2.0 | **msgspec** (ADR-016) |
+| IR library | Versioned IR models | Apache-2.0 | **msgspec** (ADR-016); reuse module-level `msgspec.json.Encoder` / `Decoder` on hot paths (`tac2iwxxm.codec`) |
 | PyO3 / maturin / rustc | Native hotspots | Apache-2.0 / MIT (typical) | **Required before cutover** (ADR-017) |
 
 Package license: **MIT**. No FastAPI/Supabase imports.
@@ -35,7 +35,7 @@ Package license: **MIT**. No FastAPI/Supabase imports.
 
 | Package | Purpose | License | Source |
 |---------|---------|---------|--------|
-| msgspec | Structured issue / fix models | Apache-2.0 | **Required** (ADR-016); pydantic only at HTTP |
+| msgspec | Structured issue / fix models | Apache-2.0 | **Required** (ADR-016); reuse `tac_validate.codec` Encoder/Decoder; pydantic only at HTTP |
 
 Package license: **MIT**. Stdlib-first preferred; no FastAPI/Supabase. No Schematron.
 
@@ -134,4 +134,5 @@ New dependencies require `[Decision]` + back-add to this file per plan-adherence
   may use pydantic/msgspec (04)
 - S008 04 (2026-07-12): msgspec required; PyO3 cutover gate; F8 worker deps (ADR-016–018)
 - S008 05 (2026-07-12): iwxxm-us = NWS HTTP 3.0 + URL/hash; cargo/maturin required; F8 deployable
+- S008 M1 (2026-07-12): msgspec added to tac2iwxxm + tac-validate with shared Encoder/Decoder modules; iwxxm-us vendored from NWS `3.0` tarball pin
   (D-S008-05-batch1)

--- a/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
+++ b/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
@@ -235,7 +235,7 @@ F6.b METAR/SPECI US already shipped in M4.
 
 | PR | Type | Milestone | Branch | Target | Status |
 |----|------|-----------|--------|--------|--------|
-| PR-M1 | Minor | M1 | feat/S008-M1-scaffold | evolve/S008-… | open |
+| PR-M1 | Minor | M1 | feat/S008-M1-scaffold | evolve/S008-… | open — https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/700 |
 | PR-M2 | Minor | M2 | feat/S008-M2-validate | evolve/S008-… | pending |
 | PR-M3 | Minor | M3 | feat/S008-M3-bulletin | evolve/S008-… | pending |
 | PR-M4 | Minor | M4 cutover | feat/S008-M4-cutover | evolve/S008-… | pending |

--- a/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
+++ b/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
@@ -14,11 +14,11 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase 1: Package Scaffold (pending approval) |
-| **Active milestone** | M1: Workspace members |
-| **Active task** | T1.1 |
-| **Tasks completed** | 0 / 51 |
-| **Last updated** | 2026-07-12 (05-verify-tech Batch 2) |
+| **Active phase** | Phase 1: Package Scaffold & Vendor Pin |
+| **Active milestone** | M1: Workspace + iwxxm-us |
+| **Active task** | T1.6 (completing) |
+| **Tasks completed** | 6 / 51 |
+| **Last updated** | 2026-07-12 (07-build EV-006; M1 T1.1–T1.6) |
 
 ## Tech Stack Summary (S008 delta)
 
@@ -81,12 +81,12 @@
 
 | # | Task | Type | Status | Spec Source | Depends On |
 |---|------|------|--------|-------------|------------|
-| T1.1 | Test: empty package import smoke for three names | Test | pending | TC-F6-M001 | — |
-| T1.2 | Config: scaffold `packages/{tac2iwxxm,iwxxm-validate,tac-validate}` (`src/` + pyproject MIT) | Config | pending | ADR-016, Q1 | T1.1 |
-| T1.3 | Config: add uv members, Makefile `lint`/`test-unit-*`, `ci-cd.yml` matrix | Config | pending | M5, ADR-007 | T1.2 |
-| T1.4 | Config: add `msgspec` to tac2iwxxm + tac-validate; document Encoder reuse | Config | pending | ADR-016, Q2 | T1.2 |
-| T1.5 | Config: pin `vendor/schemas/iwxxm-us` from NWS HTTP `3.0` + manifest URL/hash + integrity test | Config | pending | Q13=A, C07, UJ-DEV-003b | — |
-| T1.6 | Docs: dependency-inventory IR = msgspec; PyO3 required note | Docs | pending | ADR-016/017 | T1.4 |
+| T1.1 | Test: empty package import smoke for three names | Test | completed | TC-F6-M001 | — |
+| T1.2 | Config: scaffold `packages/{tac2iwxxm,iwxxm-validate,tac-validate}` (`src/` + pyproject MIT) | Config | completed | ADR-016, Q1 | T1.1 |
+| T1.3 | Config: add uv members, Makefile `lint`/`test-unit-*`, `ci-cd.yml` matrix | Config | completed | M5, ADR-007 | T1.2 |
+| T1.4 | Config: add `msgspec` to tac2iwxxm + tac-validate; document Encoder reuse | Config | completed | ADR-016, Q2 | T1.2 |
+| T1.5 | Config: pin `vendor/schemas/iwxxm-us` from NWS HTTP `3.0` + manifest URL/hash + integrity test | Config | completed | Q13=A, C07, UJ-DEV-003b | — |
+| T1.6 | Docs: dependency-inventory IR = msgspec; PyO3 required note | Docs | completed | ADR-016/017 | T1.4 |
 
 **Phase 1 gate**: T1.1–T1.6 green; no gifts deletion yet.
 

--- a/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
+++ b/docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
@@ -235,7 +235,7 @@ F6.b METAR/SPECI US already shipped in M4.
 
 | PR | Type | Milestone | Branch | Target | Status |
 |----|------|-----------|--------|--------|--------|
-| PR-M1 | Minor | M1 | feat/S008-M1-scaffold | evolve/S008-… | pending |
+| PR-M1 | Minor | M1 | feat/S008-M1-scaffold | evolve/S008-… | open |
 | PR-M2 | Minor | M2 | feat/S008-M2-validate | evolve/S008-… | pending |
 | PR-M3 | Minor | M3 | feat/S008-M3-bulletin | evolve/S008-… | pending |
 | PR-M4 | Minor | M4 cutover | feat/S008-M4-cutover | evolve/S008-… | pending |
@@ -262,7 +262,7 @@ F6.b METAR/SPECI US already shipped in M4.
 
 | Phase | Result | Date | Notes |
 |-------|--------|------|-------|
-| — | — | — | Populated during 07-build |
+| 1 | pass | 2026-07-12 | T1.1–T1.6 green; 08-verify-build M1 pass; gifts intact |
 
 ## Connectivity Checklist (04 handoff)
 

--- a/docs/sessions/S008-general-tac-iwxxm-converter/reports/verification-report.md
+++ b/docs/sessions/S008-general-tac-iwxxm-converter/reports/verification-report.md
@@ -1,0 +1,29 @@
+# Verification Report — S008 M1
+
+> **Session**: S008-general-tac-iwxxm-converter  
+> **Cycle**: EV-006  
+> **Milestone**: M1 Workspace + iwxxm-us  
+> **Branch**: `feat/S008-M1-scaffold`  
+> **Date**: 2026-07-12  
+> **Skill**: 08-verify-build (delta)
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| `make format-check` | pass |
+| `make lint-py` | pass |
+| `make typecheck-py` | pass |
+| M1 + shared + CORS tests (90) | pass |
+| H0c `tests/unit/test_cors_policy.py` | pass |
+
+## Scope verified
+
+- `packages/{tac2iwxxm,iwxxm-validate,tac-validate}` import smoke
+- msgspec codec modules
+- `vendor/schemas/iwxxm-us` + manifest integrity (incl. HTTP pin)
+- uv workspace / Makefile / CI matrix wiring
+
+## Phase 1 gate
+
+T1.1–T1.6 completed; gifts not deleted (as planned). Ready for PR-M1 → `evolve/S008-general-tac-iwxxm-converter`.

--- a/packages/iwxxm-validate/README.md
+++ b/packages/iwxxm-validate/README.md
@@ -1,0 +1,5 @@
+# iwxxm-validate
+
+IWXXM XSD + Schematron validation engine. MIT licensed.
+
+See ADR-015 / ADR-016. Consumes `vendor/schemas/*` read-only.

--- a/packages/iwxxm-validate/pyproject.toml
+++ b/packages/iwxxm-validate/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "iwxxm-validate"
+version = "0.1.0"
+description = "IWXXM XSD + Schematron validation engine (F2)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/iwxxm_validate"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/iwxxm_validate"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = ["E501"]

--- a/packages/iwxxm-validate/src/iwxxm_validate/__init__.py
+++ b/packages/iwxxm-validate/src/iwxxm_validate/__init__.py
@@ -1,0 +1,3 @@
+"""IWXXM XSD + Schematron validation engine (F2 package)."""
+
+__version__ = "0.1.0"

--- a/packages/iwxxm-validate/tests/test_iwxxm_validate_import.py
+++ b/packages/iwxxm-validate/tests/test_iwxxm_validate_import.py
@@ -1,0 +1,9 @@
+"""Package import smoke for iwxxm-validate (T1.1 / TC-F6-M001)."""
+
+from __future__ import annotations
+
+import iwxxm_validate
+
+
+def test_package_version_is_set() -> None:
+    assert iwxxm_validate.__version__

--- a/packages/shared/src/metar_shared/vendor_manifest.py
+++ b/packages/shared/src/metar_shared/vendor_manifest.py
@@ -1,4 +1,4 @@
-"""Vendor manifest schema and integrity checks for wmo-im schema snapshots (TC-M002)."""
+"""Vendor manifest schema and integrity checks for schema snapshots (TC-M002 / TC-F6-M001)."""
 
 from __future__ import annotations
 
@@ -11,17 +11,30 @@ from typing import Any, cast
 MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_RELATIVE_PATH = Path("vendor/manifest.json")
 
-VENDOR_BUNDLE_NAMES: tuple[str, ...] = (
+# GitHub (wmo-im) snapshots — require upstream_repo + commit_sha.
+GITHUB_BUNDLE_NAMES: tuple[str, ...] = (
     "iwxxm",
     "iwxxm-codelists",
     "iwxxm-modelling",
     "iwxxm-translation",
 )
 
-BUNDLE_REQUIRED_FIELDS: tuple[str, ...] = (
+# HTTP archive snapshots — require source_url (+ optional archive_sha256).
+HTTP_BUNDLE_NAMES: tuple[str, ...] = ("iwxxm-us",)
+
+VENDOR_BUNDLE_NAMES: tuple[str, ...] = GITHUB_BUNDLE_NAMES + HTTP_BUNDLE_NAMES
+
+GITHUB_BUNDLE_REQUIRED_FIELDS: tuple[str, ...] = (
     "upstream_repo",
     "tag",
     "commit_sha",
+    "local_path",
+    "tree_sha256",
+)
+
+HTTP_BUNDLE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "source_url",
+    "tag",
     "local_path",
     "tree_sha256",
 )
@@ -62,14 +75,15 @@ def compute_tree_sha256(root: Path) -> str:
     return digest.hexdigest()
 
 
-def _validate_bundle_entry(name: str, entry: Any) -> list[str]:
-    errors: list[str] = []
-    if not isinstance(entry, dict):
-        errors.append(f"bundle {name!r} must be an object")
-        return errors
+def _is_http_bundle(entry: dict[str, Any]) -> bool:
+    return isinstance(entry.get("source_url"), str) and bool(
+        cast(str, entry["source_url"]).strip()
+    )
 
-    entry_dict = cast(dict[str, Any], entry)
-    for field_name in BUNDLE_REQUIRED_FIELDS:
+
+def _validate_github_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field_name in GITHUB_BUNDLE_REQUIRED_FIELDS:
         value = entry_dict.get(field_name)
         if not isinstance(value, str) or not value.strip():
             errors.append(f"bundle {name!r} missing or empty {field_name!r}")
@@ -85,6 +99,49 @@ def _validate_bundle_entry(name: str, entry: Any) -> list[str]:
         errors.append(
             f"bundle {name!r} commit_sha must be 40 hex chars, got length {len(commit_sha)}"
         )
+
+    return errors
+
+
+def _validate_http_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field_name in HTTP_BUNDLE_REQUIRED_FIELDS:
+        value = entry_dict.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"bundle {name!r} missing or empty {field_name!r}")
+
+    source_url = entry_dict.get("source_url")
+    if (
+        isinstance(source_url, str)
+        and source_url.strip()
+        and not source_url.startswith("https://")
+    ):
+        errors.append(
+            f"bundle {name!r} source_url must be https://, got {source_url!r}"
+        )
+
+    archive_sha = entry_dict.get("archive_sha256")
+    if archive_sha is not None and (
+        not isinstance(archive_sha, str) or len(archive_sha) != 64
+    ):
+        errors.append(
+            f"bundle {name!r} archive_sha256 must be 64 hex chars when present"
+        )
+
+    return errors
+
+
+def _validate_bundle_entry(name: str, entry: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        errors.append(f"bundle {name!r} must be an object")
+        return errors
+
+    entry_dict = cast(dict[str, Any], entry)
+    if _is_http_bundle(entry_dict):
+        errors.extend(_validate_http_bundle_entry(name, entry_dict))
+    else:
+        errors.extend(_validate_github_bundle_entry(name, entry_dict))
 
     tree_sha = entry_dict.get("tree_sha256")
     if isinstance(tree_sha, str) and len(tree_sha) != 64:

--- a/packages/shared/src/metar_shared/vendor_manifest.py
+++ b/packages/shared/src/metar_shared/vendor_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -38,6 +39,8 @@ HTTP_BUNDLE_REQUIRED_FIELDS: tuple[str, ...] = (
     "local_path",
     "tree_sha256",
 )
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 @dataclass(frozen=True)
@@ -75,18 +78,23 @@ def compute_tree_sha256(root: Path) -> str:
     return digest.hexdigest()
 
 
-def _is_http_bundle(entry: dict[str, Any]) -> bool:
-    return isinstance(entry.get("source_url"), str) and bool(
-        cast(str, entry["source_url"]).strip()
-    )
+def _is_sha256_hex(value: str) -> bool:
+    return bool(_SHA256_HEX_RE.fullmatch(value))
 
 
-def _validate_github_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[str]:
+def _check_required_fields(
+    name: str, entry_dict: dict[str, Any], required_fields: tuple[str, ...]
+) -> list[str]:
     errors: list[str] = []
-    for field_name in GITHUB_BUNDLE_REQUIRED_FIELDS:
+    for field_name in required_fields:
         value = entry_dict.get(field_name)
         if not isinstance(value, str) or not value.strip():
             errors.append(f"bundle {name!r} missing or empty {field_name!r}")
+    return errors
+
+
+def _validate_github_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[str]:
+    errors = _check_required_fields(name, entry_dict, GITHUB_BUNDLE_REQUIRED_FIELDS)
 
     upstream = entry_dict.get("upstream_repo")
     if isinstance(upstream, str) and not upstream.startswith("wmo-im/"):
@@ -104,11 +112,7 @@ def _validate_github_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list
 
 
 def _validate_http_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    for field_name in HTTP_BUNDLE_REQUIRED_FIELDS:
-        value = entry_dict.get(field_name)
-        if not isinstance(value, str) or not value.strip():
-            errors.append(f"bundle {name!r} missing or empty {field_name!r}")
+    errors = _check_required_fields(name, entry_dict, HTTP_BUNDLE_REQUIRED_FIELDS)
 
     source_url = entry_dict.get("source_url")
     if (
@@ -122,7 +126,7 @@ def _validate_http_bundle_entry(name: str, entry_dict: dict[str, Any]) -> list[s
 
     archive_sha = entry_dict.get("archive_sha256")
     if archive_sha is not None and (
-        not isinstance(archive_sha, str) or len(archive_sha) != 64
+        not isinstance(archive_sha, str) or not _is_sha256_hex(archive_sha)
     ):
         errors.append(
             f"bundle {name!r} archive_sha256 must be 64 hex chars when present"
@@ -138,13 +142,15 @@ def _validate_bundle_entry(name: str, entry: Any) -> list[str]:
         return errors
 
     entry_dict = cast(dict[str, Any], entry)
-    if _is_http_bundle(entry_dict):
+
+    # Dispatch by bundle name (not source_url presence) so GitHub pins may carry URLs.
+    if name in HTTP_BUNDLE_NAMES:
         errors.extend(_validate_http_bundle_entry(name, entry_dict))
     else:
         errors.extend(_validate_github_bundle_entry(name, entry_dict))
 
     tree_sha = entry_dict.get("tree_sha256")
-    if isinstance(tree_sha, str) and len(tree_sha) != 64:
+    if isinstance(tree_sha, str) and not _is_sha256_hex(tree_sha):
         errors.append(
             f"bundle {name!r} tree_sha256 must be 64 hex chars, got length {len(tree_sha)}"
         )
@@ -152,7 +158,7 @@ def _validate_bundle_entry(name: str, entry: Any) -> list[str]:
     local_path = entry_dict.get("local_path")
     if isinstance(local_path, str) and not local_path.startswith("vendor/schemas/"):
         errors.append(
-            f"bundle {name!r} local_path must live under vendor/schemas/, got {local_path!r}"
+            f"bundle {name!r} local_path must start with 'vendor/schemas/', got {local_path!r}"
         )
 
     return errors

--- a/packages/shared/tests/test_vendor_manifest.py
+++ b/packages/shared/tests/test_vendor_manifest.py
@@ -26,6 +26,39 @@ def _sample_bundle(local_path: str, *, tree_sha256: str = "a" * 64) -> dict[str,
     }
 
 
+def _sample_http_bundle(
+    local_path: str, *, tree_sha256: str = "a" * 64
+) -> dict[str, str]:
+    return {
+        "source_url": "https://nws.weather.gov/schemas/iwxxm-us/3.0/iwxxm-us-3.0-schemas.tgz",
+        "tag": "3.0",
+        "local_path": local_path,
+        "tree_sha256": tree_sha256,
+        "archive_sha256": "c" * 64,
+    }
+
+
+def _required_bundles(
+    *,
+    tree_sha256: str = "a" * 64,
+) -> dict[str, dict[str, str]]:
+    return {
+        "iwxxm": _sample_bundle("vendor/schemas/iwxxm", tree_sha256=tree_sha256),
+        "iwxxm-codelists": _sample_bundle(
+            "vendor/schemas/iwxxm-codelists", tree_sha256=tree_sha256
+        ),
+        "iwxxm-modelling": _sample_bundle(
+            "vendor/schemas/iwxxm-modelling", tree_sha256=tree_sha256
+        ),
+        "iwxxm-translation": _sample_bundle(
+            "vendor/schemas/iwxxm-translation", tree_sha256=tree_sha256
+        ),
+        "iwxxm-us": _sample_http_bundle(
+            "vendor/schemas/iwxxm-us", tree_sha256=tree_sha256
+        ),
+    }
+
+
 def test_load_manifest_rejects_non_object_root(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps([]), encoding="utf-8")
@@ -36,12 +69,7 @@ def test_load_manifest_rejects_non_object_root(tmp_path: Path) -> None:
 def test_validate_manifest_schema_accepts_minimal_valid_manifest() -> None:
     manifest = {
         "schema_version": MANIFEST_SCHEMA_VERSION,
-        "bundles": {
-            "iwxxm": _sample_bundle("vendor/schemas/iwxxm"),
-            "iwxxm-codelists": _sample_bundle("vendor/schemas/iwxxm-codelists"),
-            "iwxxm-modelling": _sample_bundle("vendor/schemas/iwxxm-modelling"),
-            "iwxxm-translation": _sample_bundle("vendor/schemas/iwxxm-translation"),
-        },
+        "bundles": _required_bundles(),
     }
     assert validate_manifest_schema(manifest) == []
 
@@ -60,32 +88,29 @@ def test_verify_manifest_integrity_detects_checksum_drift(tmp_path: Path) -> Non
 
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    bundles = _required_bundles()
+    bundles["iwxxm"] = _sample_bundle("vendor/schemas/iwxxm", tree_sha256="0" * 64)
     manifest_path.write_text(
-        json.dumps(
-            {
-                "schema_version": MANIFEST_SCHEMA_VERSION,
-                "bundles": {
-                    "iwxxm": _sample_bundle(
-                        "vendor/schemas/iwxxm", tree_sha256="0" * 64
-                    ),
-                    "iwxxm-codelists": _sample_bundle("vendor/schemas/iwxxm-codelists"),
-                    "iwxxm-modelling": _sample_bundle("vendor/schemas/iwxxm-modelling"),
-                    "iwxxm-translation": _sample_bundle(
-                        "vendor/schemas/iwxxm-translation"
-                    ),
-                },
-            }
-        ),
+        json.dumps({"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}),
         encoding="utf-8",
     )
 
-    # Create empty dirs for other bundles so checksum step runs only on iwxxm mismatch.
-    for name in ("iwxxm-codelists", "iwxxm-modelling", "iwxxm-translation"):
+    for name in (
+        "iwxxm-codelists",
+        "iwxxm-modelling",
+        "iwxxm-translation",
+        "iwxxm-us",
+    ):
         path = tmp_path / "vendor" / "schemas" / name
         path.mkdir(parents=True)
-        bundle = _sample_bundle(
-            f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
-        )
+        if name == "iwxxm-us":
+            bundle = _sample_http_bundle(
+                f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
+            )
+        else:
+            bundle = _sample_bundle(
+                f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
+            )
         data = json.loads(manifest_path.read_text(encoding="utf-8"))
         data["bundles"][name] = bundle
         manifest_path.write_text(json.dumps(data), encoding="utf-8")
@@ -116,25 +141,21 @@ def test_validate_manifest_schema_reports_missing_required_bundle() -> None:
     }
     errors = validate_manifest_schema(manifest)
     assert any("missing required bundle 'iwxxm-codelists'" in err for err in errors)
+    assert any("missing required bundle 'iwxxm-us'" in err for err in errors)
 
 
 def test_validate_manifest_schema_reports_bundle_field_errors() -> None:
-    manifest = {
-        "schema_version": MANIFEST_SCHEMA_VERSION,
-        "bundles": {
-            "iwxxm": {
-                "upstream_repo": "other/iwxxm",
-                "tag": "",
-                "commit_sha": "short",
-                "local_path": "schemas/iwxxm",
-                "tree_sha256": "short",
-            },
-            "iwxxm-codelists": _sample_bundle("vendor/schemas/iwxxm-codelists"),
-            "iwxxm-modelling": _sample_bundle("vendor/schemas/iwxxm-modelling"),
-            "iwxxm-translation": _sample_bundle("vendor/schemas/iwxxm-translation"),
-        },
+    bundles = _required_bundles()
+    bundles["iwxxm"] = {
+        "upstream_repo": "other/iwxxm",
+        "tag": "",
+        "commit_sha": "short",
+        "local_path": "schemas/iwxxm",
+        "tree_sha256": "short",
     }
-    errors = validate_manifest_schema(manifest)
+    errors = validate_manifest_schema(
+        {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+    )
     assert any("upstream_repo must start with 'wmo-im/'" in err for err in errors)
     assert any("commit_sha must be 40" in err for err in errors)
     assert any("tree_sha256 must be 64" in err for err in errors)
@@ -143,17 +164,42 @@ def test_validate_manifest_schema_reports_bundle_field_errors() -> None:
 
 
 def test_validate_manifest_schema_rejects_non_object_bundle() -> None:
-    manifest = {
-        "schema_version": MANIFEST_SCHEMA_VERSION,
-        "bundles": {
-            "iwxxm": [],
-            "iwxxm-codelists": _sample_bundle("vendor/schemas/iwxxm-codelists"),
-            "iwxxm-modelling": _sample_bundle("vendor/schemas/iwxxm-modelling"),
-            "iwxxm-translation": _sample_bundle("vendor/schemas/iwxxm-translation"),
-        },
-    }
-    errors = validate_manifest_schema(manifest)
+    bundles: dict[str, object] = dict(_required_bundles())
+    bundles["iwxxm"] = []
+    errors = validate_manifest_schema(
+        {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+    )
     assert any("bundle 'iwxxm' must be an object" in err for err in errors)
+
+
+def test_validate_http_bundle_requires_https_source_url() -> None:
+    bundles = _required_bundles()
+    bundles["iwxxm-us"] = {
+        "source_url": "http://example.com/schemas.tgz",
+        "tag": "3.0",
+        "local_path": "vendor/schemas/iwxxm-us",
+        "tree_sha256": "a" * 64,
+    }
+    errors = validate_manifest_schema(
+        {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+    )
+    assert any("source_url must be https://" in err for err in errors)
+
+
+def test_validate_http_bundle_reports_empty_fields_and_bad_archive_hash() -> None:
+    bundles = _required_bundles()
+    bundles["iwxxm-us"] = {
+        "source_url": "https://nws.weather.gov/schemas/iwxxm-us/3.0/x.tgz",
+        "tag": "   ",
+        "local_path": "vendor/schemas/iwxxm-us",
+        "tree_sha256": "a" * 64,
+        "archive_sha256": "short",
+    }
+    errors = validate_manifest_schema(
+        {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+    )
+    assert any("missing or empty 'tag'" in err for err in errors)
+    assert any("archive_sha256 must be 64 hex chars" in err for err in errors)
 
 
 def test_verify_manifest_integrity_reports_invalid_json(tmp_path: Path) -> None:
@@ -172,14 +218,20 @@ def test_verify_manifest_integrity_skips_non_object_or_incomplete_bundle_entries
         "iwxxm": "not-an-object",
         "iwxxm-codelists": {"local_path": 123, "tree_sha256": "a" * 64},
     }
-    for name in ("iwxxm-modelling", "iwxxm-translation"):
+    for name in ("iwxxm-modelling", "iwxxm-translation", "iwxxm-us"):
         root = tmp_path / "vendor" / "schemas" / name
         root.mkdir(parents=True)
         (root / "README.md").write_text(name, encoding="utf-8")
-        bundles[name] = _sample_bundle(
-            f"vendor/schemas/{name}",
-            tree_sha256=compute_tree_sha256(root),
-        )
+        if name == "iwxxm-us":
+            bundles[name] = _sample_http_bundle(
+                f"vendor/schemas/{name}",
+                tree_sha256=compute_tree_sha256(root),
+            )
+        else:
+            bundles[name] = _sample_bundle(
+                f"vendor/schemas/{name}",
+                tree_sha256=compute_tree_sha256(root),
+            )
 
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -202,12 +254,7 @@ def test_verify_manifest_integrity_reports_missing_bundle_tree(tmp_path: Path) -
     manifest_path.parent.mkdir(parents=True)
     manifest = {
         "schema_version": MANIFEST_SCHEMA_VERSION,
-        "bundles": {
-            "iwxxm": _sample_bundle("vendor/schemas/iwxxm"),
-            "iwxxm-codelists": _sample_bundle("vendor/schemas/iwxxm-codelists"),
-            "iwxxm-modelling": _sample_bundle("vendor/schemas/iwxxm-modelling"),
-            "iwxxm-translation": _sample_bundle("vendor/schemas/iwxxm-translation"),
-        },
+        "bundles": _required_bundles(),
     }
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     result = verify_manifest_integrity(tmp_path, manifest_path=manifest_path)
@@ -222,14 +269,21 @@ def test_verify_manifest_integrity_passes_for_matching_tree(tmp_path: Path) -> N
         "iwxxm-codelists",
         "iwxxm-modelling",
         "iwxxm-translation",
+        "iwxxm-us",
     ):
         root = tmp_path / "vendor" / "schemas" / name
         root.mkdir(parents=True)
         (root / "README.md").write_text(name, encoding="utf-8")
-        bundles[name] = _sample_bundle(
-            f"vendor/schemas/{name}",
-            tree_sha256=compute_tree_sha256(root),
-        )
+        if name == "iwxxm-us":
+            bundles[name] = _sample_http_bundle(
+                f"vendor/schemas/{name}",
+                tree_sha256=compute_tree_sha256(root),
+            )
+        else:
+            bundles[name] = _sample_bundle(
+                f"vendor/schemas/{name}",
+                tree_sha256=compute_tree_sha256(root),
+            )
 
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.write_text(

--- a/packages/shared/tests/test_vendor_manifest.py
+++ b/packages/shared/tests/test_vendor_manifest.py
@@ -38,24 +38,30 @@ def _sample_http_bundle(
     }
 
 
+def _sample_for_bundle(
+    name: str, local_path: str, *, tree_sha256: str = "a" * 64
+) -> dict[str, str]:
+    """Pick GitHub vs HTTP sample factory from bundle name."""
+    if name == "iwxxm-us":
+        return _sample_http_bundle(local_path, tree_sha256=tree_sha256)
+    return _sample_bundle(local_path, tree_sha256=tree_sha256)
+
+
 def _required_bundles(
     *,
     tree_sha256: str = "a" * 64,
 ) -> dict[str, dict[str, str]]:
     return {
-        "iwxxm": _sample_bundle("vendor/schemas/iwxxm", tree_sha256=tree_sha256),
-        "iwxxm-codelists": _sample_bundle(
-            "vendor/schemas/iwxxm-codelists", tree_sha256=tree_sha256
-        ),
-        "iwxxm-modelling": _sample_bundle(
-            "vendor/schemas/iwxxm-modelling", tree_sha256=tree_sha256
-        ),
-        "iwxxm-translation": _sample_bundle(
-            "vendor/schemas/iwxxm-translation", tree_sha256=tree_sha256
-        ),
-        "iwxxm-us": _sample_http_bundle(
-            "vendor/schemas/iwxxm-us", tree_sha256=tree_sha256
-        ),
+        name: _sample_for_bundle(
+            name, f"vendor/schemas/{name}", tree_sha256=tree_sha256
+        )
+        for name in (
+            "iwxxm",
+            "iwxxm-codelists",
+            "iwxxm-modelling",
+            "iwxxm-translation",
+            "iwxxm-us",
+        )
     }
 
 
@@ -103,14 +109,9 @@ def test_verify_manifest_integrity_detects_checksum_drift(tmp_path: Path) -> Non
     ):
         path = tmp_path / "vendor" / "schemas" / name
         path.mkdir(parents=True)
-        if name == "iwxxm-us":
-            bundle = _sample_http_bundle(
-                f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
-            )
-        else:
-            bundle = _sample_bundle(
-                f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
-            )
+        bundle = _sample_for_bundle(
+            name, f"vendor/schemas/{name}", tree_sha256=compute_tree_sha256(path)
+        )
         data = json.loads(manifest_path.read_text(encoding="utf-8"))
         data["bundles"][name] = bundle
         manifest_path.write_text(json.dumps(data), encoding="utf-8")
@@ -159,7 +160,7 @@ def test_validate_manifest_schema_reports_bundle_field_errors() -> None:
     assert any("upstream_repo must start with 'wmo-im/'" in err for err in errors)
     assert any("commit_sha must be 40" in err for err in errors)
     assert any("tree_sha256 must be 64" in err for err in errors)
-    assert any("local_path must live under vendor/schemas/" in err for err in errors)
+    assert any("local_path must start with 'vendor/schemas/'" in err for err in errors)
     assert any("missing or empty 'tag'" in err for err in errors)
 
 
@@ -202,6 +203,30 @@ def test_validate_http_bundle_reports_empty_fields_and_bad_archive_hash() -> Non
     assert any("archive_sha256 must be 64 hex chars" in err for err in errors)
 
 
+def test_github_bundle_with_source_url_still_uses_github_rules() -> None:
+    """Dispatch is by bundle name, not presence of source_url (Sourcery #700)."""
+    bundles = _required_bundles()
+    bundles["iwxxm"] = {
+        **_sample_bundle("vendor/schemas/iwxxm"),
+        "source_url": "https://example.com/extra",
+    }
+    assert (
+        validate_manifest_schema(
+            {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+        )
+        == []
+    )
+
+
+def test_archive_sha256_rejects_non_hex() -> None:
+    bundles = _required_bundles()
+    bundles["iwxxm-us"]["archive_sha256"] = "g" * 64
+    errors = validate_manifest_schema(
+        {"schema_version": MANIFEST_SCHEMA_VERSION, "bundles": bundles}
+    )
+    assert any("archive_sha256 must be 64 hex chars" in err for err in errors)
+
+
 def test_verify_manifest_integrity_reports_invalid_json(tmp_path: Path) -> None:
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.parent.mkdir(parents=True)
@@ -222,16 +247,11 @@ def test_verify_manifest_integrity_skips_non_object_or_incomplete_bundle_entries
         root = tmp_path / "vendor" / "schemas" / name
         root.mkdir(parents=True)
         (root / "README.md").write_text(name, encoding="utf-8")
-        if name == "iwxxm-us":
-            bundles[name] = _sample_http_bundle(
-                f"vendor/schemas/{name}",
-                tree_sha256=compute_tree_sha256(root),
-            )
-        else:
-            bundles[name] = _sample_bundle(
-                f"vendor/schemas/{name}",
-                tree_sha256=compute_tree_sha256(root),
-            )
+        bundles[name] = _sample_for_bundle(
+            name,
+            f"vendor/schemas/{name}",
+            tree_sha256=compute_tree_sha256(root),
+        )
 
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -274,16 +294,11 @@ def test_verify_manifest_integrity_passes_for_matching_tree(tmp_path: Path) -> N
         root = tmp_path / "vendor" / "schemas" / name
         root.mkdir(parents=True)
         (root / "README.md").write_text(name, encoding="utf-8")
-        if name == "iwxxm-us":
-            bundles[name] = _sample_http_bundle(
-                f"vendor/schemas/{name}",
-                tree_sha256=compute_tree_sha256(root),
-            )
-        else:
-            bundles[name] = _sample_bundle(
-                f"vendor/schemas/{name}",
-                tree_sha256=compute_tree_sha256(root),
-            )
+        bundles[name] = _sample_for_bundle(
+            name,
+            f"vendor/schemas/{name}",
+            tree_sha256=compute_tree_sha256(root),
+        )
 
     manifest_path = tmp_path / "vendor" / "manifest.json"
     manifest_path.write_text(

--- a/packages/tac-validate/README.md
+++ b/packages/tac-validate/README.md
@@ -1,0 +1,5 @@
+# tac-validate
+
+TAC parse gate and shared business-rule pack. MIT licensed.
+
+See ADR-015 / ADR-016.

--- a/packages/tac-validate/pyproject.toml
+++ b/packages/tac-validate/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "tac-validate"
+version = "0.1.0"
+description = "TAC parse gate and business-rule pack (F6 lint)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = [
+  "msgspec>=0.19",
+]
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tac_validate"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/tac_validate"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = ["E501"]

--- a/packages/tac-validate/src/tac_validate/__init__.py
+++ b/packages/tac-validate/src/tac_validate/__init__.py
@@ -1,0 +1,3 @@
+"""TAC parse gate and business-rule pack (F6 lint)."""
+
+__version__ = "0.1.0"

--- a/packages/tac-validate/src/tac_validate/codec.py
+++ b/packages/tac-validate/src/tac_validate/codec.py
@@ -1,0 +1,14 @@
+"""Reusable msgspec JSON codec instances for lint issue models (ADR-016).
+
+Reuse module-level Encoder/Decoder instances on hot paths rather than
+constructing new ones per encode/decode call.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+json_encoder = msgspec.json.Encoder()
+json_decoder = msgspec.json.Decoder()
+
+__all__ = ["json_decoder", "json_encoder"]

--- a/packages/tac-validate/tests/test_tac_validate_codec.py
+++ b/packages/tac-validate/tests/test_tac_validate_codec.py
@@ -1,0 +1,11 @@
+"""Codec reuse smoke tests for tac-validate (ADR-016 / T1.4)."""
+
+from __future__ import annotations
+
+from tac_validate.codec import json_decoder, json_encoder
+
+
+def test_json_codec_roundtrip_reuses_module_instances() -> None:
+    payload = {"issues": [], "fixes": []}
+    encoded = json_encoder.encode(payload)
+    assert json_decoder.decode(encoded) == payload

--- a/packages/tac-validate/tests/test_tac_validate_import.py
+++ b/packages/tac-validate/tests/test_tac_validate_import.py
@@ -1,0 +1,9 @@
+"""Package import smoke for tac-validate (T1.1 / TC-F6-M001)."""
+
+from __future__ import annotations
+
+import tac_validate
+
+
+def test_package_version_is_set() -> None:
+    assert tac_validate.__version__

--- a/packages/tac2iwxxm/README.md
+++ b/packages/tac2iwxxm/README.md
@@ -1,0 +1,5 @@
+# tac2iwxxm
+
+General TAC → IWXXM converter package (F6). MIT licensed.
+
+See ADR-013 / ADR-014 / ADR-016 / ADR-017.

--- a/packages/tac2iwxxm/pyproject.toml
+++ b/packages/tac2iwxxm/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "tac2iwxxm"
+version = "0.1.0"
+description = "General TAC → IWXXM converter (F6)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = [
+  "msgspec>=0.19",
+]
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tac2iwxxm"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/tac2iwxxm"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = ["E501"]

--- a/packages/tac2iwxxm/src/tac2iwxxm/__init__.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/__init__.py
@@ -1,0 +1,3 @@
+"""General TAC → IWXXM converter (F6)."""
+
+__version__ = "0.1.0"

--- a/packages/tac2iwxxm/src/tac2iwxxm/codec.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/codec.py
@@ -1,0 +1,15 @@
+"""Reusable msgspec JSON codec instances for hot paths (ADR-016).
+
+Instantiate :class:`msgspec.json.Encoder` / :class:`msgspec.json.Decoder` once
+and reuse them instead of constructing per call
+(https://jcristharif.com/msgspec/perf-tips.html).
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+json_encoder = msgspec.json.Encoder()
+json_decoder = msgspec.json.Decoder()
+
+__all__ = ["json_decoder", "json_encoder"]

--- a/packages/tac2iwxxm/tests/test_tac2iwxxm_codec.py
+++ b/packages/tac2iwxxm/tests/test_tac2iwxxm_codec.py
@@ -1,0 +1,13 @@
+"""Codec reuse smoke tests for tac2iwxxm (ADR-016 / T1.4)."""
+
+from __future__ import annotations
+
+from tac2iwxxm.codec import json_decoder, json_encoder
+
+
+def test_json_codec_roundtrip_reuses_module_instances() -> None:
+    payload = {"ok": True, "n": 1}
+    encoded = json_encoder.encode(payload)
+    assert json_decoder.decode(encoded) == payload
+    assert json_encoder is not None
+    assert json_decoder is not None

--- a/packages/tac2iwxxm/tests/test_tac2iwxxm_import.py
+++ b/packages/tac2iwxxm/tests/test_tac2iwxxm_import.py
@@ -1,0 +1,9 @@
+"""Package import smoke for tac2iwxxm (T1.1 / TC-F6-M001)."""
+
+from __future__ import annotations
+
+import tac2iwxxm
+
+
+def test_package_version_is_set() -> None:
+    assert tac2iwxxm.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = []
 
 [tool.uv]
 package = false
-# Python 3.12 pinned per ADR-005; members added as packages scaffold (T1.4+).
-# Target members: packages/shared, packages/auth, packages/gifts, apps/backend
+# Python 3.12 pinned per ADR-005; S008 F6 members: tac2iwxxm, iwxxm-validate, tac-validate.
 
 [dependency-groups]
 dev = [
@@ -24,6 +23,9 @@ dev = [
   "gifts",
   "metar-auth",
   "metar-backend",
+  "tac2iwxxm",
+  "iwxxm-validate",
+  "tac-validate",
 ]
 
 [tool.uv.sources]
@@ -31,10 +33,20 @@ metar-shared = { workspace = true }
 gifts = { workspace = true }
 metar-auth = { workspace = true }
 metar-backend = { workspace = true }
+tac2iwxxm = { workspace = true }
+iwxxm-validate = { workspace = true }
+tac-validate = { workspace = true }
 
-# Workspace members populated incrementally during Phase 1–2 (T1.4 shared, T3.3 gifts, T4.3 auth).
 [tool.uv.workspace]
-members = ["packages/shared", "packages/gifts", "packages/auth", "apps/backend"]
+members = [
+  "packages/shared",
+  "packages/gifts",
+  "packages/auth",
+  "packages/tac2iwxxm",
+  "packages/iwxxm-validate",
+  "packages/tac-validate",
+  "apps/backend",
+]
 
 [tool.basedpyright]
 pythonVersion = "3.12"

--- a/scripts/vendor/sync_iwxxm.py
+++ b/scripts/vendor/sync_iwxxm.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from metar_shared.vendor_manifest import (
+    GITHUB_BUNDLE_NAMES,
     MANIFEST_RELATIVE_PATH,
-    VENDOR_BUNDLE_NAMES,
     compute_tree_sha256,
     load_manifest,
     verify_manifest_integrity,
@@ -89,7 +89,7 @@ def sync_from_manifest(
         msg = "manifest bundles must be an object"
         raise ValueError(msg)
 
-    for name in VENDOR_BUNDLE_NAMES:
+    for name in GITHUB_BUNDLE_NAMES:
         entry = bundles.get(name)
         if not isinstance(entry, dict):
             msg = f"missing bundle entry: {name}"
@@ -105,6 +105,9 @@ def sync_from_manifest(
                     f"manifest={pinned}, actual={actual}"
                 )
                 raise ValueError(msg)
+
+    # HTTP archive bundles (e.g. iwxxm-us) are pinned offline; refresh via dedicated
+    # sync helper / PR — not the wmo-im GitHub fetch path above.
 
     if verify:
         result = verify_manifest_integrity(repo_root, manifest_path=manifest_path)
@@ -134,7 +137,9 @@ def main() -> None:
     args = parser.parse_args()
 
     repo_root = Path.cwd()
-    manifest_path = args.manifest if args.manifest.is_absolute() else repo_root / args.manifest
+    manifest_path = (
+        args.manifest if args.manifest.is_absolute() else repo_root / args.manifest
+    )
     sync_from_manifest(
         repo_root,
         manifest_path,

--- a/tests/migration/test_tc_f6_m001_package_import_smoke.py
+++ b/tests/migration/test_tc_f6_m001_package_import_smoke.py
@@ -1,0 +1,49 @@
+"""TC-F6-M001 — empty package import smoke for F6 validate workspace members.
+
+Spec: docs/test-plan.md §TC-F6-M001 (UJ-DEV-003b); execution-plan T1.1.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Distribution / directory names use hyphens; import packages use underscores where needed.
+_PACKAGE_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("tac2iwxxm", "tac2iwxxm", "packages/tac2iwxxm"),
+    ("iwxxm_validate", "iwxxm-validate", "packages/iwxxm-validate"),
+    ("tac_validate", "tac-validate", "packages/tac-validate"),
+)
+
+
+@pytest.mark.migration
+@pytest.mark.unit
+class TestF6PackageImportSmoke:
+    """Empty packages must import and be declared as uv workspace members."""
+
+    @pytest.mark.parametrize(
+        ("import_name", "dist_name", "rel_path"),
+        _PACKAGE_SPECS,
+        ids=[spec[1] for spec in _PACKAGE_SPECS],
+    )
+    def test_package_importable(
+        self, import_name: str, dist_name: str, rel_path: str
+    ) -> None:
+        """Each F6 package root module imports and exposes __version__."""
+        pkg_root = ROOT / rel_path
+        assert pkg_root.is_dir(), f"missing package tree for {dist_name}: {pkg_root}"
+        module = importlib.import_module(import_name)
+        assert hasattr(module, "__version__")
+        assert isinstance(module.__version__, str)
+        assert module.__version__
+
+    def test_uv_workspace_declares_three_f6_members(self) -> None:
+        """Root pyproject lists all three packages as workspace members."""
+        content = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        for _, dist_name, rel_path in _PACKAGE_SPECS:
+            assert rel_path in content, f"{rel_path} missing from workspace members"
+            assert dist_name in content or dist_name.replace("-", "_") in content

--- a/tests/vendor/test_manifest_integrity.py
+++ b/tests/vendor/test_manifest_integrity.py
@@ -24,7 +24,7 @@ MANIFEST_PATH = ROOT / "vendor" / "manifest.json"
 
 @pytest.mark.migration
 class TestTcM002ManifestIntegrity:
-    """Manifest pins must match vendored wmo-im schema trees."""
+    """Manifest pins must match vendored schema trees (WMO + iwxxm-us)."""
 
     def test_manifest_integrity_passes(self) -> None:
         """Step 1-2: manifest validation reports no drift."""
@@ -32,12 +32,25 @@ class TestTcM002ManifestIntegrity:
         assert result.ok, "manifest integrity failed:\n" + "\n".join(result.errors)
 
     def test_manifest_declares_all_required_bundles(self) -> None:
-        """Each wmo-im bundle from dependency-inventory.md is pinned."""
+        """Each vendor bundle from dependency-inventory.md is pinned."""
         assert MANIFEST_PATH.is_file(), "vendor/manifest.json must exist (T2.2)"
         manifest = load_manifest(MANIFEST_PATH)
         bundles = manifest["bundles"]
         for name in VENDOR_BUNDLE_NAMES:
             assert name in bundles, f"missing bundle pin: {name}"
+
+    def test_iwxxm_us_http_pin_fields(self) -> None:
+        """TC-F6-M001 / T1.5: iwxxm-us uses NWS HTTPS archive + hashes."""
+        manifest = load_manifest(MANIFEST_PATH)
+        entry = manifest["bundles"]["iwxxm-us"]
+        assert entry["source_url"].startswith(
+            "https://nws.weather.gov/schemas/iwxxm-us/3.0/"
+        )
+        assert entry["tag"] == "3.0"
+        assert entry["local_path"] == "vendor/schemas/iwxxm-us"
+        assert len(entry["tree_sha256"]) == 64
+        assert len(entry["archive_sha256"]) == 64
+        assert (ROOT / "vendor/schemas/iwxxm-us/3.0/metarSpeci.xsd").is_file()
 
     def test_manifest_schema_version(self) -> None:
         """Manifest uses the supported schema version."""

--- a/uv.lock
+++ b/uv.lock
@@ -5,10 +5,13 @@ requires-python = ">=3.12"
 [manifest]
 members = [
     "gifts",
+    "iwxxm-validate",
     "metar-auth",
     "metar-backend",
     "metar-iwxxm-workspace",
     "metar-shared",
+    "tac-validate",
+    "tac2iwxxm",
 ]
 
 [[package]]
@@ -1005,6 +1008,11 @@ wheels = [
 ]
 
 [[package]]
+name = "iwxxm-validate"
+version = "0.1.0"
+source = { editable = "packages/iwxxm-validate" }
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1339,6 +1347,7 @@ dev = [
     { name = "gifts" },
     { name = "httpx" },
     { name = "httpx2" },
+    { name = "iwxxm-validate" },
     { name = "metar-auth" },
     { name = "metar-backend" },
     { name = "metar-shared" },
@@ -1347,6 +1356,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tac-validate" },
+    { name = "tac2iwxxm" },
 ]
 
 [package.metadata]
@@ -1357,6 +1368,7 @@ dev = [
     { name = "gifts", editable = "packages/gifts" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx2", specifier = ">=2.0" },
+    { name = "iwxxm-validate", editable = "packages/iwxxm-validate" },
     { name = "metar-auth", editable = "packages/auth" },
     { name = "metar-backend", editable = "apps/backend" },
     { name = "metar-shared", editable = "packages/shared" },
@@ -1365,6 +1377,8 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "tac-validate", editable = "packages/tac-validate" },
+    { name = "tac2iwxxm", editable = "packages/tac2iwxxm" },
 ]
 
 [[package]]
@@ -1422,6 +1436,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
     { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
     { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
 ]
 
 [[package]]
@@ -2536,6 +2590,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/79/1a8162ce7d705381a4f2668c0da68e097b103c1aa701418a31da52905c7b/supabase_functions-2.31.0-py3-none-any.whl", hash = "sha256:3fdc4c4766152bfda63bdd0e286fc8a06f50e1280711fae4a1dfc9b7e9ebabc6", size = 8794, upload-time = "2026-06-04T13:37:28.022Z" },
 ]
+
+[[package]]
+name = "tac-validate"
+version = "0.1.0"
+source = { editable = "packages/tac-validate" }
+dependencies = [
+    { name = "msgspec" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "msgspec", specifier = ">=0.19" }]
+
+[[package]]
+name = "tac2iwxxm"
+version = "0.1.0"
+source = { editable = "packages/tac2iwxxm" }
+dependencies = [
+    { name = "msgspec" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "msgspec", specifier = ">=0.19" }]
 
 [[package]]
 name = "truststore"

--- a/vendor/manifest.json
+++ b/vendor/manifest.json
@@ -28,6 +28,13 @@
       "commit_sha": "a251e8bcff2bee8215a9f193595f380accd9e238",
       "local_path": "vendor/schemas/iwxxm-translation",
       "tree_sha256": "cb918b6e595895800c1f5dfa639a3065357eb2ca9a4646596241fef9b2a4bcbf"
+    },
+    "iwxxm-us": {
+      "source_url": "https://nws.weather.gov/schemas/iwxxm-us/3.0/iwxxm-us-3.0-schemas.tgz",
+      "tag": "3.0",
+      "local_path": "vendor/schemas/iwxxm-us",
+      "tree_sha256": "05c72268bc8b7a06712b830194c1661390468e8120ec85dbbd6809f681ae93fc",
+      "archive_sha256": "2266770b01b8bb1685ad97419a7114439900d00590e876d210660b42c4b78260"
     }
   }
 }

--- a/vendor/schemas/iwxxm-us/3.0/README.txt
+++ b/vendor/schemas/iwxxm-us/3.0/README.txt
@@ -1,0 +1,24 @@
+Thank you for downloading your local copy of the IWXXM-US v3.0
+schema files.
+
+To aid in performing fast schema validation of XML documents from the
+United States, you may wish to use the OASIS catalog file,
+united-states-catalog.xml, to instruct your validation tool to refer
+to your local copy of these schema files.
+
+Using your favorite editor, open the catalog file, identify and
+uncomment the proper element to use based on the computer's operating
+system. Change the LOCAL_PARENT_DIRECTORY_PATH string to match the
+directory where the ZIP (or the TGZ) file was unpacked, then save the
+file.
+
+OR, if you already have a OASIS catalog file that you use for XML
+validation, you can simply add the relevant line to it.
+
+By using this catalog file with your validation tool, it will then
+replace any references to 'https://nws.weather.gov/schemas' inside the
+XML documents with the LOCAL_PARENT_DIRECTORY_PATH string instead of
+attempting to download the schema file(s) from the Internet. Your
+local copy of these schema files will be read instead, resulting in
+much faster XML validation. The XML document remains unchanged after
+validation.

--- a/vendor/schemas/iwxxm-us/3.0/airmet.xsd
+++ b/vendor/schemas/iwxxm-us/3.0/airmet.xsd
@@ -1,0 +1,172 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.weather.gov/iwxxm-us/3.0" version="3.0" attributeFormDefault="unqualified" xmlns:iwxxm-us="http://www.weather.gov/iwxxm-us/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1/AIXM_Features.xsd"/>
+    <annotation>
+        <documentation>This package includes the information needed to model the Federal Aviation
+        Administration's filed differences to the International Civil Aviation Organization for the
+        AIRMET product.
+
+        The National Weather Service Instruction 10-811 describes the content and preparation of its
+        AIRMETs.</documentation>
+    </annotation>
+    <element name="AIRMETEvolvingConditionExtension" type="iwxxm-us:AIRMETEvolvingConditionExtensionType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Additional parameters in use by the NWS in issuing AIRMETs.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AIRMETEvolvingConditionExtensionType">
+        <sequence>
+            <element name="validTimeSubPeriod" minOccurs="0" maxOccurs="1" type="gml:TimePrimitivePropertyType">
+                <annotation>
+                    <documentation>Time instant or period which the evolving condition is
+                    valid. This element shall have a value (or time period) that lies entirely
+                    within iwxxm:validPeriod.</documentation>
+                </annotation>
+            </element>
+            <element name="freezingLevel" minOccurs="0" maxOccurs="unbounded" type="iwxxm-us:FreezingLevelType">
+                <annotation>
+                    <documentation>Set of 0° Celsius isotherms denoting the 'shape' of the freezing
+                    levels in 3-D space.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="AIRMETEvolvingConditionExtensionPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:AIRMETEvolvingConditionExtension"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AIRMETWeatherHazards" type="iwxxm-us:AIRMETWeatherHazardsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Weather phenomena not found in WMO Code Registry that is causing the
+            hazard.
+
+            Boolean attribute/flag if weather phenomena is causing Low-Level Wind Shear conditions
+            to occur.
+
+            Boolean attribute/flag if weather phenomena is causing:
+
+	      1. Prevailing horizontal visibility reduced to less than 3 statute miles AND/OR
+	      2. Broken or overcast cloud bases below 1000 feet (300 meters) AGL.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AIRMETWeatherHazardsType">
+        <sequence>
+            <element name="weatherPhenomenon" type="iwxxm-us:AIRMETWeatherPhenomenaType" minOccurs="1" maxOccurs="unbounded">
+                <annotation>
+                    <documentation>En route weather phenomena which may affect safety of flight
+                    and/or airport operations.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="causingLLWSConditions" type="boolean">
+            <annotation>
+                <documentation>Boolean attribute/flag set to 'true' if weather phenomena is causing Low-Level Wind Shear conditions to occur.</documentation>
+            </annotation>
+        </attribute>
+        <attribute name="causingIFRConditions" type="boolean">
+            <annotation>
+                <documentation>Boolean attribute/flag set to 'true' if weather phenomena is causing:
+1. Prevailing horizontal visibility reduced to less than 3 statute miles AND/OR
+2. Broken or overcast cloud bases below 1000 feet (300 meters) AGL.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="AIRMETWeatherHazardsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:AIRMETWeatherHazards"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="FreezingLevel" type="iwxxm-us:FreezingLevelType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Depiction of 0° C isotherm at constant height, or flight level, above
+            the ground.</documentation>
+        </annotation>
+    </element>
+    <complexType name="FreezingLevelType">
+        <sequence>
+            <element name="flightLevel" type="aixm:AirspaceLayerType">
+                <annotation>
+                    <documentation>Height of planar quasi-horizontal surface above mean sea level.</documentation>
+                </annotation>
+            </element>
+            <element name="multipleLevels" type="boolean"/>
+            <element name="closedBoundary" minOccurs="0" maxOccurs="1" type="gml:LineStringSegmentType">
+                <annotation>
+                    <documentation>Sequence of geo-coordinates corresponding to the location of the 0° C 
+                    isotherm on the quasi-horizontal plane that forms a closed loop.</documentation>
+                </annotation>
+            </element>
+            <element name="openBoundary" minOccurs="0" maxOccurs="1" type="gml:LineStringSegmentType">
+                <annotation>
+                    <documentation>Sequence of geo-coordinates corresponding to the location of the 0 degree isopleth on the quasi-horizontal plane that do not form a closed loop.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="FreezingLevelPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:FreezingLevel"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="FreezingLevelForecast" type="iwxxm-us:FreezingLevelForecastType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Set of 0° C isotherms at given forecast time period or instant.</documentation>
+        </annotation>
+    </element>
+    <complexType name="FreezingLevelForecastType">
+        <sequence>
+            <element name="validTimeSubPeriod" type="gml:TimePrimitivePropertyType">
+                <annotation>
+                    <documentation>Valid time period or instant of this freezing level forecast. The
+                    time references an instant in time or period that lies entirely within
+                    iwxxm:validPeriod.</documentation>
+                </annotation>
+            </element>
+            <element name="isopleth" minOccurs="1" maxOccurs="unbounded" type="iwxxm-us:FreezingLevelType">
+                <annotation>
+                    <documentation>Set of open and/or closed boundaries denoting areas of
+                    temperatures aloft that are at or below freezing.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="FreezingLevelForecastPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:FreezingLevelForecast"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AIRMETWeatherPhenomena" type="iwxxm-us:AIRMETWeatherPhenomenaType"/>
+    <complexType name="AIRMETWeatherPhenomenaType">
+        <annotation>
+            <documentation>NWS Code List register of AIRMET weather hazards not listed in the WMO
+            Registry.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/NWSI-10-811/HazardTypes</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="FlightInformationRegions" type="iwxxm-us:FlightInformationRegionsType"/>
+    <complexType name="FlightInformationRegionsType">
+        <annotation>
+            <documentation>Pre-defined regions of Hawai'i and Alaska which forecast conditions are
+            provided by NWS Aviation Services Units.</documentation>
+            <appinfo>
+                <vocabulary>https://nws.weather.gov/schemas/iwxxm-us/geodata/AOR-FA</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/vendor/schemas/iwxxm-us/3.0/common.xsd
+++ b/vendor/schemas/iwxxm-us/3.0/common.xsd
@@ -1,0 +1,181 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.weather.gov/iwxxm-us/3.0" version="3.0.2" attributeFormDefault="unqualified" xmlns:iwxxm-us="http://www.weather.gov/iwxxm-us/3.0" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <annotation>
+        <documentation>Complex types and enumerations shared among schemas.</documentation>
+    </annotation>
+    <element name="LayerAboveAerodrome" type="iwxxm-us:LayerAboveAerodromeType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Describes the upper and lower limits of a layer above the aerodrome.
+            This is needed for a number of weather elements, including non-convective low level wind
+            shear, icing, turbulence, and volcanic ash.</documentation>
+        </annotation>
+    </element>
+    <complexType name="LayerAboveAerodromeType">
+        <sequence>
+            <element name="lowerLimit" type="gml:LengthType">
+                <annotation>
+                    <documentation>Measured or estimated lower limit (height)  of phenomenon.</documentation>
+                </annotation>
+            </element>
+            <element name="upperLimit" type="gml:LengthType">
+                <annotation>
+                    <documentation>Measured or estimated upper limit (height)  of phenomenon.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="LayerAboveAerodromePropertyType">
+        <sequence>
+            <element ref="iwxxm-us:LayerAboveAerodrome"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="Remarks" type="iwxxm-us:RemarksType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Free format text provided by the forecaster to provide additional
+            information on the entire product or region(s) not encoded elsewhere.</documentation>
+        </annotation>
+    </element>
+    <complexType name="RemarksType">
+        <sequence>
+            <element name="freeText" type="string">
+                <annotation>
+                    <documentation>Text entered by forecaster regarding any aspect of the SIGMET not
+                    already incorporated/included into the document.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="RemarksPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:Remarks"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="USMetadata" type="iwxxm-us:USMetadataType">
+        <annotation>
+            <documentation>Additional information regarding the composition and generation of the
+            observation and/or forecast product.</documentation>
+        </annotation>
+    </element>
+    <complexType name="USMetadataType">
+        <sequence>
+            <element name="procedure" minOccurs="0" maxOccurs="1" type="gml:ReferenceType">
+                <annotation>
+                    <documentation>Reference to authoritative sources that governs and elucidates
+                    the process by which the meteorological observation or forecast is
+                    made.</documentation>
+                </annotation>
+            </element>
+            <element name="reference" minOccurs="0" maxOccurs="1" type="gml:ReferenceType">
+                <annotation>
+                    <documentation>Reference to documentation on the user-supplied aspects of the
+                    observation platform.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="USMetadataPropertyType">
+        <sequence minOccurs="0">
+            <element ref="iwxxm-us:USMetadata"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="LengthWithNilReason" type="iwxxm-us:LengthWithNilReasonType">
+        <annotation>
+            <documentation>A nillable Length quantity. Unlike the base Length measure, references
+            to this type may be nil and include a nilReason.</documentation>
+        </annotation>
+    </element>
+    <complexType name="LengthWithNilReasonType">
+        <simpleContent>
+            <extension base="gml:LengthType">
+                <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <element name="MeasureWithNilReason" type="iwxxm-us:MeasureWithNilReasonType">
+        <annotation>
+            <documentation>A nillable Measure quantity. Unlike the base Measure, references to this
+            type may be nil and may include a nilReason.</documentation>
+        </annotation>
+    </element>
+    <complexType name="MeasureWithNilReasonType">
+        <simpleContent>
+            <extension base="gml:MeasureType">
+                <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <element name="AerodromePresentWeather" type="iwxxm-us:AerodromePresentWeatherType"/>
+    <complexType name="AerodromePresentWeatherType">
+        <annotation>
+            <documentation>The present weather observed at, or in near vicinity of, an aerodrome.
+
+            Only a specific set of weather phenomenon are reported within aviation meteorology as
+            defined in Regulation ICAO Annex 3 / WMO No. 49-2.
+
+            This CodeList is specifically defined for aviation purposes as defined in WMO
+            No. 49-2. A superset of definitions are defined in WMO No. 306 Vol I.1 code-table 4678
+            "Significant weather phenomena".</documentation>
+            <appinfo>
+                <vocabulary>http://codes.wmo.int/49-2/AerodromePresentOrForecastWeather</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="CloudAmountReportedAtAerodrome" type="iwxxm-us:CloudAmountReportedAtAerodromeType"/>
+    <complexType name="CloudAmountReportedAtAerodromeType">
+        <annotation>
+            <documentation>Amount of cloud - assessed by category:
+
+            - Sky clear (0 oktas)
+            - Few (1 - 2 oktas)
+            - Scattered (3 - 4 oktas)
+            - Broken (5 - 7 oktas)
+            - Overcast (8 oktas)
+
+            This CodeList is specifically defined for aviation purposes, as defined in WMO
+            No. 49-2. A superset of cloud-amount categories are defined in WMO No. 306 Vol I.2 FM 94
+            BUFR code-table 0 20 008 "Cloud distribution for aviation".</documentation>
+            <appinfo>
+                <vocabulary>http://codes.wmo.int/49-2/CloudAmountReportedAtAerodrome</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <simpleType name="RelationalOperatorType">
+        <annotation>
+            <documentation>RelationalOperator defines the restricted set of operators that may be
+            specified alongside numerical quantities.
+
+            These operators are used in cases where a precise value is not measurable, not precisely
+            known due to measurement limitations, or not reported due to reporting restrictions.
+
+            For example, the "BELOW" operator in conjunction with the reported quantity 1/4
+            indicates that the actual physical quantity is below 1/4 (at most 1/4).</documentation>
+        </annotation>
+        <restriction base="string">
+            <enumeration value="ABOVE">
+                <annotation>
+                    <documentation>The actual value is above the maximum value that can be
+                    determined by the system.</documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="BELOW">
+                <annotation>
+                    <documentation>The actual value is below the minimum value that can be
+                    determined by the system.</documentation>
+                </annotation>
+            </enumeration>
+        </restriction>
+    </simpleType>
+</schema>

--- a/vendor/schemas/iwxxm-us/3.0/metarSpeci.xsd
+++ b/vendor/schemas/iwxxm-us/3.0/metarSpeci.xsd
@@ -1,0 +1,1065 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.weather.gov/iwxxm-us/3.0" version="3.0.2" attributeFormDefault="unqualified" xmlns:iwxxm-us="http://www.weather.gov/iwxxm-us/3.0" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <include schemaLocation="common.xsd"/>
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <annotation>
+        <documentation>This package includes the information needed to model the Federal Aviation
+        Administration's filed differences to the International Civil Aviation Organization for the
+        METAR and SPECI products. Two US handbooks document observing practices and were used to guide
+        the development of this package.
+
+        The Interagency Council for Advancing Meteorological Services (ICAMS) maintains the Federal
+        Meteorological Handbook No. 1, Surface Weather Observations and Reports used primarily by the
+        National Weather Service, the FAA and its contractors.
+
+        The Secretary of the US Air Force maintains the Air Force Manual 15-111, Surface Weather
+      Observations for its airmen.</documentation>
+    </annotation>
+    <element name="Addendum" type="iwxxm-us:AddendumType">
+        <annotation>
+            <documentation>Class containing meteorological conditions observed according to FMH-1
+                not already encoded in other IWXXM classes.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AddendumType">
+        <sequence>
+            <element name="observingSystemType" type="iwxxm-us:ObservingSystemTypeType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Observing system types in use by NWS and US Military</documentation>
+                </annotation>
+            </element>
+            <element name="humanReadableText" type="string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Plaintext which further elaborate on parameters reported in the
+                    body of the report, or contain information in an unstructured format and cannot
+                    be easily parsed. Examples include information on volcanic eruptions, funnel and
+                    rotor clouds, tornadoes, virga, aircraft mishaps, etc.</documentation>
+                </annotation>
+            </element>
+            <element name="seaLevelPressure" minOccurs="0" maxOccurs="1" type="iwxxm-us:MeasureWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>At designated stations, sea-level pressure shall be computed by
+                    adjusting the station pressure to compensate for the difference between the
+                    station elevation and sea-level. This adjustment shall be based on the station
+                    elevation and the 12-hour mean temperature at the station. The 12­hour mean
+                    temperature shall be the average of the present ambient temperature and the
+                    ambient temperature 12 hours ago.
+
+                    Stations within ± 50 feet of sea-level may be authorized by their agency to use
+                    a constant value to adjust station pressure to sea-level pressure. Otherwise,
+                    stations shall use reduction ratios provided by their responsible agency to
+                    calculate sea-level pressure.</documentation>
+                </annotation>
+            </element>
+            <element name="pressureTendency3hr" minOccurs="0" maxOccurs="1" type="iwxxm-us:MeasureWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>Designated stations shall include pressure tendency data in each
+                    3- and 6-hourly report. The pressure tendency includes two parts: the
+                    characteristic (an indication of how the pressure has been changing over the
+                    past three hours) and the amount of the pressure change in the past three
+                    hours. The characteristic shall be based on the observed or recorded (barogram
+                    trace) changes in pressure over the past three hours. The amount of pressure
+                    change is the absolute value of the change in station pressure or altimeter
+                    setting in the past three hours converted to tenths of
+                    hectopascals.</documentation>
+                </annotation>
+            </element>
+            <element name="pressureTendencyCharacteristic3hr" type="iwxxm-us:PressureTendencyCharacteristicType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Pressure tendency characteristic over the past 3 hours as
+                    described in the WMO Code Registry.</documentation>
+                </annotation>
+            </element>
+            <element name="pressureChangeIndicator" type="iwxxm-us:PressureChangingRapidlyType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>At designated stations, the pressure calculated for each report
+                    shall be examined to determine if a pressure change is occurring.
+
+                    When the pressure is rising or falling rapidly at the time of observation, the
+                    remark PRESRR (pressure rising rapidly) or PRESFR (pressure falling rapidly)
+                    shall be included in the report.</documentation>
+                </annotation>
+            </element>
+            <element name="snowDepth" minOccurs="0" maxOccurs="1" type="iwxxm-us:LengthWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>Total snow depth on the ground if there is more than a trace on
+                    the ground.</documentation>
+                </annotation>
+            </element>
+            <element name="snowIncrease" type="iwxxm-us:SnowIncreasePropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="visuallyObservablePhenomena" type="iwxxm-us:VisuallyObservablePhenomenaPropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="recentWeather" type="iwxxm-us:RecentWeatherPropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="processedQuantity" type="iwxxm-us:ProcessedPropertyPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+            <element name="maxMinTemperatures" type="iwxxm-us:MaxMinTemperaturesPropertyType" minOccurs="0" maxOccurs="2"/>
+            <element name="observedAtSecondLocation" type="iwxxm-us:ObservedAtSecondLocationPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+            <element name="condensationTrail" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>True when condensation trails are observed in the past hour.</documentation>
+                </annotation>
+            </element>
+            <element name="aurora" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>True when an aurora is observed in the past hour.</documentation>
+                </annotation>
+            </element>
+            <element name="firstObservation" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>True when this report is the first one after a scheduled
+                    interruption.</documentation>
+                </annotation>
+            </element>
+            <element name="lastObservation" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>True when this report is the last one before a scheduled
+                    interruption.</documentation>
+                </annotation>
+            </element>
+            <element name="hailstoneSize" minOccurs="0" maxOccurs="1">
+                <complexType>
+                    <sequence minOccurs="0">
+                        <element ref="iwxxm-us:HailstoneSize"/>
+                    </sequence>
+                    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+                </complexType>
+            </element>
+            <element name="noSpecials" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>At manual stations where SPECI's are not taken, this shall set to
+                    'true' to indicate that no changes in weather conditions will be reported until
+                    the next METAR.</documentation>
+                </annotation>
+            </element>
+            <element name="maintenanceIndicator" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>True when the automated system detects that maintenance is needed
+                    on the system.</documentation>
+                </annotation>
+            </element>
+            <element name="durationOfSunshine" type="duration" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>The duration of sunshine that occurred the previous calendar
+                    day.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="AddendumPropertyType">
+        <sequence minOccurs="0">
+            <element ref="iwxxm-us:Addendum"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AerodromePeakWind" type="iwxxm-us:AerodromePeakWindType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>The maximum instantaneous wind speed since the last observation that
+            exceeded 25 knots and the time it occurred.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AerodromePeakWindType">
+        <sequence>
+            <element name="windDirection" type="gml:AngleType">
+                <annotation>
+                    <documentation>Wind direction of the peak gust.</documentation>
+                </annotation>
+            </element>
+            <element name="windSpeed" type="gml:SpeedType">
+                <annotation>
+                    <documentation>The maximum instantaneous wind speed.</documentation>
+                </annotation>
+            </element>
+            <element name="timeOfOccurrence" type="gml:TimeInstantPropertyType">
+                <annotation>
+                    <documentation>Time of peak wind occurrence.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="AerodromePeakWindPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:AerodromePeakWind"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AerodromeVariableRVR" type="iwxxm-us:AerodromeVariableRVRType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>In situations of varying RVR, the mean value RVR distance for the runway
+            shall be withheld and indicated with iwxxm:meanRVR attributes nilReason and
+            xsi:nil set to withheld and true, respectively.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AerodromeVariableRVRType">
+        <sequence>
+            <element name="minimumRVR" type="gml:LengthType">
+                <annotation>
+                    <documentation>Lowest reported RVR distance.</documentation>
+                </annotation>
+            </element>
+            <element name="maximumRVR" type="gml:LengthType">
+                <annotation>
+                    <documentation>Highest reported RVR distance.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="belowSensorMinimum" type="boolean">
+            <annotation>
+                <documentation>Visibility is less than sensor's minimum limits.</documentation>
+            </annotation>
+        </attribute>
+        <attribute name="aboveSensorMaximum" type="boolean">
+            <annotation>
+                <documentation>Visibility is greater than sensor's maximum limits.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="AerodromeVariableRVRPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:AerodromeVariableRVR"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AerodromeWindShift" type="iwxxm-us:AerodromeWindShiftType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>A wind shift shall be indicated if a change in the wind direction of 45
+            degrees or more in less than 15 minutes with sustained wind speeds of 10 knots or more
+            throughout the period occurs. Frontal passage may be indicated if it is reasonably
+            certain that the wind shift was the result.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AerodromeWindShiftType">
+        <sequence>
+            <element name="timeOfWindShift" type="gml:TimeInstantPropertyType">
+                <annotation>
+                    <documentation>Time of observed wind shift.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="frontalPassage" type="boolean">
+            <annotation>
+                <documentation>Set to true if its reasonably certain that the wind shift was caused by a frontal passage.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="AerodromeWindShiftPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:AerodromeWindShift"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="CharacterOfTheSky" type="iwxxm-us:CharacterOfTheSkyType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>At designated locations, and at 3- and 6-h intervals, the observer
+            provides information on the predominate types of low-, middle- and high-level clouds at
+            the time of the report.</documentation>
+        </annotation>
+    </element>
+    <complexType name="CharacterOfTheSkyType">
+        <sequence>
+            <element name="lowCloudCharacter" type="iwxxm-us:CloudTypesType">
+                <annotation>
+                    <documentation>Cloud type of the genera Stratocumulus, Stratus, Cumulus and Cumulonimbus.</documentation>
+                </annotation>
+            </element>
+            <element name="middleCloudCharacter" type="iwxxm-us:CloudTypesType">
+                <annotation>
+                    <documentation>Cloud type of the genera Altocumulus, Altostratus and Nimbostratus.</documentation>
+                </annotation>
+            </element>
+            <element name="highCloudCharacter" type="iwxxm-us:CloudTypesType">
+                <annotation>
+                    <documentation>Cloud type of the genera Cirrus, Cirrocumulus and Cirrostratus.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="CharacterOfTheSkyPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:CharacterOfTheSky"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="ConvectiveCloudLocation" type="iwxxm-us:ConvectiveCloudLocationType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>From designated or suitably equipped observation location, the distance
+            to and subtended angle which thunderstorm, cumulonimbus or cumulomammatus clouds are
+            observed.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ConvectiveCloudLocationType">
+        <sequence>
+            <element name="cloudType" type="iwxxm-us:ConvectiveCloudTypesType">
+                <annotation>
+                    <documentation>Type of convective cloud being reported, e.g., thunderstorm, or cumulonimbus.</documentation>
+                </annotation>
+            </element>
+            <element name="qualitativeDistance" type="iwxxm-us:QualitativeDistanceType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Qualitative distance estimate from observation location to
+                    convective activity, e.g, distant or in the vicinity.</documentation>
+                </annotation>
+            </element>
+            <element name="sector" minOccurs="0" maxOccurs="4" nillable="true">
+                <annotation>
+                    <documentation>One or more arcs which the convective cloud extends along the
+                    local horizon.</documentation>
+                </annotation>
+                <complexType>
+                    <complexContent>
+                        <extension base="iwxxm-us:SectorPropertyType">
+                            <attribute name="nilReason" type="gml:NilReasonType"/>
+                        </extension>
+                    </complexContent>
+                </complexType>
+            </element>
+            <element name="directionOfMotion" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Direction which the convective cloud is moving towards in degrees
+                    from true north.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="movingOverhead" type="boolean">
+            <annotation>
+                <documentation>True if thunderstorm is moving overhead at the observing platform.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="ConvectiveCloudLocationPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:ConvectiveCloudLocation" maxOccurs="8" minOccurs="1"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="FailedSensors" type="iwxxm-us:FailedSensorsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Type, and optionally, the location of the failed sensor(s).</documentation>
+        </annotation>
+    </element>
+    <complexType name="FailedSensorsType">
+        <sequence>
+            <element name="parameter" type="iwxxm-us:MeteorologicalSensorsType" minOccurs="1" maxOccurs="unbounded">
+                <annotation>
+                    <documentation>The parameter that cannot be measured due to an inoperable sensor.</documentation>
+                </annotation>
+            </element>
+            <element name="location" minOccurs="0" maxOccurs="1" type="iwxxm-us:SensorLocationPropertyType">
+                <annotation>
+                    <documentation>In case of multiple sensors of the same type at the aerodrome,
+                    location provides the position of the inoperable sensor.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="FailedSensorsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:FailedSensors"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="HailstoneSize" type="iwxxm-us:HailstoneSizeType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>At designated stations hailstone size (diameter) shall be reported in
+            increments of 1/4 inch.</documentation>
+        </annotation>
+    </element>
+    <complexType name="HailstoneSizeType">
+        <sequence>
+            <element name="maximumDiameter" type="gml:LengthType">
+                <annotation>
+                    <documentation>Hailstone size diameter in increments of 1/4 inch.</documentation>
+                </annotation>
+            </element>
+            <element name="sizeOperator" type="iwxxm-us:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Hail less than 1/4 inch in size, this attribute shall be set to
+                    BELOW.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <element name="InoperativeSensors" type="iwxxm-us:InoperativeSensorsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Current list of inoperative sensors at the time of the report.</documentation>
+        </annotation>
+    </element>
+    <complexType name="InoperativeSensorsType">
+        <sequence>
+            <element name="failedSensors" minOccurs="1" maxOccurs="unbounded" type="iwxxm-us:FailedSensorsPropertyType">
+                <annotation>
+                    <documentation>An observation system's sensor(s) which failed measurement
+                    standards and/or specifications at the time of the report.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="InoperativeSensorsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:InoperativeSensors"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="MaxMinTemperatures" type="iwxxm-us:MaxMinTemperaturesType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>At designated stations, maximum and minimum temperatures that occurred in
+                the previous 6 hours shall be determined to the nearest tenth of a degree Celsius
+                for the 0000, 0600, 1200, and 1800 UTC observations. The maximum and minimum
+                temperatures for the previous 24 hours shall be determined to the nearest tenth of a
+                degree Celsius for the 0000 LST observation.</documentation>
+        </annotation>
+    </element>
+    <complexType name="MaxMinTemperaturesType">
+        <sequence>
+            <element name="precedingPeriod" type="duration">
+                <annotation>
+                    <documentation>The preceding time period which the extremes in air temperatures
+                    were observed.</documentation>
+                </annotation>
+            </element>
+            <element name="maxTemperature" type="iwxxm-us:MeasureWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>Highest temperature that occurred during the preceding time period.</documentation>
+                </annotation>
+            </element>
+            <element name="minTemperature" type="iwxxm-us:MeasureWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>Lowest temperature that occurred during the preceding time period.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="MaxMinTemperaturesPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:MaxMinTemperatures"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="Obscurations" type="iwxxm-us:ObscurationsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Weather phenomenon, either surface-based or aloft, that completely or
+            partially obscure the sky.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ObscurationsType">
+        <sequence>
+            <element name="heightOfWeatherPhenomenon" type="gml:LengthType">
+                <annotation>
+                    <documentation>Height of obscuring phenomenon above ground level. Value of zero
+                    indicates surface-based phenomenon.</documentation>
+                </annotation>
+            </element>
+            <element name="obscurationAmount" type="iwxxm-us:CloudAmountReportedAtAerodromeType">
+                <annotation>
+                    <documentation>Portion of the sky obscured by the phenomenon.</documentation>
+                </annotation>
+            </element>
+            <element name="weatherCausingObscuration" type="iwxxm-us:AerodromePresentWeatherType">
+                <annotation>
+                    <documentation>Weather phenomenon (surface-based or aloft) that completely or
+                    partially obscures the sky.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="ObscurationsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:Obscurations"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="ObservedLightning" type="iwxxm-us:ObservedLightningType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>The location and characteristics of observed lightning at the observation site.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ObservedLightningType">
+        <sequence>
+            <element name="qualitativeDistance" type="iwxxm-us:QualitativeDistanceType" minOccurs="0" maxOccurs="2">
+                <annotation>
+                    <documentation>Qualitative distance estimate from observation location to
+                    lightning activity, e.g, distant or in the vicinity.</documentation>
+                </annotation>
+            </element>
+            <element name="frequency" type="iwxxm-us:LightningFrequencyType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Qualitative estimate of the number of lightning discharges within
+                    a 1 minute period.</documentation>
+                </annotation>
+            </element>
+            <element name="type" type="iwxxm-us:LightningTypeType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Type(s) of lightning discharge activity observed at/surrounding
+                    the observation site.</documentation>
+                </annotation>
+            </element>
+            <element name="sector" minOccurs="0" maxOccurs="4" type="iwxxm-us:SectorPropertyType" nillable="true">
+                <annotation>
+                    <documentation>One or more arcs which the lightning activity extends along the
+                    local horizon.</documentation>
+                </annotation>
+            </element>
+            <element name="measuredFlashFrequency" type="gml:MeasureType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Measured flash frequency as determined by the observation system.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="ObservedLightningPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:ObservedLightning" maxOccurs="4" minOccurs="1"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="ObservedAtSecondLocation" type="iwxxm-us:ObservedAtSecondLocationType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Where the observations occurs at aerodromes and ceiling and/or
+            visibilities are monitored at second location, usually a runway, these parameters are
+            reported when they are significantly lower than those reported at the usual observation
+            location.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ObservedAtSecondLocationType">
+        <sequence>
+            <element name="ceilingHeight" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Lowest cloud base height of a broken or overcast cloud layer, if present.</documentation>
+                </annotation>
+            </element>
+            <element name="visibility" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Horizontal visibility</documentation>
+                </annotation>
+            </element>
+            <element name="location" minOccurs="0" maxOccurs="1" type="iwxxm-us:SensorLocationPropertyType">
+                <annotation>
+                    <documentation>Location of second set of ceiling and/or visibility sensors.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="visibilityBelowSensorMinimum" type="boolean">
+            <annotation>
+                <documentation>If sensor determines that horizontal visibility is reduced below its ability to measure accurately, this attribute shall be present and set to 'true'.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="ObservedAtSecondLocationPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:ObservedAtSecondLocation"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="ObservingSystemMetadata" type="iwxxm-us:ObservingSystemMetadataType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>This class shall refer to, via xlink:href, an external resource
+            describing the geographical and/or technical specifications of the observation platform
+            used to create the observation.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ObservingSystemMetadataType">
+        <sequence>
+            <element name="observingPlatformSpecifications" type="gml:ReferenceType">
+                <annotation>
+                    <documentation>Reference to an external source that describes the technical and
+                    geographical specifications of the observation platform at the
+                    aerodrome.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="ObservingSystemMetadataPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:ObservingSystemMetadata"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="RecentWeather" type="iwxxm-us:RecentWeatherType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>For suitably equipped observation platforms, the starting and ending
+            times of precipitation/thunderstorm events are reported since the last
+            issuance.</documentation>
+        </annotation>
+    </element>
+    <complexType name="RecentWeatherType">
+        <sequence>
+            <element name="weatherPhenomenon" type="iwxxm-us:AerodromePresentWeatherType">
+                <annotation>
+                    <documentation>The weather phenomenon that occurred.</documentation>
+                </annotation>
+            </element>
+            <element name="timeOfEvent" type="gml:TimePeriodPropertyType" minOccurs="1" maxOccurs="unbounded">
+                <annotation>
+                    <documentation>The starting (if known) and ending (if known) times of the
+                    precipitation/thunderstorm event.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="RecentWeatherPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:RecentWeather" maxOccurs="unbounded" minOccurs="1"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="Sector" type="iwxxm-us:SectorType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Endpoints of the azimuth angles and, optionally, measured distances to
+            the phenomenon that defines the sector.</documentation>
+        </annotation>
+    </element>
+    <complexType name="SectorType">
+        <sequence>
+            <element name="extremeCCWDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>The counterclockwise-most extent of the observed convective cloud
+                    on the local horizon as expressed in degrees from true north.</documentation>
+                </annotation>
+            </element>
+            <element name="extremeCCWDistance" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Measured distance to the phenomena at the extreme counter-clockwise angle.</documentation>
+                </annotation>
+            </element>
+            <element name="extremeCWDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>The clockwise-most extent of the observed convective cloud on the
+                    local horizon as expressed in degrees from true north.</documentation>
+                </annotation>
+            </element>
+            <element name="extremeCWDistance" type="gml:LengthType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Measured distance to the phenomena at the extreme clockwise angle.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="inAllQuadrants" type="boolean">
+            <annotation>
+                <documentation>If event is occurring in all quadrants of the horizon, this shall be set to true and no angles or distances provided.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="SectorPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:Sector"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="SectorVisibility" type="iwxxm-us:SectorVisibilityType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Sector visibility shall be reported when it differs from the prevailing
+                visibility by one or more reportable values and either the prevailing or sector
+                visibility is less than 3 miles.</documentation>
+        </annotation>
+    </element>
+    <complexType name="SectorVisibilityType">
+        <sequence>
+            <element name="visibility" type="gml:LengthType">
+                <annotation>
+                    <documentation>Horizontal visibility in this sector</documentation>
+                </annotation>
+            </element>
+            <element name="direction" type="gml:AngleType">
+                <annotation>
+                    <documentation>The sector's mid-point direction as expressed in degrees from true north.</documentation>
+                </annotation>
+            </element>
+            <element name="belowSensorMinimum" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>If visibility in this sector is less than the nearest visual
+                    reference for distance or below sensors' minimum, this attribute shall be set to
+                    'true'.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="SectorVisibilityPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:SectorVisibility"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="SensorLocation" type="iwxxm-us:SensorLocationType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Location of secondary suite of visibility and/or ceiling sensors.
+            Candidate locations besides the airport reference point (ARP), are runways' touch down
+            thresholds, midfield, alternate runways, etc.</documentation>
+        </annotation>
+    </element>
+    <complexType name="SensorLocationType">
+        <sequence>
+            <element name="description" type="string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Concise description of the secondary sensor location. Intended
+                    use is for further elucidation in conjunction with other attributes, e.g,
+                    'Adjacent to runway touch down zone'. Or can be used by itself if the sensor's
+                    location cannot be indicated with the other attributes of this data
+                    type.</documentation>
+                </annotation>
+            </element>
+            <element name="geoLocation" type="gml:PointPropertyType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Geo-spatial location of secondary sensor(s).</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="SensorLocationPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:SensorLocation"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="SnowIncrease" type="iwxxm-us:SnowIncreaseType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>At designated stations whenever the snow depth increases by 1 in/h or
+            more in the past hour, it shall be reported.</documentation>
+        </annotation>
+    </element>
+    <complexType name="SnowIncreaseType">
+        <sequence>
+            <element name="snowDepthIncrease" type="iwxxm-us:ProcessedPropertyPropertyType">
+                <annotation>
+                    <documentation>Measured increased in snow depth during the past hour.</documentation>
+                </annotation>
+            </element>
+            <element name="snowDepth" type="iwxxm-us:LengthWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>Snow depth on the ground.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="SnowIncreasePropertyType">
+        <sequence>
+            <element ref="iwxxm-us:SnowIncrease"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="ProcessedProperty" type="iwxxm-us:ProcessedPropertyType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>This class supports a general need to capture statistically processed
+            quantities in FMH-1 based surface observation reports, such as maximum/minimum
+            temperatures, precipitation amounts over a duration, etc. The processed value contains
+            the actual measurement. The remaining attributes are needed to properly interpret the
+            value.</documentation>
+        </annotation>
+    </element>
+    <complexType name="ProcessedPropertyType">
+        <sequence>
+            <element name="processedWeatherElement"
+                type="iwxxm-us:StatisticallyProcessedWeatherElementsType">
+                <annotation>
+                    <documentation>The meteorological parameter subjected to the statistical procedure.</documentation>
+                </annotation>
+            </element>
+            <element name="valueType" type="iwxxm-us:StatisticalFunctionTypeType">
+                <annotation>
+                    <documentation>Type of extreme value, e.g., minimum or maximum.</documentation>
+                </annotation>
+            </element>
+            <element name="valuePeriod" type="duration">
+                <annotation>
+                    <documentation>The time duration of the set of values which the statistical
+                    processing was applied.</documentation>
+                </annotation>
+            </element>
+            <element name="qualifier" type="iwxxm-us:RelationalOperatorType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>If the measurement system specification(s) for the processed
+                    quantity is exceeded, i.e., ABOVE or BELOW.</documentation>
+                </annotation>
+            </element>
+            <element name="processedValue" type="iwxxm-us:MeasureWithNilReasonType" nillable="true">
+                <annotation>
+                    <documentation>The measured value of the meteorological parameter.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="ProcessedPropertyPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:ProcessedProperty"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="TowerVisibility" type="iwxxm-us:TowerVisibilityType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Reported tower visibility when controller cab visibility differs markedly
+            from surface visibility and may affect airport operation.</documentation>
+        </annotation>
+    </element>
+    <complexType name="TowerVisibilityType">
+        <sequence>
+            <element name="towerVisibility" type="gml:LengthType">
+                <annotation>
+                    <documentation>Horizontal or slant visibility from the aerodrome air traffic control tower.</documentation>
+                </annotation>
+            </element>
+            <element name="lessThan" type="boolean" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>To indicate visibility less than the nearest visibility marker.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="TowerVisibilityPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:TowerVisibility"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="VariableCeilingHeight" type="iwxxm-us:VariableCeilingHeightType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Variable ceiling height shall be reported if height varies significantly
+            during the sampling period of the report.</documentation>
+        </annotation>
+    </element>
+    <complexType name="VariableCeilingHeightType">
+        <sequence>
+            <element name="minimumHeight" type="gml:LengthType">
+                <annotation>
+                    <documentation>Minimum ceiling height observed during sampling period</documentation>
+                </annotation>
+            </element>
+            <element name="maximumHeight" type="gml:LengthType">
+                <annotation>
+                    <documentation>Maximum ceiling height observed during sampling period</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="VariableCeilingHeightPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:VariableCeilingHeight"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="VariableSkyCondition" type="iwxxm-us:VariableSkyConditionType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Sky cover shall be considered variable if it changes by one or more
+            reportable values (few, scattered, broken, overcast) during the evaluation
+            period.</documentation>
+        </annotation>
+    </element>
+    <complexType name="VariableSkyConditionType">
+        <sequence>
+            <element name="firstSkyCoverValue" type="iwxxm-us:CloudAmountReportedAtAerodromeType">
+                <annotation>
+                    <documentation>The first of the operationally significant sky cover condition.</documentation>
+                </annotation>
+            </element>
+            <element name="secondSkyCoverValue" type="iwxxm-us:CloudAmountReportedAtAerodromeType">
+                <annotation>
+                    <documentation>The second of the operationally significant sky cover condition.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="VariableSkyConditionPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:VariableSkyCondition"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="VariableVisibility" type="iwxxm-us:VariableVisibilityType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Variable prevailing visibility shall be reported if criteria is met
+            during the time of observation.</documentation>
+        </annotation>
+    </element>
+    <complexType name="VariableVisibilityType">
+        <sequence>
+            <element name="minimumVisibility" type="gml:LengthType">
+                <annotation>
+                    <documentation>The lower bound value of the prevailing visibility during the
+                    sampling period.</documentation>
+                </annotation>
+            </element>
+            <element name="maximumVisibility" type="gml:LengthType">
+                <annotation>
+                    <documentation>The upper bound value of the prevailing visibility during the
+                    sampling period.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="belowMinimum" type="boolean">
+            <annotation>
+                <documentation>If minimum visibility is below sensor limitations or, for the human observer, the nearest reference point, this attribute shall be set to 'true'.</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="VariableVisibilityPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:VariableVisibility"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="VisuallyObservablePhenomena" type="iwxxm-us:VisuallyObservablePhenomenaType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>This class contains additive data that cannot be automated. As such,
+            these reports are taken manually, or augmented by a trained observer.</documentation>
+        </annotation>
+    </element>
+    <complexType name="VisuallyObservablePhenomenaType">
+        <sequence>
+            <element name="lightning" type="iwxxm-us:ObservedLightningPropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="convection" type="iwxxm-us:ConvectiveCloudLocationPropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="characterOfTheSky" type="iwxxm-us:CharacterOfTheSkyPropertyType" minOccurs="0" maxOccurs="1"/>
+            <element name="obscuration" type="iwxxm-us:ObscurationsPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <complexType name="VisuallyObservablePhenomenaPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:VisuallyObservablePhenomena"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="CloudTypes" type="iwxxm-us:CloudTypesType"/>
+    <complexType name="CloudTypesType">
+        <annotation>
+            <documentation>The WMO International Cloud Atlas.</documentation>
+            <appinfo>
+                <vocabulary>http://codes.wmo.int/bufr4/codeflag/0-20-012</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="ConvectiveCloudTypes" type="iwxxm-us:ConvectiveCloudTypesType"/>
+    <complexType name="ConvectiveCloudTypesType">
+        <annotation>
+            <documentation>List of convective cloud types which may affect the safety and
+            navigability of aircraft surrounding the aerodrome.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/ConvectiveCloudType</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="LightningFrequency" type="iwxxm-us:LightningFrequencyType"/>
+    <complexType name="LightningFrequencyType">
+        <annotation>
+            <documentation>List of qualifiers for lightning frequency.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/LightningFrequency</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="LightningType" type="iwxxm-us:LightningTypeType"/>
+    <complexType name="LightningTypeType">
+        <annotation>
+            <documentation>List of lightning phenomena.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/LightningType</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="MeteorologicalSensors" type="iwxxm-us:MeteorologicalSensorsType"/>
+    <complexType name="MeteorologicalSensorsType">
+        <annotation>
+            <documentation>List of specialized equipment/sensors for recording or observing
+            meteorological phenomena.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/Sensor</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="ObservingSystemType" type="iwxxm-us:ObservingSystemTypeType"/>
+    <complexType name="ObservingSystemTypeType">
+        <annotation>
+            <documentation>List of commonly situated meteorological observation platforms.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/ObservingSystemType</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="PressureChangingRapidly" type="iwxxm-us:PressureChangingRapidlyType"/>
+    <complexType name="PressureChangingRapidlyType">
+        <annotation>
+            <documentation>An enumeration of falling or rising.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/PressureChangingRapidly</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="PressureTendencyCharacteristic"
+        type="iwxxm-us:PressureTendencyCharacteristicType"/>
+    <complexType name="PressureTendencyCharacteristicType">
+        <annotation>
+            <documentation>A list of the 3-hourly pressure tendency groups.</documentation>
+            <appinfo>
+                <vocabulary>http://codes.wmo.int/bufr4/codeflag/0-10-063</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="QualitativeDistance" type="iwxxm-us:QualitativeDistanceType"/>
+    <complexType name="QualitativeDistanceType">
+        <annotation>
+            <documentation>For phenomena of, or associated with, a convective nature such as
+            cumulonimbus clouds or lightning, a list of distance qualifiers.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/QualitativeDistance</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="StatisticalFunctionType" type="iwxxm-us:StatisticalFunctionTypeType"/>
+    <complexType name="StatisticalFunctionTypeType">
+        <annotation>
+            <documentation>A list of statistical functions.</documentation>
+            <appinfo>
+                <vocabulary>http://codes.wmo.int/grib2/codeflag/4.10</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="StatisticallyProcessedWeatherElements"
+        type="iwxxm-us:StatisticallyProcessedWeatherElementsType"/>
+    <complexType name="StatisticallyProcessedWeatherElementsType">
+        <annotation>
+            <documentation>List of weather parameters that are statistically processed in the
+            report.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/FMH-1/StatisticallyProcessedWeatherElement</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/vendor/schemas/iwxxm-us/3.0/sigmet.xsd
+++ b/vendor/schemas/iwxxm-us/3.0/sigmet.xsd
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.weather.gov/iwxxm-us/3.0" version="3.0" attributeFormDefault="unqualified" xmlns:iwxxm-us="http://www.weather.gov/iwxxm-us/3.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:aixm="http://www.aixm.aero/schema/5.1.1">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.aixm.aero/schema/5.1.1" schemaLocation="http://www.aixm.aero/schema/5.1.1/AIXM_Features.xsd"/>
+    <annotation>
+        <documentation>This package includes the information needed to model the Federal Aviation
+        Administration's filed differences to the International Civil Aviation Organization for the
+        SIGMET product.
+
+        The National Weather Service Instruction 10-811 describes the content and preparation of its
+        SIGMETs.</documentation>
+    </annotation>
+    <element name="AffectedStates" type="iwxxm-us:AffectedStatesType" substitutionGroup="aixm:AbstractAirspaceVolumeExtension">
+        <annotation>
+            <documentation>List of states (by 2-letter Abbreviation) affected by the iwxxm:geometry.</documentation>
+        </annotation>
+    </element>
+    <complexType name="AffectedStatesType">
+        <complexContent>
+            <extension base="aixm:AbstractExtensionType">
+                <sequence>
+                    <element name="stateIDs" type="string">
+                        <annotation>
+                            <documentation>CONUS States affected by AirspaceVolume.</documentation>
+                        </annotation>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="AffectedStatesPropertyType">
+        <sequence minOccurs="0">
+            <element ref="iwxxm-us:AffectedStates"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="SIGMETWeatherHazards" type="iwxxm-us:SIGMETWeatherHazardsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>En route weather phenomena not in the WMO Registry which will affect
+            safety of flight and/or airport operations.</documentation>
+        </annotation>
+    </element>
+    <complexType name="SIGMETWeatherHazardsType">
+        <sequence>
+            <element name="weatherPhenomenon" type="iwxxm-us:SIGMETWeatherPhenomenaType" minOccurs="0" maxOccurs="unbounded">
+                <annotation>
+                    <documentation>En route weather phenomena which will affect safety of flight
+                    operations.</documentation>
+                </annotation>
+            </element>
+            <element name="watchInformation" type="string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Forecaster free text regarding severe weather watch(es) affecting
+                    the SIGMET.</documentation>
+                </annotation>
+            </element>
+            <element name="maxWindGusts" type="gml:MeasureType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Expected or reported maximum wind speed gusts associated with
+                    convective activity.</documentation>
+                </annotation>
+            </element>
+            <element name="maxHailSize" type="gml:MeasureType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Expected or reported maximum hail size diameter with convective
+                    activity.</documentation>
+                </annotation>
+            </element>
+            <element name="tornadicPhenomena" type="iwxxm-us:HazardStateType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Status regarding the presence of tornadic phenomena with
+                    convective activity.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+        <attribute name="tag" type="string">
+            <annotation>
+                <documentation>Unique identifier of the hazardous region for tracking purposes.</documentation>
+            </annotation>
+        </attribute>
+        <attribute name="isSevere" type="boolean">
+            <annotation>
+                <documentation>This attribute is set to 'true' if any of the following conditions are present:
+1. Tornadic phenomenon, includes waterspouts
+2. Hail size greater than or equal to 3/4 inches in diameter
+3. Wind gusts exceeding 49 knots</documentation>
+            </annotation>
+        </attribute>
+    </complexType>
+    <complexType name="SIGMETWeatherHazardsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:SIGMETWeatherHazards"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="SIGMETWeatherPhenomena" type="iwxxm-us:SIGMETWeatherPhenomenaType"/>
+    <complexType name="SIGMETWeatherPhenomenaType">
+        <annotation>
+            <documentation>US specific hazards not found in WMO Code Registry which may affect the
+            safety of aircraft operations.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/NWSI-10-811/SIGMETWeatherPhenomena</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <simpleType name="HazardStateType">
+        <annotation>
+            <documentation>Forecaster's assessment of occurrence.</documentation>
+        </annotation>
+        <restriction base="string">
+            <enumeration value="POSSIBLE"/>
+            <enumeration value="EXPECTED"/>
+        </restriction>
+    </simpleType>
+</schema>

--- a/vendor/schemas/iwxxm-us/3.0/taf.xsd
+++ b/vendor/schemas/iwxxm-us/3.0/taf.xsd
@@ -1,0 +1,210 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.weather.gov/iwxxm-us/3.0" version="3.0" attributeFormDefault="unqualified" xmlns:iwxxm-us="http://www.weather.gov/iwxxm-us/3.0" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <include schemaLocation="common.xsd"/>
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <annotation>
+        <documentation>This package includes the information needed to model the Federal Aviation
+        Administration's filed differences to the International Civil Aviation Organization for the
+        TAF products. Two publications were consulted while constructing this package. They are the
+        National Weather Service Instruction 10-813, and Air Force Manual 15-124, Meteorological
+        Codes.</documentation>
+    </annotation>
+    <element name="MeteorologicalAerodromeForecastExtension" type="iwxxm-us:MeteorologicalAerodromeForecastExtensionType">
+        <annotation>
+            <documentation>Supplemental meteorological forecasting conditions at an aerodrome as
+            needed by NWS and Air Force.</documentation>
+        </annotation>
+    </element>
+    <complexType name="MeteorologicalAerodromeForecastExtensionType">
+        <sequence>
+            <element name="altimeter" type="gml:MeasureType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Forecasted lowest altimeter setting expected during the forecast
+                    period.</documentation>
+                </annotation>
+            </element>
+            <element name="volcanicAshLayer" minOccurs="0" maxOccurs="1" type="iwxxm-us:LayerAboveAerodromeType">
+                <annotation>
+                    <documentation>Forecast base and top of volcanic ash cloud (layer) above an
+                    aerodrome.</documentation>
+                </annotation>
+            </element>
+            <element name="peakGustDirection" type="gml:AngleType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Forecast of expected direction of wind gusts.</documentation>
+                </annotation>
+            </element>
+            <element name="icingAboveAerodrome" minOccurs="0" maxOccurs="1" type="iwxxm-us:IcingAboveAerodromeType">
+                <annotation>
+                    <documentation>Forecasted icing layer(s) aloft.</documentation>
+                </annotation>
+            </element>
+            <element name="turbulenceAboveAerodrome" minOccurs="0" maxOccurs="1" type="iwxxm-us:TurbulenceAboveAerodromeType">
+                <annotation>
+                    <documentation>Forecasted layers of turbulence above the aerodrome.</documentation>
+                </annotation>
+            </element>
+            <element name="remarks" type="string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Additive information entered by forecaster.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="MeteorologicalAerodromeForecastExtensionPropertyType">
+        <sequence minOccurs="0">
+            <element ref="iwxxm-us:MeteorologicalAerodromeForecastExtension"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="IcingAboveAerodrome" type="iwxxm-us:IcingAboveAerodromeType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Icing forecast for layer(s) above aerodrome.</documentation>
+        </annotation>
+    </element>
+    <complexType name="IcingAboveAerodromeType">
+        <sequence>
+            <element name="icingIntensity" type="iwxxm-us:AirFrameIcingIntensityType">
+                <annotation>
+                    <documentation>Character and intensity of icing in layer.</documentation>
+                </annotation>
+            </element>
+            <element name="layerAboveAerodrome" type="iwxxm-us:LayerAboveAerodromeType">
+                <annotation>
+                    <documentation>Vertical extent of icing above aerodrome.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="IcingAboveAerodromePropertyType">
+        <sequence>
+            <element ref="iwxxm-us:IcingAboveAerodrome"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="NonConvectiveLowLevelWindShear" type="iwxxm-us:NonConvectiveLowLevelWindShearType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Low-level wind shear in the TAF will only refer to non-convective events
+            and situations such as frontal passage, inversions, low-level wind jets, lee-side
+            mountain flows, sea-breezes, Santa Ana winds, etc.</documentation>
+        </annotation>
+    </element>
+    <complexType name="NonConvectiveLowLevelWindShearType">
+        <sequence>
+            <element name="windDirection" type="gml:AngleType">
+                <annotation>
+                    <documentation>Wind direction at the top of the wind-shear layer.</documentation>
+                </annotation>
+            </element>
+            <element name="windSpeed" type="gml:SpeedType">
+                <annotation>
+                    <documentation>Wind speed at the top of the wind shear layer.</documentation>
+                </annotation>
+            </element>
+            <element name="layerAboveAerodrome" type="iwxxm-us:LayerAboveAerodromeType">
+                <annotation>
+                    <documentation>Vertical extent of wind shear layer above/near the aerodrome.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="NonConvectiveLowLevelWindShearPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:NonConvectiveLowLevelWindShear"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="TAFAmendmentLimitations" type="iwxxm-us:TAFAmendmentLimitationsType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>If observations, or human augmentation of the observations, are not
+            available for a aerodrome, then TAFs issued for such stations will be governed by a
+            special set of rules on when and how amendments will be issued.</documentation>
+        </annotation>
+    </element>
+    <complexType name="TAFAmendmentLimitationsType">
+        <sequence>
+            <element name="amendableTAFParameter" type="iwxxm-us:AmendableTAFParameterType" minOccurs="1" maxOccurs="4">
+                <annotation>
+                    <documentation>List of weather parameters that can be amended.</documentation>
+                </annotation>
+            </element>
+            <element name="periodOfLimitation" type="gml:TimePeriodType">
+                <annotation>
+                    <documentation>Time period when amendments are restricted or unavailable.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="TAFAmendmentLimitationsPropertyType">
+        <sequence>
+            <element ref="iwxxm-us:TAFAmendmentLimitations"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="TurbulenceAboveAerodrome" type="iwxxm-us:TurbulenceAboveAerodromeType" substitutionGroup="gml:AbstractObject">
+        <annotation>
+            <documentation>Forecasted type and severity of turbulence above the aerodrome.</documentation>
+        </annotation>
+    </element>
+    <complexType name="TurbulenceAboveAerodromeType">
+        <sequence>
+            <element name="turbulenceIntensity" type="iwxxm-us:TurbulenceIntensityType">
+                <annotation>
+                    <documentation>Character and intensity of forecasted turbulence.</documentation>
+                </annotation>
+            </element>
+            <element name="layerAboveAerodrome" type="iwxxm-us:LayerAboveAerodromeType">
+                <annotation>
+                    <documentation>Vertical extent of turbulence above aerodrome.</documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="TurbulenceAboveAerodromePropertyType">
+        <sequence>
+            <element ref="iwxxm-us:TurbulenceAboveAerodrome"/>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+    <element name="AirFrameIcingIntensity" type="iwxxm-us:AirFrameIcingIntensityType"/>
+    <complexType name="AirFrameIcingIntensityType">
+        <annotation>
+            <documentation>Air Force Manual 15-124 on airframe icing intensity refer to WMO BUFR4 table.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/AFMAN/15-124/IcingType</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="AmendableTAFParameter" type="iwxxm-us:AmendableTAFParameterType"/>
+    <complexType name="AmendableTAFParameterType">
+        <annotation>
+            <documentation>List of meteorological parameters that will be monitored and updated with
+            amendments.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/NWSI-10-813/AmendableTAFParameter</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+    <element name="TurbulenceIntensity" type="iwxxm-us:TurbulenceIntensityType"/>
+    <complexType name="TurbulenceIntensityType">
+        <annotation>
+            <documentation>AFMAN 15-124 Table 1.7 lists the allowable turbulence intensity and type.</documentation>
+            <appinfo>
+                <vocabulary>https://codes.nws.noaa.gov/AFMAN/15-124/TurbulenceIntensity</vocabulary>
+                <extensibility>none</extensibility>
+            </appinfo>
+        </annotation>
+        <complexContent>
+            <extension base="gml:ReferenceType"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/vendor/schemas/iwxxm-us/3.0/united-states-catalog.xml
+++ b/vendor/schemas/iwxxm-us/3.0/united-states-catalog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+
+  <!-- This rewriteSystem element is for Windows based XML validators. Remove comment tag, if using. -->
+  <!-- rewriteSystem systemIdStartString="https://nws.weather.gov/schemas/" rewritePrefix="file:/LOCAL_PARENT_DIRECTORY_PATH"/-->
+
+  <!-- This rewriteSystem element is for UNIX/LINUX based XML validators. Remove comment tag, if using. -->
+  <!-- rewriteSystem systemIdStartString="https://nws.weather.gov/schemas/" rewritePrefix="LOCAL_PARENT_DIRECTORY_PATH"/-->
+
+</catalog>

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,7 +12,7 @@ active_session:
   status: in_progress
   branch: evolve/S008-general-tac-iwxxm-converter
   orchestrator: 16-evolve
-  evolve_cycle_id: null
+  evolve_cycle_id: EV-006
   artifacts_dir: docs/sessions/S008-general-tac-iwxxm-converter/
   routing_plan:
     - stage: 00-context
@@ -44,11 +44,13 @@ active_session:
       note: "S008 delta 05-verify-tech COMPLETED — audit done; next 16-evolve then 07-build; Phase B delta cleared (06 N/A)"
     - stage: 16-evolve
       required: true
-      status: pending
+      status: completed
       skip_rationale: null
+      note: "EV-006 B→C passed (D-S008-EV006-b-to-c=A); handed off to 07-build"
     - stage: 07-build
       required: true
-      status: pending
+      status: in_progress
+      started_at: "2026-07-12"
       skip_rationale: null
     - stage: 08-verify-build
       required: true
@@ -67,7 +69,7 @@ active_session:
       required: true
       status: pending
       skip_rationale: null
-  current_stage: 16-evolve
+  current_stage: 07-build
   started_at: "2026-07-12"
   context_briefs:
     - docs/context/general-tac-iwxxm-converter.md
@@ -98,6 +100,9 @@ active_session:
     - "2026-07-12 D-S008-05-statement-walk — 05-verify-tech statement walk started; auto-approved high-confidence tech stack from Q1–Q20 / ADR-016/017/018 (msgspec, PyO3 cutover gate, worker template, package layout, bulletin schema, H7, lint default on); consistency agent found VT-S008-C01–C10 pending user review; stage not marked completed; delta_substage S008-f6-tac2iwxxm remains in_progress"
     - "2026-07-12 D-S008-05-batch2 — Batch 2 verdicts C09a=1, C09c=1, M01=2, M02=1; delta_substage S008-f6-tac2iwxxm remains in_progress"
     - "2026-07-12 D-S008-05-complete — 05-verify-tech audit done; next=16-evolve then 07-build; Phase B delta cleared (06 N/A); delta_substage S008-f6-tac2iwxxm completed"
+    - "2026-07-12 EV-006 created — Phase B complete; B→C checkpoint pending before 07-build"
+    - "2026-07-12 D-S008-EV006-b-to-c=A — Phase B→C passed; starting 07-build Phase 1 M1 T1.1"
+    - "2026-07-12 M1 tasks T1.1–T1.6 completed on feat/S008-M1-scaffold; next 08-verify-build then PR-M1"
 sessions:
   - id: S007-docs-minimize
     type: process
@@ -872,6 +877,15 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S008-EV006-b-to-c
+    stage: 16-evolve
+    session_id: S008-general-tac-iwxxm-converter
+    decision: "Pass B→C start 07-build"
+    summary: >
+      User chose option A — Pass gate and start 07-build. EV-006 gates.b_to_c
+      and checkpoints.phase_b passed; handed off to 07-build Phase 1 M1 T1.1.
+      Orchestrator remains 16-evolve.
+    timestamp: "2026-07-12"
   - id: D-S008-05-complete
     stage: 05-verify-tech
     session_id: S008-general-tac-iwxxm-converter
@@ -2488,8 +2502,112 @@ evolve_cycles:
         status: completed
     issues: []
 
+  - id: EV-006
+    session_id: S008-general-tac-iwxxm-converter
+    cycle_type: feature
+    feature_ids: [F6, F2, F8]
+    title: "S008 general TAC→IWXXM (F6) + validate packages + F8 worker"
+    status: in_progress
+    started: "2026-07-12"
+    completed: null
+    scope_summary: |
+      Approved S008 scope from Phase A/B: F6 tac2iwxxm (bulletin, METAR/SPECI annex3+US, remaining products),
+      packages iwxxm-validate + tac-validate with thin API wrappers, PyO3 hard cutover gate (ADR-017),
+      gifts delete at cutover, F8 apps/worker Render Background Worker (ADR-018), F6.e UI in M8.
+      F7 multi-product operator UI Planned (not this cycle build). Auth/AMHS/push sinks deferred.
+      Execution plan: docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md (51 tasks, approved).
+    routing_plan:
+      required_stages:
+        - 00-context
+        - 01-requirements
+        - 04-tech-plan
+        - 05-verify-tech
+        - 07-build
+        - 08-verify-build
+        - 09-qa
+        - 10-e2e
+        - 11-verify-impl
+      skipped_stages:
+        - 02-verify-plan
+        - 03-plan-tooling
+        - 06-tech-tooling
+        - 12-verify-deploy
+        - 13-deploy-smoke
+    current_stage: 07-build
+    notes:
+      - "2026-07-12 M1 T1.1–T1.6 completed on feat/S008-M1-scaffold; current work toward 08-verify-build for M1"
+    stages:
+      00-context:
+        status: completed
+        started: "2026-07-12"
+        completed: "2026-07-12"
+      01-requirements:
+        status: completed
+        started: "2026-07-12"
+        completed: "2026-07-12"
+      04-tech-plan:
+        status: completed
+        started: "2026-07-12"
+        completed: "2026-07-12"
+      05-verify-tech:
+        status: completed
+        started: "2026-07-12"
+        completed: "2026-07-12"
+      16-evolve:
+        status: completed
+        started: "2026-07-12"
+        completed: "2026-07-12"
+      07-build:
+        status: in_progress
+        started: "2026-07-12"
+        completed: null
+        notes:
+          - "M1 T1.1–T1.6 completed; next 08-verify-build for M1 then PR-M1"
+      08-verify-build:
+        status: pending
+        started: null
+        completed: null
+      09-qa:
+        status: pending
+        started: null
+        completed: null
+      10-e2e:
+        status: pending
+        started: null
+        completed: null
+      11-verify-impl:
+        status: pending
+        started: null
+        completed: null
+    gates:
+      a_to_b: passed
+      b_to_c: passed
+      c_to_d: pending
+      deploy: pending
+    checkpoints:
+      phase_a: passed
+      phase_b: passed
+      phase_c: pending
+      phase_d: pending
+      deploy: pending
+    adrs:
+      - docs/adr/ADR-013-tac2iwxxm-package-architecture.md
+      - docs/adr/ADR-014-tac2iwxxm-rust-gifts-removal.md
+      - docs/adr/ADR-015-validate-packages-bulletin-api-f7-f8.md
+      - docs/adr/ADR-016-msgspec-subsecond-perf.md
+      - docs/adr/ADR-017-pyo3-cutover-gate.md
+      - docs/adr/ADR-018-f8-worker-template.md
+    artifacts:
+      - path: docs/sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md
+        status: approved
+      - path: docs/sessions/S008-general-tac-iwxxm-converter/reports/05-verify-tech.md
+        status: completed
+      - path: docs/sessions/S008-general-tac-iwxxm-converter/reports/evolve-summary.md
+        status: pending
+    issues: []
+
 git_history:
-  current_branch: evolve/S008-general-tac-iwxxm-converter
+  current_branch: feat/S008-M1-scaffold
   branches:
     - name: evolve/S008-general-tac-iwxxm-converter
       purpose: general TAC→IWXXM converter architecture + package design
@@ -2497,6 +2615,13 @@ git_history:
       status: active
       created_at: "2026-07-12"
       session_id: S008-general-tac-iwxxm-converter
+    - name: feat/S008-M1-scaffold
+      purpose: S008 M1 F6 package scaffold (T1.1–T1.6)
+      base: evolve/S008-general-tac-iwxxm-converter
+      status: active
+      created_at: "2026-07-12"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
     - name: docs/S007-docs-minimize
       purpose: docs minimize
       base: main
@@ -2747,6 +2872,54 @@ git_history:
       files_changed: 15
       timestamp: "2026-07-12T15:15:00Z"
       session_id: S008-general-tac-iwxxm-converter
+    - sha: 49e3d5f
+      branch: feat/S008-M1-scaffold
+      message: "[T1.2] config: scaffold tac2iwxxm, iwxxm-validate, tac-validate packages"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 12
+      timestamp: "2026-07-12T15:49:17Z"
+    - sha: 15823e1
+      branch: feat/S008-M1-scaffold
+      message: "[T1.3] config: wire F6 packages into uv workspace, Makefile, and CI"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 4
+      timestamp: "2026-07-12T15:49:17Z"
+    - sha: 97d04ff
+      branch: feat/S008-M1-scaffold
+      message: "[T1.1] test: add F6 package import smoke for TC-F6-M001"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 1
+      timestamp: "2026-07-12T15:49:17Z"
+    - sha: 3ff5edd
+      branch: feat/S008-M1-scaffold
+      message: "[T1.4] config: add reusable msgspec Encoder/Decoder modules"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 4
+      timestamp: "2026-07-12T15:49:17Z"
+    - sha: 9bf6619
+      branch: feat/S008-M1-scaffold
+      message: "[T1.5] config: pin vendor iwxxm-us 3.0 HTTP snapshot"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 12
+      timestamp: "2026-07-12T15:49:17Z"
+    - sha: cbb876b
+      branch: feat/S008-M1-scaffold
+      message: "[T1.6] docs: record msgspec Encoder reuse and M1 completion"
+      stage: "07-build"
+      session_id: S008-general-tac-iwxxm-converter
+      evolve_cycle_id: EV-006
+      files_changed: 2
+      timestamp: "2026-07-12T15:49:17Z"
 
 pr_review_cycles:
   - id: PRR-001


### PR DESCRIPTION
## Summary
- Scaffold MIT `src/` packages: `tac2iwxxm`, `iwxxm-validate`, `tac-validate` (ADR-016)
- Wire uv workspace members, Makefile unit/lint targets, and `ci-cd.yml` matrix rows
- Add msgspec with reusable `Encoder`/`Decoder` modules (`*.codec`)
- Pin NWS `iwxxm-us` 3.0 HTTP archive in `vendor/manifest.json` + integrity tests
- Update dependency-inventory; Phase 1 gate passed (T1.1–T1.6)

## Test plan
- [x] `make format-check` / `make lint-py` / `make typecheck-py`
- [x] Import smoke + vendor integrity + shared + CORS (90 tests)
- [x] `make test-unit-tac2iwxxm` / `test-unit-iwxxm-validate` / `test-unit-tac-validate`
- [ ] CI green on `feat/S008-M1-scaffold`

## Spec
- Execution plan M1; TC-F6-M001; ADR-016/017; D-S008-05-batch1 C07
- Evolve cycle **EV-006** / session **S008**


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Scaffold new TAC→IWXXM and validation Python packages as workspace members, wire them into tooling, and pin the iwxxm-us 3.0 schema snapshot with updated manifest validation and integrity checks.

New Features:
- Introduce tac2iwxxm, iwxxm-validate, and tac-validate MIT-licensed Python packages with initial importable modules and msgspec JSON codec utilities.
- Add iwxxm-us 3.0 vendor schema snapshot and treat HTTP-based bundles as first-class entries in the vendor manifest schema.

Enhancements:
- Extend vendor manifest validation to distinguish GitHub and HTTP bundles, enforcing HTTPS URLs and optional archive hash constraints.
- Integrate the new F6 packages into the uv workspace, Makefile typecheck/lint/unit targets, and CI matrix to participate fully in project tooling.
- Record S008 EV-006 evolve cycle and M1 milestone completion in workflow-state and execution/verification reports, including updated dependency inventory notes on msgspec codec reuse.

Tests:
- Add migration and package-level smoke tests ensuring the three new packages import correctly, expose version metadata, and are declared in the workspace.
- Add codec reuse smoke tests for tac2iwxxm and tac-validate to confirm shared msgspec Encoder/Decoder instances behave correctly.
- Expand vendor manifest tests to cover iwxxm-us as a required HTTP bundle and validate new schema rules for HTTP source URLs and archive hashes.