### PR TITLE
[S016] docs: 13-deploy-smoke PASS for Manual TAC Input modes

### DIFF
--- a/docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
+++ b/docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
@@ -1,0 +1,61 @@
+# Deploy smoke — S016 / EV-012 (Manual TAC Input modes)
+
+> Date: 2026-07-20  
+> Status: **deployed** — 13-deploy-smoke PASS  
+> PR: [#746](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746) (merged `37be5f8`)  
+> Main tip: `37be5f8` → CI/CD run [`29766213356`](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29766213356) Deploy **SUCCESS**  
+> API: https://metar-to-iwxxm-api.onrender.com (`dep-d9f69f3bc2fs7397bqig` live, image `…/backend:20260720180925-37be5f8`)  
+> Frontend: https://metar-to-iwxxm-frontend-v4-web.onrender.com (`dep-d9f69fjbc2fs7397brq0` live, image `…/frontend:20260720180925-37be5f8`)
+
+## Pre-deploy
+
+| Check | Result |
+|-------|--------|
+| Routing | Lean + 13 (12-verify-deploy waived by D-S016-EV012-route-1) |
+| Merge approval | User: merge |
+| PR #746 CI | All required checks SUCCESS |
+| Merge → main | `37be5f8` |
+| Path A | Push + PR then smoke after deploy (D-S016-EV012-13-path-A) |
+
+## Smoke results
+
+| Tier | What | Result |
+|------|------|--------|
+| H0ci | CI/CD on `main` @ `37be5f8` (incl. Deploy) | **PASS** |
+| H1 | API `/health` (via H3 suite) | **PASS** |
+| H0c | CORS policy unit tests | **PASS** 6/6 |
+| H3 | `make test-live-api` | **PASS** 21/21 |
+| H4 | Live CORS preflight | **PASS** 2/2 |
+| H5 | Frontend `/config.json` → API | **PASS** |
+| UJ-025 AHL | Auth multipart `POST /convert-bulletin` (manual_text) | **PASS** 200, 2 reports |
+| UJ-025 COLLECT | Auth multipart `POST /ingest-collect` | **PASS** **501** placeholder |
+| H6′ workbench | Live Playwright: AHL summary + COLLECT placeholder notice/toast | **PASS** (~12s) |
+
+Commands:
+
+```bash
+make test-live-connectivity   # H0c + H4 + H5
+make test-live-api            # H3
+# AHL + COLLECT: authenticated multipart against LIVE_API_URL
+# Workbench: loginAndOpenConverter + input-mode-* testids (ephemeral live smoke)
+```
+
+## Notes
+
+- FE App chunk (`App-OwDZEakI.js`) contains Manual TAC Input mode strings (`AHL`, `COLLECT`, `placeholder-notice`).
+- `make test-live-bulletin` (H7 harness) still posts form field `file` (singular) and gets `empty_bulletin` 400; **not a regression of this PR** — UJ-025 AHL gate verified via `manual_text` multipart + live workbench instead.
+- F7 remains **Planned**; COLLECT stays 501 (no member extract).
+
+## Health
+
+- API + FE live on `37be5f8`
+- Mode toggle, convert-bulletin happy path, and COLLECT 501 UX confirmed on staging workbench
+
+## Rollback
+
+- Redeploy prior GHCR digests (`…-cad9502`) for API then frontend
+- Re-run `verify_connectivity.sh` + AHL/COLLECT probes
+
+## Verdict
+
+**13-deploy-smoke complete.** Manual TAC Input modes validation (UJ-025 / TC-F7-007) live on Render.

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -13,9 +13,9 @@ active_session:
   intent: 'Validate Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per GitHub #730 / ADR-024; Playwright T1–T4 + Vitest + staging smoke; COLLECT stays 501; F7 stays Planned'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-012
-  branch: evolve/EV-012-manual-tac-input-modes
+  branch: main
   artifacts_dir: docs/sessions/S016-manual-tac-input-modes
-  current_stage: 13-deploy-smoke
+  current_stage: phase-d-checkpoint
   context_briefs:
     - docs/context/manual-tac-input-modes.md
   standing_docs_touched:
@@ -40,8 +40,8 @@ active_session:
       status: in_progress
       started: '2026-07-20'
       note: >-
-        EV-012 Phase A+10 complete; path A (D-S016-EV012-13-path-A) — PR #746 open;
-        13-deploy-smoke in_progress blocked on merge+Render deploy before live H4–H5
+        EV-012 13-deploy-smoke COMPLETE/PASS; Phase D checkpoint pending user deploy
+        approval / Phase 4 close (D-S016-EV012-13-pass). Session remains open.
     - stage: 01-requirements
       required: true
       mode: delta
@@ -66,11 +66,17 @@ active_session:
     - stage: 13-deploy-smoke
       required: true
       mode: full
-      status: in_progress
+      status: completed
       started: '2026-07-20'
+      completed: '2026-07-20'
       note: >-
-        PR #746 opened (path A); blocked on merge+Render deploy before live H4–H5 +
-        authenticated AHL + COLLECT 501
+        13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD run 29766213356 SUCCESS
+        (incl. Deploy); Render LIVE API dep-d9f69f3bc2fs7397bqig + FE
+        dep-d9f69fjbc2fs7397brq0; images 20260720180925-37be5f8; H0c PASS, H3 21/21,
+        H4 2/2, H5 PASS, AHL convert-bulletin 200, COLLECT ingest-collect 501, live
+        Playwright workbench PASS; report
+        docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md; awaiting
+        user deploy approval / Phase 4 close (session stays open)
 sessions:
 
   - id: S015-metar-lint-quality
@@ -2452,12 +2458,16 @@ stages:
       - id: S016-manual-tac-input-modes
         session_id: S016-manual-tac-input-modes
         evolve_cycle_id: EV-012
-        status: in_progress
+        status: completed
         started_at: '2026-07-20'
+        completed_at: '2026-07-20'
         mode: full
         note: >-
-          PR #746 opened (D-S016-EV012-13-path-A); blocked on merge+Render deploy before
-          live H4–H5 + authenticated AHL + COLLECT 501
+          13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS;
+          Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 + Playwright PASS
+        report: docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
+        overall: pass
+        merge_sha: 37be5f877bd50d9ef1d1208e78f99c12ca59f092
         pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
         pr_number: 746
         pr_id: PR-EV-012
@@ -2491,6 +2501,10 @@ stages:
         report: docs/sessions/S014-package-publish-validation/reports/deploy-smoke.md
         hard_gates_report: docs/sessions/S014-package-publish-validation/reports/t66-hard-publish-gates.md
     notes:
+      - >-
+        2026-07-20 S016/EV-012 13-deploy-smoke COMPLETE / PASS — PR #746 merged 37be5f8;
+        CI/CD 29766213356 SUCCESS; Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 +
+        Playwright PASS; awaiting Phase 4 close
       - >-
         2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — PR #746 open;
         path A (D-S016-EV012-13-path-A); blocked on merge+Render deploy before live H4–H5
@@ -2547,19 +2561,19 @@ deployment:
   staging:
     status: deployed
     last_verified: '2026-07-20'
-    commit_deployed: b405a96
-    commit_head: b405a96
+    commit_deployed: 37be5f8
+    commit_head: 37be5f8
     drift: false
     urls:
       api: https://metar-to-iwxxm-api.onrender.com
       frontend: https://metar-to-iwxxm-frontend-v4-web.onrender.com
     deploy_ids:
-      api: dep-d9er13v7f7vs73b8deug
-      frontend: dep-d9er14f41pts73feb650
-    ci_deploy_run: '29718764520'
+      api: dep-d9f69f3bc2fs7397bqig
+      frontend: dep-d9f69fjbc2fs7397brq0
+    ci_deploy_run: '29766213356'
     images:
-      api: ghcr.io/joseph-c-mcguire/metar-to-iwxxm/backend:20260720052043-b405a96
-      frontend: ghcr.io/joseph-c-mcguire/metar-to-iwxxm/frontend:20260720052043-b405a96
+      api: ghcr.io/joseph-c-mcguire/metar-to-iwxxm/backend:20260720180925-37be5f8
+      frontend: ghcr.io/joseph-c-mcguire/metar-to-iwxxm/frontend:20260720180925-37be5f8
     health_tiers:
       H0ci: pass
       H0c: pass
@@ -2567,11 +2581,14 @@ deployment:
       H3: pass
       H4: pass
       H5: pass
-      F15_catalog: pass
+      AHL_convert_bulletin: pass
+      COLLECT_ingest_collect: expected_501
+      Playwright_workbench: pass
     notes:
-      - S015/EV-011 F15 lint registry + GET /api/v1/lint-issue-catalog live @ b405a96
-      - PyPI tac-validate-v0.1.1 deferred — await Phase D close (E11-25)
-      - docs branch docs/EV-011-deploy-smoke tip a73bbe0 (deploy-smoke.md) pending merge to main
+      - S016/EV-012 Manual TAC Input modes live @ 37be5f8 (PR #746); 13-deploy-smoke PASS
+      - CI/CD run 29766213356 SUCCESS including Deploy; images 20260720180925-37be5f8
+      - H0c PASS; H3 21/21; H4 2/2; H5 PASS; AHL convert-bulletin 200; COLLECT ingest-collect 501; live Playwright workbench PASS
+      - Phase D / Phase 4 close still pending user deploy approval (session open)
   url_discovery:
     method: "bash scripts/deploy/verify_connectivity.sh"
 
@@ -2627,6 +2644,27 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S016-EV012-13-pass
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    stage: 13-deploy-smoke
+    skill: 13-deploy-smoke
+    skill_id: 13-deploy-smoke
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    status: confirmed
+    resolved_at: '2026-07-20'
+    topic: 13-deploy-smoke PASS for Manual TAC Input modes
+    decision: >-
+      13-deploy-smoke COMPLETE / PASS after PR #746 merge
+      (37be5f877bd50d9ef1d1208e78f99c12ca59f092) and Render deploy (API
+      dep-d9f69f3bc2fs7397bqig, FE dep-d9f69fjbc2fs7397brq0, images
+      20260720180925-37be5f8). CI/CD run 29766213356 SUCCESS including Deploy.
+      Smokes: H0c PASS, H3 21/21, H4 2/2, H5 PASS, AHL convert-bulletin 200,
+      COLLECT ingest-collect 501, live Playwright workbench PASS. Report:
+      docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md. Session
+      remains open — awaiting user deploy approval / Phase 4 close.
+    summary: 13-deploy-smoke PASS; Manual TAC Input modes live @ 37be5f8; Phase 4 close pending.
   - id: D-S016-EV012-13-path-A
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -6209,8 +6247,12 @@ evolve_cycles:
         - 09-qa
         - 11-verify-impl
         - 12-verify-deploy
-    current_stage: 13-deploy-smoke
+    current_stage: phase-d-checkpoint
     notes:
+      - >-
+        2026-07-20 S016/EV-012 13-deploy-smoke COMPLETE / PASS — PR #746 merged 37be5f8;
+        CI/CD 29766213356 SUCCESS; Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 +
+        Playwright PASS; awaiting user deploy approval / Phase 4 close (D-S016-EV012-13-pass)
       - >-
         2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — path A
         (D-S016-EV012-13-path-A); branch pushed; PR #746 open; blocked on merge+Render
@@ -6236,8 +6278,8 @@ evolve_cycles:
         started: '2026-07-20'
         completed:
         note: >-
-          Path A (D-S016-EV012-13-path-A) — PR #746 open; 13-deploy-smoke in_progress
-          blocked on merge+Render deploy
+          13-deploy-smoke PASS (D-S016-EV012-13-pass); awaiting user deploy approval /
+          Phase 4 close; evolve-summary still pending
       01-requirements:
         status: completed
         started: '2026-07-20'
@@ -6256,25 +6298,39 @@ evolve_cycles:
         note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
         report: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
       13-deploy-smoke:
-        status: in_progress
+        status: completed
         started: '2026-07-20'
+        completed: '2026-07-20'
         mode: full
         note: >-
-          PR #746 opened (path A); blocked on merge+Render deploy before live H4–H5
+          13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS;
+          Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 + Playwright PASS; awaiting
+          Phase 4 close
+        report: docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
+        overall: pass
         pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
         pr_number: 746
         pr_id: PR-EV-012
+        merge_sha: 37be5f877bd50d9ef1d1208e78f99c12ca59f092
     gates:
       a_to_b: waived  # lean: no Phase B tech stages
       b_to_c: waived # lean: no 07 build phase
       c_to_d: waived
-      deploy: pending
+      deploy: passed
     checkpoints:
       phase_a: passed
       phase_b: waived
       phase_c: waived
-      phase_d: pending
-      deploy: pending
+      phase_d:
+        status: pending
+        note: 13-deploy-smoke passed; awaiting user deploy approval / Phase 4 close (session open)
+      deploy:
+        status: passed
+        completed: '2026-07-20'
+        note: >-
+          PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS; Render LIVE
+          dep-d9f69f3bc2fs7397bqig / dep-d9f69fjbc2fs7397brq0; H0c/H3/H4/H5 + AHL 200 +
+          COLLECT 501 + Playwright PASS
     adrs:
       - docs/adr/ADR-024-operator-input-modes.md
     artifacts:
@@ -6295,6 +6351,8 @@ evolve_cycles:
       - path: docs/sessions/S016-manual-tac-input-modes/checkpoints/phase-a-complete.md
         status: completed
       - path: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
+        status: completed
+      - path: docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
         status: completed
       - path: docs/decisions/evolve-decisions.md
         status: in_progress
@@ -8450,11 +8508,18 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: evolve/EV-012-manual-tac-input-modes
-  ahead_of_origin: 0
+  current_branch: docs/EV-012-deploy-smoke
+  ahead_of_origin: 1
   pushed: true
   pending_commit:
   notes:
+    - >-
+      2026-07-20 S016/EV-012 — PR #746 merged 37be5f8; 13-deploy-smoke PASS; docs branch
+      docs/EV-012-deploy-smoke for deploy-smoke.md + workflow-state; Phase D close pending
+      user approval
+    - >-
+      2026-07-20 S016/EV-012 git — merge commit 37be5f877bd50d9ef1d1208e78f99c12ca59f092 on
+      main (PR #746); CI/CD 29766213356 SUCCESS
     - >-
       2026-07-20 S016/EV-012 git — branch evolve/EV-012-manual-tac-input-modes pushed to
       origin; PR-EV-012=#746 open https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
@@ -8588,21 +8653,32 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
-    - name: evolve/EV-012-manual-tac-input-modes
-      purpose: EV-012 / S016 Validate Manual TAC Input modes (#730 / ADR-024 under F7)
+    - name: docs/EV-012-deploy-smoke
+      purpose: EV-012 / S016 13-deploy-smoke report + workflow-state
       base: main
       status: active
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      tip_sha: 0b56fd1
+      tip_sha: eb2768e
       pushed: true
+      note: '[S016] docs: 13-deploy-smoke PASS — tip eb2768e'
+    - name: evolve/EV-012-manual-tac-input-modes
+      purpose: EV-012 / S016 Validate Manual TAC Input modes (#730 / ADR-024 under F7)
+      base: main
+      status: merged
+      created_at: '2026-07-20'
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      tip_sha: 37be5f8
+      pushed: true
+      merged_at: '2026-07-20'
+      merge_sha: 37be5f877bd50d9ef1d1208e78f99c12ca59f092
       pr_id: PR-EV-012
       pr_number: 746
       pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
       note: >-
-        Branch pushed to origin; PR #746 open (path A); tip 0b56fd1 pre 13-start chore;
-        13-deploy-smoke in_progress blocked on merge+Render deploy
+        PR #746 merged to main 37be5f8; 13-deploy-smoke PASS; awaiting Phase 4 close
     - name: evolve/EV-011-metar-lint-quality
       purpose: "EV-011 / S015 METAR lint issue registry + #732 quality (F15 + F6/F12 deepen)"
       base: main
@@ -8851,6 +8927,29 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 6ee2ea533376249e26e6f865a106e2836c4ee9f0
+      short: 6ee2ea5
+      branch: docs/EV-012-deploy-smoke
+      message: '[S016] docs: 13-deploy-smoke PASS for Manual TAC Input modes'
+      stage: 13-deploy-smoke
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      files_changed:
+        - docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
+        - workflow-state.yaml
+      timestamp: '2026-07-20'
+      pushed: true
+      note: deploy-smoke.md + workflow-state
+    - sha: 37be5f877bd50d9ef1d1208e78f99c12ca59f092
+      short: 37be5f8
+      branch: main
+      message: 'Merge pull request #746 from joseph-c-mcguire/evolve/EV-012-manual-tac-input-modes'
+      stage: 13-deploy-smoke
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      timestamp: '2026-07-20'
+      pushed: true
+      note: PR #746 merged; production tip for 13-deploy-smoke
     - sha: 0b56fd1
       short: 0b56fd1
       branch: evolve/EV-012-manual-tac-input-modes

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -8660,9 +8660,9 @@ git_history:
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
-      tip_sha: eb2768e
+      tip_sha: 704be17
       pushed: true
-      note: '[S016] docs: 13-deploy-smoke PASS — tip eb2768e'
+      note: '[S016] docs: 13-deploy-smoke PASS — tip 704be17'
     - name: evolve/EV-012-manual-tac-input-modes
       purpose: EV-012 / S016 Validate Manual TAC Input modes (#730 / ADR-024 under F7)
       base: main
@@ -8927,8 +8927,8 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
-    - sha: 6ee2ea533376249e26e6f865a106e2836c4ee9f0
-      short: 6ee2ea5
+    - sha: 704be17788b3cf9ec18c5d15868bddcdbe326477
+      short: 704be17
       branch: docs/EV-012-deploy-smoke
       message: '[S016] docs: 13-deploy-smoke PASS for Manual TAC Input modes'
       stage: 13-deploy-smoke


### PR DESCRIPTION
## Summary
- Records **13-deploy-smoke COMPLETE / PASS** for S016 / EV-012 Manual TAC Input modes after PR #746 merge (`37be5f8`) and Render deploy.
- Adds `docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md`.
- Updates `workflow-state.yaml` (session stays open — Phase 4 / deploy approval still pending).

### Smoke results
- CI/CD run [29766213356](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29766213356) SUCCESS (including Deploy)
- Render: API `dep-d9f69f3bc2fs7397bqig`, FE `dep-d9f69fjbc2fs7397brq0`, images `20260720180925-37be5f8`
- H0c PASS · H3 21/21 · H4 2/2 · H5 PASS · AHL convert-bulletin 200 · COLLECT ingest-collect 501 · live Playwright workbench PASS

### State highlights
- `active_session` remains S016 (`phase-d-checkpoint`); routing `13-deploy-smoke` → completed
- EV-012: `stages.13-deploy-smoke` completed; `checkpoints.deploy` / `gates.deploy` passed; `phase_d` still pending close
- `deployment.staging` → commit `37be5f8`, drift false, health tiers pass
- Decision `D-S016-EV012-13-pass` appended

## Test plan
- [ ] Skim deploy-smoke report for accuracy vs live Render
- [ ] Confirm workflow-state keys preserved (no unrelated drops)
- [ ] After merge, operator can Approve Phase 4 close for S016/EV-012


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Record completion and PASS status of the S016 / EV-012 13-deploy-smoke stage for Manual TAC Input modes and align workflow/deployment metadata with the merged PR #746.

Enhancements:
- Update workflow-state to mark S016 / EV-012 13-deploy-smoke as completed and passed, advance the evolve cycle to the Phase D checkpoint, and record associated artifacts and checkpoints.
- Refresh staging deployment metadata (commit, deploy IDs, images, health tiers, and notes) to reflect Manual TAC Input modes going live on main after PR #746.
- Record decision log and git history entries capturing the 13-deploy-smoke PASS verdict, merge SHA, and new docs branch used for the report.

Documentation:
- Add a deploy smoke report for S016 / EV-012 Manual TAC Input modes documenting live Render deployment, CI run, and health tier results.