### PR TITLE
[S011 M3] Soft-preview + Failed-TAC (#665/#666)

### DIFF
--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -30,6 +30,7 @@ try:
         ConversionResponse,
         ConversionResult,
         ErrorDetail,
+        FailedSpan,
         HealthResponse,
     )
     from .schemas.icao_opmet import TranslationStatus
@@ -69,6 +70,7 @@ except ImportError:
         ConversionResponse,
         ConversionResult,
         ErrorDetail,
+        FailedSpan,
         HealthResponse,
     )
     from schemas.icao_opmet import TranslationStatus
@@ -1229,6 +1231,10 @@ async def convert(
     lint: bool = Form(default=True, description="Run tac-validate before convert (Q14=C; default on)"),
     product: str = Form(default="METAR", description="TAC product (required for F6; default METAR for legacy)"),
     profile: str = Form(default="annex3", description="Schema profile: annex3 or iwxxm_us"),
+    preview: bool = Form(
+        default=False,
+        description="Soft-preview mode (ADR-022): best-effort IWXXM + failed_spans on partial failure",
+    ),
     user: dict = Depends(verify_supabase_token),
 ) -> ConversionResponse:
     logger.info(
@@ -1447,6 +1453,18 @@ async def convert(
     errors: List[str] = []
     issues: List[ConversionIssue] = []
     total_inputs = 0
+    preview_failed_spans: List[FailedSpan] = []
+    preview_saw_soft_fail = False
+
+    def absorb_soft_preview(soft: dict) -> None:
+        """Merge soft-preview envelope fields from convert_metar_tac_with_metadata."""
+        nonlocal preview_saw_soft_fail
+        if not preview or not soft:
+            return
+        if soft.get("ok") is False:
+            preview_saw_soft_fail = True
+            for span in soft.get("failed_spans") or []:
+                preview_failed_spans.append(FailedSpan(**span))
 
     def add_issue(
         source: str,
@@ -1658,13 +1676,25 @@ async def convert(
 
                 # Convert METAR to IWXXM
                 try:
+                    soft_preview: dict = {}
                     iwxxm_content, _ = convert_metar_tac_with_metadata(
                         normalized_metar_text,
                         iwxxm_version=iwxxm_version,
                         lenient=False,
                         product=product,
                         profile=profile,
+                        preview=preview,
+                        soft_preview_out=soft_preview if preview else None,
                     )
+                    absorb_soft_preview(soft_preview)
+                    if preview and soft_preview.get("ok") is False:
+                        add_issue(
+                            source=metar_name,
+                            message="Soft-preview: conversion incomplete",
+                            severity=ConversionIssueSeverity.ERROR,
+                            hint="Fix failed TAC spans and retry hard convert before publish.",
+                            code="SOFT_PREVIEW_PARTIAL",
+                        )
 
                     # Optional output validation (Layers 3-7)
                     validation_layers_passed = [ValidationLayer.AIRPORT_ICAO, ValidationLayer.TAC_SYNTAX]
@@ -1880,6 +1910,7 @@ async def convert(
 
             emit_recent_wx_issues(manual_source, _norm_warnings)
 
+            soft_preview: dict = {}
             xml_text, validation_result_from_conversion = convert_metar_tac_with_metadata(
                 _normalized_entry,
                 iwxxm_version=iwxxm_version,
@@ -1887,7 +1918,18 @@ async def convert(
                 lenient=False,  # normalization already applied above
                 product=product,
                 profile=profile,
+                preview=preview,
+                soft_preview_out=soft_preview if preview else None,
             )
+            absorb_soft_preview(soft_preview)
+            if preview and soft_preview.get("ok") is False:
+                add_issue(
+                    source=manual_source,
+                    message="Soft-preview: conversion incomplete",
+                    severity=ConversionIssueSeverity.ERROR,
+                    hint="Fix failed TAC spans and retry hard convert before publish.",
+                    code="SOFT_PREVIEW_PARTIAL",
+                )
 
             duration_ms = int((time.perf_counter() - start_time) * 1000)
             layers_passed = [ValidationLayer.AIRPORT_ICAO.value, ValidationLayer.TAC_SYNTAX.value]
@@ -2086,13 +2128,25 @@ async def convert(
                 start_time = time.perf_counter()
 
                 # Only convert if validation passed
+                soft_preview: dict = {}
                 xml_text, _ = convert_metar_tac_with_metadata(
                     data or "",
                     iwxxm_version=iwxxm_version,
                     validate=False,
                     product=product,
                     profile=profile,
+                    preview=preview,
+                    soft_preview_out=soft_preview if preview else None,
                 )
+                absorb_soft_preview(soft_preview)
+                if preview and soft_preview.get("ok") is False:
+                    add_issue(
+                        source=source_name,
+                        message="Soft-preview: conversion incomplete",
+                        severity=ConversionIssueSeverity.ERROR,
+                        hint="Fix failed TAC spans and retry hard convert before publish.",
+                        code="SOFT_PREVIEW_PARTIAL",
+                    )
 
                 # Calculate duration
                 duration_ms = int((time.perf_counter() - start_time) * 1000)
@@ -2255,6 +2309,10 @@ async def convert(
             ).model_dump(),
         )
 
+    envelope_ok: Optional[bool] = None
+    if preview:
+        envelope_ok = not preview_saw_soft_fail and len(errors) == 0
+
     return ConversionResponse(
         results=results,
         errors=errors,
@@ -2263,6 +2321,8 @@ async def convert(
         successful=len(results),
         failed=len(errors),
         metadata=request_metadata,
+        ok=envelope_ok,
+        failed_spans=preview_failed_spans if preview else [],
     )
 
 

--- a/apps/backend/src/schemas/conversion.py
+++ b/apps/backend/src/schemas/conversion.py
@@ -48,6 +48,25 @@ class ConversionIssue(BaseModel):
         description="Optional location context from parser/validator",
         examples=["line 1, column 12"],
     )
+    start: Optional[int] = Field(
+        default=None,
+        description="Optional inclusive character offset into the source TAC",
+        ge=0,
+    )
+    end: Optional[int] = Field(
+        default=None,
+        description="Optional exclusive character offset into the source TAC",
+        ge=0,
+    )
+
+
+class FailedSpan(BaseModel):
+    """Character span marking a soft-preview failure (ADR-022 / F7)."""
+
+    start: int = Field(..., ge=0, description="Inclusive character offset into source TAC")
+    end: int = Field(..., ge=0, description="Exclusive character offset into source TAC")
+    code: Optional[str] = Field(default=None, description="Machine-readable failure code")
+    message: Optional[str] = Field(default=None, description="Human-readable failure message")
 
 
 class ConversionResult(BaseModel):
@@ -130,6 +149,14 @@ class ConversionResponse(BaseModel):
     metadata: dict = Field(
         default_factory=dict,
         description="Echoed request metadata such as bulletin_id, issuing_center, and validation options",
+    )
+    ok: Optional[bool] = Field(
+        default=None,
+        description="Soft-preview envelope flag (ADR-022); set when preview=true",
+    )
+    failed_spans: List[FailedSpan] = Field(
+        default_factory=list,
+        description="Soft-preview failed character spans (ADR-022); empty when preview omitted/false",
     )
 
 

--- a/apps/backend/src/utilities/conversion.py
+++ b/apps/backend/src/utilities/conversion.py
@@ -142,6 +142,8 @@ def convert_metar_tac_with_metadata(
     lenient: bool = True,
     product: Optional[str] = None,
     profile: str = "annex3",
+    preview: bool = False,
+    soft_preview_out: Optional[dict] = None,
 ) -> Tuple[str, Optional[ComprehensiveValidationResult]]:
     """
     Convert TAC to IWXXM via ``tac2iwxxm`` and optionally validate.
@@ -168,6 +170,12 @@ def convert_metar_tac_with_metadata(
         ``METAR`` or ``SPECI``; auto-detected when omitted.
     profile :
         ``annex3`` or ``iwxxm_us``.
+    preview :
+        Soft-preview mode (ADR-022): return best-effort XML instead of raising on
+        parse/convert failure.
+    soft_preview_out :
+        Optional mutable dict filled when ``preview=True`` with ``ok`` and
+        ``failed_spans`` for the API response envelope.
 
     Returns
     -------
@@ -177,7 +185,7 @@ def convert_metar_tac_with_metadata(
     Raises
     ------
     ConversionError
-        When conversion (or requested validation) fails.
+        When conversion (or requested validation) fails and ``preview`` is False.
     """
     _ = (reference_time, use_test_overrides)  # gifts-era knobs; no-op after cutover
 
@@ -197,10 +205,35 @@ def convert_metar_tac_with_metadata(
         product=product_u,
         profile=profile_l,
         iwxxm_version=version,
+        preview=preview,
     )
     if not result.ok or not result.xml:
         msgs = "; ".join(f"{i.code}: {i.message}" for i in result.issues) or "unknown convert failure"
+        if preview and result.xml:
+            failed_spans = [
+                {
+                    "start": int(i.start),
+                    "end": int(i.end),
+                    "code": i.code,
+                    "message": i.message,
+                }
+                for i in result.issues
+                if i.start is not None and i.end is not None
+            ]
+            if soft_preview_out is not None:
+                soft_preview_out.clear()
+                soft_preview_out["ok"] = False
+                soft_preview_out["failed_spans"] = failed_spans
+            xml_string = result.xml
+            if not xml_string.lstrip().startswith("<?xml"):
+                xml_string = '<?xml version="1.0"?>\n' + xml_string
+            return xml_string, None
         raise ConversionError(f"Conversion failed: {msgs}")
+
+    if soft_preview_out is not None and preview:
+        soft_preview_out.clear()
+        soft_preview_out["ok"] = True
+        soft_preview_out["failed_spans"] = []
 
     xml_string = result.xml
     if not xml_string.lstrip().startswith("<?xml"):

--- a/apps/backend/tests/unit/test_tc_f7_003_convert_preview_unit.py
+++ b/apps/backend/tests/unit/test_tc_f7_003_convert_preview_unit.py
@@ -1,0 +1,112 @@
+"""T3.1 / TC-F7-003: soft-preview via preview=true on POST /api/v1/convert (S011 / EV-008).
+
+Spec: docs/adr/ADR-022-convert-preview-flag.md; docs/api-contract.md Soft-preview;
+docs/test-plan.md TC-F7-003; UJ-016.
+Expected red until T3.2 implements the preview form flag + soft-preview path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import api as api_module
+from src.utilities.security import verify_supabase_token
+
+FIXTURES = Path(__file__).resolve().parents[4] / "packages" / "tac2iwxxm" / "tests" / "fixtures" / "product_matrix"
+
+# Injectably invalid TAC: hard convert fails parse; soft-preview must still 200.
+BAD_METAR_TAC = "METAR XXXX NOT_A_REAL_REPORT GARBAGE="
+
+
+@pytest.fixture
+def client():
+    async def override_verify_token():
+        return {"sub": "test-user", "aud": "test-aud"}
+
+    api_module.app.dependency_overrides[verify_supabase_token] = override_verify_token
+    test_client = TestClient(api_module.app)
+    yield test_client
+    api_module.app.dependency_overrides.clear()
+
+
+def _multipart_convert(
+    client: TestClient,
+    *,
+    manual_text: str,
+    product: str = "METAR",
+    preview: str | None = None,
+    lint: str = "false",
+):
+    """POST /api/v1/convert as multipart/form-data."""
+    files: dict[str, tuple[None, str]] = {
+        "manual_text": (None, manual_text),
+        "product": (None, product),
+        "profile": (None, "annex3"),
+        "lint": (None, lint),
+    }
+    if preview is not None:
+        files["preview"] = (None, preview)
+    return client.post("/api/v1/convert", files=files)
+
+
+def _assert_failed_spans(payload: dict) -> None:
+    assert "failed_spans" in payload
+    spans = payload["failed_spans"]
+    assert isinstance(spans, list)
+    assert len(spans) >= 1
+    for span in spans:
+        assert isinstance(span["start"], int)
+        assert isinstance(span["end"], int)
+        assert 0 <= span["start"] <= span["end"]
+        # code / message optional per api-contract
+
+
+def test_convert_preview_partial_failure_returns_200_failed_spans_and_xml(
+    client: TestClient,
+) -> None:
+    """ADR-022: preview=true → HTTP 200, ok=false, failed_spans, best-effort IWXXM."""
+    response = _multipart_convert(client, manual_text=BAD_METAR_TAC, preview="true")
+    assert response.status_code == 200, response.text[:500]
+    payload = response.json()
+    assert payload.get("ok") is False
+    _assert_failed_spans(payload)
+
+    results = payload.get("results") or []
+    assert results, "soft-preview must return best-effort XML in results"
+    xml = results[0].get("content") or ""
+    assert "<" in xml and "iwxxm" in xml.lower(), "best-effort body must look like IWXXM XML"
+
+
+def test_convert_without_preview_keeps_hard_fail(client: TestClient) -> None:
+    """TC-F7-003: hard convert failure semantics unchanged when preview not selected."""
+    response = _multipart_convert(client, manual_text=BAD_METAR_TAC, preview=None)
+    assert response.status_code in {400, 422}, response.text[:500]
+    # Must not look like soft-preview success envelope
+    if response.headers.get("content-type", "").startswith("application/json"):
+        body = response.json()
+        assert body.get("ok") is not True
+        # Soft-preview fields should not redefine hard-fail into 200
+        assert "failed_spans" not in body or response.status_code != 200
+
+
+def test_convert_preview_false_keeps_hard_fail(client: TestClient) -> None:
+    """Explicit preview=false retains hard-fail HTTP semantics."""
+    response = _multipart_convert(client, manual_text=BAD_METAR_TAC, preview="false")
+    assert response.status_code in {400, 422}, response.text[:500]
+
+
+def test_convert_preview_success_ok_true(client: TestClient) -> None:
+    """Valid TAC with preview=true still succeeds (ok true or empty failed_spans)."""
+    tac = (FIXTURES / "metar_basic.tac").read_text(encoding="utf-8").strip()
+    response = _multipart_convert(client, manual_text=tac, preview="true")
+    assert response.status_code == 200, response.text[:500]
+    payload = response.json()
+    assert payload.get("ok") is True
+    assert payload.get("successful", 0) >= 1
+    spans = payload.get("failed_spans") or []
+    assert spans == []
+    assert payload["results"]
+    assert "<" in payload["results"][0]["content"]

--- a/apps/frontend/src/app/components/FailedTacCue.test.tsx
+++ b/apps/frontend/src/app/components/FailedTacCue.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * T3.3 — Failed-TAC visual cue in editor/results (UJ-016 / #665).
+ *
+ * Expected red until T3.4 ships FailedTacCue + TacEditor failed chrome.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FailedTacCue } from './FailedTacCue';
+import { TacEditor } from './TacEditor';
+
+describe('FailedTacCue', () => {
+  it('renders a distinct Failed-TAC label (not a generic error toast)', () => {
+    render(
+      <FailedTacCue
+        failedSpans={[
+          {
+            start: 0,
+            end: 12,
+            code: 'PARSE_ERROR',
+            message: 'no METAR/SPECI report found in TAC',
+          },
+        ]}
+      />,
+    );
+
+    const cue = screen.getByTestId('failed-tac-cue');
+    expect(cue).toBeInTheDocument();
+    expect(cue).toHaveTextContent(/Failed-TAC/i);
+    expect(cue).toHaveAttribute('role', 'status');
+    expect(screen.getByText(/PARSE_ERROR/i)).toBeInTheDocument();
+  });
+
+  it('is hidden when there are no failed spans', () => {
+    const { container } = render(<FailedTacCue failedSpans={[]} />);
+    expect(container.querySelector('[data-testid="failed-tac-cue"]')).toBeNull();
+  });
+
+  it('summarizes span count for multiple failures', () => {
+    render(
+      <FailedTacCue
+        failedSpans={[
+          { start: 0, end: 5, code: 'A', message: 'first' },
+          { start: 10, end: 15, code: 'B', message: 'second' },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('failed-tac-cue')).toHaveTextContent(/2/);
+  });
+});
+
+describe('TacEditor failed-TAC chrome', () => {
+  it('marks the editor host when failedSpans are present', () => {
+    render(
+      <TacEditor
+        value="METAR XXXX GARBAGE="
+        onChange={() => {}}
+        failedSpans={[
+          { start: 6, end: 10, code: 'PARSE_ERROR', message: 'bad station' },
+        ]}
+      />,
+    );
+    const host = screen.getByTestId('tac-editor');
+    expect(host).toHaveAttribute('data-failed-tac', 'true');
+  });
+
+  it('does not mark the editor when failedSpans are empty', () => {
+    render(
+      <TacEditor
+        value="METAR KJFK 231751Z NIL="
+        onChange={() => {}}
+        failedSpans={[]}
+      />,
+    );
+    expect(screen.getByTestId('tac-editor')).not.toHaveAttribute(
+      'data-failed-tac',
+      'true',
+    );
+  });
+});

--- a/apps/frontend/src/app/components/FailedTacCue.tsx
+++ b/apps/frontend/src/app/components/FailedTacCue.tsx
@@ -1,0 +1,52 @@
+/**
+ * Distinct Failed-TAC visual cue for soft-preview / partial convert (UJ-016 / #665).
+ */
+
+export interface FailedSpanView {
+  start: number;
+  end: number;
+  code?: string;
+  message?: string;
+}
+
+export interface FailedTacCueProps {
+  failedSpans: FailedSpanView[];
+}
+
+/**
+ * Surface soft-preview failed spans as a status cue distinct from toast errors.
+ *
+ * @param props.failedSpans - Character spans from convert ``failed_spans``
+ */
+export function FailedTacCue({ failedSpans }: FailedTacCueProps) {
+  if (!failedSpans.length) {
+    return null;
+  }
+
+  const primary = failedSpans[0];
+  const extra = failedSpans.length > 1 ? failedSpans.length : null;
+
+  return (
+    <div
+      data-testid="failed-tac-cue"
+      role="status"
+      className="mb-3 rounded-md border border-rose-400 bg-rose-50 px-3 py-2 text-sm text-rose-950 dark:border-rose-700 dark:bg-rose-950/50 dark:text-rose-100"
+    >
+      <p className="font-semibold">
+        Failed-TAC
+        {extra != null ? (
+          <span className="ml-1 font-normal">({extra} spans)</span>
+        ) : null}
+      </p>
+      {primary.code ? (
+        <p className="mt-1 font-mono text-xs opacity-90">{primary.code}</p>
+      ) : null}
+      {primary.message ? (
+        <p className="mt-0.5 text-xs opacity-90">{primary.message}</p>
+      ) : null}
+      <p className="mt-1 text-xs opacity-80">
+        Soft-preview only — not a Schematron-passed publish.
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -5,6 +5,8 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { TacEditor } from './TacEditor';
 import { DecodePanel } from './DecodePanel';
+import { FailedTacCue } from './FailedTacCue';
+import { SoftPreviewControl } from './SoftPreviewControl';
 import {
   Upload,
   X,
@@ -30,7 +32,7 @@ import { IcaoAutocomplete } from './IcaoAutocomplete';
 import { AirportDetailsCard } from './AirportDetailsCard';
 import { signOutWithScope } from '/utils/supabase/logout';
 import { convertMetarToIwxxm as callBackendConversion, decodeTac } from '/utils/api';
-import type { DecodeResidual, DecodeSegment } from '/utils/api';
+import type { DecodeResidual, DecodeSegment, FailedSpan } from '/utils/api';
 import {
   detectTacProduct,
   resolveConvertProduct,
@@ -138,6 +140,8 @@ export function FileConverter({
   const [decodeProduct, setDecodeProduct] = useState<string | undefined>();
   const [decodeLoading, setDecodeLoading] = useState(false);
   const [decodeError, setDecodeError] = useState<string | null>(null);
+  const [softPreview, setSoftPreview] = useState(false);
+  const [failedSpans, setFailedSpans] = useState<FailedSpan[]>([]);
   // Restore the guest's custom output filename from the session snapshot (R5).
   const [outputFilename, setOutputFilename] = useState(() => {
     const saved = readGuestConverterState()?.conversionParams?.output_filename;
@@ -448,6 +452,7 @@ export function FileConverter({
   const performConversion = async (): Promise<{
     files: ConvertedFile[];
     hasErrors: boolean;
+    softFail: boolean;
   } | null> => {
     if (pendingFiles.length === 0 && !manualInput.trim()) {
       toast.error('Please add files or enter manual input');
@@ -456,6 +461,7 @@ export function FileConverter({
 
     setConversionStatus({ type: 'loading', message: 'Converting...' });
     setConversionLog(null);
+    setFailedSpans([]);
 
     try {
       const newConvertedFiles: ConvertedFile[] = [];
@@ -467,6 +473,7 @@ export function FileConverter({
       console.log('[FileConverter] Starting conversion with:', {
         manualInput: manualInput.trim() ? 'provided' : 'none',
         fileCount: filesToConvert.length,
+        softPreview,
         accessToken: accessToken ? `${accessToken.substring(0, 20)}...` : 'MISSING',
       });
 
@@ -493,6 +500,7 @@ export function FileConverter({
         profile: conversionParams.profile,
         iwxxmVersion: conversionParams.iwxxmVersion,
         validateOutput: false,
+        preview: softPreview,
         accessToken: accessToken,
       });
 
@@ -548,6 +556,12 @@ export function FileConverter({
       const responseErrors = response.errors ?? [];
       const responseIssues = response.issues ?? [];
       const hasLog = responseErrors.length > 0 || responseIssues.length > 0;
+      const softFail = Boolean(softPreview && response.ok === false);
+      const spans = response.failed_spans ?? [];
+
+      if (softFail) {
+        setFailedSpans(spans);
+      }
 
       if (newConvertedFiles.length === 0) {
         if (hasLog) {
@@ -561,12 +575,16 @@ export function FileConverter({
 
       setConvertedFiles(newConvertedFiles);
       setPendingFiles([]);
-      setManualInput('');
+      // Keep TAC in editor on soft-fail so Failed-TAC cue stays contextual (UJ-016).
+      if (!softFail) {
+        setManualInput('');
+        setFailedSpans([]);
+      }
       setConversionLog(
         hasLog ? { errors: responseErrors, issues: responseIssues } : null,
       );
       setConversionStatus({ type: 'idle' });
-      return { files: newConvertedFiles, hasErrors: hasLog };
+      return { files: newConvertedFiles, hasErrors: hasLog || softFail, softFail };
     } catch (error) {
       console.error('[FileConverter] Conversion error:', error);
 
@@ -606,7 +624,13 @@ export function FileConverter({
     try {
       const result = await performConversion();
       if (result) {
-        toast.success(`Successfully converted ${result.files.length} file(s)`);
+        if (result.softFail) {
+          toast.warning(
+            'Soft-preview returned Failed-TAC markers — not ready to publish',
+          );
+        } else {
+          toast.success(`Successfully converted ${result.files.length} file(s)`);
+        }
         if (accessToken) {
           const snapshot = buildSnapshot({
             convertedFiles: result.files.map((file) => ({
@@ -647,6 +671,9 @@ export function FileConverter({
       }
 
       if (result.hasErrors) {
+        if (result.softFail) {
+          toast.warning('Soft-preview Failed-TAC — fix markers before Convert & Send');
+        }
         await persistSession(
           buildSnapshot({
             convertedFiles: result.files.map((file) => ({
@@ -654,7 +681,7 @@ export function FileConverter({
               originalContent: file.originalContent,
               convertedContent: file.convertedContent,
             })),
-            manualInput: '',
+            manualInput: result.softFail ? manualInput : '',
             pendingFiles: [],
           }),
           { status: 'failed' },
@@ -806,6 +833,7 @@ export function FileConverter({
     setConvertedFiles([]);
     setConversionLog(null);
     setConversionStatus({ type: 'idle' });
+    setFailedSpans([]);
     toast.info('Queue cleared');
   };
 
@@ -1058,6 +1086,7 @@ export function FileConverter({
               >
                 Manual TAC Input
               </label>
+              <FailedTacCue failedSpans={failedSpans} />
               <TacEditor
                 id="manual-input"
                 value={manualInput}
@@ -1066,6 +1095,7 @@ export function FileConverter({
                 placeholder="SPECI BGSF 282350Z 10RMF50MT 9999 SCT110 BKN130 0RN130 NN7/N11 Q1021"
                 aria-label="Enter METAR data manually"
                 className="min-h-[120px] focus-within:ring-2 focus-within:ring-blue-500"
+                failedSpans={failedSpans}
               />
               <DecodePanel
                 segments={decodeSegments}
@@ -1075,6 +1105,13 @@ export function FileConverter({
                 error={decodeError}
                 onOpenChange={runDecode}
               />
+              <div className="mt-3">
+                <SoftPreviewControl
+                  checked={softPreview}
+                  onChange={setSoftPreview}
+                  disabled={isReadOnly || isBusy}
+                />
+              </div>
             </div>
 
             {/* Output filename for manual input (#664 / EV-005) */}

--- a/apps/frontend/src/app/components/SoftPreviewControl.test.tsx
+++ b/apps/frontend/src/app/components/SoftPreviewControl.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * T3.3 — Soft-preview control contract for UJ-016 / #666 (wired in T3.4).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SoftPreviewControl } from './SoftPreviewControl';
+
+describe('SoftPreviewControl', () => {
+  it('exposes a preview checkbox distinct from hard convert', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SoftPreviewControl checked={false} onChange={onChange} />);
+
+    const toggle = screen.getByTestId('soft-preview-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('type', 'checkbox');
+    expect(screen.getByText(/soft-preview|preview/i)).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reflects checked state', () => {
+    render(<SoftPreviewControl checked={true} onChange={() => {}} />);
+    expect(screen.getByTestId('soft-preview-toggle')).toBeChecked();
+  });
+});

--- a/apps/frontend/src/app/components/SoftPreviewControl.tsx
+++ b/apps/frontend/src/app/components/SoftPreviewControl.tsx
@@ -1,0 +1,41 @@
+/**
+ * Soft-preview checkbox for convert ``preview=true`` (UJ-016 / ADR-022).
+ */
+
+export interface SoftPreviewControlProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Toggle soft-preview mode on convert requests.
+ *
+ * @param props.checked - Whether soft-preview is enabled
+ * @param props.onChange - Called with the next checked state
+ */
+export function SoftPreviewControl({
+  checked,
+  onChange,
+  disabled = false,
+}: SoftPreviewControlProps) {
+  return (
+    <label className="mb-4 flex cursor-pointer items-start gap-2 text-sm text-gray-800 dark:text-gray-200">
+      <input
+        type="checkbox"
+        data-testid="soft-preview-toggle"
+        className="mt-0.5 h-4 w-4 rounded border-gray-300 text-rose-600 focus:ring-rose-500"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span>
+        <span className="font-medium">Soft-preview</span>
+        <span className="block text-xs text-gray-500 dark:text-gray-400">
+          Return best-effort IWXXM and failed spans when TAC is partial (not for
+          publish).
+        </span>
+      </span>
+    </label>
+  );
+}

--- a/apps/frontend/src/app/components/TacEditor.tsx
+++ b/apps/frontend/src/app/components/TacEditor.tsx
@@ -6,6 +6,13 @@ import { useEffect, useRef } from 'react';
 import { EditorView, basicSetup } from 'codemirror';
 import { EditorState } from '@codemirror/state';
 
+export interface FailedSpanMark {
+  start: number;
+  end: number;
+  code?: string;
+  message?: string;
+}
+
 export interface TacEditorProps {
   id?: string;
   value: string;
@@ -14,6 +21,8 @@ export interface TacEditorProps {
   placeholder?: string;
   'aria-label'?: string;
   className?: string;
+  /** Soft-preview / Failed-TAC spans — marks editor chrome when non-empty (UJ-016). */
+  failedSpans?: FailedSpanMark[];
 }
 
 /**
@@ -22,6 +31,7 @@ export interface TacEditorProps {
  * @param props.value - Current TAC text
  * @param props.onChange - Called when the document changes
  * @param props.readOnly - When true, editing is disabled
+ * @param props.failedSpans - Optional soft-preview failure spans
  */
 export function TacEditor({
   id = 'manual-input',
@@ -31,11 +41,13 @@ export function TacEditor({
   placeholder = '',
   'aria-label': ariaLabel = 'Enter TAC data manually',
   className = '',
+  failedSpans = [],
 }: TacEditorProps) {
   const parentRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const hasFailedTac = failedSpans.length > 0;
 
   useEffect(() => {
     if (!parentRef.current) {
@@ -107,9 +119,14 @@ export function TacEditor({
 
   return (
     <div
-      className={`overflow-hidden rounded-md border border-gray-300 bg-white dark:border-gray-700 dark:bg-gray-800 ${className}`}
+      className={`overflow-hidden rounded-md border bg-white dark:bg-gray-800 ${
+        hasFailedTac
+          ? 'border-rose-400 dark:border-rose-600'
+          : 'border-gray-300 dark:border-gray-700'
+      } ${className}`}
       data-testid="tac-editor"
       data-placeholder={placeholder}
+      {...(hasFailedTac ? { 'data-failed-tac': 'true' } : {})}
     >
       <div ref={parentRef} />
     </div>

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -45,6 +45,15 @@ export interface ConversionIssue {
   severity?: 'error' | 'warning' | 'info';
   layer?: string;
   location?: string;
+  start?: number;
+  end?: number;
+}
+
+export interface FailedSpan {
+  start: number;
+  end: number;
+  code?: string;
+  message?: string;
 }
 
 export interface ConversionResponse {
@@ -54,6 +63,9 @@ export interface ConversionResponse {
   total_processed: number;
   successful: number;
   failed: number;
+  /** Soft-preview envelope (ADR-022); set when preview=true */
+  ok?: boolean | null;
+  failed_spans?: FailedSpan[];
 }
 
 export interface HealthResponse {
@@ -132,6 +144,7 @@ export async function convertMetarToIwxxm(params: {
   profile?: string;
   iwxxmVersion?: string;
   validateOutput?: boolean;
+  preview?: boolean;
   accessToken?: string;
 }): Promise<ConversionResponse> {
   const formData = new FormData();
@@ -155,6 +168,10 @@ export async function convertMetarToIwxxm(params: {
 
   // Add validation flag (default to false)
   formData.append('validate_output', params.validateOutput ? 'true' : 'false');
+
+  if (params.preview) {
+    formData.append('preview', 'true');
+  }
 
   try {
     const token = params.accessToken || getAccessToken() || '';

--- a/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
+++ b/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
@@ -17,9 +17,9 @@
 |-------|-------|
 | **Active phase** | Phase C — 07-build |
 | **Active milestone** | M3 — Failed-TAC + preview |
-| **Active task** | T3.3 next |
-| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) + T3.1–T3.2 |
-| **Last updated** | 2026-07-13 |
+| **Active task** | T3.5 next (PR-M3) |
+| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) + T3.1–T3.4 |
+| **Last updated** | 2026-07-14 |
 
 ## Tech Stack Summary (S011 delta)
 
@@ -115,9 +115,9 @@
 |----|------|------|--------|------|---------|
 | T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | completed | ADR-022 | M2 |
 | T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | completed | api-contract | T3.1 |
-| T3.3 | Test: Failed-TAC visual cue in editor/results | Test | in_progress | UJ-016 | T3.2 |
-| T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | pending | #665/#666 | T3.3 |
-| T3.5 | PR-M3: preview + Failed-TAC | PR | pending | — | T3.2–T3.4 |
+| T3.3 | Test: Failed-TAC visual cue in editor/results | Test | completed | UJ-016 | T3.2 |
+| T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | completed | #665/#666 | T3.3 |
+| T3.5 | PR-M3: preview + Failed-TAC | PR | in_progress | — | T3.2–T3.4 |
 
 ---
 

--- a/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
+++ b/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
@@ -16,9 +16,9 @@
 | Field | Value |
 |-------|-------|
 | **Active phase** | Phase C — 07-build |
-| **Active milestone** | M3 — Failed-TAC + preview |
-| **Active task** | T3.5 next (PR-M3) |
-| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) + T3.1–T3.4 |
+| **Active milestone** | M4 — Live workbench (next) |
+| **Active task** | T4.1 next |
+| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) + M3 (T3.1–T3.5) |
 | **Last updated** | 2026-07-14 |
 
 ## Tech Stack Summary (S011 delta)
@@ -117,7 +117,7 @@
 | T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | completed | api-contract | T3.1 |
 | T3.3 | Test: Failed-TAC visual cue in editor/results | Test | completed | UJ-016 | T3.2 |
 | T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | completed | #665/#666 | T3.3 |
-| T3.5 | PR-M3: preview + Failed-TAC | PR | in_progress | — | T3.2–T3.4 |
+| T3.5 | PR-M3: preview + Failed-TAC | PR | completed | — | T3.2–T3.4 |
 
 ---
 
@@ -189,7 +189,7 @@
 |----|------|-------|--------|
 | PR-M1 | Minor | Admin removal | pending |
 | PR-M2 | Minor | Decode + CodeMirror | open — https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716 |
-| PR-M3 | Minor | Preview + Failed-TAC | pending |
+| PR-M3 | Minor | Preview + Failed-TAC | open — https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/717 |
 | PR-M4 | Minor | Live workbench | pending |
 | PR-M5 | Minor | Unified sessions | pending |
 | PR-EV-008 | Major | Evolve → main | pending |

--- a/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
+++ b/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
@@ -115,7 +115,7 @@
 |----|------|------|--------|------|---------|
 | T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | completed | ADR-022 | M2 |
 | T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | completed | api-contract | T3.1 |
-| T3.3 | Test: Failed-TAC visual cue in editor/results | Test | pending | UJ-016 | T3.2 |
+| T3.3 | Test: Failed-TAC visual cue in editor/results | Test | in_progress | UJ-016 | T3.2 |
 | T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | pending | #665/#666 | T3.3 |
 | T3.5 | PR-M3: preview + Failed-TAC | PR | pending | — | T3.2–T3.4 |
 

--- a/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
+++ b/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
@@ -17,8 +17,8 @@
 |-------|-------|
 | **Active phase** | Phase C — 07-build |
 | **Active milestone** | M3 — Failed-TAC + preview |
-| **Active task** | T3.1 in_progress |
-| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) |
+| **Active task** | T3.3 next |
+| **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) + T3.1–T3.2 |
 | **Last updated** | 2026-07-13 |
 
 ## Tech Stack Summary (S011 delta)
@@ -113,8 +113,8 @@
 
 | ID | Task | Type | Status | Spec | Depends |
 |----|------|------|--------|------|---------|
-| T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | in_progress | ADR-022 | M2 |
-| T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | pending | api-contract | T3.1 |
+| T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | completed | ADR-022 | M2 |
+| T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | completed | api-contract | T3.1 |
 | T3.3 | Test: Failed-TAC visual cue in editor/results | Test | pending | UJ-016 | T3.2 |
 | T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | pending | #665/#666 | T3.3 |
 | T3.5 | PR-M3: preview + Failed-TAC | PR | pending | — | T3.2–T3.4 |

--- a/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
+++ b/docs/sessions/S011-f7-operator-ui/reports/execution-plan.md
@@ -16,8 +16,8 @@
 | Field | Value |
 |-------|-------|
 | **Active phase** | Phase C — 07-build |
-| **Active milestone** | M3 — Failed-TAC + preview (next) |
-| **Active task** | T3.1 next |
+| **Active milestone** | M3 — Failed-TAC + preview |
+| **Active task** | T3.1 in_progress |
 | **Tasks completed** | M1 (code uncommitted) + M2 (T2.1–T2.8) |
 | **Last updated** | 2026-07-13 |
 
@@ -113,7 +113,7 @@
 
 | ID | Task | Type | Status | Spec | Depends |
 |----|------|------|--------|------|---------|
-| T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | pending | ADR-022 | M2 |
+| T3.1 | Test: convert with `preview=true` → 200 + `failed_spans` + best-effort XML | Test | in_progress | ADR-022 | M2 |
 | T3.2 | Impl: tac2iwxxm soft-preview hooks + backend `preview` form flag | Impl | pending | api-contract | T3.1 |
 | T3.3 | Test: Failed-TAC visual cue in editor/results | Test | pending | UJ-016 | T3.2 |
 | T3.4 | Impl: Failed-TAC cue + wire preview control in UI | Impl | pending | #665/#666 | T3.3 |

--- a/packages/tac2iwxxm/src/tac2iwxxm/convert.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/convert.py
@@ -37,6 +37,13 @@ _REMARK_SPAN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 
+_PREVIEW_ROOTS = frozenset({"METAR", "SPECI", "TAF", "SIGMET", "AIRMET", "VAA", "TCA"})
+_PREVIEW_NS = {
+    "2025-2": "http://icao.int/iwxxm/2025-2",
+    "2023-1": "http://icao.int/iwxxm/2023-1",
+}
+
+
 def _content_bounds(tac: str) -> tuple[int, int]:
     """Return inclusive start / exclusive end of stripped TAC content in ``tac``."""
     stripped = tac.strip()
@@ -44,6 +51,40 @@ def _content_bounds(tac: str) -> tuple[int, int]:
         return 0, len(tac)
     leading = len(tac) - len(tac.lstrip())
     return leading, leading + len(stripped)
+
+
+def _preview_stub_xml(product: str, iwxxm_version: str, reason: str) -> str:
+    """
+    Emit a minimal best-effort IWXXM shell for soft-preview (not for publication).
+
+    Parameters
+    ----------
+    product :
+        Product root element name (e.g. ``METAR``).
+    iwxxm_version :
+        Release line used to pick the IWXXM namespace.
+    reason :
+        Short human-readable failure note embedded as an XML comment.
+
+    Returns
+    -------
+    str
+        IWXXM-looking XML document with a nil observation.
+    """
+    from xml.sax.saxutils import escape
+
+    root = product.upper() if product.upper() in _PREVIEW_ROOTS else "METAR"
+    ns = _PREVIEW_NS.get(iwxxm_version, _PREVIEW_NS["2025-2"])
+    gml_id = f"{root.lower()}.preview.failed"
+    note = escape(reason[:240])
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<iwxxm:{root} xmlns:iwxxm="{ns}" xmlns:gml="http://www.opengis.net/gml/3.2" '
+        f'gml:id="{gml_id}" reportStatus="NORMAL">\n'
+        f"  <!-- soft-preview: {note} -->\n"
+        '  <iwxxm:observation nilReason="http://codes.wmo.int/common/nil/missing"/>\n'
+        f"</iwxxm:{root}>\n"
+    )
 
 
 def _remark_span(tac: str, message: str) -> tuple[int | None, int | None]:
@@ -113,6 +154,7 @@ def convert(
     product: str,
     profile: str = "annex3",
     iwxxm_version: str = "2025-2",
+    preview: bool = False,
 ) -> ConvertResult:
     """
     Convert a TAC report to IWXXM XML.
@@ -127,6 +169,9 @@ def convert(
         ``annex3`` (default) or ``iwxxm_us`` (METAR/SPECI US extensions; others T5.4–T5.5).
     iwxxm_version :
         Target IWXXM release line.
+    preview :
+        When ``True``, fatal parse/profile failures still return best-effort stub XML
+        (soft-preview / ADR-022). Does not imply Schematron-passed publish.
 
     Returns
     -------
@@ -136,69 +181,42 @@ def convert(
     product_u = product.upper()
     profile_l = profile.lower()
 
+    def _fail(code: str, message: str, *, span: bool = False) -> ConvertResult:
+        span_start = span_end = None
+        if span:
+            span_start, span_end = _content_bounds(tac)
+        issue = ConvertIssue(
+            severity="error",
+            code=code,
+            message=message,
+            start=span_start,
+            end=span_end,
+        )
+        xml = _preview_stub_xml(product_u, iwxxm_version, f"{code}: {message}") if preview else None
+        return ConvertResult(
+            ok=False,
+            product=product_u,
+            profile=profile_l,
+            iwxxm_version=iwxxm_version,
+            xml=xml,
+            issues=[issue],
+        )
+
     if product_u not in _SUPPORTED_PRODUCTS:
-        return ConvertResult(
-            ok=False,
-            product=product_u,
-            profile=profile_l,
-            iwxxm_version=iwxxm_version,
-            issues=[
-                ConvertIssue(
-                    severity="error",
-                    code="UNSUPPORTED_PRODUCT",
-                    message=f"product {product_u!r} not supported yet",
-                )
-            ],
-        )
+        return _fail("UNSUPPORTED_PRODUCT", f"product {product_u!r} not supported yet")
     if profile_l not in _SUPPORTED_PROFILES:
-        return ConvertResult(
-            ok=False,
-            product=product_u,
-            profile=profile_l,
-            iwxxm_version=iwxxm_version,
-            issues=[
-                ConvertIssue(
-                    severity="error",
-                    code="UNSUPPORTED_PROFILE",
-                    message=f"profile {profile_l!r} not supported yet",
-                )
-            ],
-        )
+        return _fail("UNSUPPORTED_PROFILE", f"profile {profile_l!r} not supported yet")
     if profile_l == "iwxxm_us" and product_u not in _US_PRODUCTS:
-        return ConvertResult(
-            ok=False,
-            product=product_u,
-            profile=profile_l,
-            iwxxm_version=iwxxm_version,
-            issues=[
-                ConvertIssue(
-                    severity="error",
-                    code="UNSUPPORTED_PROFILE",
-                    message=f"profile iwxxm_us not supported yet for product {product_u!r}",
-                )
-            ],
+        return _fail(
+            "UNSUPPORTED_PROFILE",
+            f"profile iwxxm_us not supported yet for product {product_u!r}",
         )
 
     try:
         ir = _parse(product_u, tac)
         xml = _emit(product_u, profile_l, ir, iwxxm_version)
     except ValueError as exc:
-        span_start, span_end = _content_bounds(tac)
-        return ConvertResult(
-            ok=False,
-            product=product_u,
-            profile=profile_l,
-            iwxxm_version=iwxxm_version,
-            issues=[
-                ConvertIssue(
-                    severity="error",
-                    code="PARSE_ERROR",
-                    message=str(exc),
-                    start=span_start,
-                    end=span_end,
-                )
-            ],
-        )
+        return _fail("PARSE_ERROR", str(exc), span=True)
 
     issues: list[ConvertIssue] = []
     if profile_l == "iwxxm_us":

--- a/packages/tac2iwxxm/tests/test_convert_unit.py
+++ b/packages/tac2iwxxm/tests/test_convert_unit.py
@@ -50,6 +50,19 @@ def test_convert_parse_error_returns_ok_false() -> None:
     result = convert("NOT A REPORT", product="METAR")
     assert result.ok is False
     assert result.issues[0].code == "PARSE_ERROR"
+    assert result.xml is None
+
+
+def test_convert_preview_parse_error_returns_stub_xml() -> None:
+    """S011 / ADR-022: soft-preview keeps best-effort XML + spans on parse failure."""
+    tac = "METAR XXXX NOT_A_REAL_REPORT GARBAGE="
+    result = convert(tac, product="METAR", preview=True)
+    assert result.ok is False
+    assert result.xml is not None
+    assert "iwxxm:METAR" in result.xml
+    assert result.issues[0].code == "PARSE_ERROR"
+    assert result.issues[0].start == 0
+    assert result.issues[0].end == len(tac.strip())
 
 
 def test_parse_product_mismatch() -> None:


### PR DESCRIPTION
## Summary
- Soft-preview via `preview=true` on `POST /api/v1/convert` (ADR-022): HTTP 200 + `ok` + `failed_spans` + best-effort IWXXM
- tac2iwxxm stub XML on preview parse failure; hard convert semantics unchanged when preview omitted/false
- Failed-TAC visual cue + soft-preview checkbox in FileConverter (UJ-016 / #665/#666)

## Tasks
- [x] T3.1 Test: convert preview=true contract (TC-F7-003)
- [x] T3.2 Impl: tac2iwxxm + backend preview flag
- [x] T3.3 Test: Failed-TAC cue / SoftPreviewControl
- [x] T3.4 Impl: wire cue + preview into FileConverter

## Test plan
- [x] `pytest apps/backend/tests/unit/test_tc_f7_003_convert_preview_unit.py --no-cov`
- [x] `pytest packages/tac2iwxxm/tests/test_convert_unit.py` (preview stub)
- [x] Vitest FailedTacCue + SoftPreviewControl + TacEditor
- [ ] Manual: enable Soft-preview, convert garbage METAR → Failed-TAC cue + stub XML; hard convert still 4xx

## Notes
Base is M2 tip (`7783698`) so this PR is M3-only. Same commits are also on `evolve/S011-f7-operator-ui` (updates open PR #716). Session S011 / EV-008.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add soft-preview support for METAR TAC-to-IWXXM conversion, exposing preview results and failed TAC spans through the API and frontend UI with dedicated Failed-TAC cues.

New Features:
- Introduce soft-preview mode in tac2iwxxm conversion that can return best-effort stub IWXXM XML on parse/profile failure when preview is enabled.
- Expose a preview flag and failed span metadata on the backend convert endpoint, aggregating soft-preview results across inputs into the response envelope.
- Add a SoftPreviewControl checkbox and FailedTacCue indicator in the FileConverter UI, wiring preview requests and failed span highlighting into the manual TAC editor.

Enhancements:
- Extend conversion schemas and client typings to carry character span metadata for conversion issues and soft-preview failures.
- Refine TAC editor styling to visually highlight Failed-TAC input based on soft-preview span markers.
- Update session documentation to reflect completion of soft-preview and Failed-TAC UI tasks for the current milestone.

Documentation:
- Document soft-preview milestone progress and task completion in the S011 operator UI execution plan.

Tests:
- Add unit tests for tac2iwxxm soft-preview stub XML behavior and parse error spans.
- Add backend API tests covering preview=true convert semantics, including HTTP 200 responses, ok/failed_spans fields, and unchanged hard-fail behavior when preview is disabled.
- Add frontend tests for FailedTacCue, TacEditor failed-TAC chrome, and SoftPreviewControl interactions.