### PR TITLE
[S016/EV-012] Manual TAC Input modes — TC-F7-007 e2e + FE auto-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/ci-cd.yml)
 [![E2E](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/e2e-tests.yml)
-[![E2E tests](https://img.shields.io/badge/E2E_tests-43-blue)](apps/e2e)
+[![E2E tests](https://img.shields.io/badge/E2E_tests-49-blue)](apps/e2e)
 [![codecov](https://codecov.io/gh/joseph-c-mcguire/metar-to-IWXXM/graph/badge.svg)](https://codecov.io/gh/joseph-c-mcguire/metar-to-IWXXM)
 [![Unit coverage gate](https://img.shields.io/badge/unit_coverage-%E2%89%A598%25-success)](docs/test-plan.md)
 

--- a/apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts
+++ b/apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts
@@ -1,0 +1,310 @@
+/**
+ * TC-F7-007 / UJ-025 — Manual TAC Input modes (ADR-024 / #730 / S016 EV-012).
+ *
+ * Spec: docs/test-plan.md TC-F7-007; docs/user-journeys.md UJ-025.
+ * Hard gates: T1–T6 (S2.2).
+ */
+import { expect, test, type Page, type Request } from '@playwright/test';
+import { gzipSync } from 'node:zlib';
+import {
+  fillManualTac,
+  openConverterForE2e,
+  openConverterWithMockSession,
+} from './playwright-e2e-helpers';
+
+const METAR_TAC = 'METAR KJFK 121251Z 24016G28KT 3SM -RA BR BKN020 OVC040 14/11 A2990=';
+
+const AHL_BULLETIN = `SAUS31 KZNY 121200
+METAR KJFK 121151Z 18008KT 10SM FEW250 22/14 A3012=
+METAR KLGA 121151Z 19010KT 10SM SCT040 21/13 A3010=
+`;
+
+const COLLECT_XML = `<?xml version="1.0"?>
+<collect:MeteorologicalBulletin xmlns:collect="http://def.wmo.int/collect/1.2"
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0">
+  <iwxxm:METAR/>
+</collect:MeteorologicalBulletin>
+`;
+
+type Captured = {
+  convert: Request[];
+  convertBulletin: Request[];
+  ingestCollect: Request[];
+};
+
+async function stubWorkbenchNoise(page: Page): Promise<void> {
+  await page.route('**/api/v1/lint-tac', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        issues: [],
+        fixes: [],
+        product: 'METAR',
+      }),
+    });
+  });
+  await page.route('**/api/v1/decode-tac', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        product: 'METAR',
+        segments: [],
+        residuals: [],
+        summary: 'Stub summary',
+      }),
+    });
+  });
+}
+
+async function stubModeApis(page: Page): Promise<Captured> {
+  const captured: Captured = {
+    convert: [],
+    convertBulletin: [],
+    ingestCollect: [],
+  };
+
+  await stubWorkbenchNoise(page);
+
+  await page.route('**/api/v1/convert-bulletin', async (route) => {
+    captured.convertBulletin.push(route.request());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        bulletin_meta: {
+          ahl: 'SAUS31 KZNY 121200',
+          report_count: 2,
+          tt: 'SA',
+          aa: 'US',
+          cccc: 'KZNY',
+          yygggg: '121200',
+          bbb: null,
+        },
+        results: [
+          {
+            report_index: 0,
+            ok: true,
+            tac_input: 'METAR KJFK 121151Z 18008KT 10SM FEW250 22/14 A3012=',
+            xml: '<?xml version="1.0"?><iwxxm:METAR>KJFK</iwxxm:METAR>',
+            issues: [],
+            fixes: [],
+          },
+          {
+            report_index: 1,
+            ok: true,
+            tac_input: 'METAR KLGA 121151Z 19010KT 10SM SCT040 21/13 A3010=',
+            xml: '<?xml version="1.0"?><iwxxm:METAR>KLGA</iwxxm:METAR>',
+            issues: [],
+            fixes: [],
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/ingest-collect', async (route) => {
+    captured.ingestCollect.push(route.request());
+    await route.fulfill({
+      status: 501,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        detail: {
+          message: 'COLLECT member extract not implemented',
+          code: 'not_implemented',
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/convert', async (route) => {
+    captured.convert.push(route.request());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [
+          {
+            name: 'manual.xml',
+            content: '<?xml version="1.0"?><iwxxm:METAR>KJFK</iwxxm:METAR>',
+            source: 'manual',
+            size_bytes: 48,
+          },
+        ],
+        errors: [],
+        issues: [],
+        total_processed: 1,
+        successful: 1,
+        failed: 0,
+      }),
+    });
+  });
+
+  return captured;
+}
+
+test.describe('TC-F7-007 / UJ-025: Manual TAC Input modes', () => {
+  test('T1: TAC report + Auto-detect convert OK', async ({ page }) => {
+    const captured = await stubModeApis(page);
+    await openConverterForE2e(page);
+
+    await expect(page.getByTestId('input-mode-group')).toBeVisible();
+    await expect(page.getByTestId('input-mode-tac')).toBeVisible();
+    await expect(page.getByTestId('product-type-select')).toHaveValue('auto');
+
+    await fillManualTac(page, METAR_TAC);
+    await page.getByTestId('convert-button').click();
+
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
+      {
+        timeout: 10000,
+      },
+    );
+    expect(captured.convert.length).toBeGreaterThanOrEqual(1);
+    expect(captured.convertBulletin).toHaveLength(0);
+    expect(captured.ingestCollect).toHaveLength(0);
+  });
+
+  test('T2: AHL bulletin hits convert-bulletin + summary', async ({ page }) => {
+    const captured = await stubModeApis(page);
+    await openConverterForE2e(page);
+
+    await page.getByTestId('input-mode-ahl_bulletin').click();
+    await expect(page.getByText(/convert-bulletin/i)).toBeVisible();
+
+    await fillManualTac(page, AHL_BULLETIN);
+    await page.getByTestId('convert-button').click();
+
+    await expect(page.getByTestId('bulletin-summary')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('bulletin-summary')).toContainText(/2 report/i);
+    expect(captured.convertBulletin.length).toBeGreaterThanOrEqual(1);
+    expect(captured.convert).toHaveLength(0);
+  });
+
+  test('T3: paste AHL in TAC mode auto-switches (required)', async ({ page }) => {
+    const captured = await stubModeApis(page);
+    await openConverterForE2e(page);
+
+    await expect(page.getByTestId('input-mode-tac')).toBeVisible();
+    await fillManualTac(page, AHL_BULLETIN);
+    await page.getByTestId('convert-button').click();
+
+    await expect(page.getByTestId('input-mode-ahl_bulletin')).toHaveClass(
+      /bg-blue-600/,
+      { timeout: 10000 },
+    );
+    await expect(page.getByText(/Detected AHL bulletin/i).first()).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByTestId('bulletin-summary')).toBeVisible({ timeout: 10000 });
+    expect(captured.convertBulletin.length).toBeGreaterThanOrEqual(1);
+    expect(captured.convert).toHaveLength(0);
+  });
+
+  test('T4: IWXXM COLLECT → ingest-collect 501 placeholder UX', async ({ page }) => {
+    const captured = await stubModeApis(page);
+    await openConverterForE2e(page);
+
+    await page.getByTestId('input-mode-collect_iwxxm').click();
+    await expect(page.getByText(/ingest-collect/i)).toBeVisible();
+    await expect(page.getByText(/501/i)).toBeVisible();
+
+    await fillManualTac(page, COLLECT_XML);
+    await page.getByTestId('convert-button').click();
+
+    await expect(page.getByTestId('placeholder-notice')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/COLLECT ingest placeholder/i).first()).toBeVisible({
+      timeout: 5000,
+    });
+    expect(captured.ingestCollect.length).toBeGreaterThanOrEqual(1);
+    expect(captured.convert).toHaveLength(0);
+    expect(captured.convertBulletin).toHaveLength(0);
+  });
+
+  test('T5: .gz COLLECT inflates and hits ingest-collect 501', async ({ page }) => {
+    const captured = await stubModeApis(page);
+    await openConverterForE2e(page);
+
+    const gz = gzipSync(Buffer.from(COLLECT_XML, 'utf8'));
+    await page.setInputFiles('input[type="file"]', {
+      name: 'metar-collect.xml.gz',
+      mimeType: 'application/gzip',
+      buffer: gz,
+    });
+
+    await expect(page.getByText(/Decompressed/i).first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/Detected IWXXM COLLECT/i).first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('input-mode-collect_iwxxm')).toHaveClass(
+      /bg-blue-600/,
+    );
+
+    await page.getByTestId('convert-button').click();
+    await expect(page.getByTestId('placeholder-notice')).toBeVisible({
+      timeout: 10000,
+    });
+    expect(captured.ingestCollect.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('T6: finished session disables mode buttons', async ({ page }) => {
+    const finishedSession = {
+      id: 'finished-modes-1',
+      user_id: 'user-1',
+      product: 'metar',
+      status: 'finished',
+      title: 'KJFK finished modes',
+      manual_tac: METAR_TAC,
+      pending_files: [],
+      converted_results: [
+        {
+          name: 'manual',
+          tac_input: METAR_TAC,
+          iwxxm_xml: '<iwxxm/>',
+        },
+      ],
+      errors: [],
+      issues: [],
+      conversion_params: {},
+      kv_upload_key: 'kv-1',
+      deleted_at: null,
+      created_at: '2026-07-20T00:00:00Z',
+      updated_at: '2026-07-20T00:00:00Z',
+    };
+
+    await page.route('**/api/v1/work-sessions**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [finishedSession],
+            total: 1,
+            page: 1,
+            limit: 20,
+          }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await openConverterWithMockSession(page);
+    await expect(
+      page.getByRole('button', { name: /KJFK finished modes/i }),
+    ).toBeVisible({
+      timeout: 15000,
+    });
+    await page.getByRole('button', { name: /KJFK finished modes/i }).click();
+
+    await expect(page.getByTestId('input-mode-tac')).toBeDisabled({ timeout: 10000 });
+    await expect(page.getByTestId('input-mode-ahl_bulletin')).toBeDisabled();
+    await expect(page.getByTestId('input-mode-collect_iwxxm')).toBeDisabled();
+  });
+});

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -464,7 +464,8 @@ export function FileConverter({
         } else {
           content = await file.text();
         }
-        const kind = detectInputKind(file.name, content);
+        // Classify by decompressed display name + content (not raw .gz → kind "gzip")
+        const kind = detectInputKind(displayName, content);
         detectedMode = kindToMode(kind);
         newPendingFiles.push({
           id: `${displayName}-${Date.now()}-${i}`,
@@ -532,14 +533,16 @@ export function FileConverter({
         .filter(Boolean)
         .join('\n');
 
-      // Auto-switch when paste looks like bulletin / COLLECT
+      // Auto-switch when paste looks like bulletin / COLLECT (UJ-025 / ADR-024)
       let mode = inputMode;
       if (mode === 'tac' && looksLikeAhlBulletin(tacForDetect)) {
         mode = 'ahl_bulletin';
         setInputMode('ahl_bulletin');
+        toast.info('Detected AHL bulletin — switched input mode');
       } else if (mode === 'tac' && looksLikeCollectIwxxm(tacForDetect)) {
         mode = 'collect_iwxxm';
         setInputMode('collect_iwxxm');
+        toast.info('Detected IWXXM COLLECT — switched input mode');
       }
 
       const resolvedProduct = resolveConvertProduct(

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -22,6 +22,7 @@ part of an active pipeline session. See [sessions/README.md](../sessions/README.
 | [f7-operator-ui](f7-operator-ui.md) | F7 multi-product operator UI + workbench/decode/admin (#694/#702/#665/#666/#697) | active | 2026-07-13 | F7, F6, F5, M4 |
 | [package-publish-validation](package-publish-validation.md) | PyPI packages + validation stack perf (#703/#698/#699/#693) | active | 2026-07-18 | F11–F14, S014/EV-010 |
 | [metar-lint-quality](metar-lint-quality.md) | METAR lint issue registry + #732 quality (lint/validate/convert) | active | 2026-07-19 | F15, F6, F12, S015/EV-011 |
+| [manual-tac-input-modes](manual-tac-input-modes.md) | Validate Manual TAC Input modes TAC/AHL/COLLECT (#730 / ADR-024) | active | 2026-07-20 | F7, S016/EV-012 |
 
 **Convention**: One brief per topic at `docs/context/<slug>.md`. Reference downstream as
 `[Context: <slug> R#]`.

--- a/docs/context/manual-tac-input-modes.md
+++ b/docs/context/manual-tac-input-modes.md
@@ -1,0 +1,44 @@
+# Scoped context — Manual TAC Input modes (#730)
+
+**Status**: active  
+**Session**: S016-manual-tac-input-modes / EV-012  
+**Created**: 2026-07-20  
+**Linked**: F7, ADR-024, UJ-011, [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730)
+
+## Topic
+
+Validate the operator workbench **Manual TAC Input** surface (TAC report / AHL bulletin /
+IWXXM COLLECT) shipped under ADR-024 — operator-visible mode switching, hints, and
+end-to-end success/placeholder behavior.
+
+## Code anchors
+
+| Area | Path |
+|------|------|
+| Mode UI | `apps/frontend/src/app/components/FileConverter.tsx` (`input-mode-*` test ids) |
+| Client APIs | `apps/frontend/src/utils/api.ts` — `convertBulletin`, `ingestCollect` |
+| Kind detect | `apps/frontend/src/utils/inputKind.ts` (and Vitest) |
+| Unit coverage | `FileConverter.test.tsx`, `api.test.ts` (501 path) |
+| Playwright gap | No `apps/e2e/` matches for input-mode / convert-bulletin / ingest-collect (as of intake) |
+
+## Corpus
+
+- [ADR-024](../adr/ADR-024-operator-input-modes.md) — modes + COLLECT 501 honesty
+- `[Corpus: api]` — `/convert-bulletin`, `/ingest-collect` 501
+- `[Corpus: tests]` — UJ-011 (API/H7); F7 H6′ journeys lack mode-group cases
+- F7 remains **Planned** (E11-11); this cycle does **not** flip status
+
+## Resolutions (local)
+
+| ID | Resolution |
+|----|------------|
+| R1 | Validation-only under F7; no new Fn |
+| R2 | Auto-switch on paste/upload is acceptance-critical |
+| R3 | Playwright authored in stage **10** (lean; no 07) |
+| R4 | Staging smoke required (H4–H5 + AHL + COLLECT 501) |
+| R5 | COLLECT member extract remains deferred |
+
+## Connectivity
+
+Browser workbench → single API origin (`/api/v1/convert`, `/convert-bulletin`,
+`/ingest-collect`). H4–H5 live connectivity + authenticated workbench pass in **13**.

--- a/docs/context/manual-tac-input-modes.md
+++ b/docs/context/manual-tac-input-modes.md
@@ -34,7 +34,7 @@ end-to-end success/placeholder behavior.
 |----|------------|
 | R1 | Validation-only under F7; no new Fn |
 | R2 | Auto-switch on paste/upload is acceptance-critical |
-| R3 | Playwright authored in stage **10** (lean; no 07) |
+| R3 | Playwright authored in stage **10** (lean; no 07); **T1–T6 hard gates** (S2.2) |
 | R4 | Staging smoke required (H4–H5 + AHL + COLLECT 501) |
 | R5 | COLLECT member extract remains deferred |
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -25,10 +25,13 @@
 | ID | Category | Question | Decision | ADR |
 |----|----------|----------|----------|-----|
 | E12-1 | decision | Cycle type | A — F7 validation; no new Fn; COLLECT 501 | ADR-024 |
-| E12-2 | decision | Automation depth | Vitest + Playwright T1–T4 + live staging all green | — |
+| E12-2 | decision | Automation depth | Vitest + Playwright T1–T6 (hard) + live staging all green | — |
 | E12-3 | decision | Auto-switch (T3) | Required acceptance | ADR-024 |
 | E12-4 | decision | Deploy | Include 13-deploy-smoke | — |
 | D-S016-EV012-route-1 | decision | Routing vs lean/deploy contradiction | Lean + 13 (skip 03–09, 11–12) | — |
+| S2.1 | contradiction | H6 omits UJ-025 | Fix: add UJ-025 to H6/H6′ row | — |
+| S2.2 | ambiguity | T5/T6 vs all tests | T1–T6 all hard gates | — |
+| S2.3 | decision | UJ id | Keep UJ-025 (not fold into UJ-013) | — |
 
 ### Stage log
 
@@ -37,7 +40,7 @@
 | 00-context | 2026-07-20 | Session + scoped brief |
 | 16-evolve | — | Phase 0 complete; Phase A in progress |
 | 01-requirements | 2026-07-20 | UJ-025 + TC-F7-007 + F7 validation note |
-| 02-verify-plan | | |
+| 02-verify-plan | 2026-07-20 | PASS — S2.1 fix H6; S2.2 T1–T6 hard; S2.3 UJ-025 |
 | 10-e2e | | |
 | 13-deploy-smoke | | |
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,46 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-012 — Validate Manual TAC Input modes (#730) (S016)
+
+**Session**: S016-manual-tac-input-modes  
+**Features**: F7 (validation deepen only; status stays Planned)  
+**Issues**: [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730)  
+**Started**: 2026-07-20  
+**Branch**: `evolve/EV-012-manual-tac-input-modes`  
+**Completed**: —
+
+### Scope (Phase 0 locked 2026-07-20)
+
+1. Test/acceptance under **F7 / ADR-024** for Manual TAC Input modes (TAC / AHL / COLLECT)
+2. Playwright T1–T4 + Vitest anchors + staging H4–H5 + AHL happy path + COLLECT **501** UX
+3. Auto-switch on paste/upload is **required**
+4. **No new Fn**; COLLECT member extract out of scope; F7 remains **Planned**
+5. Routing **lean + 13**: 00 → 16 → 01 → 02 → 10 → 13
+
+### Intake decisions
+
+| ID | Category | Question | Decision | ADR |
+|----|----------|----------|----------|-----|
+| E12-1 | decision | Cycle type | A — F7 validation; no new Fn; COLLECT 501 | ADR-024 |
+| E12-2 | decision | Automation depth | Vitest + Playwright T1–T4 + live staging all green | — |
+| E12-3 | decision | Auto-switch (T3) | Required acceptance | ADR-024 |
+| E12-4 | decision | Deploy | Include 13-deploy-smoke | — |
+| D-S016-EV012-route-1 | decision | Routing vs lean/deploy contradiction | Lean + 13 (skip 03–09, 11–12) | — |
+
+### Stage log
+
+| Stage | Completed | Notes |
+|-------|-----------|-------|
+| 00-context | 2026-07-20 | Session + scoped brief |
+| 16-evolve | — | Phase 0 complete; Phase A next |
+| 01-requirements | | |
+| 02-verify-plan | | |
+| 10-e2e | | |
+| 13-deploy-smoke | | |
+
+---
+
 ## Cycle EV-011 — METAR lint registry + #732 quality (S015)
 
 **Session**: S015-metar-lint-quality  

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -41,7 +41,7 @@
 | 16-evolve | — | Phase 0 complete; Phase A in progress |
 | 01-requirements | 2026-07-20 | UJ-025 + TC-F7-007 + F7 validation note |
 | 02-verify-plan | 2026-07-20 | PASS — S2.1 fix H6; S2.2 T1–T6 hard; S2.3 UJ-025 |
-| 10-e2e | | |
+| 10-e2e | 2026-07-20 | PASS — TC-F7-007 T1–T6 Playwright + Vitest anchors |
 | 13-deploy-smoke | | |
 
 ---

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -35,8 +35,8 @@
 | Stage | Completed | Notes |
 |-------|-----------|-------|
 | 00-context | 2026-07-20 | Session + scoped brief |
-| 16-evolve | — | Phase 0 complete; Phase A next |
-| 01-requirements | | |
+| 16-evolve | — | Phase 0 complete; Phase A in progress |
+| 01-requirements | 2026-07-20 | UJ-025 + TC-F7-007 + F7 validation note |
 | 02-verify-plan | | |
 | 10-e2e | | |
 | 13-deploy-smoke | | |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -215,7 +215,7 @@
 - **Deferred (still Later)**: Full COLLECT member extract inside `ingest-collect` (UI + 501
   placeholder shipped ADR-024); deep honor of `include_nil_reasons` in tac2iwxxm emit.
 - **Validation deepen (S016 / EV-012 / #730)**: Operator-visible Manual TAC Input modes
-  (TAC / AHL / COLLECT) validated via UJ-025 / TC-F7-007 (Playwright T1–T4 + Vitest + staging
+  (TAC / AHL / COLLECT) validated via UJ-025 / TC-F7-007 (Playwright **T1–T6** hard + Vitest + staging
   H4–H5 / AHL / COLLECT 501). Auto-switch required. Does **not** flip F7 → Implemented.
 - **F6 engine companions (still F6 packages; UX under F7)**: decode segments; optional integer
   `start`/`end` on lint/validate issues; soft-preview / partial convert (flag or dedicated

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -214,6 +214,9 @@
   products; optional in-band XSD/Schematron when Strict Validation is on (hard Convert).
 - **Deferred (still Later)**: Full COLLECT member extract inside `ingest-collect` (UI + 501
   placeholder shipped ADR-024); deep honor of `include_nil_reasons` in tac2iwxxm emit.
+- **Validation deepen (S016 / EV-012 / #730)**: Operator-visible Manual TAC Input modes
+  (TAC / AHL / COLLECT) validated via UJ-025 / TC-F7-007 (Playwright T1–T4 + Vitest + staging
+  H4–H5 / AHL / COLLECT 501). Auto-switch required. Does **not** flip F7 → Implemented.
 - **F6 engine companions (still F6 packages; UX under F7)**: decode segments; optional integer
   `start`/`end` on lint/validate issues; soft-preview / partial convert (flag or dedicated
   endpoint — finalize in 04-tech-plan).

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -39,15 +39,14 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 | [S012-empty-bearer-lint-tac](S012-empty-bearer-lint-tac/session-brief.md) | hotfix | completed | Empty Bearer on lint-tac/decode-tac + lint UX issue details | fix/S012-empty-bearer-lint-tac | 2026-07-15 | 2026-07-15 |
 | [S013-live-decode-preview-ux](S013-live-decode-preview-ux/session-brief.md) | feature | completed | Value-aware live decode + plain-language summary (F9); IWXXM preview pane + lint UX clarity (F10) — EV-009; PR #723 | evolve/S013-live-decode-preview-ux | 2026-07-16 | 2026-07-18 |
 | [S014-package-publish-validation](S014-package-publish-validation/session-brief.md) | feature | completed | Validation stack perf + PyPI packages F11–F14 (#703/#698/#699/#693) — EV-010 | evolve/EV-010-package-publish-validation | 2026-07-18 | 2026-07-19 |
-| [S015-metar-lint-quality](S015-metar-lint-quality/session-brief.md) | feature | in_progress | METAR lint issue registry + #732 quality (lint/validate/convert) — EV-011; F15 + F6/F12 deepen | evolve/EV-011-metar-lint-quality | 2026-07-19 | — |
+| [S015-metar-lint-quality](S015-metar-lint-quality/session-brief.md) | feature | completed | METAR lint issue registry + #732 quality — EV-011; F15 Done; PR #742 | evolve/EV-011-metar-lint-quality | 2026-07-19 | 2026-07-20 |
+| [S016-manual-tac-input-modes](S016-manual-tac-input-modes/session-brief.md) | feature | in_progress | Validate Manual TAC Input modes (#730 / ADR-024) — EV-012 | evolve/EV-012-manual-tac-input-modes | 2026-07-20 | — |
 
 ## Active session
 
-**[S013-live-decode-preview-ux](S013-live-decode-preview-ux/session-brief.md)** — EV-009 (F9/F10), orchestrated by 16-evolve.
+**[S016-manual-tac-input-modes](S016-manual-tac-input-modes/session-brief.md)** — EV-012 (#730 Manual TAC Input validation), orchestrated by 16-evolve.
 
-Parked: **[S011-f7-operator-ui](S011-f7-operator-ui/session-brief.md)** — EV-008; PR [#716](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716) merged 2026-07-15; 13-deploy-smoke closeout pending resume.
-
-Last closed: **[S012-empty-bearer-lint-tac](S012-empty-bearer-lint-tac/session-brief.md)** — BUG resolved; PR [#721](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/721) merged (`6412b21`).
+Last closed: **[S015-metar-lint-quality](S015-metar-lint-quality/session-brief.md)** — F15 Done; PR [#742](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/742) merged.
 
 ## Folder layout
 

--- a/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-0.md
+++ b/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-0.md
@@ -1,0 +1,27 @@
+# Checkpoint — Phase 0 complete (S016 / EV-012)
+
+**Date**: 2026-07-20  
+**Decision**: D-S016-EV012-route-1 (lean + 13)
+
+## Digest
+
+- **Session**: S016-manual-tac-input-modes (feature)
+- **Cycle**: EV-012 — Validate Manual TAC Input modes (#730)
+- **Branch**: `evolve/EV-012-manual-tac-input-modes`
+- **Fn**: F7 validation only (no new Fn; F7 stays Planned)
+- **Routing**: 00 ✓ → 16 → **01** → 02 → 10 → 13
+
+## Locked scope
+
+| Item | Value |
+|------|-------|
+| Modes | TAC / AHL / COLLECT (ADR-024) |
+| COLLECT | 501 placeholder UX (no extract) |
+| Auto-switch | Required |
+| Tests | Vitest + Playwright T1–T4 + live H4–H5/AHL/COLLECT |
+| Deploy | 13-deploy-smoke after merge |
+
+## Next
+
+**01-requirements** (delta): `test-plan.md` / `user-journeys.md` rows for input-mode UJ +
+acceptance checklist; link #730 matrix T1–T6.

--- a/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
+++ b/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
@@ -1,0 +1,10 @@
+# Checkpoint — Phase A complete (S016 / EV-012)
+
+**Date**: 2026-07-20  
+**Gate**: A→B waived (lean); Phase A = 01+02 **PASS**
+
+## Digest
+
+- 01: UJ-025 + TC-F7-007
+- 02: S2.1 H6+UJ-025; S2.2 T1–T6 hard; S2.3 keep UJ-025
+- Next: **10-e2e** (author Playwright T1–T6 + Vitest gap check) → 13-deploy-smoke

--- a/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
+++ b/docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
@@ -1,0 +1,16 @@
+# Checkpoint — Phase A ready (S016 / EV-012)
+
+**Date**: 2026-07-20
+
+## Digest
+
+- **01-requirements** delta complete: UJ-025, TC-F7-007, F7/spec notes
+- **No new Fn**; F7 remains Planned; COLLECT extract still deferred
+- **Next**: 02-verify-plan → then 10-e2e (Playwright)
+
+## Artifacts
+
+- `docs/user-journeys.md` — UJ-025
+- `docs/test-plan.md` — TC-F7-007 + input-modes gate
+- `docs/feature-list.md` / `docs/spec.md` — validation deepen pointers
+- `docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md`

--- a/docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
+++ b/docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
@@ -1,0 +1,28 @@
+# 01-requirements report — S016 / EV-012
+
+**Date**: 2026-07-20  
+**Mode**: delta (lean validation cycle)
+
+## Document manifest (delta)
+
+| Document | Action | Notes |
+|----------|--------|-------|
+| `docs/user-journeys.md` | Updated | **UJ-025** Manual TAC Input modes |
+| `docs/test-plan.md` | Updated | **TC-F7-007** + H6′ mapping + S016 gate |
+| `docs/feature-list.md` | Updated | F7 validation deepen note (#730); status stays Planned |
+| `docs/spec.md` | Updated | ADR-024 pointer → UJ-025 / TC-F7-007 |
+| `docs/api-contract.md` | Unchanged | Endpoints already specified |
+| ADR-024 | Unchanged | Accepted; no redesign |
+
+## Intake carried into specs
+
+| ID | Spec reflection |
+|----|-----------------|
+| E12-1 | No new Fn; COLLECT 501; F7 Planned |
+| E12-2 | TC-F7-007 Vitest + Playwright + staging |
+| E12-3 | T3 auto-switch required |
+| E12-4 | 13-deploy-smoke in gate checklist |
+
+## Next
+
+02-verify-plan (delta consistency pass).

--- a/docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
+++ b/docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
@@ -1,0 +1,68 @@
+# 02-verify-plan audit — S016 / EV-012
+
+**Date**: 2026-07-20  
+**Mode**: delta (changed sections + cross-doc consistency)
+
+## Inventory (delta focus)
+
+| # | Document | Delta sections | Status |
+|---|----------|----------------|--------|
+| 1 | feature-list.md | F7 validation deepen | audited |
+| 2 | spec.md | F7 input modes ADR-024 + validation pointer | audited |
+| 3 | user-journeys.md | UJ-025 | audited |
+| 4 | test-plan.md | UJ-025 map, TC-F7-007, input-modes gate, UI↔API row | audited |
+| 5 | api-contract.md | convert-bulletin / ingest-collect 501 (unchanged) | consistent |
+| 6 | ADR-024 | Accepted (unchanged) | consistent |
+| 7 | acceptance-criteria.md | absent (N/A) | skip |
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Spec (F7 input modes) | PASS |
+| Feature ↔ Journey (UJ-025) | PASS |
+| Journey ↔ Test (UJ-025 ↔ TC-F7-007) | PASS |
+| Feature ↔ Test | PASS |
+| API contract ↔ ADR-024 / UJ-025 | PASS |
+| Spec ↔ Config | N/A (no new params) |
+| Naming (UJ-025 / TC-F7-007 / ADR-024) | PASS |
+| Scope (no COLLECT extract; F7 Planned) | PASS |
+| Connectivity H4–H5 in gate | PASS |
+| H6 / H6′ lists UJ-025 | **FAIL** — see S2.1 |
+
+## Auto-approved (high confidence)
+
+| ID | Statement | Source |
+|----|-----------|--------|
+| S0.1 | Cycle is F7 validation only; no new Fn | E12-1 |
+| S0.2 | COLLECT remains HTTP 501 placeholder UX | E12-1 / ADR-024 |
+| S0.3 | Auto-switch on paste/upload is required (T3) | E12-3 |
+| S0.4 | Vitest + Playwright T1–T4 + live staging all required | E12-2 |
+| S0.5 | Include 13-deploy-smoke; lean skips 03–09, 11–12 | E12-4 / route-1 |
+| S0.6 | F7 status remains Planned | E12-1 |
+| S0.7 | UJ-025 / TC-F7-007 describe modes TAC / AHL / COLLECT | 01 delta / #730 |
+| S0.8 | UJ-025 does not replace UJ-011 / H7 API gate | E12 scope / UJ-025 text |
+
+**Auto-approved**: 8
+
+## Pending user review
+
+| ID | Conf | Category | Statement |
+|----|------|----------|-----------|
+| S2.1 | Low | Contradiction | H6 connectivity row omits UJ-025 while journey maps to H6′ |
+| S2.2 | Medium | Ambiguity | T5/T6 “as coverage allows” vs E12-2 “all tests green” |
+| S2.3 | Medium | Decision | New UJ-025 (vs extending UJ-013) is correct ID choice |
+
+## Verdicts log
+
+| ID | Verdict | Notes |
+|----|---------|-------|
+| S0.1–S0.8 | auto-approved | high confidence |
+| S2.1 | approve + fix | H6 row includes UJ-025 (H6′) |
+| S2.2 | modify | T1–T6 all hard gates (not T5/T6 best-effort) |
+| S2.3 | approve | Keep UJ-025 |
+
+## Gate result
+
+**PASS** (fix-in-place applied). Phase A complete for lean route; next **10-e2e**.
+

--- a/docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
+++ b/docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
@@ -1,0 +1,36 @@
+# E2E report — S016 / EV-012 (10-e2e)
+
+**Date**: 2026-07-20  
+**Journey**: UJ-025 / TC-F7-007 Manual TAC Input modes  
+**Branch**: `evolve/EV-012-manual-tac-input-modes`
+
+## Results
+
+| Tier | Scope | Result |
+|------|-------|--------|
+| T0 Vitest | `inputKind.test.ts`, `api.test.ts` (bulletin/501), `FileConverter.test.tsx` | **PASS** (139 tests in those files) |
+| T2 Playwright | `apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts` T1–T6 | **PASS** (6/6) |
+| T2 connectivity | H4–H5 | Deferred to **13-deploy-smoke** |
+| T3 live / H6′ | Staging workbench | Deferred to **13-deploy-smoke** |
+
+## Matrix
+
+| Case | Status | Notes |
+|------|--------|-------|
+| T1 TAC + Auto-detect | PASS | `/convert` only |
+| T2 AHL bulletin | PASS | `/convert-bulletin` + `bulletin-summary` |
+| T3 auto-switch | PASS | Toast + mode; convert-time toast added |
+| T4 COLLECT 501 | PASS | `placeholder-notice` + warning toast |
+| T5 `.gz` COLLECT | PASS | Fix: classify after inflate via displayName |
+| T6 read-only modes | PASS | Finished session disables mode buttons |
+
+## Code deltas (lean 10)
+
+1. `FileConverter.tsx` — toast on convert-time AHL/COLLECT auto-switch; gzip classify after decompress
+2. `f7-manual-tac-input-modes.e2e.spec.ts` — new Playwright suite
+3. README E2E badge 43 → 49
+
+## Gaps
+
+- H7 (`make test-live-bulletin` / UJ-011) unchanged — API gate, not replaced
+- Live staging AHL + COLLECT 501 → stage **13**

--- a/docs/sessions/S016-manual-tac-input-modes/routing-plan.md
+++ b/docs/sessions/S016-manual-tac-input-modes/routing-plan.md
@@ -1,0 +1,29 @@
+# Routing plan — S016-manual-tac-input-modes
+
+| Stage | Required | Mode | Skip rationale |
+|-------|----------|------|----------------|
+| 00-context | yes | scoped | Session open + `docs/context/manual-tac-input-modes.md` |
+| 16-evolve | yes | orchestrator | EV-012 |
+| 01-requirements | yes | delta | test-plan / UJ for input modes; checklist acceptance |
+| 02-verify-plan | yes | delta | Consistency vs ADR-024 / F7 / api-contract |
+| 10-e2e | yes | delta | Author + run Playwright T1–T4; Vitest gap check |
+| 13-deploy-smoke | yes | full | H4–H5 + authenticated AHL + COLLECT 501 |
+| 03-plan-tooling | no | — | No new guardrails |
+| 04-tech-plan | no | — | No new API/arch; Playwright under 10 |
+| 05-verify-tech | no | — | Skipped with 04 |
+| 06-tech-tooling | no | — | No stack change |
+| 07-build | no | — | Lean: author tests in 10 |
+| 08-verify-build | no | — | Skipped with 07 |
+| 09-qa | no | — | Covered by 10 + Vitest |
+| 11-verify-impl | no | — | F7 stays Planned; no Fn flip |
+| 12-verify-deploy | no | — | Smoke-only via 13 |
+
+## Approved
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Scope / cycle type | A — F7 validation; no new Fn; COLLECT 501 | 2026-07-20 (E12-1) |
+| Automation | Vitest + Playwright T1–T4 + live staging | 2026-07-20 (E12-2) |
+| Auto-switch | Required | 2026-07-20 (E12-3) |
+| Deploy | 13-deploy-smoke included | 2026-07-20 (E12-4) |
+| Routing | **Lean + 13** (00, 16, 01, 02, 10, 13) | 2026-07-20 (D-S016-EV012-route-1) |

--- a/docs/sessions/S016-manual-tac-input-modes/session-brief.md
+++ b/docs/sessions/S016-manual-tac-input-modes/session-brief.md
@@ -1,0 +1,70 @@
+---
+session_id: S016-manual-tac-input-modes
+type: feature
+status: in_progress
+branch: evolve/EV-012-manual-tac-input-modes
+started_at: 2026-07-20
+intent: "Validate Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per #730 / ADR-024"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-012
+context_briefs:
+  - docs/context/manual-tac-input-modes.md
+standing_docs_touched: []
+---
+
+# Session S016 — manual-tac-input-modes
+
+## Intent
+
+Manually and automatically **test and validate** the FileConverter **Manual TAC Input**
+control surface ([#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730),
+ADR-024): mode toggle, product Auto-detect, AHL → `POST /api/v1/convert-bulletin`, and
+IWXXM COLLECT → `POST /api/v1/ingest-collect` (**501** placeholder until member extract).
+
+## Intake decisions (Phase 0 — locked 2026-07-20)
+
+| ID | Decision |
+|----|----------|
+| E12-1 | Cycle **A**: F7 validation under ADR-024; **no new Fn**; COLLECT stays **501** |
+| E12-2 | **All tests green**: Vitest anchors + Playwright T1–T4 + live staging |
+| E12-3 | Auto-switch on paste/upload is **required** (T3 fails if missing) |
+| E12-4 | Include **13-deploy-smoke** after merge |
+| E12-5 / D-S016-EV012-route-1 | **Lean + 13**: 00 → 16 → 01 → 02 → 10 → 13 |
+
+## Scope
+
+### In
+
+- Mode toggle UX (TAC / AHL / COLLECT); helper copy; read-only disable
+- TAC report happy path with Product = Auto-detect
+- AHL bulletin → `/convert-bulletin` + summary / per-report results (no silent `/convert`)
+- IWXXM COLLECT → `/ingest-collect` → **501** as placeholder notice (not success)
+- Paste/upload auto-switch (required)
+- Playwright T1–T4 under `apps/e2e/`; Vitest regression anchors
+- Staging: H4–H5 + authenticated AHL + COLLECT 501
+- Corpus deltas: `test-plan.md` / UJ rows; gaps vs H6′ / H7 called out
+- Defects from validation → separate bug issues linked from #730
+
+### Out
+
+- Full COLLECT member extract (backend beyond 501)
+- Replacing UJ-011 / H7 bulletin API gate design
+- Product-matrix convert completeness beyond mode routing
+- Flipping F7 → Implemented
+
+## Feature mapping
+
+| Fn | Role |
+|----|------|
+| **F7** (deepen validation only) | Operator UI input modes (ADR-024); status remains **Planned** |
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).
+
+## Links
+
+- Issue: [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730)
+- ADR: [ADR-024](../../adr/ADR-024-operator-input-modes.md)
+- Corpus: F7, UJ-011, test-plan H6′/H7
+- UI: `apps/frontend/src/app/components/FileConverter.tsx`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -219,7 +219,8 @@ metar-to-IWXXM/
 - **F7 input modes (ADR-024)**: TAC | AHL bulletin (`/convert-bulletin`) | IWXXM COLLECT
   (`/ingest-collect` 501 placeholder). Accept `.xml`/`.gz` (inflate). `log_level` +
   `include_nil_reasons` on Convert. Log Level filters Conversion log + console for lint/validate
-  process messages.
+  process messages. **Validation**: UJ-025 / TC-F7-007 (S016 / EV-012 / #730) — auto-switch
+  required; COLLECT 501 honest UX; F7 status unchanged.
 - **F5**: Unchanged product scope — METAR/SPECI work sessions only (not extended to other
   products); admin browse path removed.
 - **F9/F10 delta (S013)**: Decode panel gains a top **"Plain language"** block rendering the

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/joseph-c-mcguire/metar-to-IWXXM
-> **Last updated**: 2026-07-19 (S015 / EV-011 — F15 METAR lint registry + #732)
+> **Last updated**: 2026-07-20 (S016 / EV-012 — Manual TAC Input modes #730 / UJ-025 / TC-F7-007)
 
 ## Scope
 
@@ -66,6 +66,7 @@ Unified manual live test harness against Render staging:
 | UJ-DEV-005 | F12–F14 | pip install packages | CI | TC-F12-001, TC-F13-001, TC-F14-002 |
 | UJ-DEV-004 | F2/F6/M5 | `tac-validate` + `iwxxm-validate` package CI | — | TC-F6-032 |
 | UJ-024 | F15 | METAR/SPECI registry + convert→validate golden | H4–H5 if FE | TC-F15-001..005 |
+| UJ-025 | F7 | Manual TAC Input modes (ADR-024 / #730) | H6′ | TC-F7-007 |
 
 **Admin dashboard E2E**: **Retired** (S011 / #697). Replace prior admin panel locator guidance with
 **TC-F7-006** — assert `/admin` and legacy admin deep links return not-found; delete/skip old
@@ -273,9 +274,33 @@ admin suite modules.
 ### TC-F7-006: Admin routes removed (UJ-019)
 
 - **Level**: T2 / T3
-- **Objective**: `/admin` and legacy admin deep links are not-found; old admin suite retired
-- **Pass criteria**: Negative Playwright/API asserts; no AdminDashboard route registration
-- **Source**: UJ-019; #697
+- **Objective**: `/admin` and legacy admin deep links are gone
+- **Pass criteria**: Not-found / no AdminDashboard; authenticated convert still works
+- **Source**: UJ-019; F7.a / #697
+
+### TC-F7-007: Manual TAC Input modes (UJ-025 / #730)
+
+- **Level**: T2 (Vitest + Playwright) / T3 (H6′ / staging smoke)
+- **Objective**: Validate FileConverter Manual TAC Input modes per ADR-024 matrix
+- **Matrix**:
+
+  | Case | Input | Mode | Expect |
+  | ---- | ----- | ---- | ------ |
+  | T1 | Single METAR TAC | TAC report | Convert OK; Product Auto-detect |
+  | T2 | Multi-report WMO AHL | AHL bulletin | `/convert-bulletin` + summary/results |
+  | T3 | AHL or COLLECT pasted in TAC mode | (auto-switch) | Switches mode + toast (**required**) |
+  | T4 | COLLECT XML (fixture) | IWXXM COLLECT | `/ingest-collect` → **501** placeholder UX |
+  | T5 | `.gz` COLLECT/bulletin if accepted | matching | Inflate + same as T2/T4 |
+  | T6 | Read-only finished session | any | Mode buttons disabled |
+
+- **Pass criteria**:
+  1. Vitest: `inputKind`, `api` (convert-bulletin + ingest-collect 501), `FileConverter` mode group
+  2. Playwright (`apps/e2e/`): T1–T4 smoke green (T5/T6 as coverage allows)
+  3. No silent AHL fall-through to single `/convert`; COLLECT 501 not treated as success
+  4. Staging (13): H4–H5 + authenticated AHL happy path + COLLECT 501 notice
+  5. H7 (`make test-live-bulletin` / UJ-011) remains API gate — not replaced by this TC
+- **Source**: UJ-025; ADR-024; [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730);
+  S016 / EV-012 (E12-1..E12-4)
 
 ### F7 UI↔API connection integration
 
@@ -287,6 +312,7 @@ Cross-layer coverage for workbench connection points (not only isolated unit/TC 
 | Decode panel | `POST /api/v1/decode-tac` | same | same |
 | Soft-preview / Failed-TAC | `POST /api/v1/convert` (`preview=true`) | same + `test_frontend_contract_integration.py` | same |
 | My METARs / sessions | `/api/v1/work-sessions*` + `product` | same | same |
+| Manual TAC Input modes | `/convert`, `/convert-bulletin`, `/ingest-collect` | existing convert/bulletin tests + 501 | TC-F7-007 e2e (S016) |
 | Browser CORS (H0i) | OPTIONS on lint/decode/convert | same + `test_h0i_connectivity.py` | — |
 
 ### F7 verify/deploy gate
@@ -299,6 +325,14 @@ Before closing S011 / EV-008:
 - [ ] H6′ live smokes for UJ-013/015–019 (or documented waiver)
 - [ ] Admin E2E modules removed or converted to TC-F7-006
 - [ ] Child issues #697/#702/#665/#666/#694 closed or linked; #5 remains open
+
+### F7 input-modes validation gate (S016 / EV-012 / #730)
+
+- [ ] TC-F7-007 green at T2 (Playwright T1–T4 + Vitest anchors)
+- [ ] H4–H5 + authenticated AHL + COLLECT 501 on staging (13-deploy-smoke)
+- [ ] Auto-switch (T3) required — no waiver without AskQuestion
+- [ ] #730 checklist documented; defects filed as separate bugs
+- [ ] F7 status remains **Planned** (no Implemented flip this cycle)
 
 ## F9/F10 Test Cases (S013 / EV-009)
 
@@ -645,6 +679,8 @@ Before merging the PR that wires tac2iwxxm and deletes `packages/gifts`:
 - S011 / EV-008 (2026-07-13): TC-F7-001–006; TC-004 unified; admin E2E retired; H6′ F7 smokes;
   scope includes F7 build
   (D-S008-05-batch2)
+- S016 / EV-012 (2026-07-20): TC-F7-007 / UJ-025 Manual TAC Input modes (#730 / ADR-024);
+  H6′ + staging gate; F7 stays Planned
 
 ### TC-LIVE-005: Stale Test Migration
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -88,7 +88,7 @@ admin suite modules.
 | H3 | Live API smoke (pytest) | `make test-live-api` |
 | H4 | Live CORS preflight | `make test-live-connectivity` |
 | H5 | Frontend bundle URLs | `make test-live-connectivity` |
-| H6 | Live Playwright UJ-001–007 (+ UJ-008) + F7 UJ-013/015–019 smokes | `make test-live-e2e` |
+| H6 | Live Playwright UJ-001–007 (+ UJ-008) + F7 UJ-013/015–019 + **UJ-025** (H6′) | `make test-live-e2e` |
 | **H7** | Live bulletin → split → convert → Schematron (UJ-011) | `make test-live-bulletin` (planned) |
 
 **Post-migration**: Single API origin simplifies CORS — auth routes on same host as `/api/v1/*`.
@@ -295,12 +295,12 @@ admin suite modules.
 
 - **Pass criteria**:
   1. Vitest: `inputKind`, `api` (convert-bulletin + ingest-collect 501), `FileConverter` mode group
-  2. Playwright (`apps/e2e/`): T1–T4 smoke green (T5/T6 as coverage allows)
+  2. Playwright (`apps/e2e/`): **T1–T6 all green** (hard gate — S2.2)
   3. No silent AHL fall-through to single `/convert`; COLLECT 501 not treated as success
   4. Staging (13): H4–H5 + authenticated AHL happy path + COLLECT 501 notice
   5. H7 (`make test-live-bulletin` / UJ-011) remains API gate — not replaced by this TC
 - **Source**: UJ-025; ADR-024; [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730);
-  S016 / EV-012 (E12-1..E12-4)
+  S016 / EV-012 (E12-1..E12-4; S2.2 = T1–T6 hard)
 
 ### F7 UI↔API connection integration
 
@@ -328,9 +328,10 @@ Before closing S011 / EV-008:
 
 ### F7 input-modes validation gate (S016 / EV-012 / #730)
 
-- [ ] TC-F7-007 green at T2 (Playwright T1–T4 + Vitest anchors)
+- [ ] TC-F7-007 green at T2 (Playwright **T1–T6** + Vitest anchors)
 - [ ] H4–H5 + authenticated AHL + COLLECT 501 on staging (13-deploy-smoke)
 - [ ] Auto-switch (T3) required — no waiver without AskQuestion
+- [ ] T5 (`.gz`) and T6 (read-only disable) hard gates (S2.2)
 - [ ] #730 checklist documented; defects filed as separate bugs
 - [ ] F7 status remains **Planned** (no Implemented flip this cycle)
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -691,12 +691,12 @@ placeholder; does **not** replace H7 API gate design.
 3. AHL path uses `/convert-bulletin` with summary/results
 4. COLLECT path uses `/ingest-collect` and treats **501** as placeholder UX
 5. Auto-switch on paste/upload works (T3)
-6. Playwright T1–T4 green (T2/T3); Vitest anchors remain green; staging H4–H5 + AHL + COLLECT
+6. Playwright **T1–T6** green (T2/T3); Vitest anchors remain green; staging H4–H5 + AHL + COLLECT
    501 (13-deploy-smoke)
 7. Gaps vs H7 (API-only UJ-011) documented; defects filed as separate bugs linked from #730
 
 **Automated tests**: Vitest (`inputKind`, `api` 501, `FileConverter` mode group); Playwright
-`apps/e2e/` (TC-F7-007); live H6′ / staging smoke. **Tier: T2 / T3 / H6′**.
+`apps/e2e/` (TC-F7-007 T1–T6 hard); live H6′ / staging smoke. **Tier: T2 / T3 / H6′**.
 
 ---
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -3,8 +3,8 @@
 > **Project**: METAR to IWXXM Converter
 > **Source**: feature-list.md; S008 F6 + realtime amend; S011 / EV-008 F7 operator UI;
 > S013 / EV-009 F9/F10 decode + preview UX; S014 / EV-010 package publish + msgspec HTTP;
-> S015 / EV-011 F15 METAR lint registry + #732 quality
-> **Last updated**: 2026-07-19
+> S015 / EV-011 F15 METAR lint registry + #732 quality; S016 / EV-012 Manual TAC Input modes (#730)
+> **Last updated**: 2026-07-20
 
 Product-facing journeys (UJ-*) describe end-user flows. Developer journeys (UJ-DEV-*)
 describe monorepo workflows introduced by migration features M1–M6 and F6.
@@ -37,6 +37,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-022 | Operator convert/validate after msgspec HTTP | apps/frontend | F11 | T2 / **T3** / H6′ |
 | UJ-023 | PyPI release tag → install smoke | CI / maintainer | F12–F14 | CI |
 | UJ-024 | METAR/SPECI lint registry + convert→validate golden | UI / API / CI | F15 (+F6/F12) | T0 / T2 / **T3** |
+| UJ-025 | Manual TAC Input modes (TAC / AHL / COLLECT) | apps/frontend | F7 (ADR-024) | T2 / **T3** / H6′ |
 | UJ-DEV-001 | Clone and run monorepo | `git clone` + `make dev` | M1, M5 | T0 |
 | UJ-DEV-002 | Sync vendor schemas | Scheduled Action / manual | M2, M6, F6 | CI |
 | UJ-DEV-003 | ~~Merge GIFTs upstream~~ | — | M3 | **Deprecated** (ADR-014) |
@@ -654,6 +655,51 @@ this cycle (HARD — E11-23/28); non–R-theme gaps only may defer with rational
 
 ---
 
+### UJ-025: Manual TAC Input Modes (TAC / AHL Bulletin / IWXXM COLLECT)
+
+**Actor**: Operator
+
+**Goal**: Use FileConverter **Manual TAC Input** modes correctly — TAC report convert,
+AHL bulletin → `/convert-bulletin`, IWXXM COLLECT → `/ingest-collect` **501** placeholder —
+with honest UX and required paste/upload auto-switch (ADR-024 / [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730)).
+
+**Feature**: F7 (validation deepen; status remains Planned) — S016 / EV-012
+
+**Relationship**: UI surface that routes operators onto UJ-011 (bulletin API) and the COLLECT
+placeholder; does **not** replace H7 API gate design.
+
+**Steps**:
+
+1. Open operator workbench → Manual TAC Input (`data-testid="input-mode-group"`).
+2. **T1 — TAC report**: Mode = TAC; Product = Auto-detect; paste single METAR; convert succeeds.
+3. **T2 — AHL bulletin**: Mode = AHL; paste multi-report WMO AHL; convert hits
+   `POST /api/v1/convert-bulletin`; UI shows bulletin summary and/or per-report results/errors
+   (no silent fall-through to single `/convert`).
+4. **T3 — Auto-switch**: With Mode = TAC, paste AHL-looking bulletin (or COLLECT XML) → mode
+   switches to AHL (or COLLECT) with toast (“Detected AHL bulletin…” / “Detected IWXXM
+   COLLECT…”). **Required** — fail if missing (E12-3).
+5. **T4 — IWXXM COLLECT**: Mode = COLLECT; paste/upload COLLECT (`.xml` / `.gz` if supported)
+   → `POST /api/v1/ingest-collect` → **501** surfaces as placeholder notice / warning toast
+   (not success, not silent fail).
+6. **T5 — gzip** (when UI accepts): `.gz` COLLECT or bulletin inflates then matches T2/T4.
+7. **T6 — Read-only**: Finished/read-only session → mode buttons disabled.
+
+**Acceptance**:
+
+1. Mode toggle + helper copy visible; disabled when session read-only
+2. TAC Auto-detect convert happy path
+3. AHL path uses `/convert-bulletin` with summary/results
+4. COLLECT path uses `/ingest-collect` and treats **501** as placeholder UX
+5. Auto-switch on paste/upload works (T3)
+6. Playwright T1–T4 green (T2/T3); Vitest anchors remain green; staging H4–H5 + AHL + COLLECT
+   501 (13-deploy-smoke)
+7. Gaps vs H7 (API-only UJ-011) documented; defects filed as separate bugs linked from #730
+
+**Automated tests**: Vitest (`inputKind`, `api` 501, `FileConverter` mode group); Playwright
+`apps/e2e/` (TC-F7-007); live H6′ / staging smoke. **Tier: T2 / T3 / H6′**.
+
+---
+
 ## Operations Journeys
 
 ### UJ-OPS-001: Deploy Render stack (API + static + F8 worker)
@@ -677,4 +723,5 @@ live smoke (T7.4) when scheduled.
   Implemented note; admin journeys retired via UJ-019
 - S014 / EV-010 (2026-07-18): UJ-022/023 + UJ-DEV-005 (F11–F14 msgspec HTTP + PyPI)
 - S015 / EV-011 (2026-07-19): UJ-024 METAR/**SPECI** lint registry + convert→validate golden
+- S016 / EV-012 (2026-07-20): UJ-025 Manual TAC Input modes (ADR-024 / #730)
   (F15 / #732; SPECI adjacency explicit; catalog via `GET /lint-issue-catalog` E11-31)

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-012
   branch: evolve/EV-012-manual-tac-input-modes
   artifacts_dir: docs/sessions/S016-manual-tac-input-modes
-  current_stage: 02-verify-plan
+  current_stage: 10-e2e
   context_briefs:
     - docs/context/manual-tac-input-modes.md
   standing_docs_touched:
@@ -39,7 +39,7 @@ active_session:
       mode: orchestrator
       status: in_progress
       started: '2026-07-20'
-      note: EV-012 Phase 0 complete; 01-requirements completed; current_stage 02-verify-plan
+      note: EV-012 Phase A complete; 02-verify-plan completed; current_stage 10-e2e (pending)
     - stage: 01-requirements
       required: true
       mode: delta
@@ -50,7 +50,10 @@ active_session:
     - stage: 02-verify-plan
       required: true
       mode: delta
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
+      note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
     - stage: 10-e2e
       required: true
       mode: delta
@@ -4896,6 +4899,28 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
+    type: report
+    kind: verify-plan-audit
+    stage: 02-verify-plan
+    skill_id: 02-verify-plan
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
+  - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
+    type: checkpoint
+    kind: phase-a-complete
+    stage: 02-verify-plan
+    skill_id: 02-verify-plan
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: Phase A complete (lean; gates.a_to_b remains waived)
   - path: docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
     type: report
     kind: requirements-report
@@ -6124,9 +6149,11 @@ evolve_cycles:
         - 09-qa
         - 11-verify-impl
         - 12-verify-deploy
-    current_stage: 02-verify-plan
+    current_stage: 10-e2e
     notes:
-      - 2026-07-20 S016/EV-012 01-requirements COMPLETE — UJ-025 + TC-F7-007; handoff to 02-verify-plan (pending)
+      - 2026-07-20 S016/EV-012 02-verify-plan COMPLETE — PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete; handoff 10-e2e (pending); gates.a_to_b remains waived
+      - 2026-07-20 S016/EV-012 02-verify-plan STARTED (in_progress)
+      - 2026-07-20 S016/EV-012 01-requirements COMPLETE — UJ-025 + TC-F7-007; handoff to 02-verify-plan
       - 2026-07-20 S016/EV-012 01-requirements started (in_progress)
       - 2026-07-20 S016/EV-012 Phase 0 locked; lean+13 routing approved (D-S016-EV012-route-1)
     stages:
@@ -6148,7 +6175,10 @@ evolve_cycles:
         completed: '2026-07-20'
         note: UJ-025 + TC-F7-007
       02-verify-plan:
-        status: pending
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
       10-e2e:
         status: pending
       13-deploy-smoke:
@@ -6159,7 +6189,7 @@ evolve_cycles:
       c_to_d: waived
       deploy: pending
     checkpoints:
-      phase_a: pending
+      phase_a: passed
       phase_b: waived
       phase_c: waived
       phase_d: pending
@@ -6178,6 +6208,10 @@ evolve_cycles:
       - path: docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
         status: completed
       - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
         status: completed
       - path: docs/decisions/evolve-decisions.md
         status: in_progress
@@ -8339,6 +8373,10 @@ git_history:
   pending_commit:
   notes:
     - >-
+      2026-07-20 S016/EV-012 git — recorded eab76dbd9876f0c57041aa7ab9d4adfaaf9e3d88
+      (eab76db) chore(S016): record EV-012 01-requirements completion in workflow-state;
+      01-requirements; local tip on evolve/EV-012-manual-tac-input-modes
+    - >-
       2026-07-20 S016/EV-012 git — recorded 143670ac6d6e912aa16c8ea175a3e04e4695fb64
       (143670a) docs(S016): add UJ-025 and TC-F7-007 for Manual TAC Input modes;
       01-requirements; local tip on evolve/EV-012-manual-tac-input-modes; not pushed
@@ -8713,6 +8751,16 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: eab76db
+      short: eab76db
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'chore(S016): record EV-012 01-requirements completion in workflow-state'
+      stage: 01-requirements
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - workflow-state.yaml
+      timestamp: '2026-07-20'
     - sha: 143670a
       short: 143670a
       branch: evolve/EV-012-manual-tac-input-modes

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -8413,6 +8413,10 @@ git_history:
   pending_commit:
   notes:
     - >-
+      2026-07-20 S016/EV-012 git — recorded 7e052f43c0725fe590da50c455bb393281e0af98
+      (7e052f4) test(S016): add TC-F7-007 Playwright suite for Manual TAC Input modes;
+      10-e2e; local tip on evolve/EV-012-manual-tac-input-modes; not pushed
+    - >-
       2026-07-20 S016/EV-012 git — recorded eab76dbd9876f0c57041aa7ab9d4adfaaf9e3d88
       (eab76db) chore(S016): record EV-012 01-requirements completion in workflow-state;
       01-requirements; local tip on evolve/EV-012-manual-tac-input-modes
@@ -8540,9 +8544,9 @@ git_history:
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      tip_sha: 8124163
+      tip_sha: 7e052f4
       note: >-
-        Branch active; tip 8124163 (02-verify-plan pass); not pushed
+        Branch active; tip 7e052f4 (10-e2e TC-F7-007 Playwright suite); not pushed
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main
@@ -8791,6 +8795,21 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 7e052f4
+      short: 7e052f4
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'test(S016): add TC-F7-007 Playwright suite for Manual TAC Input modes'
+      stage: 10-e2e
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - README.md
+        - apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts
+        - apps/frontend/src/app/components/FileConverter.tsx
+        - docs/decisions/evolve-decisions.md
+        - docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
+        - workflow-state.yaml
+      timestamp: '2026-07-20T15:37:28Z'
     - sha: 8124163
       short: 8124163
       branch: evolve/EV-012-manual-tac-input-modes

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,11 +1,58 @@
-overall_status: completed
+overall_status: in_progress
 project:
   name: metar-to-IWXXM
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 15
-active_session: null
+session_counter: 16
+active_session:
+  id: S016-manual-tac-input-modes
+  type: feature
+  status: in_progress
+  started_at: '2026-07-20'
+  intent: 'Validate Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per GitHub #730 / ADR-024; Playwright T1–T4 + Vitest + staging smoke; COLLECT stays 501; F7 stays Planned'
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-012
+  branch: evolve/EV-012-manual-tac-input-modes
+  artifacts_dir: docs/sessions/S016-manual-tac-input-modes
+  context_briefs:
+    - docs/context/manual-tac-input-modes.md
+  standing_docs_touched:
+    - docs/decisions/evolve-decisions.md
+    - docs/context/manual-tac-input-modes.md
+    - docs/sessions/S016-manual-tac-input-modes/session-brief.md
+  routing_plan:
+    - stage: 00-context
+      required: true
+      mode: scoped
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
+      note: Phase 0 intake locked; routing lean+13 approved (D-S016-EV012-route-1)
+    - stage: 16-evolve
+      required: true
+      mode: orchestrator
+      status: in_progress
+      started: '2026-07-20'
+      note: EV-012 Phase 0 complete; next 01-requirements delta
+    - stage: 01-requirements
+      required: true
+      mode: delta
+      status: pending
+    - stage: 02-verify-plan
+      required: true
+      mode: delta
+      status: pending
+    - stage: 10-e2e
+      required: true
+      mode: delta
+      status: pending
+      note: Author + run Playwright T1–T4; Vitest gap check
+    - stage: 13-deploy-smoke
+      required: true
+      mode: full
+      status: pending
+      note: H4–H5 + authenticated AHL + COLLECT 501
 sessions:
 
   - id: S015-metar-lint-quality
@@ -990,10 +1037,10 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: empty-bearer-lint-tac
-    session_id: S012-empty-bearer-lint-tac
-    started_at: "2026-07-15"
-    completed_at: "2026-07-15"
+    scoped_slug: manual-tac-input-modes
+    session_id: S016-manual-tac-input-modes
+    started_at: "2026-07-20"
+    completed_at: "2026-07-20"
     substeps:
       phase0: completed
       phase1a: completed
@@ -1013,7 +1060,11 @@ stages:
       - docs/sessions/S015-metar-lint-quality/routing-plan.md
       - docs/context/metar-lint-quality.md
       - docs/decisions/evolve-decisions.md
+      - docs/sessions/S016-manual-tac-input-modes/session-brief.md
+      - docs/sessions/S016-manual-tac-input-modes/routing-plan.md
+      - docs/context/manual-tac-input-modes.md
     notes:
+      - 2026-07-20 S016/EV-012 00-context completed — Phase 0 intake locked; lean+13 routing approved (D-S016-EV012-route-1); handoff to 01-requirements
       - "2026-07-19 S015/EV-011 00-context completed — routing approved (D-S015-EV011-route-1); max expansion scope (D-S015-EV011-research-1); handoff to 01-requirements"
       - "2026-07-19 S015/EV-011 open — scoped_slug metar-lint-quality; Phase 0 intake locked; routing approval pending; S011 session-brief.md updated on disk to completed"
       - "2026-07-15 S012-empty-bearer-lint-tac open — scoped hotfix empty Bearer lint-tac/decode-tac + lint UX; S011/EV-008 paused (PR #716 remains open)"
@@ -2531,6 +2582,66 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S016-EV012-route-1
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 00-context
+    skill: 00-context
+    skill_id: 00-context
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: Approve reconciled lean+13 routing (00 → 16 → 01 → 02 → 10 → 13)
+    summary: 'Routing approved: required 00-context, 16-evolve, 01-requirements (delta), 02-verify-plan (delta), 10-e2e (delta), 13-deploy-smoke (full). Skip 03–09, 11–12. Gates a_to_b/b_to_c/c_to_d waived (no Phase B/C).'
+  - id: D-S016-EV012-intake-4
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 00-context
+    skill: 00-context
+    skill_id: 00-context
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: Include 13-deploy-smoke in routing (H4–H5 + AHL + COLLECT 501)
+    summary: 'Lean product/tech path still requires full 13-deploy-smoke: browser H4–H5, authenticated AHL happy path, and COLLECT 501 UX on staging.'
+  - id: D-S016-EV012-intake-3
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 00-context
+    skill: 00-context
+    skill_id: 00-context
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: Auto-switch between Manual TAC Input modes is required
+    summary: FileConverter must auto-switch mode detection among TAC report / AHL bulletin / IWXXM COLLECT per ADR-024; tests must assert auto-switch behavior.
+  - id: D-S016-EV012-intake-2
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 00-context
+    skill: 00-context
+    skill_id: 00-context
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: All tests required — Vitest anchors + Playwright T1–T4 + live staging smoke
+    summary: Acceptance coverage includes unit/Vitest gap check, Playwright T1–T4 for Manual TAC Input modes, and live staging H4–H5 plus authenticated AHL happy path and COLLECT 501 UX.
+  - id: D-S016-EV012-intake-1
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 00-context
+    skill: 00-context
+    skill_id: 00-context
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: Cycle type A under F7 — validation/acceptance only; no new Fn; COLLECT stays 501
+    summary: EV-012 is a general validation cycle under F7/ADR-024 Manual TAC Input modes. No new feature id; COLLECT member extract out of scope and endpoint remains 501; F7 stays Planned.
   - id: D-S015-EV011-phase4-close-1
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2752,7 +2863,9 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: >-
-      Milestone structure: M1 registry+CI+catalog stub; M2 migrate codes; M3 R1–R5(+R8 capacity); M4 goldens R6 + SPECI R7; M5 coverage/smoke/verify-deploy. Kill-switch → deferred row + coverage note (E11-16). Superseded for R themes by E11-23 / D-S015-EV011-04-qual-1 (HARD).
+      Milestone structure: M1 registry+CI+catalog stub; M2 migrate codes; M3 R1–R5(+R8 capacity); M4 goldens R6 + SPECI R7;
+      M5 coverage/smoke/verify-deploy. Kill-switch → deferred row + coverage note (E11-16). Superseded for R themes by E11-23
+      / D-S015-EV011-04-qual-1 (HARD).
   - id: D-S015-EV011-04-arch-2
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -2764,7 +2877,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: >-
-      Registry API: packages/tac-validate issue_registry.py with frozen IssueSpec + ISSUES/by_code(); rules emit via registry helpers (no severity literals).
+      Registry API: packages/tac-validate issue_registry.py with frozen IssueSpec + ISSUES/by_code(); rules emit via registry
+      helpers (no severity literals).
   - id: D-S015-EV011-04-arch-3
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -5951,6 +6065,89 @@ artifacts:
     status: complete
 
 evolve_cycles:
+  - id: EV-012
+    session_id: S016-manual-tac-input-modes
+    cycle_type: general  # validation/acceptance under F7, no new Fn
+    feature_ids:
+      - F7
+    feature_id:
+    title: Validate Manual TAC Input modes (#730)
+    status: in_progress
+    started: '2026-07-20'
+    completed:
+    scope_summary: "Test/acceptance under F7/ADR-024 for FileConverter Manual TAC Input modes\n(TAC report / AHL bulletin / IWXXM COLLECT). Playwright T1–T4 + Vitest anchors\n+ staging H4–H5 + AHL happy path + COLLECT 501 UX. Auto-switch required.\nNo new Fn; COLLECT member extract out of scope; F7 remains Planned.\n"
+    github_issue: 730
+    routing_plan:
+      required_stages:
+        - 00-context
+        - 16-evolve
+        - 01-requirements
+        - 02-verify-plan
+        - 10-e2e
+        - 13-deploy-smoke
+      skipped_stages:
+        - 03-plan-tooling
+        - 04-tech-plan
+        - 05-verify-tech
+        - 06-tech-tooling
+        - 07-build
+        - 08-verify-build
+        - 09-qa
+        - 11-verify-impl
+        - 12-verify-deploy
+    current_stage: 01-requirements  # pending until user approves start
+    notes:
+      - 2026-07-20 S016/EV-012 Phase 0 locked; lean+13 routing approved; awaiting user approval to start 01-requirements
+    stages:
+      00-context:
+        status: completed
+        mode: scoped
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        substeps:
+          phase0: locked
+        note: Phase 0 locked; routing lean+13 approved (D-S016-EV012-route-1)
+      16-evolve:
+        status: in_progress
+        started: '2026-07-20'
+        completed:
+      01-requirements:
+        status: pending  # pending until user approves start
+        started:
+        completed:
+      02-verify-plan:
+        status: pending
+      10-e2e:
+        status: pending
+      13-deploy-smoke:
+        status: pending
+    gates:
+      a_to_b: waived  # lean: no Phase B tech stages
+      b_to_c: waived # lean: no 07 build phase
+      c_to_d: waived
+      deploy: pending
+    checkpoints:
+      phase_a: pending
+      phase_b: waived
+      phase_c: waived
+      phase_d: pending
+      deploy: pending
+    adrs:
+      - docs/adr/ADR-024-operator-input-modes.md
+    artifacts:
+      - path: docs/sessions/S016-manual-tac-input-modes/session-brief.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/routing-plan.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-0.md
+        status: completed
+      - path: docs/context/manual-tac-input-modes.md
+        status: completed
+      - path: docs/decisions/evolve-decisions.md
+        status: in_progress
+      - path: docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
+        status: pending
+    issues: []
   - id: EV-011
     session_id: S015-metar-lint-quality
     cycle_type: feature
@@ -8105,6 +8302,7 @@ git_history:
   pushed: false
   pending_commit:
   notes:
+    - 2026-07-20 S016/EV-012 open — branch evolve/EV-012-manual-tac-input-modes recorded active (base main); Phase 0 complete; lean+13 routing approved
     - '2026-07-20 S015/EV-011 — PR #742 merged b405a96; T5.10 deploy-smoke PASS; docs a73bbe0 on docs/EV-011-deploy-smoke; EV-011 open pending Phase D close'
     - >-
       2026-07-20 S015/EV-011 M1 complete — commits e0189d4/ac0a282/a1abc7c/79aa67c
@@ -8217,6 +8415,14 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: evolve/EV-012-manual-tac-input-modes
+      purpose: EV-012 / S016 Validate Manual TAC Input modes (#730 / ADR-024 under F7)
+      base: main
+      status: active
+      created_at: '2026-07-20'
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      note: Branch recorded active; parent creates git branch
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,12 +15,17 @@ active_session:
   evolve_cycle_id: EV-012
   branch: evolve/EV-012-manual-tac-input-modes
   artifacts_dir: docs/sessions/S016-manual-tac-input-modes
+  current_stage: 02-verify-plan
   context_briefs:
     - docs/context/manual-tac-input-modes.md
   standing_docs_touched:
     - docs/decisions/evolve-decisions.md
     - docs/context/manual-tac-input-modes.md
     - docs/sessions/S016-manual-tac-input-modes/session-brief.md
+    - docs/user-journeys.md
+    - docs/test-plan.md
+    - docs/feature-list.md
+    - docs/spec.md
   routing_plan:
     - stage: 00-context
       required: true
@@ -34,11 +39,14 @@ active_session:
       mode: orchestrator
       status: in_progress
       started: '2026-07-20'
-      note: EV-012 Phase 0 complete; next 01-requirements delta
+      note: EV-012 Phase 0 complete; 01-requirements completed; current_stage 02-verify-plan
     - stage: 01-requirements
       required: true
       mode: delta
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
+      note: UJ-025 + TC-F7-007
     - stage: 02-verify-plan
       required: true
       mode: delta
@@ -4888,6 +4896,27 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
+    type: report
+    kind: requirements-report
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: UJ-025 + TC-F7-007
+  - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
+    type: checkpoint
+    kind: phase-a
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
   - path: docs/sessions/S015-metar-lint-quality/reports/evolve-summary.md
     type: report
     kind: evolve-summary
@@ -6095,9 +6124,11 @@ evolve_cycles:
         - 09-qa
         - 11-verify-impl
         - 12-verify-deploy
-    current_stage: 01-requirements  # pending until user approves start
+    current_stage: 02-verify-plan
     notes:
-      - 2026-07-20 S016/EV-012 Phase 0 locked; lean+13 routing approved; awaiting user approval to start 01-requirements
+      - 2026-07-20 S016/EV-012 01-requirements COMPLETE — UJ-025 + TC-F7-007; handoff to 02-verify-plan (pending)
+      - 2026-07-20 S016/EV-012 01-requirements started (in_progress)
+      - 2026-07-20 S016/EV-012 Phase 0 locked; lean+13 routing approved (D-S016-EV012-route-1)
     stages:
       00-context:
         status: completed
@@ -6112,9 +6143,10 @@ evolve_cycles:
         started: '2026-07-20'
         completed:
       01-requirements:
-        status: pending  # pending until user approves start
-        started:
-        completed:
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: UJ-025 + TC-F7-007
       02-verify-plan:
         status: pending
       10-e2e:
@@ -6142,6 +6174,10 @@ evolve_cycles:
       - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-0.md
         status: completed
       - path: docs/context/manual-tac-input-modes.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
         status: completed
       - path: docs/decisions/evolve-decisions.md
         status: in_progress
@@ -8297,11 +8333,15 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: docs/EV-011-deploy-smoke
+  current_branch: evolve/EV-012-manual-tac-input-modes
   ahead_of_origin: 0
   pushed: false
   pending_commit:
   notes:
+    - >-
+      2026-07-20 S016/EV-012 git — recorded 143670ac6d6e912aa16c8ea175a3e04e4695fb64
+      (143670a) docs(S016): add UJ-025 and TC-F7-007 for Manual TAC Input modes;
+      01-requirements; local tip on evolve/EV-012-manual-tac-input-modes; not pushed
     - 2026-07-20 S016/EV-012 open — branch evolve/EV-012-manual-tac-input-modes recorded active (base main); Phase 0 complete; lean+13 routing approved
     - '2026-07-20 S015/EV-011 — PR #742 merged b405a96; T5.10 deploy-smoke PASS; docs a73bbe0 on docs/EV-011-deploy-smoke; EV-011 open pending Phase D close'
     - >-
@@ -8422,7 +8462,9 @@ git_history:
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      note: Branch recorded active; parent creates git branch
+      tip_sha: 143670a
+      note: >-
+        Branch active; tip 143670a (01-requirements UJ-025 / TC-F7-007); not pushed
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main
@@ -8671,6 +8713,39 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 143670a
+      short: 143670a
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'docs(S016): add UJ-025 and TC-F7-007 for Manual TAC Input modes'
+      stage: 01-requirements
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - docs/user-journeys.md
+        - docs/test-plan.md
+        - docs/feature-list.md
+        - docs/spec.md
+        - docs/decisions/evolve-decisions.md
+        - docs/sessions/S016-manual-tac-input-modes/reports/01-requirements.md
+        - docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a.md
+      timestamp: '2026-07-20'
+    - sha: aedb4ae
+      short: aedb4ae
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'docs(S016): open EV-012 for Manual TAC Input mode validation (#730)'
+      stage: 00-context
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - docs/context/README.md
+        - docs/context/manual-tac-input-modes.md
+        - docs/decisions/evolve-decisions.md
+        - docs/sessions/README.md
+        - docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-0.md
+        - docs/sessions/S016-manual-tac-input-modes/routing-plan.md
+        - docs/sessions/S016-manual-tac-input-modes/session-brief.md
+        - workflow-state.yaml
+      timestamp: '2026-07-20'
     - sha: a73bbe0
       short: a73bbe0
       branch: docs/EV-011-deploy-smoke

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -39,7 +39,9 @@ active_session:
       mode: orchestrator
       status: in_progress
       started: '2026-07-20'
-      note: EV-012 Phase A complete; 10-e2e completed; 13-deploy-smoke pending
+      note: >-
+        EV-012 Phase A+10 complete; path A (D-S016-EV012-13-path-A) — PR #746 open;
+        13-deploy-smoke in_progress blocked on merge+Render deploy before live H4–H5
     - stage: 01-requirements
       required: true
       mode: delta
@@ -64,8 +66,11 @@ active_session:
     - stage: 13-deploy-smoke
       required: true
       mode: full
-      status: pending
-      note: H4–H5 + authenticated AHL + COLLECT 501
+      status: in_progress
+      started: '2026-07-20'
+      note: >-
+        PR #746 opened (path A); blocked on merge+Render deploy before live H4–H5 +
+        authenticated AHL + COLLECT 501
 sessions:
 
   - id: S015-metar-lint-quality
@@ -2447,9 +2452,15 @@ stages:
       - id: S016-manual-tac-input-modes
         session_id: S016-manual-tac-input-modes
         evolve_cycle_id: EV-012
-        status: pending
+        status: in_progress
+        started_at: '2026-07-20'
         mode: full
-        note: H4–H5 + authenticated AHL + COLLECT 501
+        note: >-
+          PR #746 opened (D-S016-EV012-13-path-A); blocked on merge+Render deploy before
+          live H4–H5 + authenticated AHL + COLLECT 501
+        pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
+        pr_number: 746
+        pr_id: PR-EV-012
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
         evolve_cycle_id: EV-011
@@ -2480,6 +2491,9 @@ stages:
         report: docs/sessions/S014-package-publish-validation/reports/deploy-smoke.md
         hard_gates_report: docs/sessions/S014-package-publish-validation/reports/t66-hard-publish-gates.md
     notes:
+      - >-
+        2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — PR #746 open;
+        path A (D-S016-EV012-13-path-A); blocked on merge+Render deploy before live H4–H5
       - 2026-07-20 S016/EV-012 13-deploy-smoke pending (current_stage after 10-e2e PASS)
       - 2026-07-20 S015/EV-011 13-deploy-smoke completed — T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 35 issues
       - >-
@@ -2613,6 +2627,21 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S016-EV012-13-path-A
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 13-deploy-smoke
+    skill: 13-deploy-smoke
+    skill_id: 13-deploy-smoke
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    decision: >-
+      Path A — push branch + open PR, then run 13-deploy-smoke staging after merge/deploy
+    summary: >-
+      User chose push+PR (#746) then live H4–H5 / AHL / COLLECT 501 smoke after merge and
+      Render deploy. 13-deploy-smoke started in_progress; not completed until post-deploy gates pass.
   - id: D-S016-EV012-route-1
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -6182,6 +6211,10 @@ evolve_cycles:
         - 12-verify-deploy
     current_stage: 13-deploy-smoke
     notes:
+      - >-
+        2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — path A
+        (D-S016-EV012-13-path-A); branch pushed; PR #746 open; blocked on merge+Render
+        deploy before live H4–H5; checkpoints.phase_d / gates.deploy remain pending
       - 2026-07-20 S016/EV-012 10-e2e COMPLETE — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; handoff 13-deploy-smoke (pending); checkpoints.phase_d remains pending until 13
       - 2026-07-20 S016/EV-012 10-e2e STARTED (in_progress)
       - 2026-07-20 S016/EV-012 02-verify-plan COMPLETE — PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete; handoff 10-e2e (pending); gates.a_to_b remains waived
@@ -6202,6 +6235,9 @@ evolve_cycles:
         status: in_progress
         started: '2026-07-20'
         completed:
+        note: >-
+          Path A (D-S016-EV012-13-path-A) — PR #746 open; 13-deploy-smoke in_progress
+          blocked on merge+Render deploy
       01-requirements:
         status: completed
         started: '2026-07-20'
@@ -6220,7 +6256,14 @@ evolve_cycles:
         note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
         report: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
       13-deploy-smoke:
-        status: pending
+        status: in_progress
+        started: '2026-07-20'
+        mode: full
+        note: >-
+          PR #746 opened (path A); blocked on merge+Render deploy before live H4–H5
+        pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
+        pr_number: 746
+        pr_id: PR-EV-012
     gates:
       a_to_b: waived  # lean: no Phase B tech stages
       b_to_c: waived # lean: no 07 build phase
@@ -8409,9 +8452,17 @@ evolve_cycles:
 git_history:
   current_branch: evolve/EV-012-manual-tac-input-modes
   ahead_of_origin: 0
-  pushed: false
+  pushed: true
   pending_commit:
   notes:
+    - >-
+      2026-07-20 S016/EV-012 git — branch evolve/EV-012-manual-tac-input-modes pushed to
+      origin; PR-EV-012=#746 open https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
+      (path A / D-S016-EV012-13-path-A); 13-deploy-smoke in_progress blocked on merge+deploy
+    - >-
+      2026-07-20 S016/EV-012 git — recorded 0b56fd13910e6314f4b4a7b462c406d9112c7829
+      (0b56fd1) chore(S016): record 10-e2e completion in workflow-state; tip pushed with
+      branch to origin ahead of this chore commit
     - >-
       2026-07-20 S016/EV-012 git — recorded 7e052f43c0725fe590da50c455bb393281e0af98
       (7e052f4) test(S016): add TC-F7-007 Playwright suite for Manual TAC Input modes;
@@ -8544,9 +8595,14 @@ git_history:
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      tip_sha: 7e052f4
+      tip_sha: 0b56fd1
+      pushed: true
+      pr_id: PR-EV-012
+      pr_number: 746
+      pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
       note: >-
-        Branch active; tip 7e052f4 (10-e2e TC-F7-007 Playwright suite); not pushed
+        Branch pushed to origin; PR #746 open (path A); tip 0b56fd1 pre 13-start chore;
+        13-deploy-smoke in_progress blocked on merge+Render deploy
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main
@@ -8795,6 +8851,17 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 0b56fd1
+      short: 0b56fd1
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'chore(S016): record 10-e2e completion in workflow-state'
+      stage: 10-e2e
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - workflow-state.yaml
+      timestamp: '2026-07-20'
+      pushed: true
     - sha: 7e052f4
       short: 7e052f4
       branch: evolve/EV-012-manual-tac-input-modes
@@ -8810,6 +8877,7 @@ git_history:
         - docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
         - workflow-state.yaml
       timestamp: '2026-07-20T15:37:28Z'
+      pushed: true
     - sha: 8124163
       short: 8124163
       branch: evolve/EV-012-manual-tac-input-modes

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -8500,9 +8500,9 @@ git_history:
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      tip_sha: 143670a
+      tip_sha: 8124163
       note: >-
-        Branch active; tip 143670a (01-requirements UJ-025 / TC-F7-007); not pushed
+        Branch active; tip 8124163 (02-verify-plan pass); not pushed
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main
@@ -8751,6 +8751,23 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 8124163
+      short: 8124163
+      branch: evolve/EV-012-manual-tac-input-modes
+      message: 'docs(S016): pass 02-verify-plan for Manual TAC Input modes'
+      stage: 02-verify-plan
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - docs/context/manual-tac-input-modes.md
+        - docs/decisions/evolve-decisions.md
+        - docs/feature-list.md
+        - docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
+        - docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
+        - docs/test-plan.md
+        - docs/user-journeys.md
+        - workflow-state.yaml
+      timestamp: '2026-07-20'
     - sha: eab76db
       short: eab76db
       branch: evolve/EV-012-manual-tac-input-modes

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-012
   branch: evolve/EV-012-manual-tac-input-modes
   artifacts_dir: docs/sessions/S016-manual-tac-input-modes
-  current_stage: 10-e2e
+  current_stage: 13-deploy-smoke
   context_briefs:
     - docs/context/manual-tac-input-modes.md
   standing_docs_touched:
@@ -39,7 +39,7 @@ active_session:
       mode: orchestrator
       status: in_progress
       started: '2026-07-20'
-      note: EV-012 Phase A complete; 02-verify-plan completed; current_stage 10-e2e (pending)
+      note: EV-012 Phase A complete; 10-e2e completed; 13-deploy-smoke pending
     - stage: 01-requirements
       required: true
       mode: delta
@@ -57,8 +57,10 @@ active_session:
     - stage: 10-e2e
       required: true
       mode: delta
-      status: pending
-      note: Author + run Playwright T1–T4; Vitest gap check
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
+      note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
     - stage: 13-deploy-smoke
       required: true
       mode: full
@@ -2188,6 +2190,16 @@ stages:
         status: completed
         notes: "H3 13 pass 8 skip (legacy Supabase keys); T3 browser deferred"
     delta_substages:
+      - id: S016-manual-tac-input-modes
+        session_id: S016-manual-tac-input-modes
+        evolve_cycle_id: EV-012
+        status: completed
+        started_at: '2026-07-20'
+        completed_at: '2026-07-20'
+        mode: delta
+        overall: pass
+        report: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
+        note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
         evolve_cycle_id: EV-011
@@ -2231,6 +2243,7 @@ stages:
         report: docs/sessions/S011-f7-operator-ui/reports/e2e-report.md
         note: "T6.2 pass_with_advisories; Playwright/compose SKIPPED host ports/disk"
     notes:
+      - 2026-07-20 S016/EV-012 10-e2e completed — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; next 13-deploy-smoke (pending)
       - 2026-07-20 S015/EV-011 10-e2e completed — PASS — e2e-report.md; UJ-024 catalog smoke
       - "2026-07-19 S014/EV-010 10-e2e completed — UJ-022/023/DEV-005 T0+local API PASS; T3/H6′→13; see e2e-report.md"
       - "2026-07-19 S014/EV-010 10-e2e in_progress (T6.2; D-S014-EV010-c-to-d-pass)"
@@ -2431,6 +2444,12 @@ stages:
     completed_at: "2026-07-19"
     session_id: S014-package-publish-validation
     delta_substages:
+      - id: S016-manual-tac-input-modes
+        session_id: S016-manual-tac-input-modes
+        evolve_cycle_id: EV-012
+        status: pending
+        mode: full
+        note: H4–H5 + authenticated AHL + COLLECT 501
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
         evolve_cycle_id: EV-011
@@ -2461,6 +2480,7 @@ stages:
         report: docs/sessions/S014-package-publish-validation/reports/deploy-smoke.md
         hard_gates_report: docs/sessions/S014-package-publish-validation/reports/t66-hard-publish-gates.md
     notes:
+      - 2026-07-20 S016/EV-012 13-deploy-smoke pending (current_stage after 10-e2e PASS)
       - 2026-07-20 S015/EV-011 13-deploy-smoke completed — T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 35 issues
       - >-
         2026-07-19 S014/EV-010 13-deploy-smoke completed (D-S014-EV010-t66-close-2) —
@@ -4899,6 +4919,17 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
+    type: report
+    kind: e2e-report
+    stage: 10-e2e
+    skill_id: 10-e2e
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    note: PASS TC-F7-007 T1-T6 + Vitest
   - path: docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
     type: report
     kind: verify-plan-audit
@@ -6149,8 +6180,10 @@ evolve_cycles:
         - 09-qa
         - 11-verify-impl
         - 12-verify-deploy
-    current_stage: 10-e2e
+    current_stage: 13-deploy-smoke
     notes:
+      - 2026-07-20 S016/EV-012 10-e2e COMPLETE — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; handoff 13-deploy-smoke (pending); checkpoints.phase_d remains pending until 13
+      - 2026-07-20 S016/EV-012 10-e2e STARTED (in_progress)
       - 2026-07-20 S016/EV-012 02-verify-plan COMPLETE — PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete; handoff 10-e2e (pending); gates.a_to_b remains waived
       - 2026-07-20 S016/EV-012 02-verify-plan STARTED (in_progress)
       - 2026-07-20 S016/EV-012 01-requirements COMPLETE — UJ-025 + TC-F7-007; handoff to 02-verify-plan
@@ -6180,7 +6213,12 @@ evolve_cycles:
         completed: '2026-07-20'
         note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
       10-e2e:
-        status: pending
+        status: completed
+        mode: delta
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
+        report: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
       13-deploy-smoke:
         status: pending
     gates:
@@ -6212,6 +6250,8 @@ evolve_cycles:
       - path: docs/sessions/S016-manual-tac-input-modes/reports/02-verify-plan-audit.md
         status: completed
       - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
         status: completed
       - path: docs/decisions/evolve-decisions.md
         status: in_progress


### PR DESCRIPTION
## Summary
- Validates Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per GitHub #730 / ADR-024 under F7 (F7 stays Planned; COLLECT remains 501).
- Adds Playwright suite `apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts` (TC-F7-007 T1–T6) — all green locally at `7e052f4`.
- Small FE fixes in `FileConverter.tsx`: convert-time auto-switch toast; classify COLLECT after `.gz` inflate.
- Spec deltas: UJ-025, TC-F7-007, session artifacts under `docs/sessions/S016-manual-tac-input-modes/`.

## Test plan
- [x] Local Playwright TC-F7-007 T1–T6 PASS
- [x] Vitest anchors (`inputKind`, `api` bulletin/501, `FileConverter`) PASS
- [ ] CI green on this PR (`ci.yml`)
- [ ] After merge + Render deploy: **13-deploy-smoke** — H4–H5 (`make test-live-connectivity`) + authenticated AHL happy path + COLLECT 501 UX on staging

## Notes
- Lean evolve routing: 00 → 16 → 01 → 02 → 10 → **13** (07–12 skipped by D-S016-EV012-route-1).
- Do not merge until CI is green; staging smoke runs post-deploy.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Validate and document Manual TAC Input modes under F7, adding end-to-end coverage and minor frontend UX tweaks while wiring the new S016/EV-012 evolve cycle into the workflow metadata.

New Features:
- Introduce Playwright end-to-end suite TC-F7-007 for Manual TAC Input modes covering TAC, AHL bulletin, COLLECT, gzip, and read-only session behavior.
- Add operator-facing auto-switch feedback to the Manual TAC Input UI when pasted content is detected as AHL bulletin or IWXXM COLLECT.

Bug Fixes:
- Ensure gzip-uploaded IWXXM COLLECT files are classified by decompressed display name and content rather than raw .gz type to avoid mis-detecting the input kind.

Enhancements:
- Formalize F7 Manual TAC Input validation scope as UJ-025 and tie it into the feature list, spec, and F7 validation gate without changing F7 status.
- Refine FileConverter mode-handling UX to surface COLLECT 501 as a clear placeholder notice and prevent silent fall-through from AHL to single-report convert.

Documentation:
- Add new context, session briefs, requirements, verify-plan audit, routing plan, and e2e report documentation for S016/EV-012 Manual TAC Input modes.
- Extend user journeys and test plan docs with UJ-025, TC-F7-007, and an explicit F7 input-modes validation gate, including H6′/13-deploy-smoke expectations.

Tests:
- Add a dedicated Playwright e2e spec for F7 Manual TAC Input modes (TC-F7-007 T1–T6) and record its inclusion in the test plan and README E2E badge.
- Clarify Vitest anchor coverage for input kind detection, bulletin and COLLECT 501 handling, and FileConverter mode group behavior as part of the F7 validation gate.

Chores:
- Register the new S016/EV-012 session and EV-012 evolve cycle in workflow-state, including routing, checkpoints, artifacts, and git history metadata, and mark S015/EV-011 as completed.