### PR TITLE
[EV-007] F6: TAC traceability UX in conversion results (#655)

### DIFF
--- a/apps/e2e/tac-file-conversion.e2e.spec.ts
+++ b/apps/e2e/tac-file-conversion.e2e.spec.ts
@@ -110,9 +110,11 @@ test.describe('TAC File Conversion', () => {
     await expect(
       page.getByRole('region', { name: /conversion results/i }),
     ).toBeVisible();
-    await expect(page.getByText('manual_input.txt')).toBeVisible();
+    await expect(page.getByText(/Download: manual_input\.txt/)).toBeVisible();
     await expect(page.getByText('Source TAC')).toBeVisible();
-    await expect(page.getByText('METAR KJFK 121251Z')).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: /original tac input for metar kjfk 121251z/i }),
+    ).toBeVisible();
   });
 
   test('custom output filename names manual results (#664)', async ({ page }) => {

--- a/apps/e2e/tac-file-conversion.e2e.spec.ts
+++ b/apps/e2e/tac-file-conversion.e2e.spec.ts
@@ -83,6 +83,8 @@ test.describe('TAC File Conversion', () => {
             {
               name: 'manual_input.txt',
               content: '<iwxxm:METAR>mock-success</iwxxm:METAR>',
+              tac_input:
+                'METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990',
               source: 'manual_input',
               size_bytes: 39,
             },
@@ -109,6 +111,8 @@ test.describe('TAC File Conversion', () => {
       page.getByRole('region', { name: /conversion results/i }),
     ).toBeVisible();
     await expect(page.getByText('manual_input.txt')).toBeVisible();
+    await expect(page.getByText('Source TAC')).toBeVisible();
+    await expect(page.getByText('METAR KJFK 121251Z')).toBeVisible();
   });
 
   test('custom output filename names manual results (#664)', async ({ page }) => {

--- a/apps/frontend/src/app/components/FileConverter.test.tsx
+++ b/apps/frontend/src/app/components/FileConverter.test.tsx
@@ -710,7 +710,7 @@ describe('FileConverter Component', () => {
       expect(
         screen.getByRole('region', { name: /conversion results/i }),
       ).toBeInTheDocument();
-      expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+      expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       expect(mockToast.success).toHaveBeenCalledWith(
         'Successfully converted 1 file(s)',
       );
@@ -740,12 +740,40 @@ describe('FileConverter Component', () => {
       await waitFor(() => {
         expect(
           screen.getByRole('region', {
-            name: /original tac input for manual_input\.txt/i,
+            name: /original tac input for metar faor 101200z/i,
           }),
         ).toBeInTheDocument();
       });
       expect(screen.getByText('Source TAC')).toBeInTheDocument();
       expect(screen.getByText(tac)).toBeInTheDocument();
+      expect(screen.getByText('METAR FAOR 101200Z')).toBeInTheDocument();
+      expect(screen.getByText(/Download: manual_input\.txt/)).toBeInTheDocument();
+    });
+
+    it('shows Source TAC from manual input when API omits tac_input (#655)', async () => {
+      const user = userEvent.setup();
+      const tac = 'METAR KJFK 121251Z 18012KT 10SM FEW030 24/16 A2992';
+      mockConvertMetarToIwxxm.mockResolvedValueOnce({
+        results: [
+          {
+            name: 'manual_input.txt',
+            content: '<iwxxm:METAR>converted</iwxxm:METAR>',
+            source: 'manual_input',
+            size_bytes: 32,
+          },
+        ],
+      });
+
+      const { container } = render(<FileConverter {...defaultProps} />);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      await user.type(textarea, tac);
+      await user.click(screen.getByTestId('convert-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Source TAC')).toBeInTheDocument();
+      });
+      expect(screen.getByText(tac)).toBeInTheDocument();
+      expect(screen.getByText('METAR KJFK 121251Z')).toBeInTheDocument();
     });
 
     it('maps manual-before-file API results to correct original names', async () => {
@@ -794,8 +822,8 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
-        expect(screen.getAllByText('uploaded.metar').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
+        expect(screen.getAllByText(/uploaded\.metar/).length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -932,7 +960,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -988,14 +1016,14 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
         screen.getByRole('button', { name: /remove manual_input\.txt from results/i }),
       );
       await waitFor(() => {
-        expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+        expect(screen.queryByText(/manual_input\.txt/)).not.toBeInTheDocument();
       });
     });
 
@@ -1065,7 +1093,10 @@ describe('FileConverter Component', () => {
         ).toBeInTheDocument();
       });
 
-      expect(screen.getByText('first.txt')).toBeInTheDocument();
+      expect(
+        screen.getByRole('region', { name: /original tac input for metar one/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Download: first\.txt/)).toBeInTheDocument();
       expect(screen.queryByText('second.txt')).not.toBeInTheDocument();
       expect(screen.getByText('<iwxxm>first</iwxxm>')).toBeInTheDocument();
     });
@@ -1108,7 +1139,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -1144,7 +1175,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -1182,7 +1213,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -1359,7 +1390,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -1399,7 +1430,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+        expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
       });
 
       await user.click(
@@ -1753,7 +1784,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('report.txt')).toBeInTheDocument();
+        expect(screen.getByText(/report\.txt/)).toBeInTheDocument();
       });
       expect(
         screen.getByRole('button', { name: /download report\.txt as xml/i }),
@@ -1776,8 +1807,10 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('report_1.txt')).toBeInTheDocument();
-        expect(screen.getByText('report_2.txt')).toBeInTheDocument();
+        expect(screen.getByText(/report_1\.txt/)).toBeInTheDocument();
+        expect(screen.getByText(/report_2\.txt/)).toBeInTheDocument();
+        expect(screen.getByText('Line 1 of 2')).toBeInTheDocument();
+        expect(screen.getByText('Line 2 of 2')).toBeInTheDocument();
       });
     });
 
@@ -1816,7 +1849,7 @@ describe('FileConverter Component', () => {
       await user.click(screen.getByTestId('convert-button'));
 
       await waitFor(() => {
-        expect(screen.getAllByText('uploaded.metar').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText(/uploaded\.metar/).length).toBeGreaterThanOrEqual(1);
       });
       expect(screen.queryByText('report.txt')).not.toBeInTheDocument();
     });

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -43,7 +43,10 @@ import { ErrorLogPanel, type ConversionLog } from './ErrorLogPanel';
 import { WorkHistorySidebar } from './WorkHistorySidebar';
 import type { WorkSession } from '@metar/shared';
 import { useWorkSessionSync } from '@/hooks/useWorkSessionSync';
