### PR TITLE
[hotfix] Empty Bearer on lint-tac/decode-tac + descriptive lint console

### DIFF
--- a/apps/frontend/src/app/App.test.tsx
+++ b/apps/frontend/src/app/App.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 const authServiceMocks = vi.hoisted(() => ({
   isLoggedIn: vi.fn(),
   logout: vi.fn(),
+  getAccessToken: vi.fn(),
 }));
 
 const toastMocks = vi.hoisted(() => ({
@@ -37,6 +38,7 @@ vi.mock('/utils/supabase/client', () => {
 vi.mock('@/utils/authService', () => ({
   isLoggedIn: authServiceMocks.isLoggedIn,
   logout: authServiceMocks.logout,
+  getAccessToken: authServiceMocks.getAccessToken,
 }));
 
 vi.mock('@/utils/workSessionApi', () => ({
@@ -292,6 +294,7 @@ describe('App Component', () => {
     vi.clearAllMocks();
     localStorage.clear();
     authServiceMocks.isLoggedIn.mockReturnValue(false);
+    authServiceMocks.getAccessToken.mockReturnValue(null);
     authServiceMocks.logout.mockResolvedValue(undefined);
     mockReadGuest.mockReturnValue(null);
     workSessionMocks.listWorkSessions.mockResolvedValue({ items: [], total: 0 });

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -9,7 +9,7 @@ import { PasswordReset } from './components/auth/PasswordReset';
 import { Toaster } from './components/ui/sonner';
 import { toast } from 'sonner';
 import { ThemeProvider } from './components/ThemeProvider';
-import { isLoggedIn, logout } from '@/utils/authService';
+import { getAccessToken, isLoggedIn, logout } from '@/utils/authService';
 
 import { requireApiBaseUrl } from '@/utils/apiBase';
 import { isAuthDisabled } from '@/utils/runtime-config';
@@ -56,7 +56,7 @@ function App() {
   const [userEmail, setUserEmail] = useState('');
   const [isAuthenticated, setIsAuthenticated] = useState(initialLoggedIn);
   const [accessToken, setAccessToken] = useState(() =>
-    disableAuth ? 'dev-bypass-token' : '',
+    disableAuth ? 'dev-bypass-token' : getAccessToken() || '',
   );
   const [activeWorkSessionId, setActiveWorkSessionId] = useState<string | null>(null);
   const [loadedWorkSession, setLoadedWorkSession] = useState<WorkSession | null>(null);

--- a/apps/frontend/src/hooks/useLiveWorkbenchAssist.ts
+++ b/apps/frontend/src/hooks/useLiveWorkbenchAssist.ts
@@ -142,6 +142,17 @@ export function useLiveWorkbenchAssist({
         setDecodeProduct(decodeResult.product);
 
         const summaryLevel = lintResult.ok ? 'info' : 'warn';
+        const issuePreview = lintResult.issues
+          .slice(0, 3)
+          .map((i) => {
+            const code = i.code ? `[${i.code}] ` : '';
+            return `${code}${i.message}`;
+          })
+          .join('; ');
+        const more =
+          lintResult.issues.length > 3
+            ? ` (+${lintResult.issues.length - 3} more)`
+            : '';
         setConsoleLines((prev) => [
           ...prev.slice(-198),
           {
@@ -149,7 +160,9 @@ export function useLiveWorkbenchAssist({
             source: 'lint-tac',
             message: lintResult.ok
               ? `ok (${lintResult.issues.length} messages)`
-              : `${lintResult.issues.length} issue(s)`,
+              : lintResult.issues.length === 0
+                ? '0 issue(s)'
+                : `${lintResult.issues.length} issue(s): ${issuePreview}${more}`,
             at: Date.now(),
           },
         ]);

--- a/apps/frontend/src/test/bug-2026-07-15-empty-bearer-lint-tac.test.tsx
+++ b/apps/frontend/src/test/bug-2026-07-15-empty-bearer-lint-tac.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * BUG-2026-07-15 — Empty Bearer on lint-tac/decode-tac (auth hydrate + storage key).
+ *
+ * Production HAR: Authorization: Bearer (no JWT) → Missing authorization credentials.
+ *
+ * Report: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { lintTac, decodeTac } from '@/utils/api';
+
+const authServiceMocks = vi.hoisted(() => ({
+  isLoggedIn: vi.fn(),
+  logout: vi.fn(),
+  getAccessToken: vi.fn(),
+}));
+
+vi.mock('@/utils/authService', () => ({
+  isLoggedIn: authServiceMocks.isLoggedIn,
+  logout: authServiceMocks.logout,
+  getAccessToken: authServiceMocks.getAccessToken,
+}));
+
+vi.mock('@/utils/workSessionApi', () => ({
+  listWorkSessions: vi.fn().mockResolvedValue({ items: [] }),
+  createWorkSession: vi.fn(),
+}));
+
+vi.mock('@/utils/guestConverterState', () => ({
+  readGuestConverterState: vi.fn(() => null),
+  clearGuestConverterState: vi.fn(),
+}));
+
+vi.mock('@/utils/runtime-config', () => ({
+  isAuthDisabled: () => false,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock('@/app/components/FileConverter', () => ({
+  FileConverter: ({ accessToken }: { accessToken?: string }) => (
+    <div
+      data-testid="file-converter"
+      data-access-token={accessToken === undefined ? '__undefined__' : accessToken}
+    />
+  ),
+}));
+
+vi.mock('@/app/components/auth/Login', () => ({
+  Login: () => <div data-testid="login-view" />,
+}));
+
+vi.mock('@/app/components/auth/Register', () => ({
+  Register: () => null,
+}));
+
+vi.mock('@/app/components/auth/EmailVerification', () => ({
+  EmailVerification: () => null,
+}));
+
+vi.mock('@/app/components/auth/AuthCallback', () => ({
+  AuthCallback: () => null,
+}));
+
+vi.mock('@/app/components/auth/PasswordReset', () => ({
+  PasswordReset: () => null,
+}));
+
+vi.mock('@/app/components/MyMetarsPage', () => ({
+  MyMetarsPage: () => null,
+}));
+
+vi.mock('@/app/components/ThemeProvider', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('BUG-2026-07-15 empty Bearer lint-tac / decode-tac', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+    authServiceMocks.isLoggedIn.mockReturnValue(false);
+    authServiceMocks.getAccessToken.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  function mockOkJson(data: unknown) {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: vi.fn().mockResolvedValueOnce(data),
+    });
+  }
+
+  function mockErrJson(data: unknown, status = 401) {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status,
+      statusText: 'Unauthorized',
+      json: vi.fn().mockResolvedValueOnce(data),
+    });
+  }
+
+  it('lintTac sends Bearer from authService localStorage key access_token', async () => {
+    localStorage.setItem('access_token', 'real-jwt-from-login');
+    localStorage.removeItem('supabase_access_token');
+    mockOkJson({ ok: true, issues: [], fixes: [], product: 'METAR' });
+
+    await lintTac({ manualText: 'fjgfjf', product: 'METAR' });
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer real-jwt-from-login');
+  });
+
+  it('decodeTac sends Bearer from authService localStorage key access_token', async () => {
+    localStorage.setItem('access_token', 'real-jwt-from-login');
+    localStorage.removeItem('supabase_access_token');
+    mockOkJson({ product: 'METAR', segments: [], residuals: [] });
+
+    await decodeTac({ manualText: 'fjgfjf', product: 'METAR' });
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer real-jwt-from-login');
+  });
+
+  it('lintTac surfaces FastAPI string detail on 401 (not only HTTP 401)', async () => {
+    mockErrJson({ detail: 'Missing authorization credentials' }, 401);
+
+    await expect(
+      lintTac({ manualText: 'fjgfjf', product: 'METAR', accessToken: '' }),
+    ).rejects.toThrow('Missing authorization credentials');
+  });
+
+  it('App reload hydrates FileConverter accessToken from getAccessToken when logged in', async () => {
+    authServiceMocks.isLoggedIn.mockReturnValue(true);
+    authServiceMocks.getAccessToken.mockReturnValue('hydrated-jwt');
+
+    const { default: App } = await import('@/app/App');
+    render(<App />);
+
+    const el = await screen.findByTestId('file-converter');
+    expect(el.getAttribute('data-access-token')).toBe('hydrated-jwt');
+  });
+});

--- a/apps/frontend/src/test/bug-2026-07-15-lint-tac-console-detail.test.tsx
+++ b/apps/frontend/src/test/bug-2026-07-15-lint-tac-console-detail.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * BUG-2026-07-15 — lint-tac console must show issue detail, not only a count.
+ *
+ * Report: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { LIVE_ASSIST_DEBOUNCE_MS } from '@/utils/liveAssist';
+
+const lintTac = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    ok: false,
+    issues: [
+      {
+        severity: 'error',
+        code: 'TAC_PARSE',
+        message: 'Unrecognized group fjgfjf',
+        start: 0,
+        end: 6,
+      },
+    ],
+    fixes: [],
+  }),
+);
+const decodeTac = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    product: 'METAR',
+    segments: [],
+    residuals: [],
+  }),
+);
+
+vi.mock('/utils/api', () => ({
+  lintTac,
+  decodeTac,
+}));
+
+import { useLiveWorkbenchAssist } from '@/hooks/useLiveWorkbenchAssist';
+
+async function flushDebouncedAssist(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(LIVE_ASSIST_DEBOUNCE_MS + 5);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('BUG-2026-07-15 descriptive lint-tac console', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    lintTac.mockClear();
+    decodeTac.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('console line includes lint issue message (not only issue count)', async () => {
+    const { result } = renderHook(() =>
+      useLiveWorkbenchAssist({
+        text: 'fjgfjf',
+        product: 'METAR',
+        accessToken: 'tok',
+        enabled: true,
+      }),
+    );
+
+    await flushDebouncedAssist();
+
+    const last = result.current.consoleLines.at(-1);
+    expect(last?.source).toBe('lint-tac');
+    expect(last?.message).toContain('1 issue(s):');
+    expect(last?.message).toMatch(/Unrecognized group fjgfjf|TAC_PARSE/);
+    expect(last?.message).not.toBe('1 issue(s)');
+  });
+});

--- a/apps/frontend/src/utils/api.test.ts
+++ b/apps/frontend/src/utils/api.test.ts
@@ -295,7 +295,7 @@ describe('API Utils', () => {
     });
 
     it('should include authorization token if available', async () => {
-      localStorage.setItem('supabase_access_token', 'test-token-123');
+      localStorage.setItem('access_token', 'test-token-123');
       mockFetchResponse({
         results: [],
         errors: [],
@@ -535,6 +535,7 @@ describe('API Utils', () => {
   // ============= Edge Cases =============
   describe('Edge Cases', () => {
     it('should handle requests without authentication token', async () => {
+      localStorage.removeItem('access_token');
       localStorage.removeItem('supabase_access_token');
       mockFetchResponse({
         results: [],

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -86,10 +86,38 @@ export interface ApiError {
 }
 
 /**
- * Get the access token from local storage
+ * Get the access token from local storage.
+ *
+ * Must match ``authService`` (`access_token`). Legacy ``supabase_access_token``
+ * is read as a fallback for older sessions (BUG-2026-07-15).
  */
 function getAccessToken(): string | null {
-  return localStorage.getItem('supabase_access_token');
+  return (
+    localStorage.getItem('access_token') ||
+    localStorage.getItem('supabase_access_token')
+  );
+}
+
+/** Prefer FastAPI string ``detail``, then nested message, then ``message``. */
+function apiErrorMessage(
+  error: { detail?: unknown; message?: unknown },
+  fallback: string,
+): string {
+  if (typeof error.detail === 'string' && error.detail) {
+    return error.detail;
+  }
+  if (
+    error.detail &&
+    typeof error.detail === 'object' &&
+    'message' in error.detail &&
+    typeof (error.detail as { message: unknown }).message === 'string'
+  ) {
+    return (error.detail as { message: string }).message;
+  }
+  if (typeof error.message === 'string' && error.message) {
+    return error.message;
+  }
+  return fallback;
 }
 
 /**
@@ -474,9 +502,7 @@ export async function lintTac(params: {
     const error = await response.json().catch(() => ({
       message: `Lint failed: ${response.statusText}`,
     }));
-    throw new Error(
-      error.detail?.message || error.message || `HTTP ${response.status}`,
-    );
+    throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
   }
 
   return (await response.json()) as LintTacResponse;
@@ -509,9 +535,7 @@ export async function decodeTac(params: {
     const error = await response.json().catch(() => ({
       message: `Decode failed: ${response.statusText}`,
     }));
-    throw new Error(
-      error.detail?.message || error.message || `HTTP ${response.status}`,
-    );
+    throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
   }
 
   return (await response.json()) as DecodeTacResponse;

--- a/docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+++ b/docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
@@ -1,0 +1,158 @@
+# BUG-2026-07-15 — Empty Bearer on lint-tac/decode-tac + thin lint console
+
+| Field | Value |
+|-------|-------|
+| **Status** | verifying |
+| **Feature** | F6/F7 (lint-tac / decode-tac live assist) + M4 auth |
+| **Severity** | critical / blocked (user) |
+| **Classification** | code bug (auth hydrate + storage key + UX) |
+| **Remediation path** | local-first — deploy only after explicit approval |
+| **Session** | S012-empty-bearer-lint-tac |
+| **Branch** | fix/S012-empty-bearer-lint-tac |
+
+## Error description
+
+On production, live workbench calls to `POST /api/v1/lint-tac` and
+`POST /api/v1/decode-tac` send `Authorization: Bearer` with **no JWT**, and the API
+returns `{"detail":"Missing authorization credentials"}`. Separately, when lint
+does return issues, the workbench console only shows `[lint-tac] N issue(s)`
+without codes/messages.
+
+## Error logs
+
+Browser Network (user paste, production):
+
+```
+POST https://metar-to-iwxxm-api.onrender.com/api/v1/lint-tac
+authorization: Bearer
+→ {"detail":"Missing authorization credentials"}
+
+POST https://metar-to-iwxxm-api.onrender.com/api/v1/decode-tac
+authorization: Bearer
+→ {"detail":"Missing authorization credentials"}
+```
+
+Referrer: `https://metar-to-iwxxm-frontend-v4-web.onrender.com/`
+Body: `manual_text=fjgfjf`, `product=METAR`
+
+UI: `[lint-tac] 1 issue(s)` — not descriptive of the actual issue(s).
+
+## Interview record
+
+| Step | Answer |
+|------|--------|
+| Session gate | Open new hotfix session (close/archive S011) |
+| Intent | Report new issue |
+| symptom_type | Error / crash (401 + thin lint message) |
+| where_seen | Production Render |
+| when_started | After last deploy |
+| repro_frequency | Every time |
+| repro_environment | Production only |
+| user_severity | Critical / blocked |
+| evidence_available | None beyond fetch paste |
+| already_tried | Nothing |
+| Remediation path | Fix locally first — deploy after approval |
+| Scope | One hotfix covering auth + descriptive lint UX |
+| confirm_hotfix_plan | Proceed |
+| verification_plan | success=JWT Bearer + descriptive lint UI; checks=full CI parity; monitoring=user watches prod |
+
+## Verification plan
+
+| Item | Choice |
+|------|--------|
+| Success criterion | Logged-in calls carry a real Bearer JWT **and** lint UI shows issue messages/codes (not only “[lint-tac] N issue(s)”) |
+| Checks | Full main CI parity (local) + gh on main after merge |
+| Monitoring | User will watch production after deploy |
+
+## Symptoms & reproduction
+
+- **Environment:** Production frontend → API (every time)
+- **Trigger:** Enter TAC text (e.g. `fjgfjf`) so live lint/decode fire
+- **Expected:** Authenticated request with JWT; console lists issue text/codes
+- **Actual:** `Authorization: Bearer` empty → 401; thin console summary when issues exist
+- **Local:** Not reproduced yet (production-only per intake)
+
+## Investigation
+
+### Hypotheses (2026-07-15)
+
+| # | Hypothesis | Evidence | Status |
+|---|------------|----------|--------|
+| H1 | `App` initializes `accessToken` to `''` on reload even when `isLoggedIn()` is true | `App.tsx` L52–60: `isAuthenticated` from `isLoggedIn()`, but `accessToken` only set via login handlers | Likely |
+| H2 | `api.ts` `getAccessToken()` reads `supabase_access_token` while `authService` stores `access_token` | Key mismatch — fallback never sees JWT | Likely |
+| H3 | Empty token → `Authorization: Bearer ` → FastAPI `HTTPBearer` returns `None` → “Missing authorization credentials” | Matches `security.py` L91–93 + Starlette empty-credentials behavior | Likely |
+| H4 | Console summary omits issue messages by design of `useLiveWorkbenchAssist` | L150–152: `` `${n} issue(s)` `` only | Likely (UX) |
+| H5 | 401 `detail` string not surfaced in thrown Error | `error.detail?.message` misses string `detail` | Contributing |
+
+### Spec conformance
+
+| Corpus | Section | Finding |
+|--------|---------|---------|
+| product F7 | Live assist JWT lint/decode | Implementation drift — requests must be authorized |
+| system-spec | Frontend debounced JWT calls; auth middleware | Implementation drift vs U1b/U2 |
+| api | lint-tac / decode-tac auth | No blocking contradiction — 401 is correct for missing creds; client should send token |
+| M4 | Auth merged; tokens in localStorage | Drift: dual localStorage keys |
+
+Spec conformance: **no blocking Contradiction** — code bug / UX drift.
+
+## Root cause (proposed)
+
+_(pending user confirmation after red repro)_
+
+1. **Reload auth gap:** Session cookie/token exists in `localStorage.access_token`, but React `accessToken` state is not hydrated → empty Bearer.
+2. **Wrong storage key fallback** in `api.ts` (`supabase_access_token` vs `access_token`).
+3. **Thin lint console:** summary message is count-only.
+
+## Repro test
+
+| Field | Value |
+|-------|-------|
+| Path | `apps/frontend/src/test/bug-2026-07-15-empty-bearer-lint-tac.test.tsx` + `…-lint-tac-console-detail.test.tsx` |
+| CI | Frontend job (`npm test`) — not pytest `tests/bugs/` |
+| Status | **GREEN** (5/5) after fix 2026-07-15 |
+| Asserts | (1) lint/decode send Bearer from `access_token`; (2) App reload hydrates token into FileConverter; (3) console includes issue message; (4) 401 string detail surfaced |
+
+### TDD iteration log
+
+| Time | Action | Result |
+|------|--------|--------|
+| 2026-07-15 | Phase 0 intake + branch + report | — |
+| 2026-07-15 | Wrote Vitest repros (auth Bearer + App hydrate + console detail + 401 detail) | **RED** — `Bearer ` / empty token / `1 issue(s)` / `HTTP 401` as expected |
+| 2026-07-15 | User `repro_test_matches_symptom`=Yes; `investigation_root_cause`=Agree | Confirmed |
+| 2026-07-15 | Fix: App hydrate + api.ts `access_token` + apiErrorMessage + lint console detail | **GREEN** 5/5 + related suites |
+
+## Root cause (confirmed)
+
+1. **Reload auth gap:** `App` set `isAuthenticated` from `isLoggedIn()` but left `accessToken` as `''` until a login handler ran.
+2. **Wrong storage key:** `api.ts` read `supabase_access_token`; `authService` stores `access_token`.
+3. **Thin lint console / opaque 401:** count-only summary; string FastAPI `detail` not used in thrown Error.
+
+## Fix
+
+- `App.tsx`: initialize `accessToken` from `getAccessToken()`.
+- `api.ts`: read `access_token` (legacy fallback); `apiErrorMessage` for lint/decode.
+- `useLiveWorkbenchAssist.ts`: console `N issue(s): [code] message; …`.
+
+## Verification
+
+### Layer 1 — Automated
+- [ ] Repro red→green
+- [ ] CI parity local
+- [ ] Frontend tests
+
+### Layer 2 — Reproduction
+- [ ] Pending
+
+### Layer 3 — Pre-deploy smoke
+- [ ] N/A until deploy approved
+
+### Layer 4 — Production
+- [ ] Deferred (local-first)
+
+## Prevention & countermeasures
+
+_(Phase 5)_
+
+## Follow-ups
+
+- Resume S011 / EV-008 / PR #716 after hotfix closes

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -35,11 +35,14 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 | [S008-general-tac-iwxxm-converter](S008-general-tac-iwxxm-converter/session-brief.md) | feature | completed | General TAC→IWXXM + near-RT ingest (EV-006) | evolve/S008-general-tac-iwxxm-converter | 2026-07-12 | 2026-07-12 |
 | [S009-result-card-dismiss](S009-result-card-dismiss/session-brief.md) | hotfix | completed | Results Card stays after Cancel/Remove | fix/S009-result-card-dismiss | 2026-07-12 | 2026-07-12 |
 | [S010-issue-655-tac-traceability](S010-issue-655-tac-traceability/session-brief.md) | feature | completed | Source TAC on conversion results (#655) | evolve/EV-007-issue-655-tac-traceability | 2026-07-12 | 2026-07-13 |
-| [S011-f7-operator-ui](S011-f7-operator-ui/session-brief.md) | feature | in_progress | F7 multi-product UI + workbench/decode/admin (#694/#702/#665/#666/#697) | evolve/S011-f7-operator-ui | 2026-07-13 | — |
+| [S011-f7-operator-ui](S011-f7-operator-ui/session-brief.md) | feature | paused | F7 multi-product UI + workbench/decode/admin (#694/#702/#665/#666/#697); PR #716 open for later resume | evolve/S011-f7-operator-ui | 2026-07-13 | — (paused 2026-07-15) |
+| [S012-empty-bearer-lint-tac](S012-empty-bearer-lint-tac/session-brief.md) | hotfix | in_progress | Empty Bearer on lint-tac/decode-tac + lint UX issue details | fix/S012-empty-bearer-lint-tac | 2026-07-15 | — |
 
 ## Active session
 
-**[S011-f7-operator-ui](S011-f7-operator-ui/session-brief.md)** — F7 operator UI + workbench/decode/admin (00-context in progress).
+**[S012-empty-bearer-lint-tac](S012-empty-bearer-lint-tac/session-brief.md)** — Empty Bearer lint-tac/decode-tac + lint UX (14-hotfix in progress).
+
+Parked: **[S011-f7-operator-ui](S011-f7-operator-ui/session-brief.md)** — EV-008 / PR [#716](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716) remains open for later resume.
 
 ## Folder layout
 

--- a/docs/sessions/S011-f7-operator-ui/session-brief.md
+++ b/docs/sessions/S011-f7-operator-ui/session-brief.md
@@ -1,12 +1,15 @@
 ---
 session_id: S011-f7-operator-ui
 type: feature
-status: in_progress
+status: paused
 branch: evolve/S011-f7-operator-ui
 started_at: 2026-07-13
+paused_at: 2026-07-15
+pause_reason: "Closed to open hotfix session for empty Bearer lint-tac/decode-tac + lint UX; PR #716 remains open"
 intent: "F7 multi-product TAC operator UI (7 products) + workbench (#694), decode panel (#702), failed-TAC/partial UX (#665/#666), remove admin / BYO DB (#697); #5 kept as parent tracker"
 orchestrator: 16-evolve
 evolve_cycle_id: EV-008
+pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716
 context_briefs:
   - docs/context/f7-operator-ui.md
 standing_docs_touched: []
@@ -21,6 +24,12 @@ phase3_resolutions:
 ---
 
 # Session S011 — F7 operator UI + workbench / decode / admin
+
+> **Paused 2026-07-15** — closed/archived to open hotfix
+> [S012-empty-bearer-lint-tac](../S012-empty-bearer-lint-tac/session-brief.md).
+> Close reason: *Closed to open hotfix session for empty Bearer lint-tac/decode-tac +
+> lint UX; PR #716 remains open.* EV-008 is suspended (not deleted); resume PR-EV-008
+> (#716) after S012.
 
 ## Intent
 

--- a/docs/sessions/S012-empty-bearer-lint-tac/routing-plan.md
+++ b/docs/sessions/S012-empty-bearer-lint-tac/routing-plan.md
@@ -1,0 +1,18 @@
+# Routing Plan — S012-empty-bearer-lint-tac (hotfix)
+
+| Stage | Required | Status | Notes |
+|-------|----------|--------|-------|
+| 00-context (scoped) | yes | completed | Session open 2026-07-15; intent recorded in session-brief |
+| 14-hotfix | yes | in_progress | Empty Bearer on lint-tac/decode-tac + lint UX issue details |
+
+**Skipped**
+
+| Stage | Rationale |
+|-------|-----------|
+| 15-service-health | User approved 14-only plan (no post-deploy health gate in this session) |
+| 01–13 product/deploy stages | Hotfix — surgical auth/lint UX; no new features |
+| 16-evolve | Not a feature cycle (S011/EV-008 remains paused with PR #716 open) |
+
+## Approved
+
+2026-07-15 — routing approved by user: **14-hotfix only** (15-service-health NOT in plan).

--- a/docs/sessions/S012-empty-bearer-lint-tac/session-brief.md
+++ b/docs/sessions/S012-empty-bearer-lint-tac/session-brief.md
@@ -1,0 +1,46 @@
+---
+session_id: S012-empty-bearer-lint-tac
+type: hotfix
+status: in_progress
+branch: fix/S012-empty-bearer-lint-tac
+started_at: 2026-07-15
+intent: "Production frontend sends Authorization: Bearer with empty token to POST /api/v1/lint-tac and /decode-tac → Missing authorization credentials; also lint-tac UI shows only '[lint-tac] N issue(s)' without descriptive issue details"
+orchestrator: 14-hotfix
+evolve_cycle_id: null
+context_briefs: []
+standing_docs_touched: []
+---
+
+# Session S012 — Empty Bearer lint-tac / decode-tac + lint UX
+
+## Intent
+
+Production frontend sends `Authorization: Bearer` with an empty token to
+`POST /api/v1/lint-tac` and `POST /api/v1/decode-tac`, which fails with
+**Missing authorization credentials**. Separately, the lint-tac UI only shows a
+summary like `[lint-tac] N issue(s)` without descriptive issue details.
+
+## Scope
+
+**In scope**
+
+- Fix empty Bearer / missing credentials handling for lint-tac and decode-tac
+  (frontend auth header assembly and/or API auth middleware as root cause dictates)
+- Surface descriptive lint issue details in the operator UI (not only count summary)
+- Bug report + repro regression test per 14-hotfix
+
+**Out of scope**
+
+- F7 evolve cycle resume (S011 / EV-008 / PR #716) — parked until this hotfix closes
+- 15-service-health (user approved 14-only routing)
+- Unrelated convert / work-history features
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).
+
+## Links
+
+- Parked session: [S011-f7-operator-ui](../S011-f7-operator-ui/session-brief.md) (PR [#716](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716))
+- Corpus: `[Corpus: api]` lint-tac / decode-tac; `[Corpus: product]` F7 operator UI
+- Orchestrator: 14-hotfix

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1462,8 +1462,9 @@ stages:
     status: in_progress
     session_id: S012-empty-bearer-lint-tac
     current_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    bug_status: verifying
     remediation_path: local-first
-    note: "Phase 0 complete; starting Phase 1 investigation + repro test"
+    note: "Fix committed 77d5f40; opening PR"
     notes:
     - "2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared stale S009 pointer."
     - "2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4)."
@@ -5896,6 +5897,13 @@ git_history:
     - workflow-state.yaml
     timestamp: "2026-07-15"
     note: "HEAD after PRM-016; CI success on run 29444844110"
+  - sha: 77d5f40
+    branch: fix/S012-empty-bearer-lint-tac
+    message: "hotfix: restore JWT on lint/decode after reload + richer lint console"
+    stage: "14-hotfix"
+    files_changed: 14
+    timestamp: "2026-07-15T23:30:00Z"
+    session_id: S012-empty-bearer-lint-tac
 pr_review_cycles:
 - id: PRR-001
   pr_number: 679

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -4,18 +4,54 @@ project:
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 11
+session_counter: 12
 active_session:
-  id: S011-f7-operator-ui
-  type: feature
+  id: S012-empty-bearer-lint-tac
+  type: hotfix
   status: in_progress
+  branch: fix/S012-empty-bearer-lint-tac
+  started_at: "2026-07-15"
+  intent: "Production frontend sends Authorization: Bearer with empty token to POST /api/v1/lint-tac and /decode-tac → Missing authorization credentials; also lint-tac UI shows only '[lint-tac] N issue(s)' without descriptive issue details"
+  orchestrator: 14-hotfix
+  evolve_cycle_id: null
+  artifacts_dir: docs/sessions/S012-empty-bearer-lint-tac
+  context_briefs: []
+  standing_docs_touched: []
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: scoped
+    status: completed
+    completed: "2026-07-15"
+    note: "Session open; routing approved (14-only, no 15)"
+  - stage: 14-hotfix
+    required: true
+    mode: full
+    status: in_progress
+    started: "2026-07-15"
+    note: "Empty Bearer on lint-tac/decode-tac + lint UX issue details"
+  skipped_stages:
+  - stage: 15-service-health
+    rationale: "User approved 14-only routing; 15 not in plan"
+  current_stage: 14-hotfix
+
+sessions:
+
+- id: S011-f7-operator-ui
+  type: feature
+  status: paused
+  paused_at: "2026-07-15"
+  pause_reason: "Closed to open hotfix session for empty Bearer lint-tac/decode-tac + lint UX; PR #716 remains open"
+  close_reason: "Closed to open hotfix session for empty Bearer lint-tac/decode-tac + lint UX; PR #716 remains open"
+  pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716
+  pr_number: 716
   branch: evolve/S011-f7-operator-ui
   started_at: "2026-07-13"
   intent: "F7 multi-product TAC operator UI (7 products) + interactive workbench (#694), TAC decode panel (#702), failed-TAC/partial
     convert UX (#665/#666), remove admin dashboard / BYO DB (#697); #5 kept as parent tracker"
   orchestrator: 16-evolve
   evolve_cycle_id: EV-008
-  note: "12 approved (D-S011-EV008-deploy-check-A); PR #716 open as PR-EV-008 (evolve→main; retitled/updated; NO merge, NO deploy); 13-deploy-smoke blocked on merge approval; T6.4 in_progress (12 done / 13 pending)"
+  note: "Parked for later resume — PR #716 (PR-EV-008) remains open; EV-008 NOT deleted; resume after S012-empty-bearer-lint-tac; T6.4/13-deploy-smoke still pending merge approval"
   context_briefs:
   - docs/context/f7-operator-ui.md
   standing_docs_touched: []
@@ -125,8 +161,6 @@ active_session:
   current_stage: 12-verify-deploy
   artifacts_dir: docs/sessions/S011-f7-operator-ui
 
-
-sessions:
 
 - id: S010-issue-655-tac-traceability
   type: feature
@@ -591,10 +625,10 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: f7-operator-ui
-    session_id: S011-f7-operator-ui
-    started_at: "2026-07-13"
-    completed_at: "2026-07-13"
+    scoped_slug: empty-bearer-lint-tac
+    session_id: S012-empty-bearer-lint-tac
+    started_at: "2026-07-15"
+    completed_at: "2026-07-15"
     substeps:
       phase0: completed
       phase1a: completed
@@ -611,6 +645,7 @@ stages:
     - docs/sessions/S008-general-tac-iwxxm-converter/session-brief.md
     - docs/sessions/S008-general-tac-iwxxm-converter/routing-plan.md
     notes:
+    - "2026-07-15 S012-empty-bearer-lint-tac open — scoped hotfix empty Bearer lint-tac/decode-tac + lint UX; S011/EV-008 paused (PR #716 remains open)"
     - "GitHub #555 parent feedback; 2/4 items done in S001; auto-clear + error log remain"
     - "2026-06-25 scoped run S005 — docs/context/issue-671-docker-db.md (#671 Docker DB connect failure)"
     - "2026-06-25 scoped run S006 — docs/context/issue-664-output-filename.md (#664 custom output filename, manual input;
@@ -1425,9 +1460,12 @@ stages:
 
   14-hotfix:
     status: in_progress
-    session_id: S009-result-card-dismiss
-    bug_report: docs/bug-reports/BUG-2026-07-12-result-card-dismiss.md
+    session_id: S012-empty-bearer-lint-tac
+    current_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    remediation_path: local-first
+    note: "Phase 0 complete; starting Phase 1 investigation + repro test"
     notes:
+    - "2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared stale S009 pointer."
     - "2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4)."
     - "2026-07-12 — S006 closed (S006-R5); docs reorg unblocked — open via 00-context (process session), not 14-hotfix."
     - "2026-07-12 — S009-result-card-dismiss open (FileConverter result card dismiss after Cancel/Remove)."
@@ -4372,6 +4410,8 @@ evolve_cycles:
   feature_ids: [F7]
   title: "F7 multi-product operator UI + workbench/decode/admin (#694/#702/#665/#666/#697)"
   status: in_progress
+  suspended_at: "2026-07-15"
+  suspend_reason: "Session S011 archived/paused for hotfix S012-empty-bearer-lint-tac; PR #716 work continues later — cycle NOT deleted"
   started: "2026-07-13"
   completed:
   scope_summary: |
@@ -4404,6 +4444,7 @@ evolve_cycles:
     - 06-tech-tooling
   current_stage: 12-verify-deploy
   notes:
+  - "2026-07-15 S011 paused/archived for hotfix S012-empty-bearer-lint-tac; EV-008 suspended (not deleted); PR #716 remains open for later resume"
   - "2026-07-14 PR-EV-008=#716 open (retitled/updated evolve→main; NO merge, NO deploy); 12 approved; 13 blocked on merge; T6.4 in_progress (12 done / 13 pending)"
   - "2026-07-14 D-S011-EV008-deploy-check-A — 12-verify-deploy completed (checklist approved); commit QA-001+reports; preparing PR-EV-008; 13 pending/blocked on merge; T6.4 remains in_progress (12 done / 13 pending); no merge/deploy yet"
   - "2026-07-14 S011/EV-008 12-verify-deploy — checklist written (deploy-checklist.md); awaiting user deploy-strategy approval (blocker: tip 44 commits ahead of main; QA-001 uncommitted); 12 remains in_progress; 13 not started"
@@ -4628,8 +4669,9 @@ evolve_cycles:
   issues: []
 
 git_history:
-  current_branch: evolve/S011-f7-operator-ui
+  current_branch: fix/S012-empty-bearer-lint-tac
   notes:
+  - "2026-07-15 S012-empty-bearer-lint-tac open — branch fix/S012-empty-bearer-lint-tac; S011 paused (PR #716 remains open)"
   - "2026-07-14 S011/EV-008 PR-EV-008=#716 open (evolve→main; NO merge, NO deploy); tip dc32d47; T6.4 in_progress (12 done / 13 pending)"
   - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first)"
   - "2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories; T6.3 pending; current_stage=11-verify-impl"
@@ -4651,6 +4693,12 @@ git_history:
   - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
   - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+  - name: fix/S012-empty-bearer-lint-tac
+    purpose: "Empty Bearer auth on lint-tac/decode-tac + lint UX issue details"
+    base: main
+    status: open
+    created_at: "2026-07-15"
+    session_id: S012-empty-bearer-lint-tac
   - name: evolve/EV-007-issue-655-tac-traceability
     purpose: "EV-007 / #655 F6 TAC traceability UX"
     base: main


### PR DESCRIPTION
## Summary
- Fixes production `Missing authorization credentials` when live assist calls `POST /api/v1/lint-tac` and `/decode-tac` with `Authorization: Bearer` (empty JWT) after page reload — hydrate `accessToken` from `authService` and read the correct `access_token` localStorage key in `api.ts`.
- Surfaces FastAPI string `detail` in client errors and makes lint-tac console lines show issue codes/messages (not only `N issue(s)`).
- Adds Vitest regression coverage for BUG-2026-07-15 (S012).

## Bug report
[`docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md`](docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md)

## Root cause
1. `App` treated the user as logged in on reload but left React `accessToken` as `''`.
2. `api.ts` looked up `supabase_access_token` while login stores `access_token`.
3. Live assist console summarized lint with a count only.

## Spec
- `[Corpus: product]` F7 live assist / M4 auth — implementation drift (no contradiction).
- `[Corpus: system-spec]` Frontend JWT lint/decode paths.

## Tests
- `apps/frontend/src/test/bug-2026-07-15-empty-bearer-lint-tac.test.tsx`
- `apps/frontend/src/test/bug-2026-07-15-lint-tac-console-detail.test.tsx`
- Full `npm test` in `apps/frontend` green locally.

## Test plan
- [ ] Confirm PR CI (`ci.yml`) green on this branch
- [ ] After merge: log in on production frontend, hard-refresh, type TAC → Network shows `Authorization: Bearer <jwt>` on lint-tac/decode-tac
- [ ] Confirm workbench console shows issue text (e.g. `1 issue(s): [code] message`) for invalid TAC
- [ ] Deploy only after explicit approval (local-first remediation path)

## Blast radius
- Frontend only: `App.tsx`, `api.ts`, `useLiveWorkbenchAssist.ts` + tests/docs/session state
- No API or schema changes


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Fix empty Authorization Bearer tokens and improve lint/decode error visibility for live assist, adding regression coverage and process docs for the hotfix session.

Bug Fixes:
- Ensure frontend API calls read JWTs from the correct localStorage key and hydrate the app access token on reload, preventing empty Bearer headers for lint-tac/decode-tac requests.
- Surface meaningful FastAPI error details and descriptive lint issue messages (including codes) in the live assist console instead of generic HTTP status or count-only summaries.

Enhancements:
- Add a reusable helper for extracting user-friendly error messages from API error payloads.

Documentation:
- Document BUG-2026-07-15 and the S012-empty-bearer-lint-tac hotfix session, including routing plan and status updates, while marking the S011 F7 operator UI session as paused.

Tests:
- Introduce Vitest regression tests to cover JWT propagation for lint/decode, App token hydration, and the updated lint-tac console messaging.
- Update existing API tests to use the new access token storage key and to cover unauthenticated request handling.

Chores:
- Update workflow-state metadata to track the new S012 hotfix session, pause the S011 evolve session, and record the associated git branch changes.