### PR TITLE
docs: close EV-011 / S015 (F15 Done)

### DIFF
--- a/.cursor/rules/core/plan-adherence.mdc
+++ b/.cursor/rules/core/plan-adherence.mdc
@@ -30,7 +30,7 @@ All implementation work must map to an approved feature in `[Corpus: product]`
 | F12 | Publishable `tac-validate` PyPI — **Implemented** (S014 / EV-010); deepen via F15 |
 | F13 | Fast `iwxxm-validate` Rust + Schematron + PyPI — **Implemented** (S014 / EV-010) |
 | F14 | Publish `tac2iwxxm[+validate]` + PyPI/release CI — **Implemented** (S014 / EV-010) |
-| F15 | Maintainable TAC lint issue registry + METAR/SPECI quality bar — **Planned** (S015 / EV-011; #732; ADR-028) |
+| F15 | Maintainable TAC lint issue registry + METAR/SPECI quality bar — **Done** (S015 / EV-011; #732; #742) |
 | M1 | Monorepo layout (`apps/` + `packages/` + `vendor/`) |
 | M2 | Vendor snapshot sync (wmo-im iwxxm-* + iwxxm-us) |
 | M3 | GIFTs as in-repo package — **deprecated** at F6 cutover |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable user-facing and deployable changes for METAR to IWXXM.
 
+## 2026-07-20 — S015 EV-011 (F15 METAR lint registry + #732 quality)
+
+### Added
+- **F15**: Maintainable `tac-validate` issue registry (`IssueSpec` / SCREAMING_SNAKE codes +
+  `info`|`warning`|`error`); docs/JSON catalog with CI drift gates; R1–R8 METAR/SPECI accept +
+  negative fixtures; `GET /api/v1/lint-issue-catalog` + workbench catalog tooltips/panel (ADR-028).
+- Convert goldens: expanded Annex-3 / IWXXM-US METAR/SPECI (AUTO/CAVOK/COR adjacency) + R6/R7 tests.
+
+### Changed
+- Deepened **F6** / **F12** METAR/SPECI lint and convert fidelity; coverage-matrix R1–R8 closed.
+- No new CORS origins, env knobs, or DB migrations this cycle.
+
+### Deploy
+- PR [#742](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742) merged (`b405a96`);
+  Render API + frontend-v4-web redeployed 2026-07-20. Smoke: H0ci/H1/H0c/H3/H4/H5 + F15 catalog
+  **PASS** (`docs/sessions/S015-metar-lint-quality/reports/deploy-smoke.md`).
+- PyPI `tac-validate-v0.1.1` deferred (follow-up).
+
 ## 2026-07-19 — S014 EV-010 (F11 msgspec HTTP + F12–F14 packages)
 
 ### Added

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -9,7 +9,15 @@
 **Features**: F15 (new) + deepen F6/F12  
 **Issues**: [#732](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/732)  
 **Started**: 2026-07-19  
-**Branch**: `evolve/EV-011-metar-lint-quality`
+**Branch**: `evolve/EV-011-metar-lint-quality`  
+**Completed**: 2026-07-20 (D-S015-EV011-phase4-close-1)  
+**Merge**: PR [#742](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742) → `b405a96`; deploy-smoke PR [#743](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/743)
+
+### Close
+
+| ID | Decision |
+|----|----------|
+| D-S015-EV011-phase4-close-1 | Close EV-011/S015; F15 **Done**; defer PyPI `tac-validate-v0.1.1`; close #732 |
 
 ### Scope (Phase 0–1 locked 2026-07-19)
 

--- a/docs/deploy-state.md
+++ b/docs/deploy-state.md
@@ -10,7 +10,7 @@
 | 1 | Deploy | done | 2026-07-20T05:16Z | 2026-07-20T05:22Z | CI Deploy `29718764520`; hooks → API + FE live @ `b405a96` |
 | 2 | Smoke tests | done | 2026-07-20T05:23Z | 2026-07-20T05:24Z | H0c/H1/H3/H4/H5 + F15 catalog PASS |
 | 3 | Health check | done | 2026-07-20T05:23Z | 2026-07-20T05:23Z | `/health` healthy; tac2iwxxm_available |
-| 4 | Changelog | pending | — | — | S015 entry at evolve close |
+| 4 | Changelog | done | 2026-07-20 | 2026-07-20 | `docs/CHANGELOG.md` S015 entry |
 | 5 | Monitoring baseline | done | 2026-07-20T05:23Z | 2026-07-20T05:24Z | H3 response-times acceptable |
 
 ## Current Deployment

--- a/docs/evolve-report-EV-011.md
+++ b/docs/evolve-report-EV-011.md
@@ -1,0 +1,41 @@
+# Evolve report — S015 METAR lint quality (F15)
+
+- **Cycle**: EV-011
+- **Session**: S015-metar-lint-quality
+- **Status**: completed (Phase 4 closed — D-S015-EV011-phase4-close-1)
+- **Scope**: Maintainable TAC lint issue registry (`info`/`warning`/`error`) + #732 METAR/SPECI
+  lint/validate/convert quality bar; deepen F6 convert goldens and F12 METAR/SPECI rules;
+  HTTP catalog for workbench UX (E11-31)
+- **Stages run**: 00, 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12, 13, 16
+- **ADRs**: ADR-028 (tac-validate issue registry)
+- **Deploy**: Render API + frontend-v4-web @ merge `b405a96` (CI Deploy `29718764520`);
+  smoke report tip `10efcf2` (PR #743)
+- **PyPI**: `tac-validate-v0.1.1` **not cut** this close (deferred per E11-25 / close decision)
+- **GitHub issues**: #732 **closed**
+- **Follow-ups** (non-blocking): tag/publish `tac-validate-v0.1.1`; optional 17-retrospective on
+  R1–R8 fixture strategy; F7 remains Planned (F15 smoke only)
+
+## Summary
+
+EV-011 introduced a frozen registry (`issue_registry.py` + `ISSUE_CATALOG.{md,json}`), CI gates
+against unknown codes / ad-hoc severity literals, research themes R1–R8 closed in the coverage
+matrix, expanded accept/negative fixtures and convert goldens (Annex-3 + iwxxm-us), and a
+authenticated catalog API consumed by the workbench for tooltips and a lightweight panel.
+Production smokes including H4–H5 and live catalog (35 issues) passed after merge #742.
+
+## Artifacts changed (high level)
+
+- `packages/tac-validate` — registry, product_rules wiring, fixtures, catalog regen script
+- `packages/tac2iwxxm` — METAR/SPECI golden expansion + R6/R7 tests
+- `apps/backend` — `GET /api/v1/lint-issue-catalog`
+- `apps/frontend` — `useLintIssueCatalog`, WorkbenchConsole tooltips/panel
+- Docs: feature-list F15, ADR-028, COVERAGE_MATRIX, api-contract, CHANGELOG
+- Session reports under `docs/sessions/S015-metar-lint-quality/`
+
+## Verification
+
+- 08-verify-build: PASS
+- 09-qa / 10-e2e: PASS (UJ-024 / TC-F15; live H4–H5 at 13)
+- 11-verify-impl: APPROVED
+- 12-verify-deploy: READY → merge #742
+- 13-deploy-smoke: PASS (`deploy-smoke.md`)

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -22,7 +22,7 @@
 | F12 | Publishable TAC product validation (`tac-validate`) | Implemented | Product | S014 / EV-010; #698 |
 | F13 | Fast IWXXM validate (Rust core + Schematron + PyPI) | Implemented | Product | S014 / EV-010; #699 |
 | F14 | Publish `tac2iwxxm` + validate extras + PyPI/release CI | Implemented | Product | S014 / EV-010; #693 |
-| F15 | Maintainable TAC lint issue registry + METAR/SPECI quality bar | Planned | Product | S015 / EV-011; #732 |
+| F15 | Maintainable TAC lint issue registry + METAR/SPECI quality bar | Done | Product | S015 / EV-011; #732; shipped 2026-07-20 (#742) |
 | M1 | Monorepo layout (`apps/` + `packages/` + `vendor/`) | Planned | Platform | REQ-002–006 |
 | M2 | Vendor snapshot sync (wmo-im iwxxm-*) | Planned | Platform | REQ-002, REQ-010 |
 | M3 | GIFTs as in-repo package | Deprecated (ADR-014) | Platform | REQ-003; removed with F6 cutover |
@@ -390,7 +390,8 @@
 
 ### F15: Maintainable TAC Lint Issue Registry + METAR/SPECI Quality Bar
 
-- **Status**: **Planned** — S015 / EV-011 ([#732](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/732)).
+- **Status**: **Done** — shipped S015 / EV-011 (2026-07-20, PR [#742](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742));
+  issue [#732](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/732) closed on cycle close.
 - **What it does**: Introduces a **maintainable issue registry** in `packages/tac-validate`
   (machine-readable `code` + default `severity` `info`|`warning`|`error` + message template).
   Rules import registry entries; a docs/generated catalog lists all codes for operators and

--- a/docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
+++ b/docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
@@ -1,0 +1,37 @@
+# Evolve summary — S015 / EV-011
+
+> Completed: 2026-07-20 (Phase 4 closed — D-S015-EV011-phase4-close-1)  
+> Features: **F15** (issue registry + METAR/SPECI quality); deepen **F6** / **F12**  
+> Branch: `evolve/EV-011-metar-lint-quality` → PR [#742](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742) → `main` @ `b405a96`  
+> Deploy-smoke docs: PR [#743](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/743) → `10efcf2`  
+> Issue [#732](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/732) closed on cycle close  
+> Orchestrator: 16-evolve  
+> PyPI: `tac-validate-v0.1.1` **deferred** (E11-25; cut in a follow-up)
+
+## Outcome
+
+F15 delivered: frozen `IssueSpec` registry in `tac-validate`, docs/JSON catalog with drift CI,
+R1–R8 METAR/SPECI lint fixtures, convert goldens + adjacency, and live
+`GET /api/v1/lint-issue-catalog` with workbench tooltips/panel. Render H0ci–H5 + catalog
+smoke PASS on image `…-b405a96`.
+
+## Stage trail
+
+| Stage | Result |
+|-------|--------|
+| 00–06 | Session + product/tech deltas; ADR-028; tooling (registry guard) |
+| 07–08 | M1–M5 build (registry → R1–R8 → goldens → catalog API/FE); 08 PASS |
+| 09–10 | QA + E2E UJ-024 / TC-F15 (T0); H4–H5 deferred then green at 13 |
+| 11 | F15 + F6/F12 deepen sign-off |
+| 12 | Deploy checklist; merge #742 |
+| 13 | Render H0ci–H5 + F15 catalog 35 issues PASS |
+
+## Key decisions
+
+- E11-31 — Catalog via `GET /api/v1/lint-issue-catalog` (not static FE embed)
+- D-S015-EV011-phase4-close-1 — Close cycle; defer PyPI `tac-validate-v0.1.1`
+
+## Artifacts
+
+Session reports under `docs/sessions/S015-metar-lint-quality/reports/`.  
+Standing: `docs/evolve-report-EV-011.md`, `docs/CHANGELOG.md`, `docs/deploy-state.md`, ADR-028.

--- a/docs/sessions/S015-metar-lint-quality/reports/execution-plan.md
+++ b/docs/sessions/S015-metar-lint-quality/reports/execution-plan.md
@@ -11,9 +11,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase D — 09→13 |
+| **Active phase** | Phase D — **complete** (cycle closed) |
 | **Active milestone** | M5 — Catalog API + FE + verify/deploy |
-| **Active task** | T5.10 — 13-deploy-smoke **completed** (await Phase D close) |
+| **Active task** | — (all tasks completed; EV-011 closed) |
 | **Tasks** | 35 / 35 completed |
 | **Last updated** | 2026-07-20 |
 

--- a/docs/sessions/S015-metar-lint-quality/session-brief.md
+++ b/docs/sessions/S015-metar-lint-quality/session-brief.md
@@ -1,9 +1,11 @@
 ---
 session_id: S015-metar-lint-quality
 type: feature
-status: in_progress
+status: completed
 branch: evolve/EV-011-metar-lint-quality
 started_at: 2026-07-19
+completed_at: 2026-07-20
+close_decision: D-S015-EV011-phase4-close-1
 intent: "METAR lint issue registry (INFO/WARNING/ERROR) + #732 METAR TAC lint/validate/convert quality; research + validation/conversion expansion from external METAR/IWXXM resources"
 orchestrator: 16-evolve
 evolve_cycle_id: EV-011

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -5,155 +5,14 @@ project:
   output_directory: docs/
 
 session_counter: 15
-active_session:
-
-  id: S015-metar-lint-quality
-  type: feature
-  status: in_progress
-  started_at: '2026-07-19'
-  intent: 'METAR lint issue registry (INFO/WARNING/ERROR) + #732 METAR TAC lint/validate/convert quality + research/expansion from external METAR/IWXXM resources; golden convert→XSD/Schematron; deepen F6/F12; new F15'
-  orchestrator: 16-evolve
-  evolve_cycle_id: EV-011
-  branch: main
-  artifacts_dir: docs/sessions/S015-metar-lint-quality
-  context_briefs:
-    - docs/context/metar-lint-quality.md
-  standing_docs_touched:
-    - docs/feature-list.md
-    - docs/spec.md
-    - docs/user-journeys.md
-    - docs/test-plan.md
-    - docs/domain/rules/COVERAGE_MATRIX.md
-    - docs/adr/ADR-028-tac-validate-issue-registry.md
-    - docs/sessions/S015-metar-lint-quality/reports/metar-research-catalog.md
-    - docs/api-contract.md
-    - docs/CORPUS.md
-    - docs/dependency-inventory.md
-  routing_plan:
-    - stage: 00-context
-      required: true
-      mode: scoped
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: Phase 0 intake locked; routing approved (D-S015-EV011-route-1)
-    - stage: 16-evolve
-      required: true
-      mode: orchestrator
-      status: in_progress
-      started: '2026-07-19'
-      note: Orchestrator — T5.10 / 13-deploy-smoke PASS; Phase D checkpoint pending user close (PyPI tac-validate-v0.1.1 optional); EV-011 not closed
-    - stage: 01-requirements
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: >-
-        S015/EV-011 01-requirements delta COMPLETE — interviews 7/7; E11-12/13/14 approved
-        (D-S015-EV011-spec-2/speci-3/phase-a-next); Phase A passed (D-S015-EV011-phase-a-pass)
-    - stage: 02-verify-plan
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: >-
-        PASS — 12 auto + S1.M1/S1.M2/S9.M1 all option 1
-        (D-S015-EV011-s1m1-1/s1m2-1/s9m1-1); fix-in-place F11–F14 + F15 SPECI + CORPUS;
-        #732 commented
-    - stage: 03-plan-tooling
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: >-
-        COMPLETE (D-S015-EV011-03-tooling-12) — plan-adherence + registry rule +
-        issue_registry_guard hook; Phase A stages 01–03 done; gates.a_to_b passed
-    - stage: 04-tech-plan
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: 'COMPLETE E11-31 — plan approved; GET lint-issue-catalog; 31 tasks'
-    - stage: 05-verify-tech
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: >-
-        PASS (D-S015-EV011-05-pass / E11-32) — S1–S4 all option 1; 35 tasks;
-        HARD docs; T6.0 warn→T2.2a error; ADR-028 amend
-    - stage: 06-tech-tooling
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-19'
-      note: >-
-        COMPLETE (D-S015-EV011-06-done) — T6.0 catalog-regen, warn pre-commit,
-        fixture README, connectivity OK
-    - stage: 07-build
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-19'
-      note: "M1–M5 complete (T1.1–T5.10); PR #742 merged b405a96"
-      completed: '2026-07-20'
-    - stage: 08-verify-build
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: T5.1 PASS — verification-report.md; C→D passed
-    - stage: 09-qa
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: PASS — qa-report.md
-    - stage: 10-e2e
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: PASS — e2e-report.md; UJ-024 catalog smoke
-    - stage: 11-verify-impl
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: F15 approved — verify-impl.md; phase_d work complete pending close
-    - stage: 12-verify-deploy
-      required: true
-      mode: adapted
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: 'T5.9 checklist approved; PR #742 merged (D-S015-EV011-deploy-merge)'
-    - stage: 13-deploy-smoke
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-19'
-      completed: '2026-07-20'
-      note: T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 35 issues
-  skipped_stages: []
-  current_stage: 13-deploy-smoke
-  note: "EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; Render LIVE; Phase D checkpoint pending user close (PyPI tag optional)"
+active_session: null
 sessions:
 
   - id: S015-metar-lint-quality
     type: feature
-    status: in_progress
+    status: completed
     started_at: '2026-07-19'
+    completed_at: '2026-07-20'
     intent: 'METAR lint issue registry (INFO/WARNING/ERROR) + #732 METAR TAC lint/validate/convert quality + research/expansion from external METAR/IWXXM resources; golden convert→XSD/Schematron; deepen F6/F12; new F15'
     orchestrator: 16-evolve
     evolve_cycle_id: EV-011
@@ -183,9 +42,12 @@ sessions:
       - stage: 16-evolve
         required: true
         mode: orchestrator
-        status: in_progress
+        status: completed
         started: '2026-07-19'
-        note: Orchestrator — T5.10 / 13-deploy-smoke PASS; Phase D checkpoint pending user close (PyPI tac-validate-v0.1.1 optional); EV-011 not closed
+        completed: '2026-07-20'
+        note: >-
+          Phase 4 closed (D-S015-EV011-phase4-close-1) — close EV-011/S015; defer PyPI
+          tac-validate-v0.1.1; close #732; F15 Implemented; PR #742 b405a96
       - stage: 01-requirements
         required: true
         mode: delta
@@ -289,9 +151,18 @@ sessions:
         completed: '2026-07-20'
         note: T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 35 issues
     skipped_stages: []
-    current_stage: 13-deploy-smoke
+    current_stage:
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742
+    pr_number: 742
+    pr_id: PR-EV-011
+    pr_status: merged
+    merge_sha: b405a96
+    close_note: >-
+      EV-011 complete; F15 Implemented; PR #742 b405a96; Render LIVE; PyPI tac-validate-v0.1.1
+      deferred (E11-25); GitHub issue #732 to close — D-S015-EV011-phase4-close-1
     note: >-
-      EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; Render LIVE; Phase D checkpoint pending user close (PyPI tag optional)
+      Phase 4 closed (D-S015-EV011-phase4-close-1) — EV-011/S015 complete; PyPI tag deferred;
+      #732 to close
   - id: S014-package-publish-validation
     type: feature
     status: completed
@@ -2660,6 +2531,23 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S015-EV011-phase4-close-1
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 16-evolve
+    skill: 16-evolve
+    skill_id: 16-evolve
+    session_id: S015-metar-lint-quality
+    evolve_cycle_id: EV-011
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: >
+      User chose to close EV-011/S015 now; defer PyPI tac-validate-v0.1.1 (E11-25);
+      close GitHub issue #732
+    summary: >
+      Phase 4 closed: S015 archived; active_session null; EV-011 completed 2026-07-20;
+      checkpoints.phase_d passed; evolve-summary + evolve-report-EV-011 completed;
+      PyPI tac-validate-v0.1.1 deferred to future cycle; parent to close #732.
   - id: D-S015-EV011-b-to-c
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -4886,6 +4774,28 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
+    type: report
+    kind: evolve-summary
+    stage: 16-evolve
+    skill_id: 16-evolve
+    session_id: S015-metar-lint-quality
+    evolve_cycle_id: EV-011
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: "Phase 4 closed (D-S015-EV011-phase4-close-1)"
+  - path: docs/evolve-report-EV-011.md
+    type: report
+    kind: evolve-report
+    stage: 16-evolve
+    skill_id: 16-evolve
+    session_id: S015-metar-lint-quality
+    evolve_cycle_id: EV-011
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: "Phase 4 closed (D-S015-EV011-phase4-close-1)"
   - path: docs/sessions/S015-metar-lint-quality/reports/deploy-smoke.md
     type: report
     kind: deploy-smoke
@@ -6048,9 +5958,9 @@ evolve_cycles:
       - F15
     feature_note: 'deepen F6 (tac2iwxxm) and F12 (tac-validate)'
     title: 'METAR lint issue registry + #732 METAR quality (lint/validate/convert)'
-    status: in_progress
+    status: completed
     started: '2026-07-19'
-    completed:
+    completed: '2026-07-20'
     scope_summary: |
       Full #732 METAR quality bar + maintainable issue registry (INFO/WARNING/ERROR) +
       golden convert→XSD/Schematron where fixtures exist + research/validation/conversion
@@ -6108,9 +6018,11 @@ evolve_cycles:
       approved: true
       approved_at: '2026-07-19'
       decision_id: D-S015-EV011-route-1
-    current_stage: 13-deploy-smoke
+    current_stage:
+    features_status: Implemented # F15 in feature-list
     note: >-
-      EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; Render LIVE; Phase D checkpoint pending user close (PyPI tag optional)
+      Phase 4 closed (D-S015-EV011-phase4-close-1) — close EV-011/S015; defer PyPI
+      tac-validate-v0.1.1; close #732; F15 Implemented; PR #742 b405a96
     gates:
       a_to_b: passed
       b_to_c: passed
@@ -6129,9 +6041,17 @@ evolve_cycles:
         completed: '2026-07-20'
         note: C→D passed; M1–M5 build complete; 08–11 verify stages PASS
       phase_d:
-        status: passed_pending_close
+        status: passed
         completed: '2026-07-20'
-        note: Phase D verify+deploy complete (T5.8–T5.10); F15 live on Render; awaiting user close AskQuestion — PyPI tac-validate-v0.1.1 optional (E11-25)
+        note: >-
+          Phase D verify+deploy complete (T5.8–T5.10); F15 live on Render; Phase 4 closed
+          (D-S015-EV011-phase4-close-1); PyPI tac-validate-v0.1.1 deferred (E11-25)
+      phase_4:
+        status: passed
+        completed: '2026-07-20'
+        note: >-
+          Phase 4 closed (D-S015-EV011-phase4-close-1) — close EV-011/S015; defer PyPI
+          tac-validate-v0.1.1; close #732
       deploy:
         status: passed
         completed: '2026-07-20'
@@ -6239,9 +6159,26 @@ evolve_cycles:
         status: accepted
         note: >-
           Phase B→C passed (D-S015-EV011-b-to-c=A); 07-build started at T1.1
+      - path: docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
+        kind: evolve-summary
+        stage: 16-evolve
+        session_id: S015-metar-lint-quality
+        status: completed
+        note: "Phase 4 closed (D-S015-EV011-phase4-close-1)"
+      - path: docs/evolve-report-EV-011.md
+        kind: evolve-report
+        stage: 16-evolve
+        session_id: S015-metar-lint-quality
+        status: completed
+        note: "Phase 4 closed (D-S015-EV011-phase4-close-1)"
     adrs:
       - docs/adr/ADR-028-tac-validate-issue-registry.md
+    issues:
+      - https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/732
     notes:
+      - >-
+        2026-07-20 D-S015-EV011-phase4-close-1 — Phase 4 closed: close EV-011/S015;
+        defer PyPI tac-validate-v0.1.1; close #732; F15 Implemented; PR #742 b405a96
       - '2026-07-20 S015/EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; CI Deploy 29718764520; Render LIVE; Phase D checkpoint pending user close; EV-011 remains in_progress'
       - >-
         2026-07-20 S015/EV-011 M1 complete (T1.1–T1.4; e0189d4/ac0a282/a1abc7c/79aa67c);
@@ -6314,10 +6251,16 @@ evolve_cycles:
           - docs/decisions/evolve-decisions.md
         note: Phase 0 intake locked; routing approved (D-S015-EV011-route-1)
       16-evolve:
-        status: in_progress
+        status: completed
         mode: orchestrator
         started: '2026-07-19'
-        note: Orchestrator — routing approved; max expansion scope (D-S015-EV011-research-1)
+        completed: '2026-07-20'
+        note: >-
+          Phase 4 closed (D-S015-EV011-phase4-close-1) — evolve-summary +
+          evolve-report-EV-011 completed; PyPI tac-validate-v0.1.1 deferred
+        artifacts_updated:
+          - docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
+          - docs/evolve-report-EV-011.md
       01-requirements:
         status: completed
         mode: delta


### PR DESCRIPTION
## Summary
- Phase 4 close for S015 / EV-011 (`D-S015-EV011-phase4-close-1`)
- F15 marked **Done**; evolve-summary + `docs/evolve-report-EV-011.md` + CHANGELOG
- Closes the session in `workflow-state.yaml`; PyPI `tac-validate-v0.1.1` deferred
- GitHub #732 already closed with deploy notes

## Test plan
- [x] Docs-only; no runtime change


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Close evolve cycle EV-011 / session S015 for METAR lint quality and record F15 as delivered, with supporting workflow and documentation updates.

Enhancements:
- Mark evolve cycle EV-011 and session S015 as completed in workflow-state, evolve_cycles, and session metadata, including deploy/PR linkage and closure notes.
- Record the Phase 4 close decision for EV-011/S015 in the decisions log, including deferral of the `tac-validate-v0.1.1` PyPI release and closure of GitHub issue #732.

Documentation:
- Add a dated CHANGELOG entry for S015 / EV-011 summarizing F15 delivery, METAR/SPECI quality improvements, deployment details, and PyPI deferral.
- Update evolve decisions, feature-list, and F15 feature section to reflect F15 as Done, shipped via PR #742, with EV-011 completion and #732 closed.
- Add evolve-report and evolve-summary documents for EV-011/S015 capturing scope, outcomes, verification trail, and key decisions.
- Update S015 session brief, execution plan, and deploy-state docs to show the cycle as closed, all tasks complete, and the changelog entry recorded.