-import { type ConverterSnapshot } from '/utils/workSessionPayload';
+import {
+  type ConverterSnapshot,
+  resolveManualLineMetaFromResult,
+} from '/utils/workSessionPayload';
 import {
   readGuestConverterState,
   saveGuestConverterState,
@@ -171,6 +174,8 @@ export function FileConverter({
       originalName: file.originalName,
       originalContent: file.originalContent,
       convertedContent: file.convertedContent,
+      manualLineIndex: file.manualLineIndex,
+      manualLineTotal: file.manualLineTotal,
     })),
     conversionLog: conversionLog
       ? {
@@ -261,15 +266,25 @@ export function FileConverter({
       })),
     );
     if (loadedWorkSession.converted_results?.length) {
+      const resultNames = loadedWorkSession.converted_results.map((result, index) =>
+        String(result.name ?? `result-${index + 1}`),
+      );
       setConvertedFiles(
         loadedWorkSession.converted_results.map((result, index) => {
-          const originalName = String(result.name ?? `result-${index + 1}`);
+          const originalName = resultNames[index];
           const originalContent = String(result.tac_input ?? '');
+          const lineMeta = resolveManualLineMetaFromResult(
+            originalName,
+            result,
+            resultNames,
+          );
           return {
             id: `loaded-result-${index}`,
             originalName,
             originalContent,
             displayTitle: deriveTacDisplayTitle(originalContent, originalName),
+            manualLineIndex: lineMeta.manualLineIndex,
+            manualLineTotal: lineMeta.manualLineTotal,
             convertedContent: String(
               result.iwxxm_xml ?? result.xml ?? result.content ?? '',
             ),
@@ -1495,7 +1510,9 @@ export function FileConverter({
                               Download: {file.originalName}
                             </p>
                           ) : null}
-                          {file.originalContent.length > 60 ? (
+                          {file.originalContent.length > 60 &&
+                          file.displayTitle !==
+                            file.originalContent.trim().replace(/\s+/g, ' ') ? (
                             <p className="text-xs font-mono text-gray-600 dark:text-gray-400 mt-1 break-all">
                               {truncateTacSnippet(file.originalContent)}
                             </p>

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -53,6 +53,11 @@ import {
   outputArchiveName,
   sanitizeOutputFilename,
 } from '/utils/outputFilename';
+import {
+  deriveTacDisplayTitle,
+  resolveOriginalTac,
+  truncateTacSnippet,
+} from '/utils/resultTraceability';
 
 interface ConvertedFile {
   id: string;
@@ -60,6 +65,11 @@ interface ConvertedFile {
   originalContent: string;
   convertedContent: string;
   timestamp: number;
+  /** TAC-derived card title (e.g. METAR KJFK 121251Z). */
+  displayTitle: string;
+  /** 1-based index when manual input had multiple lines. */
+  manualLineIndex?: number;
+  manualLineTotal?: number;
 }
 
 interface PendingFile {
@@ -252,15 +262,20 @@ export function FileConverter({
     );
     if (loadedWorkSession.converted_results?.length) {
       setConvertedFiles(
-        loadedWorkSession.converted_results.map((result, index) => ({
-          id: `loaded-result-${index}`,
-          originalName: String(result.name ?? `result-${index + 1}`),
-          originalContent: String(result.tac_input ?? ''),
-          convertedContent: String(
-            result.iwxxm_xml ?? result.xml ?? result.content ?? '',
-          ),
-          timestamp: Date.now(),
-        })),
+        loadedWorkSession.converted_results.map((result, index) => {
+          const originalName = String(result.name ?? `result-${index + 1}`);
+          const originalContent = String(result.tac_input ?? '');
+          return {
+            id: `loaded-result-${index}`,
+            originalName,
+            originalContent,
+            displayTitle: deriveTacDisplayTitle(originalContent, originalName),
+            convertedContent: String(
+              result.iwxxm_xml ?? result.xml ?? result.content ?? '',
+            ),
+            timestamp: Date.now(),
+          };
+        }),
       );
     } else {
       setConvertedFiles([]);
@@ -482,22 +497,25 @@ export function FileConverter({
           ) => {
             const isManualResult = index < manualResultCount;
             const fileIndex = index - manualResultCount;
-            const originalFile = isManualResult
-              ? {
-                  // Apply the optional custom output filename to manual results
-                  // only; blank ⇒ manual_input default (R2/R3/R4 / #664).
-                  name: manualOutputName(outputFilename, index, manualResultCount),
-                  content: result.tac_input || manualLines[index] || manualInput,
-                }
-              : (pendingFiles[fileIndex] ?? {
-                  name: result.name || 'unknown',
-                  content: result.tac_input || '',
-                });
+            const pendingFile = pendingFiles[fileIndex];
+            const originalName = isManualResult
+              ? manualOutputName(outputFilename, index, manualResultCount)
+              : (pendingFile?.name ?? result.name ?? 'unknown');
+            const originalContent = resolveOriginalTac(
+              result.tac_input,
+              manualLines[index],
+              pendingFile?.content,
+            );
 
             newConvertedFiles.push({
               id: `converted-${Date.now()}-${index}`,
-              originalName: originalFile.name,
-              originalContent: result.tac_input || originalFile.content,
+              originalName,
+              originalContent,
+              displayTitle: deriveTacDisplayTitle(originalContent, originalName),
+              manualLineIndex:
+                isManualResult && manualResultCount > 1 ? index + 1 : undefined,
+              manualLineTotal:
+                isManualResult && manualResultCount > 1 ? manualResultCount : undefined,
               convertedContent: result.iwxxm_xml || result.xml || result.content || '',
               timestamp: Date.now(),
             });
@@ -1460,9 +1478,29 @@ export function FileConverter({
                       className="p-4 bg-white dark:bg-gray-800 dark:border-gray-700"
                     >
                       <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
-                        <p className="text-base font-medium text-gray-900 dark:text-white">
-                          {file.originalName}
-                        </p>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="text-base font-medium text-gray-900 dark:text-white">
+                              {file.displayTitle}
+                            </p>
+                            {file.manualLineIndex != null &&
+                            file.manualLineTotal != null ? (
+                              <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+                                Line {file.manualLineIndex} of {file.manualLineTotal}
+                              </span>
+                            ) : null}
+                          </div>
+                          {file.displayTitle !== file.originalName ? (
+                            <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                              Download: {file.originalName}
+                            </p>
+                          ) : null}
+                          {file.originalContent.length > 60 ? (
+                            <p className="text-xs font-mono text-gray-600 dark:text-gray-400 mt-1 break-all">
+                              {truncateTacSnippet(file.originalContent)}
+                            </p>
+                          ) : null}
+                        </div>
                         <div className="flex gap-2">
                           <Button
                             variant="outline"
@@ -1498,20 +1536,24 @@ export function FileConverter({
                           </Button>
                         </div>
                       </div>
-                      {file.originalContent ? (
-                        <div
-                          className="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 p-4 rounded text-sm overflow-x-auto mb-3"
-                          role="region"
-                          aria-label={`Original TAC input for ${file.originalName}`}
-                        >
-                          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
-                            Source TAC
-                          </p>
+                      <div
+                        className="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 p-4 rounded text-sm overflow-x-auto mb-3 border border-gray-200 dark:border-gray-700"
+                        role="region"
+                        aria-label={`Original TAC input for ${file.displayTitle}`}
+                      >
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+                          Source TAC
+                        </p>
+                        {file.originalContent ? (
                           <pre className="whitespace-pre-wrap break-all font-mono">
                             {file.originalContent}
                           </pre>
-                        </div>
-                      ) : null}
+                        ) : (
+                          <p className="text-sm italic text-gray-500 dark:text-gray-400">
+                            Original TAC unavailable for this result.
+                          </p>
+                        )}
+                      </div>
                       <div
                         className="bg-gray-900 dark:bg-gray-950 text-green-400 dark:text-green-300 p-4 rounded text-sm overflow-x-auto"
                         role="region"

--- a/apps/frontend/src/app/components/FileConverter.work-session.test.tsx
+++ b/apps/frontend/src/app/components/FileConverter.work-session.test.tsx
@@ -371,4 +371,50 @@ describe('FileConverter F5 workflow', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('<iwxxm>hydrated</iwxxm>')).toBeInTheDocument();
   });
+
+  it('hydrates multi-line manual line chips from converted_results (#655)', async () => {
+    render(
+      <FileConverter
+        onLogout={vi.fn()}
+        userEmail="user@example.com"
+        accessToken="token"
+        loadedWorkSession={
+          {
+            id: 'sess-multi-line',
+            status: 'wip',
+            title: 'KJFK',
+            manual_tac: '',
+            pending_files: [],
+            converted_results: [
+              {
+                name: 'manual_input_1.txt',
+                iwxxm_xml: '<iwxxm>one</iwxxm>',
+                tac_input: 'METAR ONE',
+                manual_line_index: 1,
+                manual_line_total: 2,
+              },
+              {
+                name: 'manual_input_2.txt',
+                iwxxm_xml: '<iwxxm>two</iwxxm>',
+                tac_input: 'METAR TWO',
+                manual_line_index: 2,
+                manual_line_total: 2,
+              },
+            ],
+            errors: [],
+            issues: [],
+            conversion_params: {},
+            kv_upload_key: null,
+            deleted_at: null,
+            user_id: 'u1',
+            created_at: '2026-06-24T00:00:00Z',
+            updated_at: '2026-06-24T00:00:00Z',
+          } as any
+        }
+      />,
+    );
+
+    expect(screen.getByText('Line 1 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Line 2 of 2')).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx
+++ b/apps/frontend/src/test/bug-2026-07-12-result-card-dismiss.test.tsx
@@ -108,7 +108,7 @@ describe('BUG-2026-07-12 result card dismiss', () => {
     await user.click(screen.getByTestId('convert-button'));
 
     await waitFor(() => {
-      expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+      expect(screen.getByText('METAR FAOR 101200Z')).toBeInTheDocument();
     });
 
     await user.click(
@@ -118,7 +118,7 @@ describe('BUG-2026-07-12 result card dismiss', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+      expect(screen.queryByText('METAR FAOR 101200Z')).not.toBeInTheDocument();
     });
   });
 
@@ -156,7 +156,7 @@ describe('BUG-2026-07-12 result card dismiss', () => {
       />,
     );
 
-    expect(screen.getByText('manual_input.txt')).toBeInTheDocument();
+    expect(screen.getByText(/manual_input\.txt/)).toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', {
@@ -165,7 +165,7 @@ describe('BUG-2026-07-12 result card dismiss', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+      expect(screen.queryByText(/manual_input\.txt/)).not.toBeInTheDocument();
     });
 
     // Stale autosave / persist completion pushes the pre-remove session back
@@ -185,7 +185,7 @@ describe('BUG-2026-07-12 result card dismiss', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('manual_input.txt')).not.toBeInTheDocument();
+      expect(screen.queryByText(/manual_input\.txt/)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/utils/resultTraceability.test.ts
+++ b/apps/frontend/src/utils/resultTraceability.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveTacDisplayTitle,
+  parseTacHeadline,
+  resolveOriginalTac,
+  truncateTacSnippet,
+} from './resultTraceability';
+
+describe('resultTraceability', () => {
+  it('parseTacHeadline extracts METAR station and time', () => {
+    expect(
+      parseTacHeadline('METAR KJFK 121251Z 18012KT 10SM FEW030 24/16 A2992'),
+    ).toEqual({
+      product: 'METAR',
+      station: 'KJFK',
+      time: '121251Z',
+    });
+  });
+
+  it('deriveTacDisplayTitle builds headline label', () => {
+    const tac = 'METAR FAOR 101200Z COR 12012KT 9999 FEW020 22/14 Q1018';
+    expect(deriveTacDisplayTitle(tac, 'manual_input.txt')).toBe('METAR FAOR 101200Z');
+  });
+
+  it('deriveTacDisplayTitle falls back to download name for unknown TAC', () => {
+    expect(deriveTacDisplayTitle('', 'uploaded.metar')).toBe('uploaded.metar');
+  });
+
+  it('truncateTacSnippet shortens long TAC', () => {
+    const long = 'METAR ' + 'X'.repeat(100);
+    expect(truncateTacSnippet(long, 20).endsWith('…')).toBe(true);
+    expect(truncateTacSnippet(long, 20).length).toBe(20);
+  });
+
+  it('resolveOriginalTac prefers API tac_input', () => {
+    expect(resolveOriginalTac('METAR API', 'METAR MANUAL', 'METAR FILE')).toBe(
+      'METAR API',
+    );
+  });
+
+  it('resolveOriginalTac falls back to manual then file', () => {
+    expect(resolveOriginalTac(undefined, 'METAR MANUAL', 'METAR FILE')).toBe(
+      'METAR MANUAL',
+    );
+    expect(resolveOriginalTac('', '', 'METAR FILE')).toBe('METAR FILE');
+  });
+});

--- a/apps/frontend/src/utils/resultTraceability.ts
+++ b/apps/frontend/src/utils/resultTraceability.ts
@@ -1,0 +1,84 @@
+/**
+ * Helpers for conversion-result input traceability (#655 / EV-007).
+ *
+ * Derives human-readable labels from TAC text for result cards while keeping
+ * download filenames governed by {@link manualOutputName} (#664).
+ */
+
+/** Max characters for the TAC snippet shown in a result card header. */
+export const TAC_SNIPPET_MAX_LEN = 72;
+
+const TAC_HEADLINE_RE =
+  /^(?:(METAR|SPECI|TAF|SIGMET|AIRMET|VAA|TCA)\s+)?([A-Z]{4})\s+(\d{6}Z)/i;
+
+/**
+ * Parse a short headline from the first line of TAC (product, station, time).
+ */
+export function parseTacHeadline(tac: string): {
+  product: string | null;
+  station: string | null;
+  time: string | null;
+} {
+  const line = tac.trim().split(/\r?\n/)[0]?.trim() ?? '';
+  const match = line.match(TAC_HEADLINE_RE);
+  if (!match) {
+    return { product: null, station: null, time: null };
+  }
+  return {
+    product: (match[1] ?? 'METAR').toUpperCase(),
+    station: match[2].toUpperCase(),
+    time: match[3].toUpperCase(),
+  };
+}
+
+/**
+ * Build a TAC-derived card title (e.g. ``METAR KJFK 121251Z``).
+ *
+ * Falls back to ``downloadName`` when the TAC does not match a known headline.
+ *
+ * @param tac - Original TAC text for the result.
+ * @param downloadName - Filename used for download (e.g. ``manual_input.txt``).
+ */
+export function deriveTacDisplayTitle(tac: string, downloadName: string): string {
+  const { product, station, time } = parseTacHeadline(tac);
+  if (station && time) {
+    return `${product ?? 'METAR'} ${station} ${time}`;
+  }
+  const compact = tac.trim().replace(/\s+/g, ' ');
+  if (compact.length > 0 && compact.length <= 48) {
+    return compact;
+  }
+  return downloadName;
+}
+
+/**
+ * Truncate TAC for inline display in a result card header.
+ */
+export function truncateTacSnippet(tac: string, maxLen = TAC_SNIPPET_MAX_LEN): string {
+  const compact = tac.trim().replace(/\s+/g, ' ');
+  if (compact.length <= maxLen) {
+    return compact;
+  }
+  return `${compact.slice(0, maxLen - 1)}…`;
+}
+
+/**
+ * Resolve the original TAC echoed for a conversion result.
+ *
+ * Prefers API ``tac_input``; falls back to manual line or uploaded file content.
+ */
+export function resolveOriginalTac(
+  tacInput: string | undefined,
+  manualLine: string | undefined,
+  fileContent: string | undefined,
+): string {
+  const fromApi = tacInput?.trim();
+  if (fromApi) {
+    return fromApi;
+  }
+  const fromManual = manualLine?.trim();
+  if (fromManual) {
+    return fromManual;
+  }
+  return fileContent?.trim() ?? '';
+}

--- a/apps/frontend/src/utils/workSessionPayload.test.ts
+++ b/apps/frontend/src/utils/workSessionPayload.test.ts
@@ -3,6 +3,7 @@ import {
   buildWorkSessionPayload,
   extractSessionTitle,
   hasConverterContent,
+  resolveManualLineMetaFromResult,
 } from './workSessionPayload';
 
 describe('workSessionPayload', () => {
@@ -90,5 +91,46 @@ describe('workSessionPayload', () => {
         conversionParams: {},
       }),
     ).toBe(true);
+  });
+
+  it('persists manual line metadata in converted_results', () => {
+    const payload = buildWorkSessionPayload({
+      manualInput: '',
+      pendingFiles: [],
+      convertedFiles: [
+        {
+          originalName: 'manual_input_1.txt',
+          originalContent: 'METAR ONE',
+          convertedContent: '<iwxxm/>',
+          manualLineIndex: 1,
+          manualLineTotal: 2,
+        },
+      ],
+      conversionLog: null,
+      conversionParams: {},
+    });
+    expect(payload.converted_results?.[0]).toMatchObject({
+      manual_line_index: 1,
+      manual_line_total: 2,
+    });
+  });
+
+  it('restores manual line metadata from stored converted_results', () => {
+    expect(
+      resolveManualLineMetaFromResult(
+        'manual_input_1.txt',
+        { manual_line_index: 1, manual_line_total: 2 },
+        ['manual_input_1.txt', 'manual_input_2.txt'],
+      ),
+    ).toEqual({ manualLineIndex: 1, manualLineTotal: 2 });
+  });
+
+  it('infers manual line metadata from download names when not stored', () => {
+    expect(
+      resolveManualLineMetaFromResult('manual_input_2.txt', {}, [
+        'manual_input_1.txt',
+        'manual_input_2.txt',
+      ]),
+    ).toEqual({ manualLineIndex: 2, manualLineTotal: 2 });
   });
 });

--- a/apps/frontend/src/utils/workSessionPayload.ts
+++ b/apps/frontend/src/utils/workSessionPayload.ts
@@ -4,14 +4,20 @@
 
 import type { WorkSessionStatus, WorkSessionUpsertPayload } from '@metar/shared';
 
+export interface ConvertedFileSnapshot {
+  originalName: string;
+  originalContent: string;
+  convertedContent: string;
+  /** 1-based index when manual input had multiple lines (#655 / EV-007). */
+  manualLineIndex?: number;
+  /** Total manual lines in the batch. */
+  manualLineTotal?: number;
+}
+
 export interface ConverterSnapshot {
   manualInput: string;
   pendingFiles: { name: string; content: string }[];
-  convertedFiles: {
-    originalName: string;
-    originalContent: string;
-    convertedContent: string;
-  }[];
+  convertedFiles: ConvertedFileSnapshot[];
   conversionLog: { errors: string[]; issues: Record<string, unknown>[] } | null;
   conversionParams: Record<string, unknown>;
 }
@@ -48,6 +54,12 @@ export function buildWorkSessionPayload(
       name: file.originalName,
       tac_input: file.originalContent,
       iwxxm_xml: file.convertedContent,
+      ...(file.manualLineIndex != null && file.manualLineTotal != null
+        ? {
+            manual_line_index: file.manualLineIndex,
+            manual_line_total: file.manualLineTotal,
+          }
+        : {}),
     })),
     errors: snapshot.conversionLog?.errors ?? [],
     issues: snapshot.conversionLog?.issues ?? [],
@@ -60,4 +72,43 @@ export function buildWorkSessionPayload(
     payload.kv_upload_key = options.kvUploadKey;
   }
   return payload;
+}
+
+/**
+ * Restore multi-line manual chip metadata from a persisted converted result.
+ *
+ * Prefers explicit ``manual_line_index`` / ``manual_line_total`` fields; falls
+ * back to inferring from ``manual_input_N.txt`` style download names.
+ */
+export function resolveManualLineMetaFromResult(
+  name: string,
+  result: Record<string, unknown>,
+  allNames: string[],
+): { manualLineIndex?: number; manualLineTotal?: number } {
+  const storedIndex = result.manual_line_index;
+  const storedTotal = result.manual_line_total;
+  if (typeof storedIndex === 'number' && typeof storedTotal === 'number') {
+    return { manualLineIndex: storedIndex, manualLineTotal: storedTotal };
+  }
+
+  const match = name.match(/^(.+)_(\d+)\.txt$/i);
+  if (!match) {
+    return {};
+  }
+  const prefix = match[1];
+  const indexedPeers = allNames
+    .map((peer) => peer.match(/^(.+)_(\d+)\.txt$/i))
+    .filter(
+      (peerMatch): peerMatch is RegExpMatchArray =>
+        !!peerMatch && peerMatch[1] === prefix,
+    )
+    .map((peerMatch) => Number.parseInt(peerMatch[2], 10))
+    .sort((a, b) => a - b);
+  if (indexedPeers.length <= 1) {
+    return {};
+  }
+  return {
+    manualLineIndex: Number.parseInt(match[2], 10),
+    manualLineTotal: indexedPeers.length,
+  };
 }

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -18,6 +18,7 @@ part of an active pipeline session. See [sessions/README.md](../sessions/README.
 | [issue-664-output-filename](issue-664-output-filename.md) | Custom output filename for manual METAR input (GitHub #664) | active | 2026-06-25 | F1, UJ-001 |
 | [general-tac-iwxxm-converter](general-tac-iwxxm-converter.md) | Generalizable C/Cython TAC→IWXXM + IWXXM-US architecture | active | 2026-07-12 | F1, F2, F4, proposed Fn |
 | [realtime-tac-ingest](realtime-tac-ingest.md) | Near-RT ingest design + `iwxxm-validate` / `tac-validate` packages; F7/F8 Planned | active | 2026-07-12 | F2, F6, F7, F8 |
+| [issue-655-tac-traceability](issue-655-tac-traceability.md) | Source TAC display UX for conversion results (GitHub #655) | active | 2026-07-12 | F6, UJ-001 |
 
 **Convention**: One brief per topic at `docs/context/<slug>.md`. Reference downstream as
 `[Context: <slug> R#]`.

--- a/docs/context/issue-655-tac-traceability.md
+++ b/docs/context/issue-655-tac-traceability.md
@@ -1,0 +1,56 @@
+# Scoped context — Issue #655 TAC traceability UX
+
+**Status**: active  
+**Created**: 2026-07-12  
+**Session**: S010-issue-655-tac-traceability / EV-007  
+**GitHub**: [#655](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/655) (parent [#594](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/594))  
+**Feature**: F6 (operator UI delta)
+
+## Problem
+
+Operators convert METAR/SPECI TAC and see result cards titled `manual_input.txt` without a clear
+view of the **source TAC** that produced each IWXXM output. Traceability matters for multi-line
+manual input and file+manual mixes.
+
+## Prior work
+
+- **EV-003 / #594**: `ConversionResult.tac_input` on API; **Source TAC** `<pre>` panel in
+  `FileConverter` when `originalContent` is non-empty (TC-001b).
+- **EV-005 / #664**: Custom output filename for manual downloads (card title may still be custom
+  basename).
+
+## Live check (2026-07-12)
+
+| Surface | Finding |
+|---------|---------|
+| Prod API `/api/v1/convert` | Returns `tac_input` with manual METAR |
+| Prod UI (user report) | Source TAC panel **missing** after Convert |
+| Repo `FileConverter.tsx` | Panel gated on `file.originalContent` truthy |
+
+**Hypothesis**: Client mapping gap and/or weak prominence — not missing API field. UI must
+always populate `originalContent` from `tac_input` **or** pre-clear manual/file queue lines, and
+must not hide the panel when traceability is the product goal.
+
+## Approved UX (Phase 0 decisions)
+
+| ID | Decision |
+|----|----------|
+| R1 | **F6 delta**, UI-only — no API/schema change |
+| R2 | **All reasonable UX**: header TAC snippet, TAC-derived card label where helpful, prominent Source TAC, multi-line index mapping |
+| R3 | **Frontend redeploy** required (12/13) |
+| R4 | Out of scope: ZIP sidecar, bulletin UI, API changes |
+
+## Implementation notes
+
+- Harden `originalContent` assignment in convert handler (never leave empty when TAC known).
+- Consider `deriveResultTitle(tac)` — e.g. `METAR KJFK 121251Z` — while keeping download names
+  per #664 rules.
+- Multi-line: show `Line N of M` chip when `manualResultCount > 1`.
+- Always render Source TAC region (aria); use em dash + helper text only if TAC truly unknown.
+- Extend Vitest (`FileConverter.test.tsx`) and Playwright (`tac-file-conversion.e2e.spec.ts`).
+
+## References
+
+- [Context: issue-594-feedback](issue-594-feedback.md)
+- [Corpus: test-plan](../test-plan.md) TC-001b
+- `apps/frontend/src/app/components/FileConverter.tsx`

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -267,3 +267,35 @@
 | ID | Category | Decision |
 |----|----------|----------|
 | D-S008-T21-sch | Ambiguity | `iwxxm-validate` mirrors current F2: lxml XSD best-effort + catalogs; Schematron via lxml when possible, else `SCHEMATRON_SKIPPED` (non-blocking) for xslt2; optional Docker/Saxon via env. TC-F6-032 unit suite asserts API + malformed fail + skip path + vendor pins; full M-sch Docker is a soft/separate gate. |
+
+## Cycle EV-007 — Issue #655 TAC traceability UX (S010)
+
+**GitHub**: [#655](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/655)  
+**Session**: S010-issue-655-tac-traceability  
+**Feature**: F6 (general converter UI — input traceability delta)  
+**Approved**: 2026-07-12  
+**Cycle type**: feature (UI-only delta on F6)
+
+### Scope
+
+**In scope**
+
+- **Results traceability UX** — always show original TAC per conversion result in `FileConverter`:
+  header snippet, TAC-derived card label where helpful, prominent Source TAC panel, multi-line
+  index mapping; client-side fallback when API omits `tac_input`.
+- **Tests** — extend TC-001b (Vitest + Playwright).
+- **Deploy** — production frontend redeploy (12/13).
+
+**Out of scope**
+
+- API/schema changes (`tac_input` already on prod `/api/v1/convert`).
+- ZIP sidecar, bulletin UI, convert-bulletin operator surface.
+
+### Decisions
+
+| ID | Category | Decision |
+|----|----------|----------|
+| R1 | Decision | F6 delta; UI-only |
+| R2 | Decision | Full UX bundle: header snippet + derived label + prominent Source TAC + multi-line mapping |
+| R3 | Decision | Frontend redeploy required |
+| R4 | Scope | Lean routing — skip 02/03/05/06 |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -129,6 +129,8 @@
 | `iwxxm_version` | app default (e.g. `2025-2`) | Vendored pins only | Schema line |
 - **API**: Extend `POST /api/v1/convert` with `product` + `profile` (no per-product path prefix).
 - **UI**: Product + profile (+ version) pickers in v1; H4–H5 connectivity required.
+- **Input traceability (#655 / EV-007)**: Result cards always show Source TAC; TAC-derived
+  headline; multi-line index chip; client fallback when API omits `tac_input`.
 - **GIFTs**: On first PR that wires tac2iwxxm to `/api/v1/convert`, **remove `packages/gifts`**
   and stop all API use of gifts (hard cutover). REQ-014 / ADR-004 / M3 deprecated.
 - **Vendor**: Pin `vendor/schemas/iwxxm-us` via `vendor/manifest.json` — HTTP snapshot of

--- a/docs/sessions/S010-issue-655-tac-traceability/reports/execution-plan.md
+++ b/docs/sessions/S010-issue-655-tac-traceability/reports/execution-plan.md
@@ -1,0 +1,30 @@
+# Execution plan — EV-007 / S010
+
+**Cycle**: EV-007 — Issue #655 TAC traceability UX  
+**Branch**: `evolve/EV-007-issue-655-tac-traceability`  
+**Feature**: F6 delta (UI-only)
+
+## Milestone M1 — Traceability UX
+
+| Task | Description | Spec | Status |
+|------|-------------|------|--------|
+| T1.1 | `resultTraceability` util + unit tests | TC-001b | completed |
+| T1.2 | `FileConverter` — resolve TAC, card header, always-on Source TAC | UJ-001 step 7 | completed |
+| T1.3 | Vitest updates + new fallback test | TC-001b | completed |
+| T1.4 | Playwright mocked Source TAC assertion | TC-001b | completed |
+| T1.5 | Spec deltas (test-plan, journeys, feature-list) | Corpus | completed |
+
+## Milestone M2 — Verify & deploy
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T2.1 | 08-verify-build (lint, tsc, vitest) | pending |
+| T2.2 | 09-qa + 10-e2e | pending |
+| T2.3 | 11-verify-impl (UJ-001 traceability AC) | pending |
+| T2.4 | 12-verify-deploy + 13-deploy-smoke (frontend) | pending |
+
+## PR plan
+
+| PR | Title | Base |
+|----|-------|------|
+| PR-EV007 | `[EV-007] F6: TAC traceability UX (#655)` | `main` |

--- a/docs/sessions/S010-issue-655-tac-traceability/routing-plan.md
+++ b/docs/sessions/S010-issue-655-tac-traceability/routing-plan.md
@@ -1,0 +1,21 @@
+# Routing plan — S010 / EV-007
+
+| Stage | Mode | Required | Status | Skip rationale |
+|-------|------|----------|--------|----------------|
+| 00-context | scoped | yes | in_progress | — |
+| 01-requirements | delta | yes | pending | — |
+| 02-verify-plan | — | no | skipped | Lean UI-only delta; spec delta + 04 plan sufficient |
+| 03-plan-tooling | — | no | skipped | No new guardrails |
+| 04-tech-plan | delta | yes | pending | — |
+| 05-verify-tech | — | no | skipped | No stack/arch change |
+| 06-tech-tooling | — | no | skipped | No new deps |
+| 07-build | full | yes | pending | — |
+| 08-verify-build | full | yes | pending | — |
+| 09-qa | full | yes | pending | — |
+| 10-e2e | delta | yes | pending | H4–H5 connectivity after frontend deploy |
+| 11-verify-impl | full | yes | pending | — |
+| 12-verify-deploy | full | yes | pending | Frontend redeploy required |
+| 13-deploy-smoke | full | yes | pending | Prod Source TAC verification |
+
+**Branch**: `evolve/EV-007-issue-655-tac-traceability`  
+**Orchestrator**: 16-evolve

--- a/docs/sessions/S010-issue-655-tac-traceability/session-brief.md
+++ b/docs/sessions/S010-issue-655-tac-traceability/session-brief.md
@@ -1,0 +1,52 @@
+---
+session_id: S010-issue-655-tac-traceability
+type: feature
+status: in_progress
+branch: evolve/EV-007-issue-655-tac-traceability
+started_at: 2026-07-12
+intent: "F6 UI input traceability — show original TAC with each conversion result (GitHub #655)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-007
+context_briefs:
+  - docs/context/issue-655-tac-traceability.md
+standing_docs_touched: []
+---
+
+# Session S010 — Issue #655 TAC traceability UX
+
+## Intent
+
+[GitHub #655](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/655) (parent
+[#594](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/594)): operators need the
+**exact TAC** that produced each IWXXM result — not only the `manual_input.txt` filename.
+
+EV-003 shipped API `tac_input` and a **Source TAC** panel; production still shows filename-only
+results per user report. This cycle is a **F6 delta** — UI-only UX hardening + frontend redeploy.
+
+## Approved scope (Phase 0)
+
+**In scope**
+
+- `FileConverter` results cards: always show Source TAC (with client-side fallback when API omits
+  `tac_input`), TAC snippet in card header, clearer multi-line mapping, more prominent Source TAC
+- Vitest + Playwright updates (TC-001b extension)
+- Production **frontend** redeploy (12/13)
+
+**Out of scope**
+
+- API/schema changes (`tac_input` already populated on prod `/api/v1/convert`)
+- ZIP sidecar / bulletin UI / convert-bulletin operator surface
+- REQ-016 migration rewrites
+
+## Feature mapping
+
+- **F6** — general converter operator UI (delta on input traceability)
+
+## Evidence (2026-07-12)
+
+- Prod API `POST /api/v1/convert` returns `tac_input` for manual METAR (verified live).
+- Repo `FileConverter.tsx` has conditional Source TAC panel (`file.originalContent` truthy gate).
+
+## Routing (lean)
+
+00 scoped → 01 delta → 04 delta → 07–13 (skip 02/03/05/06)

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -161,15 +161,19 @@ use `.nth(1)` after clicking a card to assert the panel content heading.
 - **Pass criteria**: IWXXM XML returned; HTTP 200
 - **Source**: apps/e2e/tac-file-conversion.e2e.spec.ts
 
-### TC-001b: COR-after-time + TAC traceability (EV-003 / #594)
+### TC-001b: COR-after-time + TAC traceability (EV-003 / #594; UX hardening EV-007 / #655)
 
 - **Objective**: ICAO COR placement and per-result TAC display
 - **Input**: `METAR STID ddHHmmZ COR ...` manual TAC; multi-line manual input
 - **Pass criteria**:
   - IWXXM contains `reportStatus="CORRECTION"` (no `translationFailedTAC`)
-  - Results UI shows **Source TAC** panel with original input per result
+  - Results UI shows **Source TAC** panel with original input per result (always visible;
+    client fallback when API omits `tac_input`)
+  - Card title uses TAC-derived headline (e.g. `METAR KJFK 121251Z`); download name shown as
+    subtitle when it differs (#664 preserved)
+  - Multi-line manual input shows `Line N of M` chip per result
   - API `ConversionResult.tac_input` populated for manual and file conversions
-- **Source**: `tests/bugs/test_bug_2026_06_22_issue_594_cor_after_time.py`, `packages/gifts/tests/test_metar_encoding.py::test_cor_after_time`, `apps/e2e/tac-file-conversion.e2e.spec.ts`, `apps/frontend/src/app/components/FileConverter.test.tsx`
+- **Source**: `tests/bugs/test_bug_2026_06_22_issue_594_cor_after_time.py`, `packages/gifts/tests/test_metar_encoding.py::test_cor_after_time`, `apps/e2e/tac-file-conversion.e2e.spec.ts`, `apps/frontend/src/app/components/FileConverter.test.tsx`, `apps/frontend/src/utils/resultTraceability.test.ts`
 
 ### TC-001c: Custom output filename for manual input (EV-005 / #664)
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -72,7 +72,9 @@ must pass annex3 convert via UI (UJ-005 parametrize) and API smoke (UJ-006). US 
 4. Optionally leave product on **auto** / METAR and profile **annex3** (defaults).
 5. **#664 (EV-005)**: Optionally type an **Output filename** for manually entered TAC.
 6. Choose **Convert**, **Convert&Send**, or **Upload to Database**.
-7. View output; #555 replace-on-success and error log panel behavior unchanged.
+7. View output; each result card shows **TAC-derived title**, optional **Line N of M** for
+   multi-line manual input, prominent **Source TAC** panel, and download filename when it
+   differs (#655 / EV-007). #555 replace-on-success and error log panel behavior unchanged.
 8. On convert failure after F6 cutover: structured error only — **no gifts rollback**.
 
 **Acceptance**: METAR converts without error via tac2iwxxm; schema/Schematron pass for selected

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,55 +1,120 @@
-overall_status: completed
+overall_status: in_progress
 project:
   name: metar-to-IWXXM
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 9
+session_counter: 10
 active_session:
-  id: S009-result-card-dismiss
-  type: hotfix
-  intent: "Conversion results Card (manual_input.txt) remains visible after Cancel or Remove/Delete in FileConverter"
-  status: completed
-  branch: fix/S009-result-card-dismiss
-  orchestrator: 14-hotfix
-  evolve_cycle_id: null
-  artifacts_dir: docs/sessions/S009-result-card-dismiss/
+  id: S010-issue-655-tac-traceability
+  type: feature
+  intent: "F6 UI input traceability — show original TAC with each conversion result (GitHub #655)"
+  status: in_progress
+  branch: evolve/EV-007-issue-655-tac-traceability
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-007
+  artifacts_dir: docs/sessions/S010-issue-655-tac-traceability/
   routing_plan:
     - stage: 00-context
       mode: scoped
       required: true
-      status: completed
+      status: in_progress
       skip_rationale: null
-      note: "Scoped open for UI dismiss bug; brief docs/context/result-card-dismiss.md optional"
-    - stage: 14-hotfix
-      mode: full
+      note: "Scoped brief docs/context/issue-655-tac-traceability.md; Phase 0 intake complete"
+    - stage: 01-requirements
+      mode: delta
       required: true
-      status: completed
-      skip_rationale: null
-      note: "Phase 0 interview started; new BUG for FileConverter result card not dismissing"
-    - stage: 15-service-health
-      mode: full
-      required: false
       status: pending
-      skip_rationale: "Optional — only if production verify needed after deploy"
-  current_stage: 14-hotfix
+      skip_rationale: null
+      note: "Delta TC-001b / UJ-001 traceability UX"
+    - stage: 02-verify-plan
+      mode: delta
+      required: false
+      status: skipped
+      skip_rationale: "Lean UI-only delta; 01+04 sufficient"
+    - stage: 03-plan-tooling
+      required: false
+      status: skipped
+      skip_rationale: "No new guardrails"
+    - stage: 04-tech-plan
+      mode: delta
+      required: true
+      status: pending
+      skip_rationale: null
+    - stage: 05-verify-tech
+      required: false
+      status: skipped
+      skip_rationale: "No stack change"
+    - stage: 06-tech-tooling
+      required: false
+      status: skipped
+      skip_rationale: "No new deps"
+    - stage: 16-evolve
+      required: true
+      status: in_progress
+      skip_rationale: null
+      note: "Phase 0–1 complete; EV-007 created"
+    - stage: 07-build
+      required: true
+      status: pending
+    - stage: 08-verify-build
+      required: true
+      status: pending
+    - stage: 09-qa
+      required: true
+      status: pending
+    - stage: 10-e2e
+      mode: delta
+      required: true
+      status: pending
+    - stage: 11-verify-impl
+      required: true
+      status: pending
+    - stage: 12-verify-deploy
+      required: true
+      status: pending
+      note: "Frontend redeploy required"
+    - stage: 13-deploy-smoke
+      required: true
+      status: pending
+  current_stage: 00-context
   started_at: "2026-07-12"
-  context_briefs: []
+  context_briefs:
+    - docs/context/issue-655-tac-traceability.md
   notes:
-    - "Opened 2026-07-12 from /14-hotfix; user chose session open (1A) + report new issue (2A)"
-    - "2026-07-12 Phase 0 Batch A — symptom_type=stuck UI (B); where_seen=Production (A); when_started=After last deploy (A); routing assumed A (14 required, 15 optional) pending explicit confirm"
-    - "2026-07-12 Phase 0 Batch B — repro_frequency=Every time (A); repro_environment=Production only (A)"
-    - "2026-07-12 Phase 0 Batch C — severity=Critical/blocked (A); evidence=None yet (C); already_tried=Nothing (D)"
-    - "2026-07-12 Phase 0 Step 0.3 — remediation_path=local-first (A); deploy only after explicit approval"
-    - 2026-07-12 Phase 0 Step 0.4 — confirm_hotfix_plan=Proceed (A); advancing to verification plan Step 0.5
-    - 2026-07-12 Phase 0 Step 0.5 — success=stuck-card gone (A); checks=CI parity+main gh (B); monitoring=user watches prod (A); advancing Phase 1
-    - "2026-07-12 Phase 1.25 — Vitest repro RED (2/2): Clear leaves results; Remove undone by stale loadedWorkSession rehydrate. Awaiting repro_test_matches_symptom"
-    - "2026-07-12 Phase 1.25b — user confirmed repro matches (A). Proposed RC: Clear skips convertedFiles; Remove undone by loadedWorkSession hydrate. Awaiting investigation_root_cause"
-    - "2026-07-12 Phase 2 — fix applied on fix/S009-result-card-dismiss: Clear clears results; hydrate only on session id change; autosave includes convertedFiles. Repro GREEN 2/2; FileConverter 93/93. Local-first — PR/deploy pending user"
-    - "2026-07-12 Phase 3 — commit 07d4857; PR #713 merged b20158b; deploy dep-d9a1tql7vvec738evhmg live"
-    - "2026-07-12 Phase 4–5 — L1–4 verified; user confirmed prod; prevention rule fileconverter-f5-hydrate.mdc; session closed"
+    - "Opened 2026-07-12 from /16-evolve issue #655; closed S009; F6 delta UI-only; prod API tac_input verified"
 
 sessions:
+
+  - id: S009-result-card-dismiss
+    type: hotfix
+    intent: "Conversion results Card (manual_input.txt) remains visible after Cancel or Remove/Delete in FileConverter"
+    status: completed
+    branch: fix/S009-result-card-dismiss
+    orchestrator: 14-hotfix
+    evolve_cycle_id: null
+    artifacts_dir: docs/sessions/S009-result-card-dismiss/
+    routing_plan:
+      - stage: 00-context
+        mode: scoped
+        required: true
+        status: completed
+      - stage: 14-hotfix
+        mode: full
+        required: true
+        status: completed
+      - stage: 15-service-health
+        mode: full
+        required: false
+        status: pending
+        skip_rationale: "Optional — only if production verify needed after deploy"
+    current_stage: null
+    started_at: "2026-07-12"
+    completed_at: "2026-07-12"
+    context_briefs: []
+    notes:
+      - "Closed 2026-07-12 — PR #713 merged; prod verified; superseded by S010 for #655 traceability UX"
+
 
   - id: S008-general-tac-iwxxm-converter
     type: feature
@@ -3388,8 +3453,72 @@ evolve_cycles:
         status: completed
     issues: []
 
+  - id: EV-007
+    session_id: S010-issue-655-tac-traceability
+    cycle_type: feature
+    feature_ids: [F6]
+    title: "Issue #655 — TAC traceability UX in conversion results"
+    status: in_progress
+    started: "2026-07-12"
+    completed: null
+    scope_summary: |
+      GitHub #655 — F6 UI delta: always show original TAC per conversion result in FileConverter
+      (header snippet, derived label, prominent Source TAC, multi-line mapping). UI-only; prod API
+      already returns tac_input. Frontend redeploy required.
+    routing_plan:
+      required_stages:
+        - 00-context
+        - 01-requirements
+        - 04-tech-plan
+        - 16-evolve
+        - 07-build
+        - 08-verify-build
+        - 09-qa
+        - 10-e2e
+        - 11-verify-impl
+        - 12-verify-deploy
+        - 13-deploy-smoke
+      skipped_stages:
+        - 02-verify-plan
+        - 03-plan-tooling
+        - 05-verify-tech
+        - 06-tech-tooling
+    current_stage: 00-context
+    stages:
+      00-context:
+        status: in_progress
+        started: "2026-07-12"
+        completed: null
+        artifacts_updated:
+          - docs/context/issue-655-tac-traceability.md
+          - docs/sessions/S010-issue-655-tac-traceability/session-brief.md
+      16-evolve:
+        status: in_progress
+        started: "2026-07-12"
+        phase: 1
+        notes:
+          - "Phase 0–1 intake complete — F6 delta; lean routing; frontend deploy required"
+    gates:
+      a_to_b: pending
+      b_to_c: pending
+      c_to_d: pending
+      deploy: pending
+    checkpoints:
+      phase_a: pending
+      phase_b: pending
+      phase_c: pending
+      phase_d: pending
+      deploy: pending
+    artifacts:
+      - path: docs/context/issue-655-tac-traceability.md
+        status: active
+      - path: docs/decisions/evolve-decisions.md
+        status: updated
+    issues:
+      - https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/655
+
 git_history:
-  current_branch: evolve/S008-general-tac-iwxxm-converter
+  current_branch: evolve/EV-007-issue-655-tac-traceability
   notes:
     - "2026-07-12 D-S008-evolve-main-18-19 — on-demand 18+19 for PR #711; PRM-015 commits ecdeac5 + 79af006; head_sha 79af006; squash-merge when CI green"
     - "2026-07-12 D-S008-EV006-close — close commit 2ac4093 recorded; pushed (or will be pushed with this follow-up)"
@@ -3398,6 +3527,13 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: evolve/EV-007-issue-655-tac-traceability
+      purpose: "EV-007 / #655 F6 TAC traceability UX"
+      base: main
+      status: open
+      session_id: S010-issue-655-tac-traceability
+      evolve_cycle_id: EV-007
+      created_at: "2026-07-12"
     - name: fix/S009-result-card-dismiss
       purpose: "Dismiss conversion result card after Cancel/Remove"
       base: main


### PR DESCRIPTION
## Summary

- Adds Source TAC panel, TAC-derived headlines, and multi-line index chips on conversion result cards (#655 / EV-007)
- Client fallback when API omits `tac_input` via `resolveOriginalTac`
- Persists `manual_line_index` / `manual_line_total` in F5 work-session snapshots so multi-line chips survive reload

## Test plan

- [x] `resultTraceability` unit tests
- [x] `FileConverter` unit tests (traceability + dismiss regressions)
- [x] F5 hydrate test for multi-line chips
- [x] E2E mock assertion for Source TAC display
- [ ] CI green on PR

Closes #655

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Improve F6 conversion results UI with TAC input traceability and multi-line metadata, and wire this through work-session persistence, tests, and documentation for issue #655.

Bug Fixes:
- Ensure Source TAC is always populated and shown for conversion results, including when the API omits tac_input, restoring per-result input visibility.

Enhancements:
- Add TAC-derived card titles, Source TAC panel, optional TAC snippet, and multi-line Line N of M chips to conversion result cards in FileConverter.
- Persist and hydrate manual line index/total metadata for converted results via workSessionPayload and session snapshots.
- Introduce resultTraceability utilities to derive display labels, TAC snippets, and original TAC resolution for use in the frontend UI.

Documentation:
- Document TAC traceability UX scope and routing for EV-007, and update test-plan, user journeys, feature list, and context briefs to cover Source TAC and multi-line mapping behavior.

Tests:
- Extend FileConverter unit and work-session hydrate tests, add resultTraceability unit tests, and update e2e TAC file conversion tests to assert Source TAC display and card headline behavior.
- Update regression tests for prior bugs (e.g., result card dismiss behavior and multi-line manual outputs) to align with new TAC-derived titles and line chips.

Chores:
- Add EV-007 evolve cycle metadata, new S010 session artifacts, and workflow-state routing updates for the TAC traceability feature branch.