### PR TITLE
[hotfix] Dismiss conversion result card after Clear/Remove

### DIFF
--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -147,6 +147,7 @@ export function FileConverter({
     logLevel: 'INFO',
   });
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const hydratedWorkSessionIdRef = useRef<string | null>(null);
 
   const buildSnapshot = (
     overrides?: Partial<ConverterSnapshot>,
@@ -232,8 +233,15 @@ export function FileConverter({
   /* eslint-disable react-hooks/set-state-in-effect -- F5 hydrate converter when user loads a work session */
   useLayoutEffect(() => {
     if (!loadedWorkSession) {
+      hydratedWorkSessionIdRef.current = null;
       return;
     }
+    // Re-hydrate only when the user selects a different session — not on every
+    // autosave/onSessionUpdated refresh (which would undo Remove / Clear).
+    if (hydratedWorkSessionIdRef.current === loadedWorkSession.id) {
+      return;
+    }
+    hydratedWorkSessionIdRef.current = loadedWorkSession.id;
     setManualInput(loadedWorkSession.manual_tac || '');
     setPendingFiles(
       (loadedWorkSession.pending_files || []).map((file, index) => ({
@@ -302,7 +310,15 @@ export function FileConverter({
     }
     scheduleAutoSave(buildSnapshot());
     // eslint-disable-next-line react-hooks/exhaustive-deps -- debounced save on converter edits
-  }, [manualInput, pendingFiles, outputFilename, accessToken, isReadOnly]);
+  }, [
+    manualInput,
+    pendingFiles,
+    convertedFiles,
+    conversionLog,
+    outputFilename,
+    accessToken,
+    isReadOnly,
+  ]);
 
   useEffect(() => {
     if (accessToken || isGuest === false) {
@@ -747,6 +763,8 @@ export function FileConverter({
     setPendingFiles([]);
     setManualInput('');
     setOutputFilename('');
+    setConvertedFiles([]);
+    setConversionLog(null);
     setConversionStatus({ type: 'idle' });
     toast.info('Queue cleared');
   };

--- a/apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx
+++ b/apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * BUG-2026-07-12 — Conversion results Card not dismissed after Clear/Remove.
+ *
+ * Repro for production stuck-card: Clear leaves convertedFiles; Remove can be
+ * undone when a stale loadedWorkSession update rehydrates converted_results.
+ *
+ * Runs in frontend CI (`npm test`), not pytest `tests/bugs/`.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FileConverter } from '@/app/components/FileConverter';
+
+const mockConvertMetarToIwxxm = vi.hoisted(() => vi.fn());
+const mockPersistSession = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const mockScheduleAutoSave = vi.hoisted(() => vi.fn());
+
+vi.mock('/utils/supabase/logout', () => ({
+  signOutWithScope: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('/utils/api', () => ({
+  convertMetarToIwxxm: mockConvertMetarToIwxxm,
+  convertTafToIwxxm: vi.fn(),
+  fetchAirportRegion: vi.fn(),
+}));
+
+vi.mock('/utils/databaseUpload', () => ({
+  uploadConvertedFiles: vi.fn(),
+  CONVERT_AND_SEND_UPLOAD_OPTIONS: {},
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/hooks/useWorkSessionSync', () => ({
+  AUTOSAVE_DEBOUNCE_MS: 3000,
+  useWorkSessionSync: () => ({
+    isReadOnly: false,
+    saveIndicator: 'idle' as const,
+    scheduleAutoSave: mockScheduleAutoSave,
+    persistSession: mockPersistSession,
+    flushAutoSave: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock('@/app/components/WorkHistorySidebar', () => ({
+  WorkHistorySidebar: () => null,
+}));
+
+vi.mock('jszip', () => ({
+  default: class JSZip {
+    file() {
+      return this;
+    }
+    generateAsync() {
+      return Promise.resolve(new Blob(['test']));
+    }
+  },
+}));
+
+vi.mock('@/app/components/DatabaseUploadDialog', () => ({
+  DatabaseUploadDialog: () => null,
+}));
+vi.mock('@/app/components/UserPreferencesDialog', () => ({
+  UserPreferencesDialog: () => null,
+}));
+vi.mock('@/app/components/ThemeToggle', () => ({ ThemeToggle: () => null }));
+vi.mock('@/app/components/IcaoAutocomplete', () => ({
+  IcaoAutocomplete: () => null,
+}));
+vi.mock('@/app/components/AirportDetailsCard', () => ({
+  AirportDetailsCard: () => null,
+}));
+vi.mock('@/app/components/ErrorLogPanel', () => ({ ErrorLogPanel: () => null }));
+
+const defaultProps = {
+  onLogout: vi.fn(),
+  userEmail: 'user@example.com',
+};
+
+describe('BUG-2026-07-12 result card dismiss', () => {
+  beforeEach(() => {
+    mockConvertMetarToIwxxm.mockReset();
+    mockPersistSession.mockReset();
+    mockPersistSession.mockResolvedValue(null);
+    mockScheduleAutoSave.mockReset();
+    mockConvertMetarToIwxxm.mockResolvedValue({
+      results: [
+        {
+          iwxxm_xml: '<?xml version="1.0"?><iwxxm:METAR/>',
+          tac_input: 'METAR FAOR 101200Z COR 12012KT 9999 FEW020 22/14 Q1018',
+        },
+      ],
+    });
+  });
+
+  it('Clear dismisses the conversion results Card (manual_input.txt)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <FileConverter {...defaultProps} accessToken="token" />,
+    );
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await user.type(textarea, 'METAR FAOR 101200Z COR 12012KT 9999 FEW020 22/14 Q1018');
+    await user.click(screen.getByTestId('convert-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /clear all pending files and manual input/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Remove stays dismissed when a stale work-session update rehydrates', async () => {
+    const user = userEvent.setup();
+    const baseSession = {
+      id: 'sess-stuck-card',
+      status: 'wip' as const,
+      title: 'FAOR',
+      manual_tac: '',
+      pending_files: [],
+      converted_results: [
+        {
+          name: 'manual_input.txt',
+          tac_input: 'METAR FAOR 101200Z COR 12012KT 9999 FEW020 22/14 Q1018',
+          iwxxm_xml: '<?xml version="1.0"?><iwxxm:METAR/>',
+        },
+      ],
+      errors: [],
+      issues: [],
+      conversion_params: {},
+      kv_upload_key: null,
+      deleted_at: null,
+      user_id: 'u1',
+      created_at: '2026-07-12T00:00:00Z',
+      updated_at: '2026-07-12T00:00:00Z',
+    };
+
+    const { rerender } = render(
+      <FileConverter
+        {...defaultProps}
+        accessToken="token"
+        activeWorkSessionId={baseSession.id}
+        loadedWorkSession={baseSession as any}
+      />,
+    );
+
+    expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /remove manual_input\.txt from results/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+    });
+
+    // Stale autosave / persist completion pushes the pre-remove session back
+    // into loadedWorkSession (production: onSessionSaved → setLoadedWorkSession).
+    rerender(
+      <FileConverter
+        {...defaultProps}
+        accessToken="token"
+        activeWorkSessionId={baseSession.id}
+        loadedWorkSession={
+          {
+            ...baseSession,
+            updated_at: '2026-07-12T00:00:03Z',
+          } as any
+        }
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md
+++ b/docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md
@@ -1,0 +1,126 @@
+# BUG-2026-07-12 — Conversion results Card not dismissed after Cancel/Remove
+
+| Field | Value |
+|-------|-------|
+| **Status** | verifying |
+| **Feature** | F1 (METAR → IWXXM conversion UI) |
+| **Severity** | critical / blocked (user) |
+| **Classification** | code bug (UI state + F5 hydrate) |
+| **Remediation path** | local-first — deploy only after explicit approval |
+| **Session** | S009-result-card-dismiss |
+| **Branch** | fix/S009-result-card-dismiss |
+
+## Error description
+
+After converting TAC in the operator UI, the results `Card` for `manual_input.txt`
+(Source TAC + IWXXM XML) remains on screen after the user clicks **Cancel** or the
+**Remove** control (`aria-label="Remove manual_input.txt from results"`).
+
+DOM (user report): `div[data-slot="card"]` under `FileConverter` results list;
+React minified component name `Oe`. Example content included METAR FAOR COR sample
+and IWXXM XML.
+
+## Error logs
+
+No server stack trace (UI state). User DOM evidence:
+
+```
+aria-label="Remove manual_input.txt from results"
+data-slot="card" … manual_input.txt DOWNLOAD COPY SOURCE TAC METAR FAOR …
+```
+
+## Interview record
+
+| Step | Answer |
+|------|--------|
+| Intent | Report new issue (2A) |
+| Session | Open S009 (1A) |
+| Routing | Assumed A — 14 required; 15 optional |
+| symptom_type | B — Wrong output / stuck UI |
+| where_seen | A — Production (Render frontend) |
+| when_started | A — After last deploy |
+| repro_frequency | A — Every time |
+| repro_environment | A — Production only |
+| user_severity | A — Critical / blocked |
+| evidence_available | C — None yet (DOM path from report is the evidence) |
+| Remediation path | A — Fix locally first; deploy only after approval |
+| confirm_hotfix_plan | A — Proceed (2026-07-12) |
+| verification_plan | success=A; checks=B; monitoring=A |
+
+## Symptoms & reproduction
+
+- **Environment:** Production frontend only (every time)
+- **Trigger:** Convert (manual input) → results Card appears → Cancel or Remove (X)
+- **Expected:** Card dismissed / results cleared
+- **Actual:** Card remains visible
+- **Local:** Not reproduced yet (production-only per intake)
+
+## Investigation
+
+### Hypotheses (2026-07-12)
+
+| # | Hypothesis | Evidence | Status |
+|---|------------|----------|--------|
+| H1 | `handleClear` clears queue/input only — **not** `convertedFiles` | `FileConverter.tsx` L746–751; prior note in `docs/context/issue-555-feedback.md` | Confirmed in code; repro #1 RED |
+| H2 | Remove works locally but stale `loadedWorkSession` rehydrate restores card | `useLayoutEffect` on `[loadedWorkSession]` L233–297; autosave schedules snapshot **before** debounce without including later Remove | Repro #2 RED |
+| H3 | Remove `onClick` broken / no-op | Existing unit test expects Remove to work; button wiring present | Unlikely sole cause |
+
+### Spec conformance
+
+| Corpus | Section | Finding |
+|--------|---------|---------|
+| product F1 | #555 UX — replace result cards | Implementation drift: Clear does not dismiss results; Remove can be undone by hydrate |
+| product F5 | Auto-save 3s debounce + hydrate | Implementation drift: hydrate from `loadedWorkSession` overwrites intentional local Remove |
+| system-spec | Frontend FileConverter / F5 | No blocking contradiction — fix aligns with expected dismiss UX |
+| api | N/A | No API change required |
+
+Spec conformance: **no blocking Contradiction**; fix is code bug / UX drift vs F1 #555 intent.
+
+## Root cause (proposed)
+
+1. **Clear** (`handleClear`) clears pending files + manual input only — leaves `convertedFiles` / results Card.
+2. **Remove** updates local state, but any later `loadedWorkSession` change (stale autosave/`onSessionSaved`) re-runs hydrate `useLayoutEffect` and restores `converted_results`.
+
+## Repro test
+
+| Field | Value |
+|-------|-------|
+| Path | `apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx` |
+| CI | Frontend job (`npm test`) — not pytest `tests/bugs/` |
+| Status | **GREEN** (2/2 passed) 2026-07-12; user confirmed matches symptom (A) |
+| Assert 1 | Clear dismisses `manual_input.txt` Card |
+| Assert 2 | After Remove, stale `loadedWorkSession` update must not restore Card |
+
+### TDD iteration log
+
+| Time | Action | Result |
+|------|--------|--------|
+| 2026-07-12 | Wrote Vitest repro (Clear + stale rehydrate) | RED — both assertions fail as expected |
+| 2026-07-12 | User `repro_test_matches_symptom`=A | Confirmed |
+| 2026-07-12 | User `investigation_root_cause`=A | Proceed to fix |
+| 2026-07-12 | Patch applied | GREEN — 2/2 repro pass; FileConverter suites 93/93 |
+
+## Fix
+
+**Branch:** `fix/S009-result-card-dismiss`
+
+**Changes** (`apps/frontend/src/app/components/FileConverter.tsx`):
+
+1. **`handleClear`** — also clears `convertedFiles` and `conversionLog`.
+2. **Work-session hydrate** — track `hydratedWorkSessionIdRef`; only full hydrate when session **id** changes, not on every autosave/`onSessionUpdated` refresh.
+3. **Autosave deps** — include `convertedFiles` and `conversionLog` so Remove/Clear persist to F5 draft.
+
+## Verification plan
+
+| Field | Value |
+|-------|-------|
+| success_criterion | A — Remove/Cancel clears results Card (stuck-card gone) |
+| verification_checks | B — Full main CI parity (local) + gh CI on main after merge |
+| monitoring_followup | A — User watches production after deploy |
+
+### Layer checklist (to fill during verify)
+
+- [x] Layer 1 — Automated (bug repro green; FileConverter 93/93; full CI parity pending)
+- [ ] Layer 2 — Reproduction (scripted remove/cancel clears card)
+- [ ] Layer 3 — Pre-deploy smoke (frontend unit / Playwright if available)
+- [ ] Layer 4 — Production (after deploy approval; user confirms)

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -32,11 +32,12 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 | [S005-issue-671-docker-db](S005-issue-671-docker-db/session-brief.md) | hotfix | completed | Docker Compose bundled Postgres (#671) | fix/S005-issue-671-docker-db | 2026-06-25 | 2026-06-25 |
 | [S006-issue-664-output-filename](S006-issue-664-output-filename/session-brief.md) | feature | completed | Custom output filename for manual METAR (#664) | feat/S006-issue-664-output-filename | 2026-06-25 | 2026-07-12 |
 | [S007-docs-minimize](S007-docs-minimize/session-brief.md) | process | completed | Minimize docs/ root; nest non-standing docs | docs/S007-docs-minimize | 2026-07-12 | 2026-07-12 |
-| [S008-general-tac-iwxxm-converter](S008-general-tac-iwxxm-converter/session-brief.md) | feature | in_progress | General TAC→IWXXM + IWXXM-US converter architecture | evolve/S008-general-tac-iwxxm-converter | 2026-07-12 | — |
+| [S008-general-tac-iwxxm-converter](S008-general-tac-iwxxm-converter/session-brief.md) | feature | completed | General TAC→IWXXM + near-RT ingest (EV-006) | evolve/S008-general-tac-iwxxm-converter | 2026-07-12 | 2026-07-12 |
+| [S009-result-card-dismiss](S009-result-card-dismiss/session-brief.md) | hotfix | in_progress | Results Card stays after Cancel/Remove | fix/S009-result-card-dismiss | 2026-07-12 | — |
 
 ## Active session
 
-**S008-general-tac-iwxxm-converter** (`feature`) — converter architecture on `evolve/S008-general-tac-iwxxm-converter`.
+**S009-result-card-dismiss** (`hotfix`) — FileConverter result card dismiss on `fix/S009-result-card-dismiss`.
 
 ## Folder layout
 

--- a/docs/sessions/S009-result-card-dismiss/routing-plan.md
+++ b/docs/sessions/S009-result-card-dismiss/routing-plan.md
@@ -1,0 +1,18 @@
+# Routing Plan — S009-result-card-dismiss (hotfix)
+
+| Stage | Required | Status | Notes |
+|-------|----------|--------|-------|
+| 00-context (scoped) | yes | completed | Session open; intent recorded in session-brief |
+| 14-hotfix | yes | in_progress | Phase 0 intake → bug report → repro → fix |
+| 15-service-health | no | pending | Optional post-deploy prod verify |
+
+**Skipped**
+
+| Stage | Rationale |
+|-------|-----------|
+| 01–13 product/deploy stages | Hotfix — surgical UI dismiss bug; no new features |
+| 16-evolve | Not a feature cycle |
+
+## Approved
+
+2026-07-12 — routing A (14 required; 15 optional). Remediation: local-first. Deploy only after explicit approval.

--- a/docs/sessions/S009-result-card-dismiss/session-brief.md
+++ b/docs/sessions/S009-result-card-dismiss/session-brief.md
@@ -1,0 +1,44 @@
+---
+session_id: S009-result-card-dismiss
+type: hotfix
+status: in_progress
+branch: fix/S009-result-card-dismiss
+started_at: 2026-07-12
+intent: "Conversion results Card (manual_input.txt) remains visible after Cancel or Remove/Delete in FileConverter"
+orchestrator: 14-hotfix
+evolve_cycle_id: null
+context_briefs: []
+standing_docs_touched: []
+---
+
+# Session S009 — Result card dismiss failure
+
+## Intent
+
+After a successful METAR→IWXXM convert in the operator UI, the results `Card` for
+`manual_input.txt` (Source TAC + IWXXM XML) stays on screen when the user hits
+**Cancel** or the **Remove** (X) control (`aria-label="Remove … from results"`).
+
+## Scope
+
+**In scope**
+
+- Frontend `FileConverter` (and related state) so Remove/Cancel dismisses the results card
+- Bug report + repro regression test under `tests/bugs/` / frontend test suite as required by 14-hotfix
+- Spec conformance vs F1 conversion UI / UJ convert journeys
+
+**Out of scope**
+
+- New conversion features (F6/F7 product UI)
+- Backend convert API changes unless root cause proves server-driven
+- Unrelated work-history sidebar behavior (unless it re-hydrates the stuck card)
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).
+
+## Links
+
+- Component: `apps/frontend/src/app/components/FileConverter.tsx`
+- Corpus: `[Corpus: product]` F1; `[Corpus: system-spec]` Frontend
+- Prior remove-path unit coverage: `FileConverter.test.tsx` (remove from results)

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -4,8 +4,48 @@ project:
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 8
-active_session: null
+session_counter: 9
+active_session:
+  id: S009-result-card-dismiss
+  type: hotfix
+  intent: "Conversion results Card (manual_input.txt) remains visible after Cancel or Remove/Delete in FileConverter"
+  status: in_progress
+  branch: fix/S009-result-card-dismiss
+  orchestrator: 14-hotfix
+  evolve_cycle_id: null
+  artifacts_dir: docs/sessions/S009-result-card-dismiss/
+  routing_plan:
+    - stage: 00-context
+      mode: scoped
+      required: true
+      status: completed
+      skip_rationale: null
+      note: "Scoped open for UI dismiss bug; brief docs/context/result-card-dismiss.md optional"
+    - stage: 14-hotfix
+      mode: full
+      required: true
+      status: in_progress
+      skip_rationale: null
+      note: "Phase 0 interview started; new BUG for FileConverter result card not dismissing"
+    - stage: 15-service-health
+      mode: full
+      required: false
+      status: pending
+      skip_rationale: "Optional — only if production verify needed after deploy"
+  current_stage: 14-hotfix
+  started_at: "2026-07-12"
+  context_briefs: []
+  notes:
+    - "Opened 2026-07-12 from /14-hotfix; user chose session open (1A) + report new issue (2A)"
+    - "2026-07-12 Phase 0 Batch A — symptom_type=stuck UI (B); where_seen=Production (A); when_started=After last deploy (A); routing assumed A (14 required, 15 optional) pending explicit confirm"
+    - "2026-07-12 Phase 0 Batch B — repro_frequency=Every time (A); repro_environment=Production only (A)"
+    - "2026-07-12 Phase 0 Batch C — severity=Critical/blocked (A); evidence=None yet (C); already_tried=Nothing (D)"
+    - "2026-07-12 Phase 0 Step 0.3 — remediation_path=local-first (A); deploy only after explicit approval"
+    - 2026-07-12 Phase 0 Step 0.4 — confirm_hotfix_plan=Proceed (A); advancing to verification plan Step 0.5
+    - 2026-07-12 Phase 0 Step 0.5 — success=stuck-card gone (A); checks=CI parity+main gh (B); monitoring=user watches prod (A); advancing Phase 1
+    - "2026-07-12 Phase 1.25 — Vitest repro RED (2/2): Clear leaves results; Remove undone by stale loadedWorkSession rehydrate. Awaiting repro_test_matches_symptom"
+    - "2026-07-12 Phase 1.25b — user confirmed repro matches (A). Proposed RC: Clear skips convertedFiles; Remove undone by loadedWorkSession hydrate. Awaiting investigation_root_cause"
+    - "2026-07-12 Phase 2 — fix applied on fix/S009-result-card-dismiss: Clear clears results; hydrate only on session id change; autosave includes convertedFiles. Repro GREEN 2/2; FileConverter 93/93. Local-first — PR/deploy pending user"
 
 sessions:
 
@@ -906,12 +946,14 @@ stages:
       - "S004 / EV-004 — strategy verified 2026-06-24; H0c 6/6 PASS; H4 FAIL (CORS); H5 PASS (/config.json); operator T1.3 + S003 keys + redeploy required before 13"
 
   14-hotfix:
-    status: skipped
-    session_id: S006-issue-664-output-filename
-    skipped_at: "2026-07-12"
+    status: in_progress
+    session_id: S009-result-card-dismiss
+    bug_report: docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md
     notes:
       - "2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4)."
       - "2026-07-12 — S006 closed (S006-R5); docs reorg unblocked — open via 00-context (process session), not 14-hotfix."
+      - "2026-07-12 — S009-result-card-dismiss open (FileConverter result card dismiss after Cancel/Remove)."
+      - "S009 Batch A recorded — production stuck results Card after Cancel/Remove; after last deploy"
 
 stages_pending: []
 
@@ -2126,6 +2168,17 @@ decisions_log:
     topic: Stale corpus path references post-reorg
     decision: "Verified/fixed stale corpus path references post-reorg (workflow-state + relative links)."
     status: confirmed
+
+  - id: D-S009-open
+    skill: 00-context/14-hotfix
+    date: "2026-07-12"
+    timestamp: "2026-07-12"
+    session_id: S009-result-card-dismiss
+    stage: 00-context
+    topic: Open hotfix session S009
+    decision: "Open hotfix session S009-result-card-dismiss; orchestrator 14-hotfix"
+    status: confirmed
+
 artifacts:
   - path: docs/sessions/S008-general-tac-iwxxm-converter/reports/evolve-summary.md
     kind: evolve-summary
@@ -3343,6 +3396,12 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: fix/S009-result-card-dismiss
+      purpose: "Dismiss conversion result card after Cancel/Remove"
+      base: main
+      status: open
+      created_at: "2026-07-12"
+      session_id: S009-result-card-dismiss
     - name: evolve/S008-general-tac-iwxxm-converter
       purpose: general TAC→IWXXM converter architecture + package design
       base: main


### PR DESCRIPTION
## Summary
- **Issue:** Production conversion results Card (`manual_input.txt`) stayed visible after Clear or Remove.
- **Bug report:** [docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md](docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md)
- **Root cause:** (1) `handleClear` cleared queue/input only, not `convertedFiles`; (2) F5 `useLayoutEffect` rehydrated from every `loadedWorkSession` autosave refresh, undoing Remove.
- **Fix:** Clear results on Clear; hydrate only when work-session **id** changes; include `convertedFiles`/`conversionLog` in autosave deps.
- **Spec:** F1 #555 dismiss UX / F5 hydrate — implementation drift; no API change.
- **Tests:** `apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx` (frontend CI); FileConverter suites green.
- **Session:** S009-result-card-dismiss

## Test plan
- [x] Vitest bug repro green (Clear + Remove vs stale rehydrate)
- [x] FileConverter + work-session unit suites
- [ ] CI green on PR branch
- [ ] Production: convert → Clear/Remove → Card stays gone
- [ ] User confirms production after deploy


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Fix the FileConverter UI so conversion results cards are properly dismissed when clearing or removing results, and ensure work-session hydration and autosave behavior no longer reintroduce stale result cards.

Bug Fixes:
- Ensure the Clear action also clears converted results and logs so the conversion results card disappears.
- Prevent stale work-session rehydration from restoring removed result cards by hydrating only when the active session changes.
- Persist Clear/Remove actions through autosave by including converted results and conversion logs in the autosave snapshot dependencies.

Enhancements:
- Add a hotfix-specific regression test suite that reproduces and guards against the stuck conversion results card behavior.

Documentation:
- Document BUG-2026-07-12 and the associated hotfix session, routing plan, and workflow-state updates, including marking S008 complete and registering S009 as in progress.

Tests:
- Introduce a Vitest regression test that verifies the results card is dismissed on Clear and remains dismissed when stale work-session updates arrive.

Chores:
- Update workflow-state, session registry, and git history metadata to track the new S009 hotfix session and its branch.