### PR TITLE
[S016] docs: close EV-012 / S016 (Manual TAC Input modes)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable user-facing and deployable changes for METAR to IWXXM.
 
+## 2026-07-20 — S016 EV-012 (Manual TAC Input modes validation / #730)
+
+### Added
+- Playwright **TC-F7-007** (UJ-025): Manual TAC Input modes T1–T6 (TAC / AHL / COLLECT,
+  auto-switch, `.gz` COLLECT, read-only finished session).
+
+### Changed
+- Workbench: toast on convert-time AHL/COLLECT auto-switch; classify COLLECT after gzip inflate.
+- Specs: UJ-025 + TC-F7-007; F7 remains **Planned**; COLLECT stays **501** (ADR-024).
+
+### Deploy
+- PR [#746](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746) merged (`37be5f8`);
+  Render API + frontend-v4-web redeployed 2026-07-20. Smoke: H0ci/H0c/H3/H4/H5 + AHL + COLLECT
+  501 + live workbench **PASS** (`docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md`).
+
 ## 2026-07-20 — S015 EV-011 (F15 METAR lint registry + #732 quality)
 
 ### Added

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -10,7 +10,7 @@
 **Issues**: [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730)  
 **Started**: 2026-07-20  
 **Branch**: `evolve/EV-012-manual-tac-input-modes`  
-**Completed**: —
+**Completed**: 2026-07-20 (D-S016-EV012-phase4-close-1)
 
 ### Scope (Phase 0 locked 2026-07-20)
 
@@ -32,17 +32,20 @@
 | S2.1 | contradiction | H6 omits UJ-025 | Fix: add UJ-025 to H6/H6′ row | — |
 | S2.2 | ambiguity | T5/T6 vs all tests | T1–T6 all hard gates | — |
 | S2.3 | decision | UJ id | Keep UJ-025 (not fold into UJ-013) | — |
+| D-S016-EV012-13-path-A | decision | Deploy path | Push/PR then smoke after merge/deploy | — |
+| D-S016-EV012-13-pass | decision | 13 result | Deploy smoke PASS @ `37be5f8` | — |
+| D-S016-EV012-phase4-close-1 | decision | Phase 4 | Close EV-012/S016; close #730 | — |
 
 ### Stage log
 
 | Stage | Completed | Notes |
 |-------|-----------|-------|
 | 00-context | 2026-07-20 | Session + scoped brief |
-| 16-evolve | — | Phase 0 complete; Phase A in progress |
+| 16-evolve | 2026-07-20 | Phase 4 closed |
 | 01-requirements | 2026-07-20 | UJ-025 + TC-F7-007 + F7 validation note |
 | 02-verify-plan | 2026-07-20 | PASS — S2.1 fix H6; S2.2 T1–T6 hard; S2.3 UJ-025 |
 | 10-e2e | 2026-07-20 | PASS — TC-F7-007 T1–T6 Playwright + Vitest anchors |
-| 13-deploy-smoke | | |
+| 13-deploy-smoke | 2026-07-20 | PASS — H0ci–H5 + AHL + COLLECT 501 + live workbench |
 
 ---
 

--- a/docs/deploy-state.md
+++ b/docs/deploy-state.md
@@ -7,11 +7,11 @@
 
 | # | Step | Status | Started | Completed | Notes |
 |---|------|--------|---------|-----------|-------|
-| 1 | Deploy | done | 2026-07-20T05:16Z | 2026-07-20T05:22Z | CI Deploy `29718764520`; hooks → API + FE live @ `b405a96` |
-| 2 | Smoke tests | done | 2026-07-20T05:23Z | 2026-07-20T05:24Z | H0c/H1/H3/H4/H5 + F15 catalog PASS |
-| 3 | Health check | done | 2026-07-20T05:23Z | 2026-07-20T05:23Z | `/health` healthy; tac2iwxxm_available |
-| 4 | Changelog | done | 2026-07-20 | 2026-07-20 | `docs/CHANGELOG.md` S015 entry |
-| 5 | Monitoring baseline | done | 2026-07-20T05:23Z | 2026-07-20T05:24Z | H3 response-times acceptable |
+| 1 | Deploy | done | 2026-07-20T18:09Z | 2026-07-20T18:11Z | CI Deploy `29766213356`; hooks → API + FE live @ `37be5f8` |
+| 2 | Smoke tests | done | 2026-07-20T18:12Z | 2026-07-20T18:18Z | H0c/H3/H4/H5 + AHL + COLLECT 501 + live workbench PASS |
+| 3 | Health check | done | 2026-07-20T18:12Z | 2026-07-20T18:12Z | `/health` healthy; convert-bulletin OK |
+| 4 | Changelog | done | 2026-07-20 | 2026-07-20 | `docs/CHANGELOG.md` S016 entry |
+| 5 | Monitoring baseline | done | 2026-07-20T18:12Z | 2026-07-20T18:18Z | H3 response-times acceptable |
 
 ## Current Deployment
 
@@ -21,8 +21,8 @@
 | Deploy URL (API) | https://metar-to-iwxxm-api.onrender.com |
 | Deploy URL (FE) | https://metar-to-iwxxm-frontend-v4-web.onrender.com |
 | Deploy mode | GHCR `main-latest` + Render deploy hooks |
-| Commit | b405a96 (merge #742) |
+| Commit | 37be5f8 (merge #746) |
 | Branch | main |
-| API deploy id | dep-d9er13v7f7vs73b8deug |
-| FE deploy id | dep-d9er14f41pts73feb650 |
-| Session report | docs/sessions/S015-metar-lint-quality/reports/deploy-smoke.md |
+| API deploy id | dep-d9f69f3bc2fs7397bqig |
+| FE deploy id | dep-d9f69fjbc2fs7397brq0 |
+| Session report | docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md |

--- a/docs/evolve-report-EV-012.md
+++ b/docs/evolve-report-EV-012.md
@@ -1,0 +1,34 @@
+# Evolve report — S016 Manual TAC Input modes (F7 validation)
+
+- **Cycle**: EV-012
+- **Session**: S016-manual-tac-input-modes
+- **Status**: completed (Phase 4 closed — D-S016-EV012-phase4-close-1)
+- **Scope**: Validate Manual TAC Input modes (TAC / AHL / COLLECT) under F7 / ADR-024 / #730;
+  no new Fn; COLLECT remains HTTP 501 placeholder; F7 stays Planned
+- **Stages run**: 00, 01, 02, 10, 13, 16 (lean + 13)
+- **ADRs**: ADR-024 (consumed; no new ADR)
+- **Deploy**: Render API + frontend-v4-web @ merge `37be5f8` (CI Deploy `29766213356`);
+  smoke docs PR #747
+- **GitHub issues**: #730 **closed**
+- **Follow-ups** (non-blocking): fix H7 live harness form field `file`→`files` (pre-existing);
+  optional COLLECT member extract (future Fn / evolve)
+
+## Summary
+
+EV-012 locked acceptance for UJ-025 / TC-F7-007 (T1–T6 hard), authored Playwright coverage,
+and small FE fixes (convert-time auto-switch toast; classify COLLECT after `.gz` inflate).
+Post-merge Render smokes confirmed H0c–H5, authenticated `convert-bulletin`, `ingest-collect`
+501, and live workbench placeholder UX.
+
+## Artifacts changed (high level)
+
+- `apps/e2e/f7-manual-tac-input-modes.e2e.spec.ts` — TC-F7-007 suite
+- `apps/frontend/.../FileConverter.tsx` — toast + gzip classify
+- Docs: UJ-025, TC-F7-007, feature-list F7 note, session S016
+- Session reports under `docs/sessions/S016-manual-tac-input-modes/`
+
+## Verification
+
+- 02-verify-plan: PASS
+- 10-e2e: PASS (T1–T6 + Vitest)
+- 13-deploy-smoke: PASS (H0ci–H5 + AHL + COLLECT 501 + live workbench)

--- a/docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
+++ b/docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
@@ -1,0 +1,37 @@
+# Evolve summary — S016 / EV-012
+
+> Completed: 2026-07-20 (Phase 4 closed — D-S016-EV012-phase4-close-1)  
+> Features: **F7** validation deepen only (status stays **Planned**)  
+> Branch: `evolve/EV-012-manual-tac-input-modes` → PR [#746](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746) → `main` @ `37be5f8`  
+> Deploy-smoke docs: PR [#747](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/747)  
+> Issue [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730) closed on cycle close  
+> Orchestrator: 16-evolve  
+> Routing: lean + 13 (00 → 16 → 01 → 02 → 10 → 13)
+
+## Outcome
+
+Validated Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per ADR-024 / #730:
+Playwright TC-F7-007 T1–T6 + Vitest anchors green; FE toast on convert-time auto-switch and
+gzip COLLECT classify-after-inflate; staging H0ci–H5 + authenticated AHL + COLLECT **501** UX
+PASS on image `…-37be5f8`. F7 remains Planned; COLLECT member extract still out of scope.
+
+## Stage trail
+
+| Stage | Result |
+|-------|--------|
+| 00 / 16 | Session + Phase 0 intake; lean+13 routing |
+| 01–02 | UJ-025 + TC-F7-007; 02 PASS (H6+UJ-025; T1–T6 hard) |
+| 10 | Playwright T1–T6 + Vitest PASS (`7e052f4`) |
+| 13 | Render deploy + H4–H5 + live workbench AHL/COLLECT PASS |
+
+## Key decisions
+
+- E12-1 — No new Fn; COLLECT stays 501; F7 Planned
+- D-S016-EV012-route-1 — Lean + 13 (skip 03–09, 11–12)
+- D-S016-EV012-13-path-A — Push/PR then smoke after merge/deploy
+- D-S016-EV012-phase4-close-1 — Close EV-012/S016 after deploy approval
+
+## Artifacts
+
+Session reports under `docs/sessions/S016-manual-tac-input-modes/reports/`.  
+Standing: `docs/evolve-report-EV-012.md`, `docs/CHANGELOG.md`, `docs/deploy-state.md`.

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -6,85 +6,98 @@ project:
 
 session_counter: 16
 active_session:
-  id: S016-manual-tac-input-modes
-  type: feature
-  status: in_progress
-  started_at: '2026-07-20'
-  intent: 'Validate Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per GitHub #730 / ADR-024; Playwright T1–T4 + Vitest + staging smoke; COLLECT stays 501; F7 stays Planned'
-  orchestrator: 16-evolve
-  evolve_cycle_id: EV-012
-  branch: main
-  artifacts_dir: docs/sessions/S016-manual-tac-input-modes
-  current_stage: phase-d-checkpoint
-  context_briefs:
-    - docs/context/manual-tac-input-modes.md
-  standing_docs_touched:
-    - docs/decisions/evolve-decisions.md
-    - docs/context/manual-tac-input-modes.md
-    - docs/sessions/S016-manual-tac-input-modes/session-brief.md
-    - docs/user-journeys.md
-    - docs/test-plan.md
-    - docs/feature-list.md
-    - docs/spec.md
-  routing_plan:
-    - stage: 00-context
-      required: true
-      mode: scoped
-      status: completed
-      started: '2026-07-20'
-      completed: '2026-07-20'
-      note: Phase 0 intake locked; routing lean+13 approved (D-S016-EV012-route-1)
-    - stage: 16-evolve
-      required: true
-      mode: orchestrator
-      status: in_progress
-      started: '2026-07-20'
-      note: >-
-        EV-012 13-deploy-smoke COMPLETE/PASS; Phase D checkpoint pending user deploy
-        approval / Phase 4 close (D-S016-EV012-13-pass). Session remains open.
-    - stage: 01-requirements
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-20'
-      completed: '2026-07-20'
-      note: UJ-025 + TC-F7-007
-    - stage: 02-verify-plan
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-20'
-      completed: '2026-07-20'
-      note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
-    - stage: 10-e2e
-      required: true
-      mode: delta
-      status: completed
-      started: '2026-07-20'
-      completed: '2026-07-20'
-      note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
-    - stage: 13-deploy-smoke
-      required: true
-      mode: full
-      status: completed
-      started: '2026-07-20'
-      completed: '2026-07-20'
-      note: >-
-        13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD run 29766213356 SUCCESS
-        (incl. Deploy); Render LIVE API dep-d9f69f3bc2fs7397bqig + FE
-        dep-d9f69fjbc2fs7397brq0; images 20260720180925-37be5f8; H0c PASS, H3 21/21,
-        H4 2/2, H5 PASS, AHL convert-bulletin 200, COLLECT ingest-collect 501, live
-        Playwright workbench PASS; report
-        docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md; awaiting
-        user deploy approval / Phase 4 close (session stays open)
 sessions:
 
+  - id: S016-manual-tac-input-modes
+    type: feature
+    status: completed
+    started_at: '2026-07-20'
+    completed_at: '2026-07-20'
+    intent: 'Validate Manual TAC Input modes (TAC / AHL bulletin / IWXXM COLLECT) per GitHub #730 / ADR-024; Playwright T1–T4
+      + Vitest + staging smoke; COLLECT stays 501; F7 stays Planned'
+    orchestrator: 16-evolve
+    evolve_cycle_id: EV-012
+    branch: main
+    artifacts_dir: docs/sessions/S016-manual-tac-input-modes
+    current_stage:
+    context_briefs:
+      - docs/context/manual-tac-input-modes.md
+    standing_docs_touched:
+      - docs/decisions/evolve-decisions.md
+      - docs/context/manual-tac-input-modes.md
+      - docs/sessions/S016-manual-tac-input-modes/session-brief.md
+      - docs/user-journeys.md
+      - docs/test-plan.md
+      - docs/feature-list.md
+      - docs/spec.md
+    routing_plan:
+      - stage: 00-context
+        required: true
+        mode: scoped
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: Phase 0 intake locked; routing lean+13 approved (D-S016-EV012-route-1)
+      - stage: 16-evolve
+        required: true
+        mode: orchestrator
+        status: completed
+        started: '2026-07-20'
+        note: >-
+          Phase 4 closed (D-S016-EV012-phase4-close-1) — close EV-012/S016; PR #746 37be5f8; docs #747 dd305ba; #730 CLOSED;
+          F7 remains Planned
+        completed: '2026-07-20'
+      - stage: 01-requirements
+        required: true
+        mode: delta
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: UJ-025 + TC-F7-007
+      - stage: 02-verify-plan
+        required: true
+        mode: delta
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: 'PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete'
+      - stage: 10-e2e
+        required: true
+        mode: delta
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md
+      - stage: 13-deploy-smoke
+        required: true
+        mode: full
+        status: completed
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: >-
+          13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD run 29766213356 SUCCESS
+          (incl. Deploy); Render LIVE API dep-d9f69f3bc2fs7397bqig + FE
+          dep-d9f69fjbc2fs7397brq0; images 20260720180925-37be5f8; H0c PASS, H3 21/21,
+          H4 2/2, H5 PASS, AHL convert-bulletin 200, COLLECT ingest-collect 501, live
+          Playwright workbench PASS; report
+          docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md; awaiting
+          user deploy approval / Phase 4 close (session stays open)
+    pr_id: PR-EV-012
+    pr_number: 746
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
+    pr_status: merged
+    merge_sha: 37be5f877bd50d9ef1d1208e78f99c12ca59f092
+    close_note: 'Phase 4 closed (D-S016-EV012-phase4-close-1) — EV-012/S016 complete; PR #746 merged 37be5f877bd50d9ef1d1208e78f99c12ca59f092;
+      docs #747 merged dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73; issue #730 CLOSED; F7 remains Planned (validation deepen
+      only)'
+    note: 'Phase 4 closed (D-S016-EV012-phase4-close-1) — EV-012/S016 complete; #730 CLOSED'
   - id: S015-metar-lint-quality
     type: feature
     status: completed
     started_at: '2026-07-19'
     completed_at: '2026-07-20'
-    intent: 'METAR lint issue registry (INFO/WARNING/ERROR) + #732 METAR TAC lint/validate/convert quality + research/expansion from external METAR/IWXXM resources; golden convert→XSD/Schematron; deepen F6/F12; new F15'
+    intent: 'METAR lint issue registry (INFO/WARNING/ERROR) + #732 METAR TAC lint/validate/convert quality + research/expansion
+      from external METAR/IWXXM resources; golden convert→XSD/Schematron; deepen F6/F12; new F15'
     orchestrator: 16-evolve
     evolve_cycle_id: EV-011
     branch: main
@@ -388,7 +401,8 @@ sessions:
     type: feature
     status: completed
     started_at: '2026-07-16'
-    intent: Value-aware live TAC decode translations + plain-language report summary (F9); workbench IWXXM preview pane + soft-fail/terminator lint UX clarity (F10)
+    intent: Value-aware live TAC decode translations + plain-language report summary (F9); workbench IWXXM preview pane 
+      + soft-fail/terminator lint UX clarity (F10)
     orchestrator: 16-evolve
     evolve_cycle_id: EV-009
     branch: evolve/S013-live-decode-preview-ux
@@ -444,7 +458,8 @@ sessions:
         status: completed
         started: '2026-07-16'
         completed: '2026-07-16'
-        note: PASS — lint/format/typecheck clean; make test green (backend 1182 @98.01% cov, Vitest 631, tac2iwxxm 136, tac-validate 33, worker 11, bugs 39); H0c CORS 29 passed; gitleaks clean; pip-audit no project-dep CVEs
+        note: PASS — lint/format/typecheck clean; make test green (backend 1182 @98.01% cov, Vitest 631, tac2iwxxm 136, 
+          tac-validate 33, worker 11, bugs 39); H0c CORS 29 passed; gitleaks clean; pip-audit no project-dep CVEs
       - stage: 09-qa
         required: true
         mode: full
@@ -472,7 +487,8 @@ sessions:
         status: completed
         started: '2026-07-17'
         completed: '2026-07-17'
-        note: deploy-checklist.md approved (D-S013-EV009-deploy-check-A); PR-EV-009=#723 CI green; merge + deploy approved
+        note: deploy-checklist.md approved (D-S013-EV009-deploy-check-A); PR-EV-009=#723 CI green; merge + deploy 
+          approved
       - stage: 13-deploy-smoke
         required: true
         mode: full
@@ -490,7 +506,8 @@ sessions:
     pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/723
     pr_number: 723
     merge_sha: '4660602'
-    close_note: EV-009 complete; F9/F10 shipped (#723); deploy smokes H1/H0c/H3/H4/H5 + H6' UJ-020/021 PASS; user approved deploy results (option 1) 2026-07-18
+    close_note: EV-009 complete; F9/F10 shipped (#723); deploy smokes H1/H0c/H3/H4/H5 + H6' UJ-020/021 PASS; user 
+      approved deploy results (option 1) 2026-07-18
 
   - id: S012-empty-bearer-lint-tac
     type: hotfix
@@ -502,7 +519,8 @@ sessions:
     close_note: "BUG-2026-07-15 resolved; PR #721 merged 6412b21; production verified; Cursor rule frontend-auth-token-hydrate.mdc"
     branch: fix/S012-empty-bearer-lint-tac
     started_at: "2026-07-15"
-    intent: "Production frontend sends Authorization: Bearer with empty token to POST /api/v1/lint-tac and /decode-tac → Missing authorization credentials; also lint-tac UI shows only '[lint-tac] N issue(s)' without descriptive issue details"
+    intent: "Production frontend sends Authorization: Bearer with empty token to POST /api/v1/lint-tac and /decode-tac → Missing
+      authorization credentials; also lint-tac UI shows only '[lint-tac] N issue(s)' without descriptive issue details"
     orchestrator: 14-hotfix
     evolve_cycle_id:
     artifacts_dir: docs/sessions/S012-empty-bearer-lint-tac
@@ -531,15 +549,18 @@ sessions:
   - id: S011-f7-operator-ui
     type: feature
     status: completed
-    close_reason: "User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed; later deploys via S013/S014)"
+    close_reason: "User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed;
+      later deploys via S013/S014)"
     pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/716
     pr_number: 716
     branch: evolve/S011-f7-operator-ui
     started_at: "2026-07-13"
-    intent: "F7 multi-product TAC operator UI (7 products) + interactive workbench (#694), TAC decode panel (#702), failed-TAC/partial convert UX (#665/#666), remove admin dashboard / BYO DB (#697); #5 kept as parent tracker"
+    intent: "F7 multi-product TAC operator UI (7 products) + interactive workbench (#694), TAC decode panel (#702), failed-TAC/partial
+      convert UX (#665/#666), remove admin dashboard / BYO DB (#697); #5 kept as parent tracker"
     orchestrator: 16-evolve
     evolve_cycle_id: EV-008
-    note: "User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed; later deploys via S013/S014)"
+    note: "User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed; later
+      deploys via S013/S014)"
     context_briefs:
       - docs/context/f7-operator-ui.md
     standing_docs_touched: []
@@ -557,7 +578,8 @@ sessions:
         mode: delta
         status: completed
         completed: "2026-07-13"
-        note: "D-S011-02-m1m2-A PASS; artifact docs/sessions/S011-f7-operator-ui/reports/02-verify-plan-audit.md (deploy.md consistency fixes)"
+        note: "D-S011-02-m1m2-A PASS; artifact docs/sessions/S011-f7-operator-ui/reports/02-verify-plan-audit.md (deploy.md
+          consistency fixes)"
       - stage: 04-tech-plan
         required: true
         mode: delta
@@ -619,15 +641,18 @@ sessions:
         status: completed
         started: "2026-07-14"
         completed: "2026-07-14"
-        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (evolve→main; no merge/deploy yet); 13 blocked on merge approval"
+        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (evolve→main; no merge/deploy yet); 13
+          blocked on merge approval"
         artifacts:
           - docs/sessions/S011-f7-operator-ui/reports/deploy-checklist.md
       - stage: 13-deploy-smoke
         required: true
         mode: full
         status: skipped
-        note: "13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014 (D-S011-EV008-close-1)"
-        skip_rationale: '13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014 (D-S011-EV008-close-1)'
+        note: "13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014
+          (D-S011-EV008-close-1)"
+        skip_rationale: '13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via
+          S013/S014 (D-S011-EV008-close-1)'
         completed: '2026-07-19'
       - stage: 18-pr-review
         required: false
@@ -779,7 +804,8 @@ sessions:
 
   - id: S008-general-tac-iwxxm-converter
     type: feature
-    intent: "General TAC→IWXXM converter (F6/tac2iwxxm) plus data-entry and near-realtime ingest conversion with Schematron gate on IWXXM output"
+    intent: "General TAC→IWXXM converter (F6/tac2iwxxm) plus data-entry and near-realtime ingest conversion with Schematron
+      gate on IWXXM output"
     status: completed
     branch: evolve/S008-general-tac-iwxxm-converter
     orchestrator: 16-evolve
@@ -824,14 +850,16 @@ sessions:
         started_at: "2026-07-12"
         completed_at: "2026-07-12"
         skip_rationale:
-        note: "All M1–M8 tasks (51/51) done; PR-M8 #710 merged; Phase C implementation complete; handing to 08-verify-build for C→D gate"
+        note: "All M1–M8 tasks (51/51) done; PR-M8 #710 merged; Phase C implementation complete; handing to 08-verify-build
+          for C→D gate"
       - stage: 08-verify-build
         required: true
         status: completed
         started_at: "2026-07-12"
         completed_at: "2026-07-12"
         skip_rationale:
-        note: "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c). Awaiting C→D AskQuestion before 09-qa."
+        note: "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c). Awaiting C→D AskQuestion
+          before 09-qa."
       - stage: 09-qa
         required: true
         status: completed
@@ -863,74 +891,127 @@ sessions:
       - docs/context/realtime-tac-ingest.md
     notes:
       - "Opened after closing S007; user approved routing 2026-07-12"
-      - "00-context complete 2026-07-12 — R1=new tac2iwxxm pkg; R2=pure Py then Cython; R3=FAA five v1; R4=vendor iwxxm-us; R5=CPython+C/Cython; ADR-013"
-      - "2026-07-12 amend: reopen scoped 00 + delta 01 for realtime ingest + data entry; intent expansion — general TAC data entry + near-realtime ingest conversion + Schematron gate on IWXXM (D-S008-realtime-amend-q1q2q3)"
-      - "2026-07-12 D-S008-realtime-amend-q4q8 — Q4=C both UI+ingest; Q5=D research sources in 00; Q6=A seconds E2E; Q7=B add worker (template drift ADR); Q8=A all F6 products. Pending interview: template drift static+api→+worker; F5 METAR-only non-goal vs multi-product operator UI"
-      - "2026-07-12 D-S008-realtime-amend-q9q13 — Q9=A new F7 multi-product TAC sessions (F5 stays METAR-only); Q10=A confirm Render worker + ADR/template update; Q11=B store+push sinks; Q12=A new F8 near-RT ingest pipeline; Q13=A quarantine on Schematron/convert fail. Issues I-S008-template-drift-worker + I-S008-f5-f6-metar-only-vs-multiproduct-ui resolved. Proposed for 01-requirements delta: F7, F8"
-      - "2026-07-12 D-S008-realtime-amend-q14q18 — Q14=postpone auth (focus on package); Q15=postpone push sinks; Q16=C parse gate + shared TAC rule pack; Q17=D research bulletin-aware default; Q18=A scale worker replicas (no drop). Package-first; auth/sinks deferred. Pending: I-S008-package-first-scope (F7/F8 design-only vs deferred vs package APIs only)"
-      - "2026-07-12 D-S008-realtime-amend-q19q22 — Q19=A package APIs only this cycle (F7/F8 Planned in docs; no worker/UI/auth/sinks build); Q20=B packages/iwxxm-validate + separate TAC validate package (name TBD e.g. packages/tac-validate); Q21=A bulletin split required for v1; Q22=A write scoped brief then 01 manifest. I-S008-package-first-scope resolved."
-      - "2026-07-12 scoped 00-context complete — docs/context/realtime-tac-ingest.md written and active; advancing to 01-requirements delta S008-realtime-ingest"
-      - "2026-07-12 D-S008-01-manifest-q23 — interview plan 7 docs (4 mandatory + Deps + API light + ADRs); skip Config Spec + Deploy; Feature List interview starting"
-      - "2026-07-12 D-S008-01-feature-list-q24q28 — Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A F7 stub; Q27=A F8 stub; Q28=A F2 evolves to wrapper over iwxxm-validate. Feature List interview → non-goals"
-      - "2026-07-12 D-S008-01-feature-list-q29q33 — Q29=C leave F6 non-goals unchanged (worker only under F8); Q30=B package APIs + API thin wrappers this cycle (tac-validate + iwxxm-validate); Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS out of build; Q33=A write feature-list then Spec. Feature List → writing feature-list"
-      - "2026-07-12 Feature List written (docs/feature-list.md delta) — interviews 1/7 complete; Spec interview starting at components"
-      - "2026-07-12 D-S008-01-spec-q34q38 — Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase; Q37=B dashed future worker in diagram; Q38=A write Spec then Journeys. Spec interview → writing Spec"
-      - "2026-07-12 Spec written (docs/spec.md delta) — interviews 2/7 complete; planned_docs.status.spec=completed; current_template=user-journeys; current_section=happy-paths"
-      - "2026-07-12 D-S008-01-journeys-q39q43 — Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub UJ-013/014; Q42=A T2 for 011/012; Q43=A write journeys then test plan. User Journeys → writing-journeys"
-      - "2026-07-12 User Journeys written — interviews 3/7 complete; planned_docs.status.user-journeys=completed; current_template=test-plan; current_section=types"
-      - "2026-07-12 D-S008-01-test-plan-q44q47 — Q44=B; Q44b=B H7; Q45=A; Q46=A; Q47=A. Test Plan → writing then Dependency Inventory"
-      - "2026-07-12 Test Plan written (docs/test-plan.md delta) — interviews 4/7 complete; planned_docs.status.test-plan=completed; current_template=dependency-inventory; current_section=packages"
-      - "2026-07-12 D-S008-01-deps-q48q50 — Q48=A MIT; Q49=B pydantic/msgspec in 04; Q50=A. Dependency Inventory → writing then API Contract"
-      - "2026-07-12 Dependency Inventory written (docs/dependency-inventory.md delta) — interviews 5/7 complete; planned_docs.status.dependency-inventory=completed; current_template=api-contract; current_section=endpoints"
-      - "2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. Delta S008-realtime-ingest COMPLETED (7/7); advancing to 04-tech-plan"
-      - "2026-07-12 D-S008-04-approved — Q21–Q24=A; 04-tech-plan delta complete; execution plan + ADR-016/017/018 approved; advancing to 05-verify-tech"
-      - "2026-07-12 D-S008-05-statement-walk — 05-verify-tech statement walk started; auto-approved high-confidence tech stack from Q1–Q20 / ADR-016/017/018 (msgspec, PyO3 cutover gate, worker template, package layout, bulletin schema, H7, lint default on); consistency agent found VT-S008-C01–C10 pending user review; stage not marked completed; delta_substage S008-f6-tac2iwxxm remains in_progress"
-      - "2026-07-12 D-S008-05-batch2 — Batch 2 verdicts C09a=1, C09c=1, M01=2, M02=1; delta_substage S008-f6-tac2iwxxm remains in_progress"
-      - "2026-07-12 D-S008-05-complete — 05-verify-tech audit done; next=16-evolve then 07-build; Phase B delta cleared (06 N/A); delta_substage S008-f6-tac2iwxxm completed"
+      - "00-context complete 2026-07-12 — R1=new tac2iwxxm pkg; R2=pure Py then Cython; R3=FAA five v1; R4=vendor iwxxm-us;
+        R5=CPython+C/Cython; ADR-013"
+      - "2026-07-12 amend: reopen scoped 00 + delta 01 for realtime ingest + data entry; intent expansion — general TAC data
+        entry + near-realtime ingest conversion + Schematron gate on IWXXM (D-S008-realtime-amend-q1q2q3)"
+      - "2026-07-12 D-S008-realtime-amend-q4q8 — Q4=C both UI+ingest; Q5=D research sources in 00; Q6=A seconds E2E; Q7=B
+        add worker (template drift ADR); Q8=A all F6 products. Pending interview: template drift static+api→+worker; F5 METAR-only
+        non-goal vs multi-product operator UI"
+      - "2026-07-12 D-S008-realtime-amend-q9q13 — Q9=A new F7 multi-product TAC sessions (F5 stays METAR-only); Q10=A confirm
+        Render worker + ADR/template update; Q11=B store+push sinks; Q12=A new F8 near-RT ingest pipeline; Q13=A quarantine
+        on Schematron/convert fail. Issues I-S008-template-drift-worker + I-S008-f5-f6-metar-only-vs-multiproduct-ui resolved.
+        Proposed for 01-requirements delta: F7, F8"
+      - "2026-07-12 D-S008-realtime-amend-q14q18 — Q14=postpone auth (focus on package); Q15=postpone push sinks; Q16=C parse
+        gate + shared TAC rule pack; Q17=D research bulletin-aware default; Q18=A scale worker replicas (no drop). Package-first;
+        auth/sinks deferred. Pending: I-S008-package-first-scope (F7/F8 design-only vs deferred vs package APIs only)"
+      - "2026-07-12 D-S008-realtime-amend-q19q22 — Q19=A package APIs only this cycle (F7/F8 Planned in docs; no worker/UI/auth/sinks
+        build); Q20=B packages/iwxxm-validate + separate TAC validate package (name TBD e.g. packages/tac-validate); Q21=A
+        bulletin split required for v1; Q22=A write scoped brief then 01 manifest. I-S008-package-first-scope resolved."
+      - "2026-07-12 scoped 00-context complete — docs/context/realtime-tac-ingest.md written and active; advancing to 01-requirements
+        delta S008-realtime-ingest"
+      - "2026-07-12 D-S008-01-manifest-q23 — interview plan 7 docs (4 mandatory + Deps + API light + ADRs); skip Config Spec
+        + Deploy; Feature List interview starting"
+      - "2026-07-12 D-S008-01-feature-list-q24q28 — Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A
+        F7 stub; Q27=A F8 stub; Q28=A F2 evolves to wrapper over iwxxm-validate. Feature List interview → non-goals"
+      - "2026-07-12 D-S008-01-feature-list-q29q33 — Q29=C leave F6 non-goals unchanged (worker only under F8); Q30=B package
+        APIs + API thin wrappers this cycle (tac-validate + iwxxm-validate); Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS
+        out of build; Q33=A write feature-list then Spec. Feature List → writing feature-list"
+      - "2026-07-12 Feature List written (docs/feature-list.md delta) — interviews 1/7 complete; Spec interview starting at
+        components"
+      - "2026-07-12 D-S008-01-spec-q34q38 — Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase;
+        Q37=B dashed future worker in diagram; Q38=A write Spec then Journeys. Spec interview → writing Spec"
+      - "2026-07-12 Spec written (docs/spec.md delta) — interviews 2/7 complete; planned_docs.status.spec=completed; current_template=user-journeys;
+        current_section=happy-paths"
+      - "2026-07-12 D-S008-01-journeys-q39q43 — Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub
+        UJ-013/014; Q42=A T2 for 011/012; Q43=A write journeys then test plan. User Journeys → writing-journeys"
+      - "2026-07-12 User Journeys written — interviews 3/7 complete; planned_docs.status.user-journeys=completed; current_template=test-plan;
+        current_section=types"
+      - "2026-07-12 D-S008-01-test-plan-q44q47 — Q44=B; Q44b=B H7; Q45=A; Q46=A; Q47=A. Test Plan → writing then Dependency
+        Inventory"
+      - "2026-07-12 Test Plan written (docs/test-plan.md delta) — interviews 4/7 complete; planned_docs.status.test-plan=completed;
+        current_template=dependency-inventory; current_section=packages"
+      - "2026-07-12 D-S008-01-deps-q48q50 — Q48=A MIT; Q49=B pydantic/msgspec in 04; Q50=A. Dependency Inventory → writing
+        then API Contract"
+      - "2026-07-12 Dependency Inventory written (docs/dependency-inventory.md delta) — interviews 5/7 complete; planned_docs.status.dependency-inventory=completed;
+        current_template=api-contract; current_section=endpoints"
+      - "2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. Delta S008-realtime-ingest
+        COMPLETED (7/7); advancing to 04-tech-plan"
+      - "2026-07-12 D-S008-04-approved — Q21–Q24=A; 04-tech-plan delta complete; execution plan + ADR-016/017/018 approved;
+        advancing to 05-verify-tech"
+      - "2026-07-12 D-S008-05-statement-walk — 05-verify-tech statement walk started; auto-approved high-confidence tech stack
+        from Q1–Q20 / ADR-016/017/018 (msgspec, PyO3 cutover gate, worker template, package layout, bulletin schema, H7, lint
+        default on); consistency agent found VT-S008-C01–C10 pending user review; stage not marked completed; delta_substage
+        S008-f6-tac2iwxxm remains in_progress"
+      - "2026-07-12 D-S008-05-batch2 — Batch 2 verdicts C09a=1, C09c=1, M01=2, M02=1; delta_substage S008-f6-tac2iwxxm remains
+        in_progress"
+      - "2026-07-12 D-S008-05-complete — 05-verify-tech audit done; next=16-evolve then 07-build; Phase B delta cleared (06
+        N/A); delta_substage S008-f6-tac2iwxxm completed"
       - "2026-07-12 EV-006 created — Phase B complete; B→C checkpoint pending before 07-build"
       - "2026-07-12 D-S008-EV006-b-to-c=A — Phase B→C passed; starting 07-build Phase 1 M1 T1.1"
       - "2026-07-12 M1 tasks T1.1–T1.6 completed on feat/S008-M1-scaffold; next 08-verify-build then PR-M1"
-      - "2026-07-12 M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for main/dev so PR to evolve has no Actions yet"
+      - "2026-07-12 M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for
+        main/dev so PR to evolve has no Actions yet"
       - "2026-07-12 resume: user chose resume 07-build at T2.1 (D-S008-EV006-resume=A); active_task T2.1 in_progress on feat/S008-M2-validate"
       - "2026-07-12 D-S008-T21-sch — Schematron strategy locked (option 1); T2.1 remains in_progress until commit"
-      - "2026-07-12 T2.1+T2.2 done; D-S008-T21-sch applied; active_task T2.3 pending (T2.2 git SHA not yet on HEAD when recorded — only T2.1 db27737 in git_history)"
+      - "2026-07-12 T2.1+T2.2 done; D-S008-T21-sch applied; active_task T2.3 pending (T2.2 git SHA not yet on HEAD when recorded
+        — only T2.1 db27737 in git_history)"
       - "2026-07-12 T2.3+T2.4 complete (b167e71, d27090d); active_task T2.5 in_progress on feat/S008-M2-validate"
-      - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete (82b5bad, 7c49e34, 174fa1c); 08-verify-build scoped pass (format, package types, unit packages + wrappers + soft benches); active_task M2 complete — opening PR-M2"
-      - "2026-07-12 D-S008-PR700-19 — waive routing for 19-address-pr-review; PRM-008 completed on PR #700; merged at user request (anti-merge override)"
+      - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete (82b5bad, 7c49e34, 174fa1c); 08-verify-build scoped pass (format, package
+        types, unit packages + wrappers + soft benches); active_task M2 complete — opening PR-M2"
+      - "2026-07-12 D-S008-PR700-19 — waive routing for 19-address-pr-review; PRM-008 completed on PR #700; merged at user
+        request (anti-merge override)"
       - "2026-07-12 D-S008-PR701-19 — waive AskQuestion; PRM-009 completed on PR #701; explicit push+merge (anti-merge override)"
-      - "2026-07-12 D-S008-PR704-19 — waive AskQuestion; PRM-010 in_progress on PR #704; explicit remediate+push+merge (anti-merge override)"
+      - "2026-07-12 D-S008-PR704-19 — waive AskQuestion; PRM-010 in_progress on PR #704; explicit remediate+push+merge (anti-merge
+        override)"
       - "2026-07-12 D-S008-EV006-resume-m4 — resume M4 T4.1"
       - "2026-07-12 D-S008-EV006-resume-t410 — resume 07-build at T4.10"
       - "2026-07-12 T4.10+T4.11 done; next T4.6"
       - "2026-07-12 D-S008-EV006-t47-cutover — T4.7 in progress"
       - "2026-07-12 M4 remaining tasks T4.10–T4.9 done; ready 08-verify-build + PR"
-      - "2026-07-12 D-S008-EV006-merge-m4-m7 — user said Merge; #706–#709 merged into evolve (anti-merge override for 18/19); M4–M7 complete; next M8 or continue 07-build"
-      - "2026-07-12 M8 T8.1–T8.4 complete; PR-M8 #710 MERGED into evolve (PRM-014 / e4fe492); M8 complete; next Phase C→D (08-verify-build / 09-qa) or redeploy for live F6.e"
+      - "2026-07-12 D-S008-EV006-merge-m4-m7 — user said Merge; #706–#709 merged into evolve (anti-merge override for 18/19);
+        M4–M7 complete; next M8 or continue 07-build"
+      - "2026-07-12 M8 T8.1–T8.4 complete; PR-M8 #710 MERGED into evolve (PRM-014 / e4fe492); M8 complete; next Phase C→D
+        (08-verify-build / 09-qa) or redeploy for live F6.e"
       - "2026-07-12 User chose resume option 1 — close Phase C / mark 07-build complete → C→D via 08-verify-build (D-S008-EV006-c-close)"
       - "2026-07-12 08-verify-build Phase C FAIL — awaiting fix decision on typecheck + coverage"
       - "2026-07-12 D-S008-EV006-08-fix — User chose option 1 fix-in-place for typecheck+coverage; 08 re-verify PASS"
-      - "2026-07-12 08-verify-build Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c). Awaiting C→D AskQuestion before 09-qa; gates.c_to_d/phase_c remain pending"
+      - "2026-07-12 08-verify-build Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c).
+        Awaiting C→D AskQuestion before 09-qa; gates.c_to_d/phase_c remain pending"
       - "2026-07-12 D-S008-EV006-c-to-d — User chose option 1; C→D passed; Phase D started; advancing to 09-qa"
       - "2026-07-12 10-e2e started in parallel with 09-qa after C→D"
       - "2026-07-12 09-qa completed — pass_with_advisories; see reports/qa-report.md"
       - "2026-07-12 10-e2e completed — FAIL (10 pass / 2 fail COR correction e2e); see e2e-report.md"
-      - "2026-07-12 Phase D 09+10 done; checkpoint before 11-verify-impl (phase_d remains pending until AskQuestion) [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 Phase D 09+10 done; checkpoint before 11-verify-impl (phase_d remains pending until AskQuestion) [RESOLVED
+        by D-S008-EV006-phase-d]"
       - "2026-07-12 D-S008-EV006-3-then-2 — User chose 3 then 2: commit Phase C/D artifacts then hotfix COR e2e"
-      - "2026-07-12 commit 48037c1 Phase C/D reports; COR hotfix landed; 10-e2e T0 PASS (12/12 Playwright smoke); phase_d remains pending until AskQuestion before 11 [RESOLVED by D-S008-EV006-phase-d]"
-      - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 commit 48037c1 Phase C/D reports; COR hotfix landed; 10-e2e T0 PASS (12/12 Playwright smoke); phase_d
+        remains pending until AskQuestion before 11 [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl [RESOLVED
+        by D-S008-EV006-phase-d]"
       - "2026-07-12 D-S008-EV006-phase-d — phase_d checkpoint passed (AskQuestion option 1); 11-verify-impl started"
       - "2026-07-12 phase_d passed; active_session.current_stage=11-verify-impl (in_progress); 11 not completed"
       - "2026-07-12 Journey signoff: UJ-001 approved (T3 pending waiver); UJ-003 approved (T3 pending waiver)."
-      - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005). Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3 live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014). Cycle product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion; 11-verify-impl remains in_progress."
-      - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
-      - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005).
+        Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3 live
+        pending waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live
+        pending waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live pending
+        waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014). Cycle
+        product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion; 11-verify-impl
+        remains in_progress."
+      - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred
+        (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
+      - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred;
+        11-verify-impl remains in_progress."
       - "2026-07-12 All cycle features F6/F2/F8 approved; writing verify-impl.md next."
-      - "2026-07-12 11-verify-impl completed; F6/F2/F8 approved; F6/F8 corpus Implemented (ADR-019); live gates deferred; S008 routing has no 12/13 — next is session close checkpoint or amend routing for deploy."
-      - "2026-07-12 Routing complete — all required routing_plan stages completed; current_stage=null pending session close AskQuestion (active_session remains open)."
+      - "2026-07-12 11-verify-impl completed; F6/F2/F8 approved; F6/F8 corpus Implemented (ADR-019); live gates deferred;
+        S008 routing has no 12/13 — next is session close checkpoint or amend routing for deploy."
+      - "2026-07-12 Routing complete — all required routing_plan stages completed; current_stage=null pending session close
+        AskQuestion (active_session remains open)."
       - "2026-07-12 D-S008-EV006-close — session closed; deploy waived"
 
   - id: S007-docs-minimize
@@ -997,7 +1078,8 @@ sessions:
     started_at: "2026-06-25"
     completed_at: "2026-07-12"
     pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/695
-    close_note: "PR #695 merged 2026-06-25; user waived 11-verify-impl; stages 07–10 PASS reports; 12/13 skipped; docs reorg unblocked via 00-context"
+    close_note: "PR #695 merged 2026-06-25; user waived 11-verify-impl; stages 07–10 PASS reports; 12/13 skipped; docs reorg
+      unblocked via 00-context"
     routing_plan:
       - stage: 00-context
         mode: scoped
@@ -1041,9 +1123,13 @@ sessions:
         status: skipped
         skip_rationale: "Deploy not requested; waived at session close"
     notes:
-      - "00-context scoped complete 2026-06-25 — default name manual_input[_N] set in apps/backend/src/api.py, surfaced as ConversionResult.name, used by FileConverter download handlers"
-      - "Approved scope: frontend-only (R1); blank ⇒ manual_input default (R2); applies to manual results only, uploads unchanged (R3); multi-line _1/_2 suffix assumed (R4)"
-      - "16-evolve EV-005 Phase 0–1 2026-06-25 — R4 multi-line suffix confirmed; R5 persist across reload confirmed; R6 carry via conversion_params JSONB (no migration/API change); R7 ZIP archive renamed to custom base; R8 extend F1 + touch F5 (no new Fn); routing stays lean (frontend-only build)"
+      - "00-context scoped complete 2026-06-25 — default name manual_input[_N] set in apps/backend/src/api.py, surfaced as
+        ConversionResult.name, used by FileConverter download handlers"
+      - "Approved scope: frontend-only (R1); blank ⇒ manual_input default (R2); applies to manual results only, uploads unchanged
+        (R3); multi-line _1/_2 suffix assumed (R4)"
+      - "16-evolve EV-005 Phase 0–1 2026-06-25 — R4 multi-line suffix confirmed; R5 persist across reload confirmed; R6 carry
+        via conversion_params JSONB (no migration/API change); R7 ZIP archive renamed to custom base; R8 extend F1 + touch
+        F5 (no new Fn); routing stays lean (frontend-only build)"
       - "07–10 complete with PASS reports under docs/sessions/S006-issue-664-output-filename/reports/"
       - "Closed 2026-07-12 — user waived 11-verify-impl; PR #695 merged; docs reorg path unblocked"
     context_briefs:
@@ -1088,23 +1174,38 @@ stages:
       - docs/sessions/S016-manual-tac-input-modes/routing-plan.md
       - docs/context/manual-tac-input-modes.md
     notes:
-      - 2026-07-20 S016/EV-012 00-context completed — Phase 0 intake locked; lean+13 routing approved (D-S016-EV012-route-1); handoff to 01-requirements
-      - "2026-07-19 S015/EV-011 00-context completed — routing approved (D-S015-EV011-route-1); max expansion scope (D-S015-EV011-research-1); handoff to 01-requirements"
-      - "2026-07-19 S015/EV-011 open — scoped_slug metar-lint-quality; Phase 0 intake locked; routing approval pending; S011 session-brief.md updated on disk to completed"
-      - "2026-07-15 S012-empty-bearer-lint-tac open — scoped hotfix empty Bearer lint-tac/decode-tac + lint UX; S011/EV-008 paused (PR #716 remains open)"
+      - 2026-07-20 S016/EV-012 00-context completed — Phase 0 intake locked; lean+13 routing approved 
+        (D-S016-EV012-route-1); handoff to 01-requirements
+      - "2026-07-19 S015/EV-011 00-context completed — routing approved (D-S015-EV011-route-1); max expansion scope (D-S015-EV011-research-1);
+        handoff to 01-requirements"
+      - "2026-07-19 S015/EV-011 open — scoped_slug metar-lint-quality; Phase 0 intake locked; routing approval pending; S011
+        session-brief.md updated on disk to completed"
+      - "2026-07-15 S012-empty-bearer-lint-tac open — scoped hotfix empty Bearer lint-tac/decode-tac + lint UX; S011/EV-008
+        paused (PR #716 remains open)"
       - "GitHub #555 parent feedback; 2/4 items done in S001; auto-clear + error log remain"
       - "2026-06-25 scoped run S005 — docs/context/issue-671-docker-db.md (#671 Docker DB connect failure)"
-      - "2026-06-25 scoped run S006 — docs/context/issue-664-output-filename.md (#664 custom output filename, manual input; frontend-only)"
+      - "2026-06-25 scoped run S006 — docs/context/issue-664-output-filename.md (#664 custom output filename, manual input;
+        frontend-only)"
       - "Prior scoped_slug before S008 amend: issue-555-feedback (completed 2026-06-23)"
-      - "2026-07-12 S008 amend — scoped refresh realtime-tac-ingest linked from S008 (general-tac brief remains; new brief for ingest/data-entry delta)"
-      - "2026-07-12 interview issues resolved (D-S008-realtime-amend-q9q13): I-S008-template-drift-worker via Q10=A; I-S008-f5-f6-metar-only-vs-multiproduct-ui via Q9=A"
+      - "2026-07-12 S008 amend — scoped refresh realtime-tac-ingest linked from S008 (general-tac brief remains; new brief
+        for ingest/data-entry delta)"
+      - "2026-07-12 interview issues resolved (D-S008-realtime-amend-q9q13): I-S008-template-drift-worker via Q10=A; I-S008-f5-f6-metar-only-vs-multiproduct-ui
+        via Q9=A"
       - "2026-07-12 proposed features for 01-requirements delta: F7 (multi-product TAC sessions), F8 (near-RT ingest pipeline)"
-      - "2026-07-12 D-S008-realtime-amend-q14q18 — package-first; postpone auth + push sinks; parse gate + shared TAC rule pack; research bulletin-aware default; scale worker replicas. Pending Ambiguity I-S008-package-first-scope (F7/F8 scope)"
-      - "2026-07-12 D-S008-realtime-amend-q19q22 locked — Q19=A package APIs only (F7/F8 Planned docs; no worker/UI/auth/sinks build); Q20=B packages/iwxxm-validate + TAC validate pkg TBD; Q21=A bulletin split v1; Q22=A scoped brief then 01. I-S008-package-first-scope resolved."
-      - "2026-07-12 scoped refresh completed — phase4 done; brief docs/context/realtime-tac-ingest.md active and indexed in docs/context/README.md; overall 00-context completed for this scoped refresh"
-      - "2026-07-13 S011 open — scoped_slug f7-operator-ui; Phase 0 completed, phase1a in_progress; F7 operator UI packaging (user-approved defaults)"
-      - "Phase 1A: frontend F6.e pickers exist; no spans; no decode API; no CodeMirror/Monaco; admin still live; convert hard-fails incomplete TAC"
-      - "Phase 2: contradictions — #697 vs F5 admin corpus; #694/#702 need new span schema vs api-contract unchanged validate shape"
+      - "2026-07-12 D-S008-realtime-amend-q14q18 — package-first; postpone auth + push sinks; parse gate + shared TAC rule
+        pack; research bulletin-aware default; scale worker replicas. Pending Ambiguity I-S008-package-first-scope (F7/F8
+        scope)"
+      - "2026-07-12 D-S008-realtime-amend-q19q22 locked — Q19=A package APIs only (F7/F8 Planned docs; no worker/UI/auth/sinks
+        build); Q20=B packages/iwxxm-validate + TAC validate pkg TBD; Q21=A bulletin split v1; Q22=A scoped brief then 01.
+        I-S008-package-first-scope resolved."
+      - "2026-07-12 scoped refresh completed — phase4 done; brief docs/context/realtime-tac-ingest.md active and indexed in
+        docs/context/README.md; overall 00-context completed for this scoped refresh"
+      - "2026-07-13 S011 open — scoped_slug f7-operator-ui; Phase 0 completed, phase1a in_progress; F7 operator UI packaging
+        (user-approved defaults)"
+      - "Phase 1A: frontend F6.e pickers exist; no spans; no decode API; no CodeMirror/Monaco; admin still live; convert hard-fails
+        incomplete TAC"
+      - "Phase 2: contradictions — #697 vs F5 admin corpus; #694/#702 need new span schema vs api-contract unchanged validate
+        shape"
       - "Phase 3 R1–R6 resolved by user 2026-07-13; R6 BYO-only includes Postgres/DATABASE_URL/SQL URIs"
       - "Phase 4 wrote docs/context/f7-operator-ui.md; indexed in docs/context/README.md"
   01-requirements:
@@ -1187,7 +1288,8 @@ stages:
         session_id: S008-general-tac-iwxxm-converter
         started_at: "2026-07-12"
         completed_at: "2026-07-12"
-        note: "User approved: option 3 — include API Contract; full FAA-five feature coverage; F6 proposed. S008 01-requirements delta complete — F6 specs + ADR-014"
+        note: "User approved: option 3 — include API Contract; full FAA-five feature coverage; F6 proposed. S008 01-requirements
+          delta complete — F6 specs + ADR-014"
         substeps:
           interviews:
             completed: 7
@@ -1200,11 +1302,13 @@ stages:
         session_id: S008-general-tac-iwxxm-converter
         started_at: "2026-07-12"
         completed_at: "2026-07-12"
-        note: "S008-realtime-ingest delta COMPLETED — interviews 7/7; ADR-015; API Q51=A validate→iwxxm-validate; Q52=B POST /lint-tac; Q53=B POST /convert-bulletin; Q54=A write API+ADR. F7/F8 Planned; package APIs + thin wrappers this cycle."
+        note: "S008-realtime-ingest delta COMPLETED — interviews 7/7; ADR-015; API Q51=A validate→iwxxm-validate; Q52=B POST
+          /lint-tac; Q53=B POST /convert-bulletin; Q54=A write API+ADR. F7/F8 Planned; package APIs + thin wrappers this cycle."
         proposed_features:
           - F7
           - F8
-        build_scope_this_cycle: "package APIs + backend thin wrappers for tac-validate and iwxxm-validate (D-S008-01-feature-list-q29q33 Q30=B; expands Q19=A package-first)"
+        build_scope_this_cycle: "package APIs + backend thin wrappers for tac-validate and iwxxm-validate (D-S008-01-feature-list-q29q33
+          Q30=B; expands Q19=A package-first)"
         artifacts:
           - docs/feature-list.md
           - docs/spec.md
@@ -1252,7 +1356,8 @@ stages:
         evolve_cycle_id: EV-008
         started_at: "2026-07-13"
         completed_at: "2026-07-13"
-        note: "S011/EV-008 01-requirements delta COMPLETE — interviews 8/8; Config/env Batch option B (D-S011-01-cfg-B); ADR-020/021/022 accepted; all approved docs done. Phase A checkpoint pending before 02-verify-plan."
+        note: "S011/EV-008 01-requirements delta COMPLETE — interviews 8/8; Config/env Batch option B (D-S011-01-cfg-B); ADR-020/021/022
+          accepted; all approved docs done. Phase A checkpoint pending before 02-verify-plan."
         artifacts:
           - docs/feature-list.md
           - docs/spec.md
@@ -1340,34 +1445,67 @@ stages:
       - >-
         2026-07-19 S015/EV-011 02-verify-plan COMPLETE (D-S015-EV011-s1m1-1/s1m2-1/s9m1-1) —
         PASS; handoff 03-plan-tooling
-      - "2026-07-19 S015/EV-011 02-verify-plan audit pending medium review — 12 auto-approved; 3 medium pending (S1.M1, S1.M2, S9.M1); fix-in-place F11–F14 status + F15 SPECI naming"
-      - "2026-07-19 S015/EV-011 D-S015-EV011-phase-a-pass — Phase A passed (option A); Phase A digest accepted; 02-verify-plan in_progress"
-      - "2026-07-19 S015/EV-011 01-requirements COMPLETE (D-S015-EV011-spec-2/speci-3/phase-a-next) — interviews 7/7; api-contract wire-shape note; SPECI adjacency UJ-024/TC-F15-005; Phase A checkpoint pending before 02-verify-plan"
-      - "2026-07-19 S015/EV-011 D-S015-EV011-f15-1/codes-1/f7-1 — Feature List E11-9/10/11 approved; F15 as written; stable codes; F7 stays Planned; ADR-028 Accepted; interviews 1/7 → user-journeys+test-plan confirmation"
-      - "2026-07-19 S015/EV-011 D-S015-EV011-manifest-1 — 01 document manifest approved option A (E11-7); interviews starting feature-list (0/7)"
-      - "2026-07-19 S015/EV-011 D-S015-EV011-registry-1 — registry home packages/tac-validate module + generated/docs catalog (E11-8 option A); ADR-028 Accepted"
+      - "2026-07-19 S015/EV-011 02-verify-plan audit pending medium review — 12 auto-approved; 3 medium pending (S1.M1, S1.M2,
+        S9.M1); fix-in-place F11–F14 status + F15 SPECI naming"
+      - "2026-07-19 S015/EV-011 D-S015-EV011-phase-a-pass — Phase A passed (option A); Phase A digest accepted; 02-verify-plan
+        in_progress"
+      - "2026-07-19 S015/EV-011 01-requirements COMPLETE (D-S015-EV011-spec-2/speci-3/phase-a-next) — interviews 7/7; api-contract
+        wire-shape note; SPECI adjacency UJ-024/TC-F15-005; Phase A checkpoint pending before 02-verify-plan"
+      - "2026-07-19 S015/EV-011 D-S015-EV011-f15-1/codes-1/f7-1 — Feature List E11-9/10/11 approved; F15 as written; stable
+        codes; F7 stays Planned; ADR-028 Accepted; interviews 1/7 → user-journeys+test-plan confirmation"
+      - "2026-07-19 S015/EV-011 D-S015-EV011-manifest-1 — 01 document manifest approved option A (E11-7); interviews starting
+        feature-list (0/7)"
+      - "2026-07-19 S015/EV-011 D-S015-EV011-registry-1 — registry home packages/tac-validate module + generated/docs catalog
+        (E11-8 option A); ADR-028 Accepted"
       - "Monorepo migration requirements interview complete; big-bang approach approved"
-      - "2026-07-13 S011/EV-008 01-requirements COMPLETE (D-S011-01-cfg-B) — interviews 8/8; BYO + deprecate ADMIN_*→E2E_USER_*; ADR-020/021/022; Phase A checkpoint pending before 02-verify-plan"
-      - "2026-07-13 S011/EV-008 Spec Batch 1–2 + ADR-020 (D-S011-01-spec-r2-prime) — Override R2 unified tac_work_sessions; interviews 2/8; current_template=user-journeys; current_section=f7-journeys; artifacts: feature-list, spec, ADR-020, f7-operator-ui context"
-      - "2026-07-13 S011/EV-008 Feature List done (D-S011-01-fl-batch2-A) — docs/feature-list.md updated for F7; interviews 1/8; current_template=spec; current_section=architecture"
-      - "2026-07-13 S011/EV-008 document manifest approved option A (D-S011-01-manifest-A) — mandatory + api-contract/config/deps/ADRs; skip acceptance-criteria; interviews at feature-list/core (0/8)"
-      - "2026-07-12 S008 amend — delta S008-realtime-ingest in_progress after 00 scoped brief (realtime-tac-ingest); prior S008 F6 delta remains completed"
+      - "2026-07-13 S011/EV-008 01-requirements COMPLETE (D-S011-01-cfg-B) — interviews 8/8; BYO + deprecate ADMIN_*→E2E_USER_*;
+        ADR-020/021/022; Phase A checkpoint pending before 02-verify-plan"
+      - "2026-07-13 S011/EV-008 Spec Batch 1–2 + ADR-020 (D-S011-01-spec-r2-prime) — Override R2 unified tac_work_sessions;
+        interviews 2/8; current_template=user-journeys; current_section=f7-journeys; artifacts: feature-list, spec, ADR-020,
+        f7-operator-ui context"
+      - "2026-07-13 S011/EV-008 Feature List done (D-S011-01-fl-batch2-A) — docs/feature-list.md updated for F7; interviews
+        1/8; current_template=spec; current_section=architecture"
+      - "2026-07-13 S011/EV-008 document manifest approved option A (D-S011-01-manifest-A) — mandatory + api-contract/config/deps/ADRs;
+        skip acceptance-criteria; interviews at feature-list/core (0/8)"
+      - "2026-07-12 S008 amend — delta S008-realtime-ingest in_progress after 00 scoped brief (realtime-tac-ingest); prior
+        S008 F6 delta remains completed"
       - "2026-07-12 proposed features for S008-realtime-ingest delta: F7, F8 (D-S008-realtime-amend-q9q13)"
-      - "2026-07-12 D-S008-realtime-amend-q19q22 — this-cycle build = package APIs only; F7/F8 Planned in docs; worker/UI/auth/sinks out of build scope"
-      - "2026-07-12 D-S008-01-manifest-q23 — Q23=A approve mandatory Feature List, Spec, User Journeys, Test Plan + Deps, API light, ADRs; skip Config Spec and Deploy. Interview plan: 7 docs (4 mandatory + 3 recommended); interviews started at feature-list/core (completed 0/7)"
-      - "2026-07-12 D-S008-01-feature-list-q24q28 — Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A F7 stub; Q27=A F8 stub; Q28=A F2→iwxxm-validate wrapper. Feature List current_section: non-goals (still feature-list; completed 0/7)"
-      - "2026-07-12 D-S008-01-feature-list-q29q33 — Q29=C leave F6 non-goals unchanged (worker only under F8); Q30=B package APIs + API thin wrappers this cycle (expands package-first to include backend thin wrappers for tac-validate and iwxxm-validate); Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS out of build; Q33=A write feature-list then Spec. interviews.current_section: writing feature-list (completed 0/7)"
-      - "2026-07-12 Feature List document written (docs/feature-list.md delta) — interviews.completed 1/7; planned_docs.status.feature-list=completed; current_template=spec; current_section=components"
-      - "2026-07-12 D-S008-01-spec-q34q38 — Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase; Q37=B dashed future worker in diagram; Q38=A write Spec then Journeys. interviews.current_section: writing-spec (completed 1/7)"
-      - "2026-07-12 Spec written (docs/spec.md delta) — interviews.completed 2/7; planned_docs.status.spec=completed; current_template=user-journeys; current_section=happy-paths"
-      - "2026-07-12 D-S008-01-journeys-q39q43 — Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub UJ-013/014; Q42=A T2 for 011/012; Q43=A write journeys then test plan. interviews.current_section: writing-journeys (completed 2/7)"
-      - "2026-07-12 User Journeys written (docs/user-journeys.md delta) — interviews.completed 3/7; planned_docs.status.user-journeys=completed; current_template=test-plan; current_section=types"
-      - "2026-07-12 D-S008-01-test-plan-q44q47 — Q44=B; Q44b=B H7; Q45=A; Q46=A; Q47=A. interviews.current_section: writing-test-plan then dependency-inventory (completed 3/7)"
-      - "2026-07-12 Test Plan written (docs/test-plan.md delta) — interviews.completed 4/7; planned_docs.status.test-plan=completed; current_template=dependency-inventory; current_section=packages"
-      - "2026-07-12 D-S008-01-deps-q48q50 — Q48=A MIT; Q49=B pydantic/msgspec in 04; Q50=A. interviews.current_section: writing-deps then api-contract (completed 4/7)"
-      - "2026-07-12 Dependency Inventory written (docs/dependency-inventory.md delta) — interviews.completed 5/7; planned_docs.status.dependency-inventory=completed; current_template=api-contract; current_section=endpoints"
-      - "2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. interviews.completed 7/7; planned_docs api-contract+adr completed"
-      - "2026-07-12 S008-realtime-ingest amend COMPLETE — delta status completed; overall 01-requirements completed; advancing to 04-tech-plan (pending)"
+      - "2026-07-12 D-S008-realtime-amend-q19q22 — this-cycle build = package APIs only; F7/F8 Planned in docs; worker/UI/auth/sinks
+        out of build scope"
+      - "2026-07-12 D-S008-01-manifest-q23 — Q23=A approve mandatory Feature List, Spec, User Journeys, Test Plan + Deps,
+        API light, ADRs; skip Config Spec and Deploy. Interview plan: 7 docs (4 mandatory + 3 recommended); interviews started
+        at feature-list/core (completed 0/7)"
+      - "2026-07-12 D-S008-01-feature-list-q24q28 — Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A
+        F7 stub; Q27=A F8 stub; Q28=A F2→iwxxm-validate wrapper. Feature List current_section: non-goals (still feature-list;
+        completed 0/7)"
+      - "2026-07-12 D-S008-01-feature-list-q29q33 — Q29=C leave F6 non-goals unchanged (worker only under F8); Q30=B package
+        APIs + API thin wrappers this cycle (expands package-first to include backend thin wrappers for tac-validate and iwxxm-validate);
+        Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS out of build; Q33=A write feature-list then Spec.
+        interviews.current_section: writing feature-list (completed 0/7)"
+      - "2026-07-12 Feature List document written (docs/feature-list.md delta) — interviews.completed 1/7; planned_docs.status.feature-list=completed;
+        current_template=spec; current_section=components"
+      - "2026-07-12 D-S008-01-spec-q34q38 — Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase;
+        Q37=B dashed future worker in diagram; Q38=A write Spec then Journeys. interviews.current_section: writing-spec (completed
+        1/7)"
+      - "2026-07-12 Spec written (docs/spec.md delta) — interviews.completed 2/7; planned_docs.status.spec=completed; current_template=user-journeys;
+        current_section=happy-paths"
+      - "2026-07-12 D-S008-01-journeys-q39q43 — Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub
+        UJ-013/014; Q42=A T2 for 011/012; Q43=A write journeys then test plan. interviews.current_section: writing-journeys
+        (completed 2/7)"
+      - "2026-07-12 User Journeys written (docs/user-journeys.md delta) — interviews.completed 3/7; planned_docs.status.user-journeys=completed;
+        current_template=test-plan; current_section=types"
+      - "2026-07-12 D-S008-01-test-plan-q44q47 — Q44=B; Q44b=B H7; Q45=A; Q46=A; Q47=A. interviews.current_section: writing-test-plan
+        then dependency-inventory (completed 3/7)"
+      - "2026-07-12 Test Plan written (docs/test-plan.md delta) — interviews.completed 4/7; planned_docs.status.test-plan=completed;
+        current_template=dependency-inventory; current_section=packages"
+      - "2026-07-12 D-S008-01-deps-q48q50 — Q48=A MIT; Q49=B pydantic/msgspec in 04; Q50=A. interviews.current_section: writing-deps
+        then api-contract (completed 4/7)"
+      - "2026-07-12 Dependency Inventory written (docs/dependency-inventory.md delta) — interviews.completed 5/7; planned_docs.status.dependency-inventory=completed;
+        current_template=api-contract; current_section=endpoints"
+      - "2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. interviews.completed
+        7/7; planned_docs api-contract+adr completed"
+      - "2026-07-12 S008-realtime-ingest amend COMPLETE — delta status completed; overall 01-requirements completed; advancing
+        to 04-tech-plan (pending)"
 
   02-verify-plan:
     status: completed
@@ -1427,7 +1565,8 @@ stages:
         2026-07-19 S015/EV-011 02-verify-plan COMPLETE (D-S015-EV011-s1m1-1/s1m2-1/s9m1-1) —
         PASS; 12 auto + medium verdicts all option 1; CORPUS F1–F15/M1–M6; #732 commented;
         handoff 03-plan-tooling; gates.a_to_b pending until 03 completes
-      - "2026-07-19 S015/EV-011 02-verify-plan delta in_progress — audit pending medium review; 12 auto-approved; 3 medium pending (S1.M1, S1.M2, S9.M1); fix-in-place F11–F14 + F15 SPECI naming"
+      - "2026-07-19 S015/EV-011 02-verify-plan delta in_progress — audit pending medium review; 12 auto-approved; 3 medium
+        pending (S1.M1, S1.M2, S9.M1); fix-in-place F11–F14 + F15 SPECI naming"
       - "Product plan verification complete; 4 source docs updated"
 
   03-plan-tooling:
@@ -1599,7 +1738,8 @@ stages:
               Q18: B  # separate quarantine table/bucket
               Q19: A  # apps/worker/
               Q20: C  # Supabase service JWT for writers
-          q5_cutover_clarification: "(ii) aggressive — delete gifts when METAR/SPECI annex3 + wrappers + bulletin green; other products post-delete on tac2iwxxm only"
+          q5_cutover_clarification: "(ii) aggressive — delete gifts when METAR/SPECI annex3 + wrappers + bulletin green; other
+            products post-delete on tac2iwxxm only"
         interview_review:
           Q21: A
           Q22: A
@@ -1660,7 +1800,8 @@ stages:
       - >-
         2026-07-19 S015/EV-011 04-tech-plan Batch 2 done (2/1/1/1) —
         D-S015-EV011-04-qual-1..4 (E11-23..26); Batch 3 pending
-      - 2026-07-19 S015/EV-011 04-tech-plan STARTED (D-S015-EV011-04-start) — Phase B in_progress; historical baseline status remains completed; tracked via delta_substages + active_session
+      - 2026-07-19 S015/EV-011 04-tech-plan STARTED (D-S015-EV011-04-start) — Phase B in_progress; historical baseline 
+        status remains completed; tracked via delta_substages + active_session
       - "Monorepo plan 2026-06-15; EV-004 delta completed 2026-06-23"
       - "Historical baseline status remains completed — S008 tracked via delta_substages only"
       - "S008 delta 04-tech-plan completed 2026-07-12 — execution plan + ADR-016/017/018 approved"
@@ -1723,7 +1864,9 @@ stages:
         completed_at: "2026-07-12"
         mode: delta
         notes:
-          - "2026-07-12 statement walk started — auto-approved high-confidence tech stack from Q1–Q20 / ADR-016/017/018 (msgspec, PyO3 cutover gate, worker template, package layout, bulletin schema, H7, lint default on); consistency agent found contradictions VT-S008-C01 through C10 pending user review; do not mark stage completed"
+          - "2026-07-12 statement walk started — auto-approved high-confidence tech stack from Q1–Q20 / ADR-016/017/018 (msgspec,
+            PyO3 cutover gate, worker template, package layout, bulletin schema, H7, lint default on); consistency agent found
+            contradictions VT-S008-C01 through C10 pending user review; do not mark stage completed"
           - "2026-07-12 D-S008-05-batch1 — Batch 1 verdicts C01/C04/C05/C07=1, C02/C03=2; delta remains in_progress"
           - "2026-07-12 D-S008-05-batch2 — Batch 2 verdicts C09a=1, C09c=1, M01=2, M02=1; delta remains in_progress"
           - "2026-07-12 D-S008-05-complete — delta audit completed; Phase B delta cleared (06 N/A); next 16-evolve then 07-build"
@@ -1736,7 +1879,8 @@ stages:
         mode: delta
         notes:
           - "2026-07-13 started after D-S011-04-plan-approve-A; phase_b pending until 05 completes + user checkpoint"
-          - "2026-07-13 D-S011-05-pass — audit PASS (reports/05-verify-tech-audit.md); A1–A3 approved as-is; phase_b remains pending until user Phase B AskQuestion"
+          - "2026-07-13 D-S011-05-pass — audit PASS (reports/05-verify-tech-audit.md); A1–A3 approved as-is; phase_b remains
+            pending until user Phase B AskQuestion"
       - id: S014-package-publish-validation
         session_id: S014-package-publish-validation
         evolve_cycle_id: EV-010
@@ -1763,10 +1907,12 @@ stages:
         Phase B delta; historical baseline status remains completed
       - "Technical plan verification complete; 3 source docs updated"
       - "Historical baseline status remains completed — S008 tracked via delta_substages only"
-      - "S008 delta 05-verify-tech statement walk in progress 2026-07-12 — auto-approved high-confidence stack; VT-S008-C01–C10 pending user review"
+      - "S008 delta 05-verify-tech statement walk in progress 2026-07-12 — auto-approved high-confidence stack; VT-S008-C01–C10
+        pending user review"
       - "2026-07-12 D-S008-05-batch1 recorded — Batch 1 contradiction verdicts; delta_substage still in_progress"
       - "2026-07-12 D-S008-05-batch2 recorded — Batch 2 contradiction/missing verdicts; delta_substage still in_progress"
-      - "S008 delta 05-verify-tech completed 2026-07-12 — audit done; Phase B delta cleared (06 N/A); historical baseline status unchanged (completed)"
+      - "S008 delta 05-verify-tech completed 2026-07-12 — audit done; Phase B delta cleared (06 N/A); historical baseline
+        status unchanged (completed)"
       - "S011/EV-008 delta 05-verify-tech completed 2026-07-13 — audit PASS; A1–A3 as-is; phase_b still pending (no auto-pass)"
       - "S014/EV-010 delta 05-verify-tech PASS 2026-07-18 — 12 auto + 44A–47A; Phase B checkpoint before 06"
 
@@ -1914,7 +2060,8 @@ stages:
         evolve_cycle_id: EV-006
         started_at: "2026-07-12"
         completed_at: "2026-07-12"
-        note: "All M1–M8 tasks (51/51) done; PR-M8 #710 merged; Phase C implementation complete; handing to 08-verify-build for C→D gate"
+        note: "All M1–M8 tasks (51/51) done; PR-M8 #710 merged; Phase C implementation complete; handing to 08-verify-build
+          for C→D gate"
       - id: S011-f7-operator-ui
         session_id: S011-f7-operator-ui
         evolve_cycle_id: EV-008
@@ -1935,7 +2082,8 @@ stages:
         2026-07-20 S015/EV-011 M1 complete (T1.1–T1.4; e0189d4/ac0a282/a1abc7c/79aa67c);
         next 08-verify-build (M1) then M2 T2.1
       - 2026-07-19 S015/EV-011 delta 07-build in_progress — B→C passed; M1 T1.1 in_progress (D-S015-EV011-b-to-c=A)
-      - '2026-07-19 S011/EV-008 closed completed (D-S011-EV008-close-1) — PR #716 merged 22a6199; 07-build delta completed; 13-deploy-smoke waived'
+      - '2026-07-19 S011/EV-008 closed completed (D-S011-EV008-close-1) — PR #716 merged 22a6199; 07-build delta completed;
+        13-deploy-smoke waived'
       - >-
         2026-07-19 S014/EV-010 T6.6 completed (D-S014-EV010-t66-close-2) — Approve T6.6 and
         commit on main; 07-build M6 complete; live PyPI tags deferred
@@ -1963,9 +2111,11 @@ stages:
       - "2026-07-19 S014/EV-010 T6.3 completed (D-S014-EV010-t63-features); T6.4 12-verify-deploy in_progress"
       - "2026-07-19 S014/EV-010 T6.2 PASS (09+10); next T6.3 11-verify-impl after Phase D checkpoint"
       - "2026-07-19 S014/EV-010 C→D passed (D-S014-EV010-c-to-d-pass); T6.2 09-qa+10-e2e in_progress"
-      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED; next T6.2 after C→D; git commit d3dbbfb recorded"
+      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED; next T6.2 after C→D; git commit d3dbbfb
+        recorded"
       - "2026-07-19 S014/EV-010 M6 started — T6.1 08-verify-build in_progress"
-      - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task T6.1 pending"
+      - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task
+        T6.1 pending"
       - "2026-07-19 S014/EV-010 T5.1–T5.2 completed (54a7180 / 6186888); active_task T5.3 in_progress"
       - "2026-07-19 S014/EV-010 M5 started — T5.1 in progress (msgspec HTTP API tests)"
       - "2026-07-19 S014/EV-010 M4 complete (T4.1–T4.5); next M5 T5.1"
@@ -1986,12 +2136,18 @@ stages:
       - "2026-07-18 S014/EV-010 M3 T3.1–T3.2 complete (1770086 / 947020b); next T3.3 Rust validate_iwxxm"
       - "2026-07-18 S014/EV-010 T3.1 complete — iwxxm-validate rust/maturin scaffold; hatch pure path retained"
       - "2026-07-18 S014/EV-010 user 52:A — continue 07-build at M3 T3.1 after M2 complete"
-      - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin scaffold)"
-      - "2026-07-18 S014/EV-010 M1 complete (T1.1–T1.3; 9f9f67b/3ad66cd/70d157b); next M2 T2.1; ci-cd.yml triggers only on main/dev — push alone did not run GHA; local format-check + perf tests green"
-      - "2026-07-18 S014/EV-010 delta 07-build in_progress — B→C passed (50B push-then-07); push about to happen; Phase C M1 T1.1 (D-S014-EV010-b-to-c-push)"
-      - "2026-07-14 S011/EV-008 PR-EV-008 prepared as #716 open (retitle/update evolve→main; NO merge, NO deploy); T6.4 in_progress (12 done / 13 pending); 13 blocked on merge approval"
-      - "2026-07-14 S011/EV-008 D-S011-EV008-deploy-check-A — 12 approved; T6.4 still in_progress (12 done / 13 pending); preparing PR-EV-008; 13 blocked on merge"
-      - "2026-07-14 S011/EV-008 T6.3 completed approved_with_waivers (D-S011-EV008-f7-approve); active_task T6.4 in_progress (12-verify-deploy)"
+      - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin
+        scaffold)"
+      - "2026-07-18 S014/EV-010 M1 complete (T1.1–T1.3; 9f9f67b/3ad66cd/70d157b); next M2 T2.1; ci-cd.yml triggers only on
+        main/dev — push alone did not run GHA; local format-check + perf tests green"
+      - "2026-07-18 S014/EV-010 delta 07-build in_progress — B→C passed (50B push-then-07); push about to happen; Phase C
+        M1 T1.1 (D-S014-EV010-b-to-c-push)"
+      - "2026-07-14 S011/EV-008 PR-EV-008 prepared as #716 open (retitle/update evolve→main; NO merge, NO deploy); T6.4 in_progress
+        (12 done / 13 pending); 13 blocked on merge approval"
+      - "2026-07-14 S011/EV-008 D-S011-EV008-deploy-check-A — 12 approved; T6.4 still in_progress (12 done / 13 pending);
+        preparing PR-EV-008; 13 blocked on merge"
+      - "2026-07-14 S011/EV-008 T6.3 completed approved_with_waivers (D-S011-EV008-f7-approve); active_task T6.4 in_progress
+        (12-verify-deploy)"
       - "2026-07-13 S011/EV-008 M3 T3.1 in_progress — test preview=true convert; active_milestone M3; active_task T3.1 in_progress"
       - "2026-07-13 S011/EV-008 M2 complete (T2.1–T2.8); PR-M2 #716 open; active_milestone M3 active_task T3.1"
       - "2026-07-13 S011/EV-008 delta 07-build in_progress — B→C passed; M1 T1.1 in_progress (D-S011-EV008-b-to-c-pass)"
@@ -2001,15 +2157,24 @@ stages:
       - "M7 complete (T7.1–T7.4); minor PR pending"
       - "S004 / EV-004 delta 07-build complete 2026-06-24 — 36/38 tasks; see 07-build-progress.md"
       - "2026-07-12 S008 / EV-006 Phase C — M8/all tasks done (51/51); PR-M8 #710 merged; Phase C implementation complete"
-      - '2026-07-14 S011/EV-008 M4 complete (T4.1–T4.6); PR-M4 #718 open; H0c PASS; H4–H5 deferred to M6; active_milestone M5; active_task T5.1 pending'
-      - "2026-07-14 S011/EV-008 M5 started — T5.1 in_progress (unified tac_work_sessions); active_milestone M5; active_task T5.1 in_progress"
-      - "2026-07-14 S011/EV-008 M5 T5.1–T5.5 complete; migration 20260714000010 applied remotely (13 rows cutover); active_milestone M5; active_task T5.6 in_progress (next PR-M5)"
-      - "2026-07-14 S011/EV-008 M5 complete (T5.1–T5.6); PR-M5 https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/720 open; remote migration applied (13 rows); Validate green after pyright fix; tip may still have unrelated red CI (admin bug regressions, etc.); active_milestone M6; active_task T6.1 pending"
-      - "2026-07-14 S011/EV-008 M6 started — T6.1 08-verify-build in_progress; M1 leftover + domain docs committed (bdcb9b8, b5b79d7); PR-M5 #720 still open"
-      - "2026-07-14 S011/EV-008 T6.1 PASS (verification-report.md); integration SKIPPED host ports/disk; active_task T6.2 pending"
+      - '2026-07-14 S011/EV-008 M4 complete (T4.1–T4.6); PR-M4 #718 open; H0c PASS; H4–H5 deferred to M6; active_milestone
+        M5; active_task T5.1 pending'
+      - "2026-07-14 S011/EV-008 M5 started — T5.1 in_progress (unified tac_work_sessions); active_milestone M5; active_task
+        T5.1 in_progress"
+      - "2026-07-14 S011/EV-008 M5 T5.1–T5.5 complete; migration 20260714000010 applied remotely (13 rows cutover); active_milestone
+        M5; active_task T5.6 in_progress (next PR-M5)"
+      - "2026-07-14 S011/EV-008 M5 complete (T5.1–T5.6); PR-M5 https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/720
+        open; remote migration applied (13 rows); Validate green after pyright fix; tip may still have unrelated red CI (admin
+        bug regressions, etc.); active_milestone M6; active_task T6.1 pending"
+      - "2026-07-14 S011/EV-008 M6 started — T6.1 08-verify-build in_progress; M1 leftover + domain docs committed (bdcb9b8,
+        b5b79d7); PR-M5 #720 still open"
+      - "2026-07-14 S011/EV-008 T6.1 PASS (verification-report.md); integration SKIPPED host ports/disk; active_task T6.2
+        pending"
       - "2026-07-14 S011/EV-008 C→D passed (D-S011-EV008-c-to-d-pass); T6.2 09-qa+10-e2e in_progress"
-      - "2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED host ports/disk; QA-001 api.py type narrow uncommitted; active_task T6.3 pending"
-      - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress"
+      - "2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED
+        host ports/disk; QA-001 api.py type narrow uncommitted; active_task T6.3 pending"
+      - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task
+        T6.3 in_progress"
     active_session:
       session_id: S015-metar-lint-quality
       evolve_cycle_id: EV-011
@@ -2136,7 +2301,8 @@ stages:
         completed_at: "2026-07-19"
         mode: full
         overall: approved
-        note: "verify-impl.md F11–F14 + journeys approved (D-S014-EV010-t63-features / D-S014-EV010-t63-journeys); hard publish/live tag/Render deferred to T6.4–T6.6"
+        note: "verify-impl.md F11–F14 + journeys approved (D-S014-EV010-t63-features / D-S014-EV010-t63-journeys); hard publish/live
+          tag/Render deferred to T6.4–T6.6"
         report: docs/sessions/S014-package-publish-validation/reports/verify-impl.md
         active_milestone: M6
         active_task: T6.3
@@ -2165,13 +2331,18 @@ stages:
         mode: full
         overall: approved_with_waivers
         report: docs/sessions/S011-f7-operator-ui/reports/verify-impl.md
-        note: "D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout T6.5"
+        note: "D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout
+          T6.5"
     notes:
-      - 2026-07-20 S015/EV-011 11-verify-impl completed — F15 approved — verify-impl.md; phase_d work complete pending close
-      - "2026-07-19 S014/EV-010 11-verify-impl completed — F11–F14 + journeys approved (D-S014-EV010-t63-features); next T6.4 12-verify-deploy"
-      - "2026-07-19 S014/EV-010 journey signoff complete (D-S014-EV010-t63-journeys); next Fn F11–F14 approval; T6.3/11-verify-impl remains in_progress"
+      - 2026-07-20 S015/EV-011 11-verify-impl completed — F15 approved — verify-impl.md; phase_d work complete pending 
+        close
+      - "2026-07-19 S014/EV-010 11-verify-impl completed — F11–F14 + journeys approved (D-S014-EV010-t63-features); next T6.4
+        12-verify-deploy"
+      - "2026-07-19 S014/EV-010 journey signoff complete (D-S014-EV010-t63-journeys); next Fn F11–F14 approval; T6.3/11-verify-impl
+        remains in_progress"
       - "2026-07-19 S014/EV-010 Phase D passed (D-S014-EV010-phase-d-to-t63); T6.3 11-verify-impl in_progress"
-      - "2026-07-14 S011/EV-008 T6.3 completed approved_with_waivers (D-S011-EV008-f7-approve); see reports/verify-impl.md; next T6.4"
+      - "2026-07-14 S011/EV-008 T6.3 completed approved_with_waivers (D-S011-EV008-f7-approve); see reports/verify-impl.md;
+        next T6.4"
       - "S003 / BUG-2026-06-23 — user approved M4+F3 delta; T3 auth + UI E2E deferred"
       - "08-verify-build + 09-qa still pending on routing plan"
       - "Next: 12-verify-deploy (Render key rotation)"
@@ -2254,7 +2425,8 @@ stages:
         report: docs/sessions/S011-f7-operator-ui/reports/e2e-report.md
         note: "T6.2 pass_with_advisories; Playwright/compose SKIPPED host ports/disk"
     notes:
-      - 2026-07-20 S016/EV-012 10-e2e completed — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; next 13-deploy-smoke (pending)
+      - 2026-07-20 S016/EV-012 10-e2e completed — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; next 13-deploy-smoke 
+        (pending)
       - 2026-07-20 S015/EV-011 10-e2e completed — PASS — e2e-report.md; UJ-024 catalog smoke
       - "2026-07-19 S014/EV-010 10-e2e completed — UJ-022/023/DEV-005 T0+local API PASS; T3/H6′→13; see e2e-report.md"
       - "2026-07-19 S014/EV-010 10-e2e in_progress (T6.2; D-S014-EV010-c-to-d-pass)"
@@ -2327,7 +2499,8 @@ stages:
         completed_at: "2026-07-12"
         overall: pass
         report: docs/sessions/S008-general-tac-iwxxm-converter/reports/verification-report.md
-        note: "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c). Awaiting C→D AskQuestion before 09-qa."
+        note: "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c). Awaiting C→D AskQuestion
+          before 09-qa."
       - id: S011-f7-operator-ui
         session_id: S011-f7-operator-ui
         evolve_cycle_id: EV-008
@@ -2340,16 +2513,20 @@ stages:
     notes:
       - 2026-07-20 S015/EV-011 08-verify-build completed — T5.1 PASS — verification-report.md; C→D passed
       - "2026-07-19 S014/EV-010 C→D passed (D-S014-EV010-c-to-d-pass); T6.2 09-qa+10-e2e in_progress"
-      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED (docker pull); C→D pending AskQuestion; git commit d3dbbfb recorded"
+      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED (docker pull); C→D pending AskQuestion;
+        git commit d3dbbfb recorded"
       - "2026-07-19 S014/EV-010 M6 started — T6.1 08-verify-build in_progress"
       - "S001 / EV-001 — PASS 2026-06-22 (docs/sessions/S001-convert-send-buttons/reports/verification-report.md)"
       - "S004 / EV-004 — FAIL 2026-06-24 on feat/S004-issue-555-feedback"
       - "H0c CORS 6/6 pass; connectivity artifacts present"
       - "make test-integration not re-run (port conflict advisory)"
-      - "2026-07-12 S008 / EV-006 — Full Phase-C gate verification on evolve/S008-general-tac-iwxxm-converter tip after M8 merge"
-      - "2026-07-12 S008 / EV-006 — Phase C full verify FAIL (typecheck-py + coverage); report written; awaiting user decision; c_to_d/phase_c remain pending"
+      - "2026-07-12 S008 / EV-006 — Full Phase-C gate verification on evolve/S008-general-tac-iwxxm-converter tip after M8
+        merge"
+      - "2026-07-12 S008 / EV-006 — Phase C full verify FAIL (typecheck-py + coverage); report written; awaiting user decision;
+        c_to_d/phase_c remain pending"
       - "2026-07-12 D-S008-EV006-08-fix — User chose option 1 fix-in-place for typecheck+coverage; 08 re-verify PASS"
-      - "2026-07-12 S008 / EV-006 — Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c); Overall PASS; awaiting C→D AskQuestion; c_to_d/phase_c remain pending"
+      - "2026-07-12 S008 / EV-006 — Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c);
+        Overall PASS; awaiting C→D AskQuestion; c_to_d/phase_c remain pending"
       - "2026-07-14 S011/EV-008 08-verify-build completed (T6.1 PASS; verification-report.md); C→D passed D-S011-EV008-c-to-d-pass"
 
   18-pr-review:
@@ -2360,9 +2537,13 @@ stages:
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-006
     notes:
-      - "PRR-018 completed on #711 — COMMENT (self-PR cannot REQUEST_CHANGES); blockers=1 advisories=1 praise=1; ci_status=success on prior HEAD 1e7b57a; review https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/711#pullrequestreview-4680875095; handed to PRM-015 (D-S008-evolve-main-18-19)"
-      - "PRR-017 completed on #710 — REQUEST_CHANGES (posted as comment; own-PR); blockers=2 advisories=2 praise=1; ci_status=n/a-evolve-base; handed to PRM-014; PR #710 MERGED after PRM-014 remediation"
-      - "Re-review pass after PRM-012/013 (D-S008-PR706-709-18b); cycles PRR-013…PRR-016 on #706–#709 completed; intended approve posted as COMMENT; do not merge"
+      - "PRR-018 completed on #711 — COMMENT (self-PR cannot REQUEST_CHANGES); blockers=1 advisories=1 praise=1; ci_status=success
+        on prior HEAD 1e7b57a; review https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/711#pullrequestreview-4680875095;
+        handed to PRM-015 (D-S008-evolve-main-18-19)"
+      - "PRR-017 completed on #710 — REQUEST_CHANGES (posted as comment; own-PR); blockers=2 advisories=2 praise=1; ci_status=n/a-evolve-base;
+        handed to PRM-014; PR #710 MERGED after PRM-014 remediation"
+      - "Re-review pass after PRM-012/013 (D-S008-PR706-709-18b); cycles PRR-013…PRR-016 on #706–#709 completed; intended
+        approve posted as COMMENT; do not merge"
       - "Prior stack review PRR-009…PRR-012 lived in reports/pr-review.md only (not in pr_review_cycles[])"
       - "2026-07-12 PRs #706–#709 merged into evolve (D-S008-EV006-merge-m4-m7; user said Merge; anti-merge override)"
 
@@ -2373,8 +2554,11 @@ stages:
     last_cycle: PRM-016
     session_id: S011-f7-operator-ui
     notes:
-      - "PRM-016 completed on #716 — F1/F3/F4 583605e, F2 8a13d8c; F5 deferred (Playwright T2/H4-H5 host ports/disk; CI E2E + T6.4); fixed=4 deferred=1 wont_fix=0; linked PRR-019; head_sha 95c7647; CI success; follow_up pr_review_rerun offered"
-      - "PRM-015 completed on #711 — B1 ecdeac5 (validate TAC auto-convert forwards profile), A1 79af006 (bound uploads + MAX_BULLETIN_REPORTS=100); fixed=2 deferred=0 wont_fix=0; linked PRR-018; head_sha 79af006; squash-merge authorized when CI green (D-S008-evolve-main-18-19)"
+      - "PRM-016 completed on #716 — F1/F3/F4 583605e, F2 8a13d8c; F5 deferred (Playwright T2/H4-H5 host ports/disk; CI E2E
+        + T6.4); fixed=4 deferred=1 wont_fix=0; linked PRR-019; head_sha 95c7647; CI success; follow_up pr_review_rerun offered"
+      - "PRM-015 completed on #711 — B1 ecdeac5 (validate TAC auto-convert forwards profile), A1 79af006 (bound uploads +
+        MAX_BULLETIN_REPORTS=100); fixed=2 deferred=0 wont_fix=0; linked PRR-018; head_sha 79af006; squash-merge authorized
+        when CI green (D-S008-evolve-main-18-19)"
       - "PRM-014 completed — PR #710 MERGED after remediation (B1 1358b6e, B2 4e5d84b, A1/A2 1e3358b; merge e4fe492)"
       - "2026-07-12 PRM-012/013 complete; PRs #706–#709 merged into evolve (D-S008-EV006-merge-m4-m7)"
 
@@ -2427,7 +2611,8 @@ stages:
         started_at: "2026-07-14"
         completed_at: "2026-07-14"
         mode: full
-        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge approval"
+        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge
+          approval"
         report: docs/sessions/S011-f7-operator-ui/reports/deploy-checklist.md
     notes:
       - '2026-07-20 S015/EV-011 12-verify-deploy completed — T5.9 checklist approved; PR #742 merged (D-S015-EV011-deploy-merge)'
@@ -2438,16 +2623,21 @@ stages:
         2026-07-19 S014/EV-010 T6.4 awaiting_merge — D-S014-EV010-t64-deploy-A (1A/2A);
         PR-EV-010=#726 open https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/726;
         tip f1a8799; checklist_approved; 12 not completed; next after merge T6.5 13-deploy-smoke
-      - "2026-07-19 S014/EV-010 T6.4 12-verify-deploy in_progress (D-S014-EV010-t63-features); deploy-checklist.md pending; 12 not completed"
-      - "2026-07-14 S011/EV-008 PR-EV-008=#716 open (retitled/updated evolve→main; NO merge, NO deploy); 12 done; 13 pending on merge approval; T6.4 in_progress"
-      - "2026-07-14 S011/EV-008 D-S011-EV008-deploy-check-A — 12-verify-deploy completed (checklist approved); commit QA-001+reports; prepare PR-EV-008; 13 pending until merge approval; no merge/deploy yet"
-      - "2026-07-14 S011/EV-008 12-verify-deploy — checklist written (deploy-checklist.md); awaiting user deploy-strategy approval (blocker: tip 44 commits ahead of main; QA-001 uncommitted); 12 remains in_progress; 13 not started"
+      - "2026-07-19 S014/EV-010 T6.4 12-verify-deploy in_progress (D-S014-EV010-t63-features); deploy-checklist.md pending;
+        12 not completed"
+      - "2026-07-14 S011/EV-008 PR-EV-008=#716 open (retitled/updated evolve→main; NO merge, NO deploy); 12 done; 13 pending
+        on merge approval; T6.4 in_progress"
+      - "2026-07-14 S011/EV-008 D-S011-EV008-deploy-check-A — 12-verify-deploy completed (checklist approved); commit QA-001+reports;
+        prepare PR-EV-008; 13 pending until merge approval; no merge/deploy yet"
+      - "2026-07-14 S011/EV-008 12-verify-deploy — checklist written (deploy-checklist.md); awaiting user deploy-strategy
+        approval (blocker: tip 44 commits ahead of main; QA-001 uncommitted); 12 remains in_progress; 13 not started"
       - "2026-07-14 S011/EV-008 T6.4 12-verify-deploy in_progress (D-S011-EV008-f7-approve)"
       - "S001 delta — static+api Render; H0c/H4/H5 PASS on live staging"
       - "E2E-002 resolved — /auth/* routes present on deployed API"
       - "S002 / EV-003 — user approved mitigations + rollback; H0c/H4/H5 PASS pre-merge baseline"
       - "S003 — strategy verified; deploy blocked on key rotation (Docker COPY fixed in repo)"
-      - "S004 / EV-004 — strategy verified 2026-06-24; H0c 6/6 PASS; H4 FAIL (CORS); H5 PASS (/config.json); operator T1.3 + S003 keys + redeploy required before 13"
+      - "S004 / EV-004 — strategy verified 2026-06-24; H0c 6/6 PASS; H4 FAIL (CORS); H5 PASS (/config.json); operator T1.3
+        + S003 keys + redeploy required before 13"
 
   13-deploy-smoke:
     status: completed
@@ -2509,7 +2699,8 @@ stages:
         2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — PR #746 open;
         path A (D-S016-EV012-13-path-A); blocked on merge+Render deploy before live H4–H5
       - 2026-07-20 S016/EV-012 13-deploy-smoke pending (current_stage after 10-e2e PASS)
-      - 2026-07-20 S015/EV-011 13-deploy-smoke completed — T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 35 issues
+      - 2026-07-20 S015/EV-011 13-deploy-smoke completed — T5.10 PASS — Render LIVE; H0ci/H1/H0c/H3/H4/H5 + F15 catalog 
+        35 issues
       - >-
         2026-07-19 S014/EV-010 13-deploy-smoke completed (D-S014-EV010-t66-close-2) —
         T6.5+T6.6 done; UJ-023 Trusted Publisher still deferred
@@ -2541,7 +2732,8 @@ stages:
     pr_number: 721
     merge_sha: 6412b21
     notes:
-      - "2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared stale S009 pointer."
+      - "2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared
+        stale S009 pointer."
       - "2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4)."
       - "2026-07-12 — S006 closed (S006-R5); docs reorg unblocked — open via 00-context (process session), not 14-hotfix."
       - "2026-07-12 — S009-result-card-dismiss open (FileConverter result card dismiss after Cancel/Remove)."
@@ -2587,7 +2779,8 @@ deployment:
     notes:
       - S016/EV-012 Manual TAC Input modes live @ 37be5f8 (PR #746); 13-deploy-smoke PASS
       - CI/CD run 29766213356 SUCCESS including Deploy; images 20260720180925-37be5f8
-      - H0c PASS; H3 21/21; H4 2/2; H5 PASS; AHL convert-bulletin 200; COLLECT ingest-collect 501; live Playwright workbench PASS
+      - H0c PASS; H3 21/21; H4 2/2; H5 PASS; AHL convert-bulletin 200; COLLECT ingest-collect 501; live Playwright 
+        workbench PASS
       - Phase D / Phase 4 close still pending user deploy approval (session open)
   url_discovery:
     method: "bash scripts/deploy/verify_connectivity.sh"
@@ -2608,14 +2801,17 @@ issue_log:
     session_id: S008-general-tac-iwxxm-converter
     summary: "Q15 asks new Render service; ADR-015/F6 non-goal deferred F8 worker and no new deployable this cycle"
     status: resolved
-    resolution: "Q15b=B F8 Render Background Worker; Q15c=B promote F8; template→static+api+worker via ADR; convert stays on metar-to-iwxxm-api"
+    resolution: "Q15b=B F8 Render Background Worker; Q15c=B promote F8; template→static+api+worker via ADR; convert stays
+      on metar-to-iwxxm-api"
     resolved_at: "2026-07-12"
     related_decision: D-S008-04-q15b
   - id: I-S008-package-first-scope
     category: Ambiguity
-    summary: "Clarify whether F7/F8 remain in this amend as design-only, deferred entirely, or package APIs only (ingest/worker/UI later)"
+    summary: "Clarify whether F7/F8 remain in this amend as design-only, deferred entirely, or package APIs only (ingest/worker/UI
+      later)"
     status: resolved
-    resolution: "Resolved via Q19=A (D-S008-realtime-amend-q19q22) — package APIs only this cycle; F7/F8 Planned in docs; no worker/UI/auth/sinks build"
+    resolution: "Resolved via Q19=A (D-S008-realtime-amend-q19q22) — package APIs only this cycle; F7/F8 Planned in docs;
+      no worker/UI/auth/sinks build"
     blocking_for:
     session_id: S008-general-tac-iwxxm-converter
     stage: 00-context
@@ -2624,9 +2820,11 @@ issue_log:
     related_decision: D-S008-realtime-amend-q19q22
   - id: I-S008-template-drift-worker
     category: Template Drift
-    summary: "Q7=B add worker deployable — template drift static+api → static+api+worker; ADR required before layout/deploy changes"
+    summary: "Q7=B add worker deployable — template drift static+api → static+api+worker; ADR required before layout/deploy
+      changes"
     status: resolved
-    resolution: "Resolved via Q10=A (D-S008-realtime-amend-q9q13) — confirm Render worker; ADR/template update required in 01/04"
+    resolution: "Resolved via Q10=A (D-S008-realtime-amend-q9q13) — confirm Render worker; ADR/template update required in
+      01/04"
     blocking_for:
     session_id: S008-general-tac-iwxxm-converter
     stage: 00-context
@@ -2634,9 +2832,11 @@ issue_log:
     resolved_at: "2026-07-12"
   - id: I-S008-f5-f6-metar-only-vs-multiproduct-ui
     category: Contradiction
-    summary: "Possible contradiction — F5/F6 non-goal (F5 METAR-only) vs multi-product operator UI (Q4=C both operator UI + machine ingest; Q8=A all F6 products)"
+    summary: "Possible contradiction — F5/F6 non-goal (F5 METAR-only) vs multi-product operator UI (Q4=C both operator UI
+      + machine ingest; Q8=A all F6 products)"
     status: resolved
-    resolution: "Resolved via Q9=A (D-S008-realtime-amend-q9q13) — new F7 multi-product TAC sessions; F5 stays METAR-only unchanged"
+    resolution: "Resolved via Q9=A (D-S008-realtime-amend-q9q13) — new F7 multi-product TAC sessions; F5 stays METAR-only
+      unchanged"
     blocking_for:
     session_id: S008-general-tac-iwxxm-converter
     stage: 00-context
@@ -2644,6 +2844,22 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S016-EV012-phase4-close-1
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    resolved_at: '2026-07-20'
+    session_id: S016-manual-tac-input-modes
+    evolve_cycle_id: EV-012
+    skill: 16-evolve
+    skill_id: 16-evolve
+    stage: 16-evolve
+    status: confirmed
+    topic: Phase 4 close for Manual TAC Input modes (EV-012 / S016)
+    decision: 'User chose option 1 — close Phase 4 / EV-012 / S016 now. Feature PR #746 merged 37be5f877bd50d9ef1d1208e78f99c12ca59f092;
+      docs PR #747 merged dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73; GitHub issue #730 CLOSED; F7 remains Planned (validation
+      deepen only).'
+    summary: 'Phase 4 closed: S016 archived; active_session null; EV-012 completed 2026-07-20; checkpoints.phase_d passed;
+      evolve-summary + evolve-report-EV-012 completed; #730 CLOSED.'
   - id: D-S016-EV012-13-pass
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2691,7 +2907,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-20'
     decision: Approve reconciled lean+13 routing (00 → 16 → 01 → 02 → 10 → 13)
-    summary: 'Routing approved: required 00-context, 16-evolve, 01-requirements (delta), 02-verify-plan (delta), 10-e2e (delta), 13-deploy-smoke (full). Skip 03–09, 11–12. Gates a_to_b/b_to_c/c_to_d waived (no Phase B/C).'
+    summary: 'Routing approved: required 00-context, 16-evolve, 01-requirements (delta), 02-verify-plan (delta), 10-e2e (delta),
+      13-deploy-smoke (full). Skip 03–09, 11–12. Gates a_to_b/b_to_c/c_to_d waived (no Phase B/C).'
   - id: D-S016-EV012-intake-4
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2703,7 +2920,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-20'
     decision: Include 13-deploy-smoke in routing (H4–H5 + AHL + COLLECT 501)
-    summary: 'Lean product/tech path still requires full 13-deploy-smoke: browser H4–H5, authenticated AHL happy path, and COLLECT 501 UX on staging.'
+    summary: 'Lean product/tech path still requires full 13-deploy-smoke: browser H4–H5, authenticated AHL happy path, and
+      COLLECT 501 UX on staging.'
   - id: D-S016-EV012-intake-3
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2715,7 +2933,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-20'
     decision: Auto-switch between Manual TAC Input modes is required
-    summary: FileConverter must auto-switch mode detection among TAC report / AHL bulletin / IWXXM COLLECT per ADR-024; tests must assert auto-switch behavior.
+    summary: FileConverter must auto-switch mode detection among TAC report / AHL bulletin / IWXXM COLLECT per ADR-024; 
+      tests must assert auto-switch behavior.
   - id: D-S016-EV012-intake-2
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2727,7 +2946,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-20'
     decision: All tests required — Vitest anchors + Playwright T1–T4 + live staging smoke
-    summary: Acceptance coverage includes unit/Vitest gap check, Playwright T1–T4 for Manual TAC Input modes, and live staging H4–H5 plus authenticated AHL happy path and COLLECT 501 UX.
+    summary: Acceptance coverage includes unit/Vitest gap check, Playwright T1–T4 for Manual TAC Input modes, and live 
+      staging H4–H5 plus authenticated AHL happy path and COLLECT 501 UX.
   - id: D-S016-EV012-intake-1
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2739,7 +2959,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-20'
     decision: Cycle type A under F7 — validation/acceptance only; no new Fn; COLLECT stays 501
-    summary: EV-012 is a general validation cycle under F7/ADR-024 Manual TAC Input modes. No new feature id; COLLECT member extract out of scope and endpoint remains 501; F7 stays Planned.
+    summary: EV-012 is a general validation cycle under F7/ADR-024 Manual TAC Input modes. No new feature id; COLLECT 
+      member extract out of scope and endpoint remains 501; F7 stays Planned.
   - id: D-S015-EV011-phase4-close-1
     date: '2026-07-20'
     timestamp: '2026-07-20'
@@ -2768,7 +2989,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: Pass B→C and start T1.1 now (option A)
-    summary: 'User chose option A at Phase B→C checkpoint: Pass B→C and start 07-build at T1.1. EV-011 checkpoints.phase_b and gates.b_to_c passed; handed off to 07-build Phase C. Orchestrator remains 16-evolve.'
+    summary: 'User chose option A at Phase B→C checkpoint: Pass B→C and start 07-build at T1.1. EV-011 checkpoints.phase_b
+      and gates.b_to_c passed; handed off to 07-build Phase C. Orchestrator remains 16-evolve.'
   - id: D-S015-EV011-06-done
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3012,7 +3234,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: Start 04-tech-plan Phase B now (user option 1)
-    summary: 'Phase B started — 04-tech-plan in_progress after A→B pass; execution plan scope: registry → rules R1–R8 → goldens → CI'
+    summary: 'Phase B started — 04-tech-plan in_progress after A→B pass; execution plan scope: registry → rules R1–R8 → goldens
+      → CI'
   - id: D-S015-EV011-03-tooling-12
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3207,7 +3430,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: 'Approve routing as proposed (option A) — 00–13 incl. 03/06 + Render 12–13 (E11-5)'
-    summary: 'Routing plan approved: full pipeline 00-context through 13-deploy-smoke including 03-plan-tooling, 06-tech-tooling, and Render deploy gates 12-verify-deploy + 13-deploy-smoke'
+    summary: 'Routing plan approved: full pipeline 00-context through 13-deploy-smoke including 03-plan-tooling, 06-tech-tooling,
+      and Render deploy gates 12-verify-deploy + 13-deploy-smoke'
   - id: D-S015-EV011-research-1
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3218,8 +3442,10 @@ decisions_log:
     evolve_cycle_id: EV-011
     status: confirmed
     resolved_at: '2026-07-19'
-    decision: 'Research depth = 1+2+3+ — aggressive R1–R6 encode AND research catalog in 01 AND registry+goldens AND opportunistic METAR quality improvements (E11-6)'
-    summary: 'Max expansion research scope: aggressive R1–R6 encoding, research catalog in 01-requirements, METAR lint registry+golden fixtures, opportunistic METAR quality improvements from external resources'
+    decision: 'Research depth = 1+2+3+ — aggressive R1–R6 encode AND research catalog in 01 AND registry+goldens AND opportunistic
+      METAR quality improvements (E11-6)'
+    summary: 'Max expansion research scope: aggressive R1–R6 encoding, research catalog in 01-requirements, METAR lint registry+golden
+      fixtures, opportunistic METAR quality improvements from external resources'
   - id: D-S015-EV011-fn-1
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3231,7 +3457,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: New F15 + deepen F6/F12 (Q4=1)
-    summary: 'Feature allocation: new F15 METAR lint issue registry; deepen F6 (tac2iwxxm) and F12 (tac-validate) within cycle scope'
+    summary: 'Feature allocation: new F15 METAR lint issue registry; deepen F6 (tac2iwxxm) and F12 (tac-validate) within cycle
+      scope'
   - id: D-S015-EV011-scope-1
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3243,7 +3470,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: 'Full #732 + registry + goldens + research/validation/conversion expansion (Q3=1+)'
-    summary: 'Scope: METAR lint issue registry (INFO/WARNING/ERROR); #732 quality bar; golden convert→XSD/Schematron; research MetarCentral/AviationRef/iwxxmConverter'
+    summary: 'Scope: METAR lint issue registry (INFO/WARNING/ERROR); #732 quality bar; golden convert→XSD/Schematron; research
+      MetarCentral/AviationRef/iwxxmConverter'
   - id: D-S015-open-1
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3255,7 +3483,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: Open S015-metar-lint-quality feature → 16-evolve (user Q2=1)
-    summary: Session S015-metar-lint-quality opened; EV-011 allocated; branch evolve/EV-011-metar-lint-quality; 00-context in_progress
+    summary: Session S015-metar-lint-quality opened; EV-011 allocated; branch evolve/EV-011-metar-lint-quality; 
+      00-context in_progress
   - id: D-S011-EV008-close-1
     date: '2026-07-19'
     timestamp: '2026-07-19'
@@ -3267,7 +3496,8 @@ decisions_log:
     status: confirmed
     resolved_at: '2026-07-19'
     decision: 'User closed S011/EV-008 (option: close last session); PR #716 already merged; start S015 for #732'
-    summary: 'S011 completed; EV-008 completed with deploy gate waived; 13-deploy-smoke skipped; PR #716 merge 22a6199; S015-metar-lint-quality opened for #732'
+    summary: 'S011 completed; EV-008 completed with deploy gate waived; 13-deploy-smoke skipped; PR #716 merge 22a6199; S015-metar-lint-quality
+      opened for #732'
   - id: D-S014-EV010-phase4-close-1
     date: "2026-07-19"
     timestamp: "2026-07-19"
@@ -3360,7 +3590,8 @@ decisions_log:
     date: '2026-07-19'
     skill_id: 13-deploy-smoke
     session_id: S014-package-publish-validation
-    decision: "T6.5 Render path PASS — H0ci/H1/H0c/H3/H4/H5 + H6′ UJ-022 green after #726 merge deploy; PyPI Trusted Publisher still BLOCKED for live tags (soft defer). Awaiting user deploy-results checkpoint."
+    decision: "T6.5 Render path PASS — H0ci/H1/H0c/H3/H4/H5 + H6′ UJ-022 green after #726 merge deploy; PyPI Trusted Publisher
+      still BLOCKED for live tags (soft defer). Awaiting user deploy-results checkpoint."
   - id: D-S014-EV010-t64-merge-A
     date: "2026-07-19"
     timestamp: "2026-07-19"
@@ -3588,7 +3819,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "User approved deploy results (option 1) and closed S013/EV-009. F9/F10 shipped via PR #723 (merge 4660602); all routing stages completed; active_session cleared."
+    decision: "User approved deploy results (option 1) and closed S013/EV-009. F9/F10 shipped via PR #723 (merge 4660602);
+      all routing stages completed; active_session cleared."
     summary: "S013 closed; EV-009 completed; F9/F10 Done in production."
     timestamp: "2026-07-18"
   - id: D-S013-EV009-deploy-smoke-pass
@@ -3597,7 +3829,8 @@ decisions_log:
     skill_id: 13-deploy-smoke
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "T4.5 complete: PR #723 merged (4660602); Render API+FE live; H1/H0c/H3 21/21 / H4 2/2 / H5 / H6' UJ-020 (decode-tac summary) + UJ-021 (lint-tac info+fix) all PASS. Awaiting user deploy-results approval to close session."
+    decision: "T4.5 complete: PR #723 merged (4660602); Render API+FE live; H1/H0c/H3 21/21 / H4 2/2 / H5 / H6' UJ-020 (decode-tac
+      summary) + UJ-021 (lint-tac info+fix) all PASS. Awaiting user deploy-results approval to close session."
     summary: "13-deploy-smoke PASS; F9/F10 live in production."
     timestamp: "2026-07-17"
   - id: D-S013-EV009-deploy-check-A
@@ -3606,7 +3839,9 @@ decisions_log:
     skill_id: 12-verify-deploy
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "T4.4 sign-off: user approved deploy checklist + rollback plan (image-only rollback; last known good main@4b6cff8) AND merge + deploy — merge PR #723 (evolve→main) and proceed to 13-deploy-smoke (T4.5: H1–H3, H4–H5 verify_connectivity.sh, H6' UJ-020/021). PR CI fully green pre-merge. Deploy gate passed."
+    decision: "T4.4 sign-off: user approved deploy checklist + rollback plan (image-only rollback; last known good main@4b6cff8)
+      AND merge + deploy — merge PR #723 (evolve→main) and proceed to 13-deploy-smoke (T4.5: H1–H3, H4–H5 verify_connectivity.sh,
+      H6' UJ-020/021). PR CI fully green pre-merge. Deploy gate passed."
     summary: "Deploy checklist approved; merge #723 + deploy approved; deploy gate passed; continue to 13-deploy-smoke."
     timestamp: "2026-07-17"
   - id: D-S013-EV009-f9-f10-approved
@@ -3615,7 +3850,9 @@ decisions_log:
     skill_id: 11-verify-impl
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "T4.3 per-Fn sign-off: user approved F9 (value-aware decode + plain-language summary) and F10 (IWXXM preview pane + terminator quick fix) — '1 / 1'. 8/8 acceptance criteria PASS; UJ-020/021 signed off with T3 deferral waiver (QA-002 live pre-deploy H0c/H4/H5 PASS, re-run at 13). Phase D checkpoint passed; proceed to 12-verify-deploy (T4.4)."
+    decision: "T4.3 per-Fn sign-off: user approved F9 (value-aware decode + plain-language summary) and F10 (IWXXM preview
+      pane + terminator quick fix) — '1 / 1'. 8/8 acceptance criteria PASS; UJ-020/021 signed off with T3 deferral waiver
+      (QA-002 live pre-deploy H0c/H4/H5 PASS, re-run at 13). Phase D checkpoint passed; proceed to 12-verify-deploy (T4.4)."
     summary: "F9 + F10 approved at 11-verify-impl; verify-impl.md written; continue to 12-verify-deploy."
     timestamp: "2026-07-17"
   - id: D-S013-EV009-qa-advisories-resolved
@@ -3624,8 +3861,14 @@ decisions_log:
     skill_id: 11-verify-impl
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "User chose 'Address both' for QA-001/QA-002. QA-001: project-scoped pip-audit found ecdsa PYSEC-2026-1325 (transitive via python-jose; no upstream fix); risk accepted — JWT paths are HS256-only and jose[cryptography] delegates EC to pyca/cryptography; ignore documented in audit/pip-audit-ignore.txt. QA-002: verify_connectivity.sh run live vs production (H0c 6/6, H4 2/2, H5 PASS) pre-deploy; re-runs at 13."
-    summary: "User chose 'Address both' for QA-001/QA-002. QA-001: project-scoped pip-audit found ecdsa PYSEC-2026-1325 (transitive via python-jose; no upstream fix); risk accepted — JWT paths are HS256-only and jose[cryptography] delegates EC to pyca/cryptography; ignore documented in audit/pip-audit-ignore.txt. QA-002: verify_connectivity.sh run live vs production (H0c 6/6, H4 2/2, H5 PASS) pre-deploy; re-runs at 13."
+    decision: "User chose 'Address both' for QA-001/QA-002. QA-001: project-scoped pip-audit found ecdsa PYSEC-2026-1325 (transitive
+      via python-jose; no upstream fix); risk accepted — JWT paths are HS256-only and jose[cryptography] delegates EC to pyca/cryptography;
+      ignore documented in audit/pip-audit-ignore.txt. QA-002: verify_connectivity.sh run live vs production (H0c 6/6, H4
+      2/2, H5 PASS) pre-deploy; re-runs at 13."
+    summary: "User chose 'Address both' for QA-001/QA-002. QA-001: project-scoped pip-audit found ecdsa PYSEC-2026-1325 (transitive
+      via python-jose; no upstream fix); risk accepted — JWT paths are HS256-only and jose[cryptography] delegates EC to pyca/cryptography;
+      ignore documented in audit/pip-audit-ignore.txt. QA-002: verify_connectivity.sh run live vs production (H0c 6/6, H4
+      2/2, H5 PASS) pre-deploy; re-runs at 13."
     timestamp: "2026-07-17"
   - id: D-S013-EV009-c-to-d-pass
     date: "2026-07-17"
@@ -3633,7 +3876,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "Phase C checkpoint approved (option 1 recommended); C→D gate passed (M1–M3 complete, T4.1 08-verify-build PASS, decode contract additive-only); proceed to 09-qa + 10-e2e in parallel (T4.2)"
+    decision: "Phase C checkpoint approved (option 1 recommended); C→D gate passed (M1–M3 complete, T4.1 08-verify-build PASS,
+      decode contract additive-only); proceed to 09-qa + 10-e2e in parallel (T4.2)"
     summary: "User selected 'Proceed to Phase D' (recommended); 09-qa + 10-e2e started in parallel."
     timestamp: "2026-07-17"
   - id: D-S013-EV009-b-to-c-pass
@@ -3642,7 +3886,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S013-live-decode-preview-ux
     evolve_cycle_id: EV-009
-    decision: "Phase B checkpoint approved; B→C gate passed (04 approved + 05 PASS + 06 skipped per routing); start 07-build at M1 T1.1"
+    decision: "Phase B checkpoint approved; B→C gate passed (04 approved + 05 PASS + 06 skipped per routing); start 07-build
+      at M1 T1.1"
     summary: "User selected 'Pass B→C gate — start 07-build at M1 T1.1'."
     timestamp: "2026-07-16"
   - id: D-S012-frontend-auth-token-hydrate
@@ -3650,7 +3895,8 @@ decisions_log:
     stage: 14-hotfix
     skill_id: 14-hotfix
     session_id: S012-empty-bearer-lint-tac
-    decision: "Approve Cursor rule frontend-auth-token-hydrate.mdc — hydrate JWT from persist before lint-tac/decode-tac Authorization headers"
+    decision: "Approve Cursor rule frontend-auth-token-hydrate.mdc — hydrate JWT from persist before lint-tac/decode-tac Authorization
+      headers"
     summary: "S012 empty-Bearer hotfix; rule prevents regression after reload."
     timestamp: "2026-07-15"
   - id: D-S011-PR716-19-assumed
@@ -3658,7 +3904,8 @@ decisions_log:
     stage: 19-address-pr-review
     skill_id: 19-address-pr-review
     session_id: S011-f7-operator-ui
-    decision: "Remediate all PRR-019 🔴+🟡 on #716; defer Playwright/H4-H5 (host/deploy); Sourcery nits out of scope unless trivial"
+    decision: "Remediate all PRR-019 🔴+🟡 on #716; defer Playwright/H4-H5 (host/deploy); Sourcery nits out of scope unless
+      trivial"
     summary: "User invoked 19 with explicit blockers+advisories scope."
     timestamp: "2026-07-15"
   - id: D-S011-PR716-18-assumed
@@ -3667,7 +3914,8 @@ decisions_log:
     skill_id: 18-pr-review
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Proceed 18-pr-review on #716 with full checklist + connectivity; local QA parity despite CI red (npm audit endpoint 410)"
+    decision: "Proceed 18-pr-review on #716 with full checklist + connectivity; local QA parity despite CI red (npm audit
+      endpoint 410)"
     summary: "AskQuestion tool unavailable; user intent current branch + integration/solid → assumed recommendations."
     timestamp: "2026-07-15"
   - id: D-S011-EV008-deploy-check-A
@@ -3675,13 +3923,15 @@ decisions_log:
     skill: 12-verify-deploy
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Approve deploy checklist; commit QA-001+reports; prepare PR-EV-008 evolve→main; no merge/deploy until explicit approval"
+    decision: "Approve deploy checklist; commit QA-001+reports; prepare PR-EV-008 evolve→main; no merge/deploy until explicit
+      approval"
   - id: D-S011-EV008-f7-approve
     date: "2026-07-14"
     skill: 11-verify-impl
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Approve F7 (criteria 1–6 met T0; 7 H4–H5 waived to T6.4/CI; AdminDashboard dead files advisory; issue closeout T6.5); proceed T6.4"
+    decision: "Approve F7 (criteria 1–6 met T0; 7 H4–H5 waived to T6.4/CI; AdminDashboard dead files advisory; issue closeout
+      T6.5); proceed T6.4"
   - id: D-S011-EV008-c-to-d-pass
     date: "2026-07-14"
     category: decision
@@ -3710,7 +3960,8 @@ decisions_log:
     skill_id: 05-verify-tech
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "05-verify-tech audit PASS — approve A1–A3 as-is; artifact reports/05-verify-tech-audit.md; phase_b remains pending until user Phase B AskQuestion (do not auto-pass)"
+    decision: "05-verify-tech audit PASS — approve A1–A3 as-is; artifact reports/05-verify-tech-audit.md; phase_b remains
+      pending until user Phase B AskQuestion (do not auto-pass)"
     status: confirmed
   - id: D-S011-04-plan-approve-A
     date: "2026-07-13"
@@ -3720,7 +3971,8 @@ decisions_log:
     skill_id: 04-tech-plan
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "User approved execution-plan.md option A — 04-tech-plan complete; proceed to 05-verify-tech (Phase B checkpoint still pending until 05 completes)"
+    decision: "User approved execution-plan.md option A — 04-tech-plan complete; proceed to 05-verify-tech (Phase B checkpoint
+      still pending until 05 completes)"
     status: confirmed
   - id: D-S011-04-batch1-A
     date: "2026-07-13"
@@ -3730,7 +3982,8 @@ decisions_log:
     skill_id: 04-tech-plan
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "04 Batch 1 A — expand-cutover migrate; CM6 package set; 300ms debounce; live IWXXM off; keep work-sessions paths; reuse CORS"
+    decision: "04 Batch 1 A — expand-cutover migrate; CM6 package set; 300ms debounce; live IWXXM off; keep work-sessions
+      paths; reuse CORS"
     status: confirmed
   - id: D-S011-EV008-a-to-b-pass
     date: "2026-07-13"
@@ -3771,7 +4024,8 @@ decisions_log:
     skill_id: 01-requirements
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Config/env Batch option B — BYO + deprecate ADMIN_* → E2E_USER_*; ADR-021/022 accepted; 01-requirements document set complete"
+    decision: "Config/env Batch option B — BYO + deprecate ADMIN_* → E2E_USER_*; ADR-021/022 accepted; 01-requirements document
+      set complete"
     status: confirmed
   - id: D-S011-01-spec-r2-prime
     date: "2026-07-13"
@@ -3781,7 +4035,8 @@ decisions_log:
     skill_id: 01-requirements
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Override R2 — unified tac_work_sessions + migrate metar_work_sessions (Spec Batch 2 C→A). ADR-020 accepted. Spec Batch 1–2 written."
+    decision: "Override R2 — unified tac_work_sessions + migrate metar_work_sessions (Spec Batch 2 C→A). ADR-020 accepted.
+      Spec Batch 1–2 written."
     status: confirmed
   - id: D-S011-01-fl-batch2-A
     date: "2026-07-13"
@@ -3791,7 +4046,8 @@ decisions_log:
     skill_id: 01-requirements
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "Feature List Batch 2 option A — accept F7 acceptance 1–8 + gaps G1–G4 (DISABLE_AUTH keep; signup=Supabase policy; clean BYO cut; VAA/TCA best-effort+residuals)"
+    decision: "Feature List Batch 2 option A — accept F7 acceptance 1–8 + gaps G1–G4 (DISABLE_AUTH keep; signup=Supabase policy;
+      clean BYO cut; VAA/TCA best-effort+residuals)"
     status: confirmed
   - id: D-S011-01-manifest-A
     date: "2026-07-13"
@@ -3811,7 +4067,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S011-f7-operator-ui
     evolve_cycle_id: EV-008
-    decision: "abandon EV-004 (orphan — S004 completed 2026-06-25); allocate EV-008 for S011; start 01-requirements (user approved option A 2026-07-13)"
+    decision: "abandon EV-004 (orphan — S004 completed 2026-06-25); allocate EV-008 for S011; start 01-requirements (user
+      approved option A 2026-07-13)"
     status: confirmed
   - id: D-S011-R1-R6
     date: "2026-07-13"
@@ -3820,7 +4077,8 @@ decisions_log:
     skill: 00-context
     skill_id: 00-context
     session_id: S011-f7-operator-ui
-    decision: "S011 Phase3: R1=#697→#702→#665/#666→#694; R2=F7 multi-product sessions in v1; R3=CodeMirror6; R4=decode-tac+span fields; R5=soft preview partial XML; R6=BYO-only (Supabase+Postgres/DATABASE_URL), drop shared multi-tenant admin"
+    decision: "S011 Phase3: R1=#697→#702→#665/#666→#694; R2=F7 multi-product sessions in v1; R3=CodeMirror6; R4=decode-tac+span
+      fields; R5=soft preview partial XML; R6=BYO-only (Supabase+Postgres/DATABASE_URL), drop shared multi-tenant admin"
     status: confirmed
   - id: D-S011-open-packaging
     date: "2026-07-13"
@@ -3829,7 +4087,8 @@ decisions_log:
     skill: 00-context
     skill_id: 00-context
     session_id: S011-f7-operator-ui
-    decision: "S011 packaging: single session for F7+#694+#702+#665+#666+#697; routing full 00→01→02→04→05→07–13; #5 kept as parent tracker (user approved all defaults 2026-07-13)"
+    decision: "S011 packaging: single session for F7+#694+#702+#665+#666+#697; routing full 00→01→02→04→05→07–13; #5 kept
+      as parent tracker (user approved all defaults 2026-07-13)"
     status: confirmed
   - id: D-S010-close
     date: "2026-07-13"
@@ -4090,7 +4349,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S008-general-tac-iwxxm-converter
     evolve_cycle_id: EV-006
-    decision: "User chose option 1 — close Phase C (07-build complete, 51/51 tasks, PR-M8 #710 merged) and invoke 08-verify-build for C→D gate"
+    decision: "User chose option 1 — close Phase C (07-build complete, 51/51 tasks, PR-M8 #710 merged) and invoke 08-verify-build
+      for C→D gate"
     timestamp: "2026-07-12"
   - id: D-S008-EV006-resume-m8
     date: "2026-07-12"
@@ -4098,7 +4358,8 @@ decisions_log:
     skill_id: 16-evolve
     session_id: S008-general-tac-iwxxm-converter
     evolve_cycle_id: EV-006
-    decision: "User chose Resume — continue EV-006 Phase C at 07-build M8 (F6.e UI pickers + H4–H5/H6); create feat/S008-M8-ui-connectivity from evolve"
+    decision: "User chose Resume — continue EV-006 Phase C at 07-build M8 (F6.e UI pickers + H4–H5/H6); create feat/S008-M8-ui-connectivity
+      from evolve"
     timestamp: "2026-07-12"
   - id: D-S008-EV006-merge-m4-m7
     date: "2026-07-12"
@@ -4106,7 +4367,8 @@ decisions_log:
     skill_id: 07-build
     session_id: S008-general-tac-iwxxm-converter
     evolve_cycle_id: EV-006
-    decision: "User said Merge; merged PRs #706–#709 into evolve/S008-general-tac-iwxxm-converter (anti-merge override for 18/19)"
+    decision: "User said Merge; merged PRs #706–#709 into evolve/S008-general-tac-iwxxm-converter (anti-merge override for
+      18/19)"
     summary: >
       Explicit user Merge approval for S008 M4–M7 stack. Merged into
       evolve/S008-general-tac-iwxxm-converter: PR-M4b #706 (feat/S008-M4-us-metar,
@@ -4132,11 +4394,13 @@ decisions_log:
       SUPERSEDED for merge policy by D-S008-EV006-merge-m4-m7 (user said Merge).
     timestamp: "2026-07-12"
   - id: D-S008-EV006-t47-cutover
-    decision: "User chose A — continue T4.7 cutover now (wire convert→tac2iwxxm, delete packages/gifts, fix fallout; then T4.8–T4.9)"
+    decision: "User chose A — continue T4.7 cutover now (wire convert→tac2iwxxm, delete packages/gifts, fix fallout; then
+      T4.8–T4.9)"
     rationale: "AskQuestion after T4.6 → A"
     timestamp: "2026-07-12"
   - id: D-S008-EV006-resume-t410
-    decision: "User chose A — resume EV-006 Phase C at 07-build T4.10 (US METAR/SPECI goldens); new feat branch from evolve for remaining M4"
+    decision: "User chose A — resume EV-006 Phase C at 07-build T4.10 (US METAR/SPECI goldens); new feat branch from evolve
+      for remaining M4"
     rationale: "AskQuestion resume/abandon/new → A"
     timestamp: "2026-07-12"
   - id: D-S008-PRM4-18-19
@@ -4291,7 +4555,8 @@ decisions_log:
   - id: D-S008-04-q15b
     stage: 04-tech-plan
     session_id: S008-general-tac-iwxxm-converter
-    summary: "Q15b=B accept recommendation — F8 near-RT Render worker; HTTP convert/lint/validate on existing API; promote F8 this cycle; amend ADR-015 + template"
+    summary: "Q15b=B accept recommendation — F8 near-RT Render worker; HTTP convert/lint/validate on existing API; promote
+      F8 this cycle; amend ADR-015 + template"
     timestamp: "2026-07-12"
   - id: D-S008-04-q12b-q15c
     stage: 04-tech-plan
@@ -4335,7 +4600,9 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "API Contract endpoints / write order (Q51–Q54): validate wraps iwxxm-validate; new POST /api/v1/lint-tac; new POST /api/v1/convert-bulletin (convert stays single-report); write API contract + ADR-015. See ADR-015 and requirements-decisions.md RT-R1–R16."
+    summary: "API Contract endpoints / write order (Q51–Q54): validate wraps iwxxm-validate; new POST /api/v1/lint-tac; new
+      POST /api/v1/convert-bulletin (convert stays single-report); write API contract + ADR-015. See ADR-015 and requirements-decisions.md
+      RT-R1–R16."
     resolutions: "Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written"
     related:
       - ADR-015
@@ -4363,7 +4630,8 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "S008-realtime-ingest 01-requirements delta complete — interviews 7/7; standing docs amended; ADR-015 accepted; RT-R1–R16 confirmed. Advancing to 04-tech-plan."
+    summary: "S008-realtime-ingest 01-requirements delta complete — interviews 7/7; standing docs amended; ADR-015 accepted;
+      RT-R1–R16 confirmed. Advancing to 04-tech-plan."
     related:
       - ADR-015
       - docs/decisions/requirements-decisions.md
@@ -4375,7 +4643,8 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "Dependency Inventory packages / licenses / write order (Q48–Q50): MIT for new packages; defer pydantic/msgspec choice to 04-tech-plan; write Dependency Inventory then API Contract"
+    summary: "Dependency Inventory packages / licenses / write order (Q48–Q50): MIT for new packages; defer pydantic/msgspec
+      choice to 04-tech-plan; write Dependency Inventory then API Contract"
     resolutions: "Q48=A MIT; Q49=B pydantic/msgspec in 04; Q50=A"
     next_step: "01-requirements delta S008-realtime-ingest — API Contract interview (interviews.current_section: endpoints)"
   - id: D-S008-01-test-plan-q44q47
@@ -4385,7 +4654,8 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "Test Plan types / connectivity / write order (Q44–Q47): extend live harness with H7 bulletin gate; package TCs for tac-validate/iwxxm-validate; F7/F8 stubs no automated TC this cycle; write test plan then Dependency Inventory"
+    summary: "Test Plan types / connectivity / write order (Q44–Q47): extend live harness with H7 bulletin gate; package TCs
+      for tac-validate/iwxxm-validate; F7/F8 stubs no automated TC this cycle; write test plan then Dependency Inventory"
     resolutions: "Q44=B; Q44b=B H7; Q45=A; Q46=A; Q47=A"
     next_step: "01-requirements delta S008-realtime-ingest — Dependency Inventory interview (interviews.current_section: packages)"
   - id: D-S008-01-journeys-q39q43
@@ -4395,9 +4665,12 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "User Journeys happy-paths / write order (Q39–Q43): update UJ-002/007/005/006; add UJ-011/012 + UJ-DEV-004; stub UJ-013/014; T2 for 011/012; write journeys then test plan"
-    resolutions: "Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub UJ-013/014; Q42=A T2 for 011/012; Q43=A write journeys then test plan"
-    next_step: "01-requirements delta S008-realtime-ingest — write User Journeys then Test Plan (interviews.current_section: writing-journeys)"
+    summary: "User Journeys happy-paths / write order (Q39–Q43): update UJ-002/007/005/006; add UJ-011/012 + UJ-DEV-004; stub
+      UJ-013/014; T2 for 011/012; write journeys then test plan"
+    resolutions: "Q39=A update UJ-002/007/005/006; Q40=A UJ-011/012 + UJ-DEV-004; Q41=A stub UJ-013/014; Q42=A T2 for 011/012;
+      Q43=A write journeys then test plan"
+    next_step: "01-requirements delta S008-realtime-ingest — write User Journeys then Test Plan (interviews.current_section:
+      writing-journeys)"
   - id: D-S008-01-spec-q34q38
     date: "2026-07-12"
     stage: 01-requirements
@@ -4405,8 +4678,10 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "Spec components / pipeline / SoC / diagram / write order (Q34–Q38): add both packages; unified pipeline; SoC no FastAPI/Supabase in packages; dashed future worker in diagram; write Spec then Journeys"
-    resolutions: "Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase; Q37=B dashed future worker in diagram; Q38=A write Spec then Journeys"
+    summary: "Spec components / pipeline / SoC / diagram / write order (Q34–Q38): add both packages; unified pipeline; SoC
+      no FastAPI/Supabase in packages; dashed future worker in diagram; write Spec then Journeys"
+    resolutions: "Q34=A add both packages; Q35=A unified pipeline; Q36=A SoC no FastAPI/Supabase; Q37=B dashed future worker
+      in diagram; Q38=A write Spec then Journeys"
     next_step: "01-requirements delta S008-realtime-ingest — write Spec then User Journeys (interviews.current_section: writing-spec)"
   - id: D-S008-01-feature-list-q29q33
     date: "2026-07-12"
@@ -4415,10 +4690,14 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "Feature List non-goals / write order (Q29–Q33): leave F6 non-goals unchanged (worker only under F8); package APIs + backend thin wrappers this cycle; F6.bulletin with/before METAR; F7/F8/auth/sinks/AMHS out of build; write feature-list then Spec"
-    resolutions: "Q29=C leave F6 non-goals unchanged worker only under F8; Q30=B package APIs + API thin wrappers this cycle; Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS out of build; Q33=A write feature-list then Spec"
+    summary: "Feature List non-goals / write order (Q29–Q33): leave F6 non-goals unchanged (worker only under F8); package
+      APIs + backend thin wrappers this cycle; F6.bulletin with/before METAR; F7/F8/auth/sinks/AMHS out of build; write feature-list
+      then Spec"
+    resolutions: "Q29=C leave F6 non-goals unchanged worker only under F8; Q30=B package APIs + API thin wrappers this cycle;
+      Q31=A F6.bulletin with/before METAR; Q32=A F7/F8/auth/sinks/AMHS out of build; Q33=A write feature-list then Spec"
     scope_note: "Q30=B expands package-first (Q19=A) to include backend thin wrappers for tac-validate and iwxxm-validate"
-    next_step: "01-requirements delta S008-realtime-ingest — write Feature List then Spec (interviews.current_section: writing feature-list)"
+    next_step: "01-requirements delta S008-realtime-ingest — write Feature List then Spec (interviews.current_section: writing
+      feature-list)"
   - id: D-S008-01-feature-list-q24q28
     date: "2026-07-12"
     stage: 01-requirements
@@ -4426,8 +4705,10 @@ decisions_log:
     category: Decision
     delta_id: S008-realtime-ingest
     skill_id: 01-requirements
-    summary: "Feature List core (Q24–Q28): F6 bulletin acceptance; packages iwxxm-validate + tac-validate; F7/F8 stubs Planned; F2 evolves to wrapper over iwxxm-validate"
-    resolutions: "Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A F7 stub; Q27=A F8 stub; Q28=A F2 evolves to wrapper over iwxxm-validate"
+    summary: "Feature List core (Q24–Q28): F6 bulletin acceptance; packages iwxxm-validate + tac-validate; F7/F8 stubs Planned;
+      F2 evolves to wrapper over iwxxm-validate"
+    resolutions: "Q24=A F6 bulletin acceptance; Q25=A iwxxm-validate + tac-validate; Q26=A F7 stub; Q27=A F8 stub; Q28=A F2
+      evolves to wrapper over iwxxm-validate"
     next_step: "01-requirements delta S008-realtime-ingest — continue Feature List interview (non-goals)"
   - id: D-S008-01-manifest-q23
     date: "2026-07-12"
@@ -4435,7 +4716,8 @@ decisions_log:
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
     delta_id: S008-realtime-ingest
-    summary: "Q23=A approve mandatory Feature List, Spec, User Journeys, Test Plan + Dependency Inventory, API Contract (light), ADRs; skip Config Spec and Deployment Plan"
+    summary: "Q23=A approve mandatory Feature List, Spec, User Journeys, Test Plan + Dependency Inventory, API Contract (light),
+      ADRs; skip Config Spec and Deployment Plan"
     resolutions: "Q23=A approve 4 mandatory + Deps + API light + ADRs; skip Config Spec + Deploy"
     interview_plan:
       mandatory: 4
@@ -4459,8 +4741,11 @@ decisions_log:
     stage: 00-context
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
-    summary: "Q19=A package APIs only this cycle; F7/F8 Planned in docs, no worker/UI/auth/sinks build. Q20=B separate packages/iwxxm-validate for Schematron/XSD PLUS separate package for TAC (all products) validation/linting (name TBD e.g. packages/tac-validate). Q21=A bulletin split required for v1 package acceptance. Q22=A write scoped brief then 01 manifest."
-    resolutions: "Q19=A package APIs only; Q20=B packages/iwxxm-validate + TAC validate pkg TBD; Q21=A bulletin split required v1; Q22=A scoped brief then 01 manifest"
+    summary: "Q19=A package APIs only this cycle; F7/F8 Planned in docs, no worker/UI/auth/sinks build. Q20=B separate packages/iwxxm-validate
+      for Schematron/XSD PLUS separate package for TAC (all products) validation/linting (name TBD e.g. packages/tac-validate).
+      Q21=A bulletin split required for v1 package acceptance. Q22=A write scoped brief then 01 manifest."
+    resolutions: "Q19=A package APIs only; Q20=B packages/iwxxm-validate + TAC validate pkg TBD; Q21=A bulletin split required
+      v1; Q22=A scoped brief then 01 manifest"
     resolves_issues:
       - I-S008-package-first-scope
     package_layout:
@@ -4472,16 +4757,21 @@ decisions_log:
     stage: 00-context
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
-    summary: "Q14=postpone auth (focus on package); Q15=postpone push sinks; Q16=C parse gate + shared TAC rule pack; Q17=D research bulletin-aware default; Q18=A scale worker replicas (no drop). Scope note: user wants package-first design; auth/sinks deferred."
-    resolutions: "Q14=postpone auth; Q15=postpone push sinks; Q16=C parse gate + shared TAC rule pack; Q17=D research bulletin-aware default; Q18=A scale worker replicas (no drop)"
+    summary: "Q14=postpone auth (focus on package); Q15=postpone push sinks; Q16=C parse gate + shared TAC rule pack; Q17=D
+      research bulletin-aware default; Q18=A scale worker replicas (no drop). Scope note: user wants package-first design;
+      auth/sinks deferred."
+    resolutions: "Q14=postpone auth; Q15=postpone push sinks; Q16=C parse gate + shared TAC rule pack; Q17=D research bulletin-aware
+      default; Q18=A scale worker replicas (no drop)"
     scope_note: "package-first; auth/sinks deferred"
   - id: D-S008-realtime-amend-q9q13
     date: "2026-07-12"
     stage: 00-context
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
-    summary: "Q9=A new F7 multi-product TAC sessions (F5 stays METAR-only); Q10=A confirm Render worker + ADR/template update; Q11=B store+push sinks; Q12=A new F8 near-RT ingest pipeline; Q13=A quarantine on Schematron/convert fail"
-    resolutions: "Q9=A F7 new (F5 unchanged); Q10=A Render worker + ADR/template; Q11=B store+push sinks; Q12=A F8 near-RT ingest; Q13=A quarantine on fail"
+    summary: "Q9=A new F7 multi-product TAC sessions (F5 stays METAR-only); Q10=A confirm Render worker + ADR/template update;
+      Q11=B store+push sinks; Q12=A new F8 near-RT ingest pipeline; Q13=A quarantine on Schematron/convert fail"
+    resolutions: "Q9=A F7 new (F5 unchanged); Q10=A Render worker + ADR/template; Q11=B store+push sinks; Q12=A F8 near-RT
+      ingest; Q13=A quarantine on fail"
     proposed_features:
       - F7
       - F8
@@ -4490,25 +4780,30 @@ decisions_log:
     stage: 00-context
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
-    summary: "Q4=C both operator UI + machine ingest; Q5=D research ingest sources in 00; Q6=A seconds (<5–15s E2E); Q7=B add worker deployable (template drift ADR required); Q8=A all F6 products (7)"
-    resolutions: "Q4=C both UI+ingest; Q5=D research sources in 00; Q6=A seconds E2E; Q7=B add worker (ADR); Q8=A all F6 products (7)"
+    summary: "Q4=C both operator UI + machine ingest; Q5=D research ingest sources in 00; Q6=A seconds (<5–15s E2E); Q7=B
+      add worker deployable (template drift ADR required); Q8=A all F6 products (7)"
+    resolutions: "Q4=C both UI+ingest; Q5=D research sources in 00; Q6=A seconds E2E; Q7=B add worker (ADR); Q8=A all F6 products
+      (7)"
   - id: D-S008-realtime-amend-q1q2q3
     date: "2026-07-12"
     stage: 00-context
     session_id: S008-general-tac-iwxxm-converter
     category: Decision
-    summary: "User chose amend S008 (reopen 00+01); realtime = ingest pipeline (continuous feed→near-RT convert+Schematron); Schematron IWXXM-only (extend F2); TAC uses separate syntax/business checks"
+    summary: "User chose amend S008 (reopen 00+01); realtime = ingest pipeline (continuous feed→near-RT convert+Schematron);
+      Schematron IWXXM-only (extend F2); TAC uses separate syntax/business checks"
     resolutions: "Q1=A amend S008; Q2=B ingest pipeline; Q3=A IWXXM Schematron only"
   - id: D-S008-01-requirements-complete
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "S008 01-requirements delta complete — all 7 interviews done; F6 standing specs + ADR-014 written; advancing to 04-tech-plan."
+    decision: "S008 01-requirements delta complete — all 7 interviews done; F6 standing specs + ADR-014 written; advancing
+      to 04-tech-plan."
   - id: D-S008-cfg-batch1
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "no new version/product config keys; profile default in code; no feature flag; no new secrets; US via request profile."
+    decision: "no new version/product config keys; profile default in code; no feature flag; no new secrets; US via request
+      profile."
   - id: D-S008-api-complete
     date: "2026-07-12"
     stage: 01-requirements
@@ -4523,12 +4818,14 @@ decisions_log:
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "validate profile field; F5 stores params UI copies to multipart; error codes; auth unchanged; OpenAPI doc now codegen later."
+    decision: "validate profile field; F5 stores params UI copies to multipart; error codes; auth unchanged; OpenAPI doc now
+      codegen later."
   - id: D-S008-api-batch1
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "health tac2iwxxm_available; product ALWAYS required; multipart only for product/profile; response unchanged no metrics; 400/422/5xx. Note: supersedes API auto-detect default — auto-detect is UI-side only."
+    decision: "health tac2iwxxm_available; product ALWAYS required; multipart only for product/profile; response unchanged
+      no metrics; 400/422/5xx. Note: supersedes API auto-detect default — auto-detect is UI-side only."
   - id: D-S008-deps-complete
     date: "2026-07-12"
     stage: 01-requirements
@@ -4548,7 +4845,8 @@ decisions_log:
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "TC table accepted; cutover PR gate METAR/SPECI+UJ-001; CI matrix gifts→tac2iwxxm; Rust tests deferred; TC-M003 deprecated."
+    decision: "TC table accepted; cutover PR gate METAR/SPECI+UJ-001; CI matrix gifts→tac2iwxxm; Rust tests deferred; TC-M003
+      deprecated."
   - id: D-S008-tp-batch1
     date: "2026-07-12"
     stage: 01-requirements
@@ -4563,12 +4861,14 @@ decisions_log:
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "UJ-008/009/010; explicit product wins with warn; per-file auto-detect batch; guests get product/profile; no gifts rollback."
+    decision: "UJ-008/009/010; explicit product wins with warn; per-file auto-detect batch; guests get product/profile; no
+      gifts rollback."
   - id: D-S008-uj-batch1
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "Extend UJ-001; T3 all 7 products; add UJ-005/006/007; deprecate UJ-DEV-003→003b tac2iwxxm/vendor; extend UJ-002 for iwxxm_us."
+    decision: "Extend UJ-001; T3 all 7 products; add UJ-005/006/007; deprecate UJ-DEV-003→003b tac2iwxxm/vendor; extend UJ-002
+      for iwxxm_us."
   - id: D-S008-spec-complete
     date: "2026-07-12"
     stage: 01-requirements
@@ -4578,12 +4878,14 @@ decisions_log:
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "Spec batch2: dataflow tac2iwxxm; hard constraints no gifts/SoC/vendor RO; assumptions replace REQ-014; keep METAR perf + note other products; known limitations as drafted"
+    decision: "Spec batch2: dataflow tac2iwxxm; hard constraints no gifts/SoC/vendor RO; assumptions replace REQ-014; keep
+      METAR perf + note other products; known limitations as drafted"
   - id: D-S008-spec-batch1
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "Spec batch1: runtime tac2iwxxm only; component SoC; replace gifts_adapter same PR; IR TBD in 04; F2 combined catalogs for iwxxm_us"
+    decision: "Spec batch1: runtime tac2iwxxm only; component SoC; replace gifts_adapter same PR; IR TBD in 04; F2 combined
+      catalogs for iwxxm_us"
   - id: D-S008-F6-feature-list-complete
     date: "2026-07-12"
     stage: 01-requirements
@@ -4607,7 +4909,8 @@ decisions_log:
     date: "2026-07-12"
     stage: 01-requirements
     session_id: S008-general-tac-iwxxm-converter
-    decision: "Manifest: mandatory 4 + Dependency Inventory + API Contract + Config Spec; full FAA five product features; skip deploy rewrite"
+    decision: "Manifest: mandatory 4 + Dependency Inventory + API Contract + Config Spec; full FAA five product features;
+      skip deploy rewrite"
   - id: D-S008-F6-identity
     date: "2026-07-12"
     stage: 01-requirements
@@ -4639,7 +4942,8 @@ decisions_log:
     stage: 01-requirements
     date: "2026-06-14"
     topic: Monorepo direction
-    decision: "Exploratory — user wants single git, reduce submodule complexity, preserve upstream pull from authoritative iwxxm repos"
+    decision: "Exploratory — user wants single git, reduce submodule complexity, preserve upstream pull from authoritative
+      iwxxm repos"
     status: confirmed
   - id: REQ-002
     stage: 01-requirements
@@ -4676,7 +4980,8 @@ decisions_log:
     stage: 01-requirements
     date: "2026-06-23"
     topic: Supabase key naming
-    decision: "SUPABASE_SECRET_KEY + SUPABASE_PUBLISHABLE_KEY canonical; deprecate SUPABASE_SERVICE_ROLE_KEY with fallback shim"
+    decision: "SUPABASE_SECRET_KEY + SUPABASE_PUBLISHABLE_KEY canonical; deprecate SUPABASE_SERVICE_ROLE_KEY with fallback
+      shim"
     status: confirmed
     session_id: S003-supabase-keys-config
   - id: S003-R2
@@ -4719,7 +5024,8 @@ decisions_log:
     stage: 16-evolve
     date: "2026-06-23"
     topic: F5 work history interview re-confirmation
-    decision: "F5 work history interview re-confirmed 2026-06-23 — all answers align with drafted spec; user approved proceed routing"
+    decision: "F5 work history interview re-confirmed 2026-06-23 — all answers align with drafted spec; user approved proceed
+      routing"
     status: confirmed
     session_id: S004-issue-555-feedback
     evolve_cycle_id: EV-004
@@ -4776,14 +5082,16 @@ decisions_log:
     stage: 00-context
     date: "2026-06-25"
     topic: Issue #671 fix approach
-    decision: "Bundle a Postgres service in docker-compose and default backend DATABASE_URL to it so `docker compose up --build` is self-contained (vs fail-fast+docs or reply-only)"
+    decision: "Bundle a Postgres service in docker-compose and default backend DATABASE_URL to it so `docker compose up --build`
+      is self-contained (vs fail-fast+docs or reply-only)"
     status: confirmed
     session_id: S005-issue-671-docker-db
   - id: S005-R3
     stage: 00-context
     date: "2026-06-25"
     topic: Bundled Postgres scope limit
-    decision: "Bundled bare Postgres serves SQLAlchemy ORM tables (statistics/evaluation) only; auth + F5 metar_work_sessions remain on Supabase (RLS + migrations) and still require Supabase config locally"
+    decision: "Bundled bare Postgres serves SQLAlchemy ORM tables (statistics/evaluation) only; auth + F5 metar_work_sessions
+      remain on Supabase (RLS + migrations) and still require Supabase config locally"
     status: confirmed
     session_id: S005-issue-671-docker-db
 
@@ -4798,14 +5106,16 @@ decisions_log:
     stage: 00-context
     date: "2026-06-25"
     topic: Issue #664 implementation layer
-    decision: "Frontend-only — name manual-derived downloads client-side in FileConverter; no change to backend ConversionResult.name or manual_input naming (API contract preserved)"
+    decision: "Frontend-only — name manual-derived downloads client-side in FileConverter; no change to backend ConversionResult.name
+      or manual_input naming (API contract preserved)"
     status: confirmed
     session_id: S006-issue-664-output-filename
   - id: S006-R3
     stage: 00-context
     date: "2026-06-25"
     topic: Issue #664 scope and default
-    decision: "Custom name applies to manual-input results only (uploads unchanged); blank ⇒ default manual_input; multi-line manual input suffixes _1/_2 on the custom base (assumed — confirm in 16-evolve)"
+    decision: "Custom name applies to manual-input results only (uploads unchanged); blank ⇒ default manual_input; multi-line
+      manual input suffixes _1/_2 on the custom base (assumed — confirm in 16-evolve)"
     status: confirmed
     session_id: S006-issue-664-output-filename
 
@@ -4823,8 +5133,10 @@ decisions_log:
     stage: 00-context
     date: "2026-07-12"
     topic: S006 close — waived 11-verify-impl; docs reorg unblocked
-    decision: "Close S006 completed (PR #695 merged 2026-06-25); waive 11-verify-impl; skip 12-verify-deploy and 13-deploy-smoke; archive EV-005; docs reorg unblocked via 00-context"
-    context: "User chose Close S006 now (PR #695 merged; skip 11-verify-impl) — then docs reorg via 00-context. Stages 07-10 synced completed from PASS reports."
+    decision: "Close S006 completed (PR #695 merged 2026-06-25); waive 11-verify-impl; skip 12-verify-deploy and 13-deploy-smoke;
+      archive EV-005; docs reorg unblocked via 00-context"
+    context: "User chose Close S006 now (PR #695 merged; skip 11-verify-impl) — then docs reorg via 00-context. Stages 07-10
+      synced completed from PASS reports."
     skill: 00-context
     status: confirmed
     session_id: S006-issue-664-output-filename
@@ -4833,7 +5145,8 @@ decisions_log:
     stage: 00-context
     date: "2026-07-12"
     topic: S007 opened — conservative docs layout
-    decision: "S007 opened; user approved conservative layout (option 1) — minimize docs/ root; nest non-standing docs into decisions/ops/guides/domain/reports; keep pipeline standing specs at docs/ root"
+    decision: "S007 opened; user approved conservative layout (option 1) — minimize docs/ root; nest non-standing docs into
+      decisions/ops/guides/domain/reports; keep pipeline standing specs at docs/ root"
     skill: 00-context
     status: confirmed
     session_id: S007-docs-minimize
@@ -4851,7 +5164,8 @@ decisions_log:
     stage: 00-context
     date: "2026-07-12"
     topic: Minimal design/parity corpus
-    decision: "Created docs/CORPUS.md + docs/tech-spec.md + docs-corpus.mdc rule so skills cite a common minimal design/parity corpus (product, system-spec, tech-spec, api, tests, adr, decisions)"
+    decision: "Created docs/CORPUS.md + docs/tech-spec.md + docs-corpus.mdc rule so skills cite a common minimal design/parity
+      corpus (product, system-spec, tech-spec, api, tests, adr, decisions)"
     skill: 00-context
     status: confirmed
     session_id: S007-docs-minimize
@@ -4964,7 +5278,8 @@ decisions_log:
     stage: 12-verify-deploy
     date: "2026-06-24"
     topic: Supabase CI sync
-    decision: "Add supabase-sync.yml — db push on main; PR dry-run; deploy legacy upload edge functions until ADR-010 follow-up; secrets SUPABASE_ACCESS_TOKEN + SUPABASE_DB_PASSWORD"
+    decision: "Add supabase-sync.yml — db push on main; PR dry-run; deploy legacy upload edge functions until ADR-010 follow-up;
+      secrets SUPABASE_ACCESS_TOKEN + SUPABASE_DB_PASSWORD"
     status: confirmed
 
   - id: S007-R4
@@ -5620,7 +5935,8 @@ artifacts:
     updated_at: "2026-07-13"
     status: completed
     overall: pass
-    note: "D-S011-02-m1m2-A; deploy.md consistency fixes (/admin baseUrl, E2E_USER_*); M1 one WIP, M2 decode product required; L1/L2 → 04"
+    note: "D-S011-02-m1m2-A; deploy.md consistency fixes (/admin baseUrl, E2E_USER_*); M1 one WIP, M2 decode product required;
+      L1/L2 → 04"
   - path: docs/context/f7-operator-ui.md
     kind: context-scoped
     slug: f7-operator-ui
@@ -5754,7 +6070,8 @@ artifacts:
     created_at: "2026-07-12"
     updated_at: "2026-07-12"
     status: approved
-    note: "51 tasks; PR Plan — PR-M4b–M7 merged; PR-M8 #710 MERGED (feat/S008-M8-ui-connectivity → evolve, e4fe492); M8 complete; next Phase C→D or redeploy for live F6.e"
+    note: "51 tasks; PR Plan — PR-M4b–M7 merged; PR-M8 #710 MERGED (feat/S008-M8-ui-connectivity → evolve, e4fe492); M8 complete;
+      next Phase C→D or redeploy for live F6.e"
   - path: docs/sessions/S008-general-tac-iwxxm-converter/reports/04-tech-plan.md
     kind: stage-report
     session_id: S008-general-tac-iwxxm-converter
@@ -6224,10 +6541,12 @@ evolve_cycles:
       - F7
     feature_id:
     title: Validate Manual TAC Input modes (#730)
-    status: in_progress
+    status: completed
     started: '2026-07-20'
-    completed:
-    scope_summary: "Test/acceptance under F7/ADR-024 for FileConverter Manual TAC Input modes\n(TAC report / AHL bulletin / IWXXM COLLECT). Playwright T1–T4 + Vitest anchors\n+ staging H4–H5 + AHL happy path + COLLECT 501 UX. Auto-switch required.\nNo new Fn; COLLECT member extract out of scope; F7 remains Planned.\n"
+    completed: '2026-07-20'
+    scope_summary: "Test/acceptance under F7/ADR-024 for FileConverter Manual TAC Input modes\n(TAC report / AHL bulletin
+      / IWXXM COLLECT). Playwright T1–T4 + Vitest anchors\n+ staging H4–H5 + AHL happy path + COLLECT 501 UX. Auto-switch
+      required.\nNo new Fn; COLLECT member extract out of scope; F7 remains Planned.\n"
     github_issue: 730
     routing_plan:
       required_stages:
@@ -6247,8 +6566,10 @@ evolve_cycles:
         - 09-qa
         - 11-verify-impl
         - 12-verify-deploy
-    current_stage: phase-d-checkpoint
+    current_stage:
     notes:
+      - '2026-07-20 D-S016-EV012-phase4-close-1 — Phase 4 closed: close EV-012/S016; PR #746 @ 37be5f8; docs #747 @ dd305ba;
+        #730 CLOSED; F7 remains Planned'
       - >-
         2026-07-20 S016/EV-012 13-deploy-smoke COMPLETE / PASS — PR #746 merged 37be5f8;
         CI/CD 29766213356 SUCCESS; Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 +
@@ -6257,9 +6578,11 @@ evolve_cycles:
         2026-07-20 S016/EV-012 13-deploy-smoke STARTED (in_progress) — path A
         (D-S016-EV012-13-path-A); branch pushed; PR #746 open; blocked on merge+Render
         deploy before live H4–H5; checkpoints.phase_d / gates.deploy remain pending
-      - 2026-07-20 S016/EV-012 10-e2e COMPLETE — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; handoff 13-deploy-smoke (pending); checkpoints.phase_d remains pending until 13
+      - 2026-07-20 S016/EV-012 10-e2e COMPLETE — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; handoff 13-deploy-smoke 
+        (pending); checkpoints.phase_d remains pending until 13
       - 2026-07-20 S016/EV-012 10-e2e STARTED (in_progress)
-      - 2026-07-20 S016/EV-012 02-verify-plan COMPLETE — PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A complete; handoff 10-e2e (pending); gates.a_to_b remains waived
+      - 2026-07-20 S016/EV-012 02-verify-plan COMPLETE — PASS — S2.1 H6+UJ-025; S2.2 T1-T6 hard; S2.3 UJ-025; Phase A 
+        complete; handoff 10-e2e (pending); gates.a_to_b remains waived
       - 2026-07-20 S016/EV-012 02-verify-plan STARTED (in_progress)
       - 2026-07-20 S016/EV-012 01-requirements COMPLETE — UJ-025 + TC-F7-007; handoff to 02-verify-plan
       - 2026-07-20 S016/EV-012 01-requirements started (in_progress)
@@ -6274,12 +6597,14 @@ evolve_cycles:
           phase0: locked
         note: Phase 0 locked; routing lean+13 approved (D-S016-EV012-route-1)
       16-evolve:
-        status: in_progress
+        status: completed
         started: '2026-07-20'
-        completed:
+        completed: '2026-07-20'
         note: >-
-          13-deploy-smoke PASS (D-S016-EV012-13-pass); awaiting user deploy approval /
-          Phase 4 close; evolve-summary still pending
+          Phase 4 closed (D-S016-EV012-phase4-close-1) — evolve-summary + evolve-report-EV-012 completed; #730 CLOSED
+        docs_updated:
+          - docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
+          - docs/evolve-report-EV-012.md
       01-requirements:
         status: completed
         started: '2026-07-20'
@@ -6303,9 +6628,8 @@ evolve_cycles:
         completed: '2026-07-20'
         mode: full
         note: >-
-          13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS;
-          Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 + Playwright PASS; awaiting
-          Phase 4 close
+          13-deploy-smoke PASS — PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS; Render LIVE; H0c/H3/H4/H5 + AHL 200 +
+          COLLECT 501 + Playwright PASS; Phase 4 closed (D-S016-EV012-phase4-close-1)
         report: docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
         overall: pass
         pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746
@@ -6322,8 +6646,10 @@ evolve_cycles:
       phase_b: waived
       phase_c: waived
       phase_d:
-        status: pending
-        note: 13-deploy-smoke passed; awaiting user deploy approval / Phase 4 close (session open)
+        status: passed
+        note: 'Phase 4 closed (D-S016-EV012-phase4-close-1) — 13-deploy-smoke PASS; user chose option 1 close Phase 4; #730
+          CLOSED'
+        completed: '2026-07-20'
       deploy:
         status: passed
         completed: '2026-07-20'
@@ -6331,6 +6657,10 @@ evolve_cycles:
           PR #746 merged 37be5f8; CI/CD 29766213356 SUCCESS; Render LIVE
           dep-d9f69f3bc2fs7397bqig / dep-d9f69fjbc2fs7397brq0; H0c/H3/H4/H5 + AHL 200 +
           COLLECT 501 + Playwright PASS
+      phase_4:
+        status: passed
+        completed: '2026-07-20'
+        note: 'Phase 4 closed (D-S016-EV012-phase4-close-1) — close EV-012/S016; close #730'
     adrs:
       - docs/adr/ADR-024-operator-input-modes.md
     artifacts:
@@ -6355,9 +6685,20 @@ evolve_cycles:
       - path: docs/sessions/S016-manual-tac-input-modes/reports/deploy-smoke.md
         status: completed
       - path: docs/decisions/evolve-decisions.md
-        status: in_progress
+        status: completed
+        note: EV-012 completed; Phase 4 closed (D-S016-EV012-phase4-close-1)
       - path: docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
-        status: pending
+        status: completed
+        kind: evolve-summary
+        stage: 16-evolve
+        session_id: S016-manual-tac-input-modes
+        note: Phase 4 closed (D-S016-EV012-phase4-close-1)
+      - path: docs/evolve-report-EV-012.md
+        kind: evolve-report
+        stage: 16-evolve
+        session_id: S016-manual-tac-input-modes
+        status: completed
+        note: Phase 4 closed (D-S016-EV012-phase4-close-1)
     issues: []
   - id: EV-011
     session_id: S015-metar-lint-quality
@@ -6463,7 +6804,8 @@ evolve_cycles:
       deploy:
         status: passed
         completed: '2026-07-20'
-        note: 'PR #742 merged b405a96; CI Deploy run 29718764520 SUCCESS; API dep-d9er13v7f7vs73b8deug + FE dep-d9er14f41pts73feb650 LIVE; H0ci/H1/H0c 6/6/H3 21/21/H4 2/2/H5 + F15 catalog 35 issues PASS'
+        note: 'PR #742 merged b405a96; CI Deploy run 29718764520 SUCCESS; API dep-d9er13v7f7vs73b8deug + FE dep-d9er14f41pts73feb650
+          LIVE; H0ci/H1/H0c 6/6/H3 21/21/H4 2/2/H5 + F15 catalog 35 issues PASS'
     artifacts:
       - path: docs/sessions/S015-metar-lint-quality/reports/deploy-smoke.md
         kind: deploy-smoke
@@ -6587,7 +6929,8 @@ evolve_cycles:
       - >-
         2026-07-20 D-S015-EV011-phase4-close-1 — Phase 4 closed: close EV-011/S015;
         defer PyPI tac-validate-v0.1.1; close #732; F15 Implemented; PR #742 b405a96
-      - '2026-07-20 S015/EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; CI Deploy 29718764520; Render LIVE; Phase D checkpoint pending user close; EV-011 remains in_progress'
+      - '2026-07-20 S015/EV-011 T5.10 / 13-deploy-smoke PASS — PR #742 merged b405a96; CI Deploy 29718764520; Render LIVE;
+        Phase D checkpoint pending user close; EV-011 remains in_progress'
       - >-
         2026-07-20 S015/EV-011 M1 complete (T1.1–T1.4; e0189d4/ac0a282/a1abc7c/79aa67c);
         next 08-verify-build (M1) then M2 T2.1
@@ -6622,20 +6965,30 @@ evolve_cycles:
       - >-
         2026-07-19 S015/EV-011 04-tech-plan Batch 2 done (2/1/1/1) —
         D-S015-EV011-04-qual-1..4 (E11-23..26); Batch 3 pending
-      - 2026-07-19 S015/EV-011 04-tech-plan STARTED (D-S015-EV011-04-start) — Phase B; user option 1 after A→B pass; scope registry → rules R1–R8 → goldens → CI
+      - 2026-07-19 S015/EV-011 04-tech-plan STARTED (D-S015-EV011-04-start) — Phase B; user option 1 after A→B pass; 
+        scope registry → rules R1–R8 → goldens → CI
       - >-
         2026-07-19 S015/EV-011 03-plan-tooling COMPLETE (D-S015-EV011-03-tooling-12) —
         plan-adherence + registry rule + issue_registry_guard hook; Phase A 01–03 done;
         gates.a_to_b passed; awaiting user to start 04-tech-plan
-      - '2026-07-19 S015/EV-011 opened — METAR lint registry + #732 quality (D-S015-open-1); 00-context in_progress pending routing approval'
-      - '2026-07-19 S015/EV-011 00-context — Phase 0 intake locked; routing-plan + scoped brief on disk; routing approval pending'
-      - '2026-07-19 D-S015-EV011-route-1 — routing approved (E11-5 option A): 00–13 incl. 03/06 + Render 12–13; 00-context completed; handoff 01-requirements'
-      - '2026-07-19 D-S015-EV011-research-1 — max expansion scope (E11-6): aggressive R1–R6 + research catalog in 01 + registry+goldens + opportunistic METAR quality'
-      - '2026-07-19 D-S015-EV011-f15-1/codes-1/f7-1 — Feature List E11-9/10/11 approved; F15 as written; stable codes; F7 stays Planned; ADR-028 Accepted; interviews 1/7 → user-journeys+test-plan confirmation'
-      - '2026-07-19 D-S015-EV011-manifest-1 — 01 document manifest approved option A (E11-7); interviews starting feature-list (0/7)'
-      - '2026-07-19 S015/EV-011 01-requirements COMPLETE (D-S015-EV011-spec-2/speci-3/phase-a-next) — interviews 7/7; api-contract wire-shape note; SPECI adjacency; Phase A checkpoint pending before 02'
-      - '2026-07-19 D-S015-EV011-registry-1 — registry home packages/tac-validate module + generated/docs catalog (E11-8 option A); ADR-028 Accepted (adr_number=028)'
-      - '2026-07-19 D-S015-EV011-phase-a-pass — Phase A passed (option A); Phase A digest accepted; 02-verify-plan in_progress; gates.a_to_b pending until 02 completes'
+      - '2026-07-19 S015/EV-011 opened — METAR lint registry + #732 quality (D-S015-open-1); 00-context in_progress pending
+        routing approval'
+      - '2026-07-19 S015/EV-011 00-context — Phase 0 intake locked; routing-plan + scoped brief on disk; routing approval
+        pending'
+      - '2026-07-19 D-S015-EV011-route-1 — routing approved (E11-5 option A): 00–13 incl. 03/06 + Render 12–13; 00-context
+        completed; handoff 01-requirements'
+      - '2026-07-19 D-S015-EV011-research-1 — max expansion scope (E11-6): aggressive R1–R6 + research catalog in 01 + registry+goldens
+        + opportunistic METAR quality'
+      - '2026-07-19 D-S015-EV011-f15-1/codes-1/f7-1 — Feature List E11-9/10/11 approved; F15 as written; stable codes; F7
+        stays Planned; ADR-028 Accepted; interviews 1/7 → user-journeys+test-plan confirmation'
+      - '2026-07-19 D-S015-EV011-manifest-1 — 01 document manifest approved option A (E11-7); interviews starting feature-list
+        (0/7)'
+      - '2026-07-19 S015/EV-011 01-requirements COMPLETE (D-S015-EV011-spec-2/speci-3/phase-a-next) — interviews 7/7; api-contract
+        wire-shape note; SPECI adjacency; Phase A checkpoint pending before 02'
+      - '2026-07-19 D-S015-EV011-registry-1 — registry home packages/tac-validate module + generated/docs catalog (E11-8 option
+        A); ADR-028 Accepted (adr_number=028)'
+      - '2026-07-19 D-S015-EV011-phase-a-pass — Phase A passed (option A); Phase A digest accepted; 02-verify-plan in_progress;
+        gates.a_to_b pending until 02 completes'
       - >-
         2026-07-19 S015/EV-011 02-verify-plan COMPLETE (D-S015-EV011-s1m1-1/s1m2-1/s9m1-1) —
         PASS; 12 auto + medium verdicts all option 1; CORPUS F1–F15/M1–M6; #732 commented
@@ -7018,7 +7371,8 @@ evolve_cycles:
         started_at: '2026-07-19T16:10:00Z'
         completed: '2026-07-19'
         overall: approved
-        note: "verify-impl.md F11–F14 + journeys approved (D-S014-EV010-t63-features / D-S014-EV010-t63-journeys); hard publish/live tag/Render deferred to T6.4–T6.6"
+        note: "verify-impl.md F11–F14 + journeys approved (D-S014-EV010-t63-features / D-S014-EV010-t63-journeys); hard publish/live
+          tag/Render deferred to T6.4–T6.6"
         report: docs/sessions/S014-package-publish-validation/reports/verify-impl.md
         active_milestone: M6
         active_task: T6.3
@@ -7152,14 +7506,18 @@ evolve_cycles:
         2A commit/push/open PR then pause); PR-EV-010=#726 open
         https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/726; tip f1a8799; Trusted
         Publisher blocked for tags; 12 not completed; next after merge T6.5 13-deploy-smoke
-      - "2026-07-19 S014/EV-010 T6.3/11-verify-impl completed (D-S014-EV010-t63-features); T6.4 12-verify-deploy in_progress; deploy-checklist.md pending"
-      - "2026-07-19 S014/EV-010 journey signoff complete (D-S014-EV010-t63-journeys); next Fn F11–F14 approval batch; T6.3/11-verify-impl remains in_progress"
+      - "2026-07-19 S014/EV-010 T6.3/11-verify-impl completed (D-S014-EV010-t63-features); T6.4 12-verify-deploy in_progress;
+        deploy-checklist.md pending"
+      - "2026-07-19 S014/EV-010 journey signoff complete (D-S014-EV010-t63-journeys); next Fn F11–F14 approval batch; T6.3/11-verify-impl
+        remains in_progress"
       - "2026-07-19 S014/EV-010 Phase D passed (D-S014-EV010-phase-d-to-t63); T6.3 11-verify-impl in_progress"
       - "2026-07-19 S014/EV-010 T6.2 PASS (09+10); next T6.3 11-verify-impl after Phase D checkpoint"
       - "2026-07-19 S014/EV-010 C→D passed (user A); T6.2 09-qa + 10-e2e in_progress"
-      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED; next T6.2 after C→D; git commit d3dbbfb recorded"
+      - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED; next T6.2 after C→D; git commit d3dbbfb
+        recorded"
       - "2026-07-19 S014/EV-010 M6 started — T6.1 08-verify-build in_progress"
-      - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task T6.1 pending"
+      - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task
+        T6.1 pending"
       - "2026-07-19 S014/EV-010 T5.1–T5.2 completed (54a7180 / 6186888); active_task T5.3 in_progress"
       - "2026-07-19 S014/EV-010 M5 started — T5.1 in progress (msgspec HTTP API tests)"
       - "2026-07-19 S014/EV-010 M4 complete (T4.1–T4.5); next M5 T5.1"
@@ -7180,9 +7538,12 @@ evolve_cycles:
       - "2026-07-18 S014/EV-010 M3 T3.1–T3.2 complete (1770086 / 947020b); next T3.3 Rust validate_iwxxm"
       - "2026-07-18 S014/EV-010 T3.1 complete — iwxxm-validate rust/maturin scaffold; hatch pure path retained"
       - "2026-07-18 S014/EV-010 user 52:A — continue 07-build at M3 T3.1 after M2 complete"
-      - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin scaffold)"
-      - "2026-07-18 M1 complete (T1.1–T1.3); SHAs 9f9f67b/3ad66cd/70d157b + chore 59a65bd; next M2 T2.1; ci-cd.yml only main/dev — no GHA on push; local format-check + perf green"
-      - "2026-07-18 D-S014-EV010-b-to-c-push — B→C passed (option B); push evolve/EV-010 to origin about to happen; Phase C starting at M1 T1.1"
+      - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin
+        scaffold)"
+      - "2026-07-18 M1 complete (T1.1–T1.3); SHAs 9f9f67b/3ad66cd/70d157b + chore 59a65bd; next M2 T2.1; ci-cd.yml only main/dev
+        — no GHA on push; local format-check + perf green"
+      - "2026-07-18 D-S014-EV010-b-to-c-push — B→C passed (option B); push evolve/EV-010 to origin about to happen; Phase
+        C starting at M1 T1.1"
     adrs:
       - docs/adr/ADR-026-msgspec-http-openapi.md
       - docs/adr/ADR-027-xsdata-codegen.md
@@ -7565,7 +7926,8 @@ evolve_cycles:
       - "07-build complete 2026-06-24 — EV-004 product code + tests green; T1.3 deferred"
       - "08-verify-build 2026-06-24 — FAIL (ESLint react-hooks + 1 Vitest); see verification-report.md"
       - "09-qa 2026-06-24 — FAIL; see qa-report.md"
-      - "2026-07-13 cancelled/abandoned as orphan — S004 already completed 2026-06-25; reconciled for S011 open (D-S011-EV008-open, option A)"
+      - "2026-07-13 cancelled/abandoned as orphan — S004 already completed 2026-06-25; reconciled for S011 open (D-S011-EV008-open,
+        option A)"
     stages:
       16-evolve:
         status: completed
@@ -7689,7 +8051,8 @@ evolve_cycles:
           - "Frontend-only delta — sanitizer util + FileConverter wiring + tests"
           - "outputFilename util (6e8809a); FileConverter input/naming/ZIP/persistence (4b3624c); e2e (49c4dc8)"
           - "Local checks green: eslint, tsc, vitest 530/530, prettier (changed files)"
-          - "Minor PR https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/695 (base main) — CI green (Validate + all Test(*) + E2E Smoke + Sourcery pass; Deploy skipped on PR)"
+          - "Minor PR https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/695 (base main) — CI green (Validate + all Test(*)
+            + E2E Smoke + Sourcery pass; Deploy skipped on PR)"
       08-verify-build:
         status: completed
         started: "2026-06-25"
@@ -7776,50 +8139,73 @@ evolve_cycles:
     current_stage:
     notes:
       - "2026-07-12 M1 T1.1–T1.6 completed on feat/S008-M1-scaffold; current work toward 08-verify-build for M1"
-      - "2026-07-12 M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for main/dev so PR to evolve has no Actions yet"
+      - "2026-07-12 M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for
+        main/dev so PR to evolve has no Actions yet"
       - "Resumed Phase C at T2.1 on feat/S008-M2-validate"
-      - "2026-07-12 D-S008-T21-sch — iwxxm-validate mirrors F2 (lxml XSD + Schematron skip/Docker); TC-F6-032 unit; M-sch Docker soft gate; active_task T2.1 remains in_progress until commit"
-      - "2026-07-12 T2.1+T2.2 done; D-S008-T21-sch applied; next T2.3 pending (T2.2 commit SHA not yet on HEAD — git_history has T2.1 only)"
+      - "2026-07-12 D-S008-T21-sch — iwxxm-validate mirrors F2 (lxml XSD + Schematron skip/Docker); TC-F6-032 unit; M-sch
+        Docker soft gate; active_task T2.1 remains in_progress until commit"
+      - "2026-07-12 T2.1+T2.2 done; D-S008-T21-sch applied; next T2.3 pending (T2.2 commit SHA not yet on HEAD — git_history
+        has T2.1 only)"
       - "2026-07-12 T2.3+T2.4 complete (b167e71, d27090d); active_task T2.5 in_progress"
-      - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete; 08-verify-build scoped pass (format, package types, unit packages + wrappers + soft benches); opening PR-M2"
+      - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete; 08-verify-build scoped pass (format, package types, unit packages + wrappers
+        + soft benches); opening PR-M2"
       - "2026-07-12 PR-M1 (#700) merged to evolve (D-S008-PR700-19; PRM-008)"
       - "2026-07-12 PR-M2 (#701) merged to evolve (D-S008-PR701-19; PRM-009); feat/S008-M2-validate merged"
       - "2026-07-12 Resume option 1 — M3 bulletin on feat/S008-M3-bulletin; start T3.1"
       - "2026-07-12 M3 T3.1–T3.5 complete; PR-M3 #704 merged"
       - "2026-07-12 Resume option 1 — M4 cutover on feat/S008-M4-cutover; start T4.1 (D-S008-EV006-resume-m4)"
-      - "2026-07-12 D-S008-EV006-resume-t410 — resume 07-build at T4.10 (US METAR/SPECI goldens); new feat branch needed (feat/S008-M4-cutover merged)"
+      - "2026-07-12 D-S008-EV006-resume-t410 — resume 07-build at T4.10 (US METAR/SPECI goldens); new feat branch needed (feat/S008-M4-cutover
+        merged)"
       - "2026-07-12 T4.10+T4.11 complete on feat/S008-M4-us-metar; next T4.6 cutover gate"
       - "2026-07-12 D-S008-EV006-t47-cutover — starting T4.7 gifts delete cutover"
       - "2026-07-12 M4 T4.10–T4.11 + T4.6–T4.9 complete on feat/S008-M4-us-metar; next 08-verify-build then PR"
-      - "2026-07-12 D-S008-EV006-merge-m4-m7 — PRs #706–#709 (PR-M4b…PR-M7) merged into evolve; M4–M7 complete; next M8 or continue 07-build"
-      - "2026-07-12 D-S008-EV006-resume-m8 — user resumed at M8 (option A); continue Phase C 07-build at T8.1; create feat/S008-M8-ui-connectivity from evolve"
+      - "2026-07-12 D-S008-EV006-merge-m4-m7 — PRs #706–#709 (PR-M4b…PR-M7) merged into evolve; M4–M7 complete; next M8 or
+        continue 07-build"
+      - "2026-07-12 D-S008-EV006-resume-m8 — user resumed at M8 (option A); continue Phase C 07-build at T8.1; create feat/S008-M8-ui-connectivity
+        from evolve"
       - "2026-07-12 T8.1–T8.4 done; PR-M8 opened (feat/S008-M8-ui-connectivity)"
-      - "2026-07-12 PR-M8 #710 MERGED into evolve (PRM-014; e4fe492); M8 complete; next Phase C→D (08-verify-build / 09-qa) or redeploy for live F6.e"
-      - "2026-07-12 Phase C close (D-S008-EV006-c-close) — 07-build completed (51/51); starting 08-verify-build for C→D gate; phase_c/c_to_d remain pending until 08 passes"
+      - "2026-07-12 PR-M8 #710 MERGED into evolve (PRM-014; e4fe492); M8 complete; next Phase C→D (08-verify-build / 09-qa)
+        or redeploy for live F6.e"
+      - "2026-07-12 Phase C close (D-S008-EV006-c-close) — 07-build completed (51/51); starting 08-verify-build for C→D gate;
+        phase_c/c_to_d remain pending until 08 passes"
       - "2026-07-12 08-verify-build Phase C FAIL — awaiting fix decision on typecheck + coverage"
       - "2026-07-12 D-S008-EV006-08-fix — User chose option 1 fix-in-place for typecheck+coverage; 08 re-verify PASS"
-      - "2026-07-12 08-verify-build Phase C full verify PASS (Overall PASS); awaiting C→D AskQuestion before 09-qa; gates.c_to_d and checkpoints.phase_c remain pending"
+      - "2026-07-12 08-verify-build Phase C full verify PASS (Overall PASS); awaiting C→D AskQuestion before 09-qa; gates.c_to_d
+        and checkpoints.phase_c remain pending"
       - "2026-07-12 D-S008-EV006-c-to-d — C→D passed; Phase D started; current_stage 09-qa"
       - "2026-07-12 10-e2e started in parallel with 09-qa after C→D"
       - "2026-07-12 09-qa completed — pass_with_advisories; see reports/qa-report.md"
       - "2026-07-12 10-e2e completed — FAIL (10 pass / 2 fail COR correction e2e); see e2e-report.md"
-      - "2026-07-12 Phase D 09+10 done; checkpoint before 11-verify-impl (phase_d remains pending until AskQuestion) [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 Phase D 09+10 done; checkpoint before 11-verify-impl (phase_d remains pending until AskQuestion) [RESOLVED
+        by D-S008-EV006-phase-d]"
       - "2026-07-12 D-S008-EV006-3-then-2 — User chose 3 then 2: commit Phase C/D artifacts then hotfix COR e2e"
-      - "2026-07-12 commit 48037c1 Phase C/D reports; COR hotfix landed; 10-e2e T0 PASS (12/12 Playwright smoke); phase_d remains pending until AskQuestion before 11 [RESOLVED by D-S008-EV006-phase-d]"
-      - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 commit 48037c1 Phase C/D reports; COR hotfix landed; 10-e2e T0 PASS (12/12 Playwright smoke); phase_d
+        remains pending until AskQuestion before 11 [RESOLVED by D-S008-EV006-phase-d]"
+      - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl [RESOLVED
+        by D-S008-EV006-phase-d]"
       - "2026-07-12 D-S008-EV006-phase-d — phase_d checkpoint passed (AskQuestion option 1); 11-verify-impl started"
       - "2026-07-12 phase_d passed; EV-006.current_stage=11-verify-impl; stages.11-verify-impl in_progress"
       - "2026-07-12 Journey signoff: UJ-001 approved (T3 pending waiver); UJ-003 approved (T3 pending waiver)."
-      - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005). Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3 live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live pending waiver; 11-verify-impl remains in_progress."
-      - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014). Cycle product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion; 11-verify-impl remains in_progress."
-      - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
-      - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005).
+        Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3 live
+        pending waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live
+        pending waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live pending
+        waiver; 11-verify-impl remains in_progress."
+      - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014). Cycle
+        product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion; 11-verify-impl
+        remains in_progress."
+      - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred
+        (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
+      - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred;
+        11-verify-impl remains in_progress."
       - "2026-07-12 All cycle features F6/F2/F8 approved; writing verify-impl.md next."
-      - "2026-07-12 11-verify-impl completed; F6/F2/F8 approved; F6/F8 corpus Implemented (ADR-019); live gates deferred; S008 routing has no 12/13 — next is session close checkpoint or amend routing for deploy."
-      - "2026-07-12 D-S008-11-scope-f6-f8-status — F6+F8 Implemented / F7 Planned (ADR-019); stages.11-verify-impl completed overall approved; current_stage=null (11 done); gates.deploy still pending."
+      - "2026-07-12 11-verify-impl completed; F6/F2/F8 approved; F6/F8 corpus Implemented (ADR-019); live gates deferred;
+        S008 routing has no 12/13 — next is session close checkpoint or amend routing for deploy."
+      - "2026-07-12 D-S008-11-scope-f6-f8-status — F6+F8 Implemented / F7 Planned (ADR-019); stages.11-verify-impl completed
+        overall approved; current_stage=null (11 done); gates.deploy still pending."
       - "2026-07-12 D-S008-EV006-close — cycle completed; deploy waived; session closed; commit+push pending"
     stages:
       00-context:
@@ -7851,21 +8237,27 @@ evolve_cycles:
         active_milestone:
         notes:
           - "M1 T1.1–T1.6 completed; next 08-verify-build for M1 then PR-M1"
-          - "M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for main/dev so PR to evolve has no Actions yet"
+          - "M1 complete PR-M1 #700; M2 started on feat/S008-M2-validate; CI advisory — ci-cd.yml only triggers for main/dev
+            so PR to evolve has no Actions yet"
           - "2026-07-12 resume: active_task T2.1 in_progress (D-S008-EV006-resume=A) on feat/S008-M2-validate"
           - "2026-07-12 D-S008-T21-sch recorded; active_task T2.1 remains in_progress until commit"
-          - "2026-07-12 T2.1 completed (db27737); T2.2 completed (implement iwxxm-validate); D-S008-T21-sch applied; active_task T2.3 pending; T2.2 SHA not yet committed when recorded"
+          - "2026-07-12 T2.1 completed (db27737); T2.2 completed (implement iwxxm-validate); D-S008-T21-sch applied; active_task
+            T2.3 pending; T2.2 SHA not yet committed when recorded"
           - "2026-07-12 T2.3+T2.4 complete (b167e71, d27090d); active_task T2.5 in_progress"
-          - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete; 08-verify-build scoped pass (format, package types, unit packages + wrappers + soft benches); active_task M2 complete — opening PR-M2"
+          - "2026-07-12 Phase 2 / M2 T2.1–T2.7 complete; 08-verify-build scoped pass (format, package types, unit packages
+            + wrappers + soft benches); active_task M2 complete — opening PR-M2"
           - "2026-07-12 PR-M2 (#701) merged (PRM-009 / D-S008-PR701-19); next milestone M3"
           - "2026-07-12 Resume option 1 — M3 bulletin on feat/S008-M3-bulletin; start T3.1"
           - "2026-07-12 M3 T3.1–T3.5 complete; PR-M3 #704 merged; M4 started — active_task T4.1 on feat/S008-M4-cutover"
           - "2026-07-12 Resume option 1 — M4 cutover on feat/S008-M4-cutover; start T4.1 (D-S008-EV006-resume-m4)"
           - "2026-07-12 T4.1–T4.3 complete on feat/S008-M4-cutover"
           - "2026-07-12 T4.1–T4.5 complete; next T4.10 US METAR/SPECI goldens"
-          - "2026-07-12 D-S008-EV006-resume-t410 — active handoff from 16-evolve; resume at T4.10; new feat branch needed (feat/S008-M4-cutover merged)"
-          - "2026-07-12 D-S008-EV006-merge-m4-m7 — PR-M4b #706 / PR-M5 #707 / PR-M6 #708 / PR-M7 #709 merged into evolve; next M8"
-          - "2026-07-12 D-S008-EV006-resume-m8 — user resumed at M8; active_task T8.1; branch feat/S008-M8-ui-connectivity (to create)"
+          - "2026-07-12 D-S008-EV006-resume-t410 — active handoff from 16-evolve; resume at T4.10; new feat branch needed
+            (feat/S008-M4-cutover merged)"
+          - "2026-07-12 D-S008-EV006-merge-m4-m7 — PR-M4b #706 / PR-M5 #707 / PR-M6 #708 / PR-M7 #709 merged into evolve;
+            next M8"
+          - "2026-07-12 D-S008-EV006-resume-m8 — user resumed at M8; active_task T8.1; branch feat/S008-M8-ui-connectivity
+            (to create)"
           - "2026-07-12 T8.1–T8.4 done; PR-M8 opened"
           - "2026-07-12 PR-M8 #710 MERGED (PRM-014; e4fe492); M8 complete"
           - "2026-07-12 M8/all tasks done (51/51); PR-M8 #710 merged; Phase C implementation complete"
@@ -7879,9 +8271,11 @@ evolve_cycles:
         report: docs/sessions/S008-general-tac-iwxxm-converter/reports/verification-report.md
         artifacts: docs/sessions/S008-general-tac-iwxxm-converter/reports/verification-report.md
         notes:
-          - "Phase C full verify FAIL — typecheck-py 4 errors; backend cov 97.07%<98%; tac2iwxxm cov 89.61%<95%; report written; awaiting user fix decision; c_to_d/phase_c remain pending"
+          - "Phase C full verify FAIL — typecheck-py 4 errors; backend cov 97.07%<98%; tac2iwxxm cov 89.61%<95%; report written;
+            awaiting user fix decision; c_to_d/phase_c remain pending"
           - "2026-07-12 D-S008-EV006-08-fix — User chose option 1 fix-in-place for typecheck+coverage; 08 re-verify PASS"
-          - "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c); Overall PASS; awaiting C→D AskQuestion; c_to_d/phase_c remain pending"
+          - "Phase C full verify PASS (format/lint/typecheck; backend 98.13%; tac2iwxxm 97.41%; H0c); Overall PASS; awaiting
+            C→D AskQuestion; c_to_d/phase_c remain pending"
       09-qa:
         status: completed
         started: "2026-07-12"
@@ -7929,15 +8323,24 @@ evolve_cycles:
           F8: approved_live_deferred
         notes:
           - "2026-07-12 Journey signoff: UJ-001 approved (T3 pending waiver); UJ-003 approved (T3 pending waiver)."
-          - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005). Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
-          - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3 live pending waiver; 11-verify-impl remains in_progress."
-          - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live pending waiver; 11-verify-impl remains in_progress."
-          - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live pending waiver; 11-verify-impl remains in_progress."
-          - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014). Cycle product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion; 11-verify-impl remains in_progress."
-          - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
-          - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred; 11-verify-impl remains in_progress."
+          - "2026-07-12 Journey signoff: UJ-002 approved_t3_waiver; UJ-005 approved_t3_waiver_partial_matrix (D-S008-11-uj-002-005).
+            Full UJ-005 7-product annex3 matrix and live H6 deferred; 11-verify-impl remains in_progress."
+          - "2026-07-12 Journey signoff: UJ-006 approved_t3_waiver; UJ-007 approved_t3_waiver (D-S008-11-uj-006-007). T3/H3
+            live pending waiver; 11-verify-impl remains in_progress."
+          - "2026-07-12 Journey signoff: UJ-011 approved_h7_waiver; UJ-012 approved_t3_waiver (D-S008-11-uj-011-012). H7/live
+            pending waiver; 11-verify-impl remains in_progress."
+          - "2026-07-12 Journey signoff: UJ-008 approved_t3_waiver; UJ-009 approved_t3_waiver (D-S008-11-uj-008-009). Live
+            pending waiver; 11-verify-impl remains in_progress."
+          - "2026-07-12 Journey signoff: UJ-010 approved_t3_waiver; UJ-014 approved_live_t74_waiver (D-S008-11-uj-010-014).
+            Cycle product journeys (UJ-001–012, UJ-014) signed off; UJ-013/UJ-004 still pending user deferral AskQuestion;
+            11-verify-impl remains in_progress."
+          - "2026-07-12 D-S008-11-f6-uj-remaining — UJ-013 deferred_planned_f7; UJ-004 skipped_out_of_cycle; F6 approved_live_deferred
+            (live H4–H7 / full UI 7-product matrix deferred); 11-verify-impl remains in_progress."
+          - "2026-07-12 D-S008-11-f2 — User approved Feature F2 (AskQuestion option 1) with live H3 deferred; feature_signoffs.F2=approved_live_deferred;
+            11-verify-impl remains in_progress."
           - "2026-07-12 All cycle features F6/F2/F8 approved; writing verify-impl.md next."
-          - "2026-07-12 D-S008-11-scope-f6-f8-status — F6+F8 Implemented / F7 Planned (ADR-019); 11-verify-impl completed overall approved; live gates deferred."
+          - "2026-07-12 D-S008-11-scope-f6-f8-status — F6+F8 Implemented / F7 Planned (ADR-019); 11-verify-impl completed
+            overall approved; live gates deferred."
     gates:
       a_to_b: passed
       b_to_c: passed
@@ -8120,36 +8523,58 @@ evolve_cycles:
         - 06-tech-tooling
     current_stage:
     notes:
-      - '2026-07-19 D-S011-EV008-close-1 — User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; gates.deploy waived; 13-deploy-smoke skipped (later deploys via S013/S014)'
-      - "2026-07-15 S011 paused/archived for hotfix S012-empty-bearer-lint-tac; EV-008 suspended (not deleted); PR #716 remains open for later resume"
-      - "2026-07-14 PR-EV-008=#716 open (retitled/updated evolve→main; NO merge, NO deploy); 12 approved; 13 blocked on merge; T6.4 in_progress (12 done / 13 pending)"
-      - "2026-07-14 D-S011-EV008-deploy-check-A — 12-verify-deploy completed (checklist approved); commit QA-001+reports; preparing PR-EV-008; 13 pending/blocked on merge; T6.4 remains in_progress (12 done / 13 pending); no merge/deploy yet"
-      - "2026-07-14 S011/EV-008 12-verify-deploy — checklist written (deploy-checklist.md); awaiting user deploy-strategy approval (blocker: tip 44 commits ahead of main; QA-001 uncommitted); 12 remains in_progress; 13 not started"
-      - "2026-07-14 D-S011-EV008-f7-approve — F7 approved_with_waivers; T6.3 completed; T6.4 12-verify-deploy in_progress; H4–H5 waived to T6.4/CI; AdminDashboard advisory"
-      - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress"
-      - "2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED host ports/disk; QA-001 api.py type narrow uncommitted; next T6.3 (11-verify-impl pending)"
+      - '2026-07-19 D-S011-EV008-close-1 — User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; gates.deploy
+        waived; 13-deploy-smoke skipped (later deploys via S013/S014)'
+      - "2026-07-15 S011 paused/archived for hotfix S012-empty-bearer-lint-tac; EV-008 suspended (not deleted); PR #716 remains
+        open for later resume"
+      - "2026-07-14 PR-EV-008=#716 open (retitled/updated evolve→main; NO merge, NO deploy); 12 approved; 13 blocked on merge;
+        T6.4 in_progress (12 done / 13 pending)"
+      - "2026-07-14 D-S011-EV008-deploy-check-A — 12-verify-deploy completed (checklist approved); commit QA-001+reports;
+        preparing PR-EV-008; 13 pending/blocked on merge; T6.4 remains in_progress (12 done / 13 pending); no merge/deploy
+        yet"
+      - "2026-07-14 S011/EV-008 12-verify-deploy — checklist written (deploy-checklist.md); awaiting user deploy-strategy
+        approval (blocker: tip 44 commits ahead of main; QA-001 uncommitted); 12 remains in_progress; 13 not started"
+      - "2026-07-14 D-S011-EV008-f7-approve — F7 approved_with_waivers; T6.3 completed; T6.4 12-verify-deploy in_progress;
+        H4–H5 waived to T6.4/CI; AdminDashboard advisory"
+      - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task
+        T6.3 in_progress"
+      - "2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED
+        host ports/disk; QA-001 api.py type narrow uncommitted; next T6.3 (11-verify-impl pending)"
       - "2026-07-14 S011/EV-008 M3 complete (T3.1–T3.4); PR-M3 #717 open; active_milestone M4; active_task T4.1"
       - "2026-07-13 M3 T3.1 in_progress — test preview=true convert; active_milestone M3; active_task T3.1 in_progress"
       - "2026-07-13 opened — EV-004 cancelled as orphan; EV-008 allocated for S011 (D-S011-EV008-open, option A)"
       - "2026-07-13 D-S011-01-manifest-A — 01-requirements document manifest approved option A; interviews starting feature-list/core"
-      - "2026-07-13 D-S011-01-fl-batch2-A — Feature List Batch 2 option A accepted; docs/feature-list.md updated for F7; interviews 1/8 → spec/architecture"
-      - "2026-07-13 D-S011-01-spec-r2-prime — Override R2 unified tac_work_sessions + migrate metar_work_sessions (Spec Batch 2 C→A); ADR-020 accepted; Spec Batch 1–2 written; interviews 2/8 → user-journeys/f7-journeys"
-      - "2026-07-13 D-S011-01-cfg-B — Config/env Batch option B (BYO + ADMIN_*→E2E_USER_*); ADR-021/022 accepted; 01-requirements complete (8/8); Phase A checkpoint pending before 02-verify-plan"
+      - "2026-07-13 D-S011-01-fl-batch2-A — Feature List Batch 2 option A accepted; docs/feature-list.md updated for F7; interviews
+        1/8 → spec/architecture"
+      - "2026-07-13 D-S011-01-spec-r2-prime — Override R2 unified tac_work_sessions + migrate metar_work_sessions (Spec Batch
+        2 C→A); ADR-020 accepted; Spec Batch 1–2 written; interviews 2/8 → user-journeys/f7-journeys"
+      - "2026-07-13 D-S011-01-cfg-B — Config/env Batch option B (BYO + ADMIN_*→E2E_USER_*); ADR-021/022 accepted; 01-requirements
+        complete (8/8); Phase A checkpoint pending before 02-verify-plan"
       - "2026-07-13 D-S011-EV008-phase-a-pass — Phase A passed (option A); 02-verify-plan in_progress"
-      - "2026-07-13 D-S011-02-m1m2-A — 02-verify-plan PASS (M1 one WIP total; M2 decode product required; L1/L2 defer to 04); deploy.md consistency fixes; awaiting A→B before 04-tech-plan"
+      - "2026-07-13 D-S011-02-m1m2-A — 02-verify-plan PASS (M1 one WIP total; M2 decode product required; L1/L2 defer to 04);
+        deploy.md consistency fixes; awaiting A→B before 04-tech-plan"
       - "2026-07-13 D-S011-EV008-a-to-b-pass — A→B passed; 04-tech-plan in_progress"
       - "2026-07-13 D-S011-04-batch1-A — 04 Batch 1 A; plan drafted awaiting approval; execution-plan.md pending_user_approval"
-      - "2026-07-13 D-S011-04-plan-approve-A — 04-tech-plan completed; execution-plan.md approved; 05-verify-tech in_progress; phase_b still pending"
-      - "2026-07-13 D-S011-05-pass — 05-verify-tech completed (audit PASS; A1–A3 as-is); current_stage stays 05 awaiting Phase B / B→C; checkpoints.phase_b pending (no auto-pass)"
+      - "2026-07-13 D-S011-04-plan-approve-A — 04-tech-plan completed; execution-plan.md approved; 05-verify-tech in_progress;
+        phase_b still pending"
+      - "2026-07-13 D-S011-05-pass — 05-verify-tech completed (audit PASS; A1–A3 as-is); current_stage stays 05 awaiting Phase
+        B / B→C; checkpoints.phase_b pending (no auto-pass)"
       - "2026-07-13 D-S011-EV008-b-to-c-pass — Phase B / B→C passed; 07-build in_progress; M1 T1.1 in_progress"
       - "2026-07-13 M2 complete (T2.1–T2.8); PR-M2 #716 open; active_milestone M3 / active_task T3.1"
       - 2026-07-14 16-evolve resume Phase C — M4 Live workbench; active_milestone M4; active_task T4.1 in_progress
-      - '2026-07-14 S011/EV-008 M4 complete (T4.1–T4.6); PR-M4 #718 open; H0c PASS; H4–H5 deferred to M6; active_milestone M5; active_task T5.1 pending'
-      - "2026-07-14 S011/EV-008 M5 started — T5.1 in_progress (unified tac_work_sessions); active_milestone M5; active_task T5.1 in_progress"
-      - "2026-07-14 S011/EV-008 M5 T5.1–T5.5 complete; migration 20260714000010 applied remotely (13 rows cutover); active_milestone M5; active_task T5.6 in_progress (next PR-M5)"
-      - "2026-07-14 S011/EV-008 M5 complete (T5.1–T5.6); PR-M5 https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/720 open; remote migration applied (13 rows); Validate green after pyright fix; tip may still have unrelated red CI (admin bug regressions, etc.); active_milestone M6; active_task T6.1 pending"
-      - "2026-07-14 S011/EV-008 M6 started — T6.1 08-verify-build in_progress; M1 leftover + domain docs committed (bdcb9b8, b5b79d7); PR-M5 #720 still open"
-      - "2026-07-14 S011/EV-008 T6.1 PASS (verification-report.md); integration SKIPPED host ports/disk; active_task T6.2 pending"
+      - '2026-07-14 S011/EV-008 M4 complete (T4.1–T4.6); PR-M4 #718 open; H0c PASS; H4–H5 deferred to M6; active_milestone
+        M5; active_task T5.1 pending'
+      - "2026-07-14 S011/EV-008 M5 started — T5.1 in_progress (unified tac_work_sessions); active_milestone M5; active_task
+        T5.1 in_progress"
+      - "2026-07-14 S011/EV-008 M5 T5.1–T5.5 complete; migration 20260714000010 applied remotely (13 rows cutover); active_milestone
+        M5; active_task T5.6 in_progress (next PR-M5)"
+      - "2026-07-14 S011/EV-008 M5 complete (T5.1–T5.6); PR-M5 https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/720
+        open; remote migration applied (13 rows); Validate green after pyright fix; tip may still have unrelated red CI (admin
+        bug regressions, etc.); active_milestone M6; active_task T6.1 pending"
+      - "2026-07-14 S011/EV-008 M6 started — T6.1 08-verify-build in_progress; M1 leftover + domain docs committed (bdcb9b8,
+        b5b79d7); PR-M5 #720 still open"
+      - "2026-07-14 S011/EV-008 T6.1 PASS (verification-report.md); integration SKIPPED host ports/disk; active_task T6.2
+        pending"
       - "2026-07-14 D-S011-EV008-c-to-d-pass — C→D passed; T6.2 09-qa+10-e2e in_progress (option 1)"
     stages:
       01-requirements:
@@ -8258,21 +8683,25 @@ evolve_cycles:
         overall: approved_with_waivers
         artifacts_updated:
           - docs/sessions/S011-f7-operator-ui/reports/verify-impl.md
-        note: "D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout T6.5"
+        note: "D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout
+          T6.5"
       12-verify-deploy:
         status: completed
         started: "2026-07-14"
         completed: "2026-07-14"
         artifacts_updated:
           - docs/sessions/S011-f7-operator-ui/reports/deploy-checklist.md
-        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge approval"
+        note: "D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge
+          approval"
       13-deploy-smoke:
         status: skipped
         started:
         completed: '2026-07-19'
         artifacts_updated: []
-        note: "13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014 (D-S011-EV008-close-1)"
-        skip_rationale: '13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014 (D-S011-EV008-close-1)'
+        note: "13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via S013/S014
+          (D-S011-EV008-close-1)"
+        skip_rationale: '13-deploy-smoke waived — PR #716 merge landed 2026-07-15 (22a6199); later deploy verification via
+          S013/S014 (D-S011-EV008-close-1)'
     gates:
       a_to_b: passed  # D-S011-EV008-a-to-b-pass 2026-07-13
       b_to_c: passed  # D-S011-EV008-b-to-c-pass 2026-07-13
@@ -8344,7 +8773,8 @@ evolve_cycles:
     pr_status: merged
     pr_merge_commit: 22a6199823d6299758aeedab1340885e38d572aa
     merge_sha: 22a6199
-    close_reason: 'User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed; later deploys via S013/S014)'
+    close_reason: 'User closed S011/EV-008 to start S015 (#732); PR #716 merged 22a6199; 13-deploy-smoke waived (merge landed;
+      later deploys via S013/S014)'
 
   - id: EV-009
     session_id: S013-live-decode-preview-ux
@@ -8432,7 +8862,8 @@ evolve_cycles:
         completed: "2026-07-16"
         report: docs/sessions/S013-live-decode-preview-ux/reports/verification-report.md
         overall: pass
-        notes: "All checks green; out-of-scope backend integration/env-dependent failures noted as pre-existing (untouched by S013)"
+        notes: "All checks green; out-of-scope backend integration/env-dependent failures noted as pre-existing (untouched
+          by S013)"
       09-qa:
         status: completed
         mode: full
@@ -8440,7 +8871,8 @@ evolve_cycles:
         completed: "2026-07-17"
         report: docs/sessions/S013-live-decode-preview-ux/reports/qa-report.md
         overall: pass
-        notes: "All blocking checks green; QA-001 (ecdsa PYSEC-2026-1325 risk-accepted, audit/pip-audit-ignore.txt) + QA-002 (live H0c/H4/H5 PASS pre-deploy 2026-07-17) both RESOLVED"
+        notes: "All blocking checks green; QA-001 (ecdsa PYSEC-2026-1325 risk-accepted, audit/pip-audit-ignore.txt) + QA-002
+          (live H0c/H4/H5 PASS pre-deploy 2026-07-17) both RESOLVED"
       10-e2e:
         status: completed
         mode: full
@@ -8448,7 +8880,8 @@ evolve_cycles:
         completed: "2026-07-17"
         report: docs/sessions/S013-live-decode-preview-ux/reports/e2e-report.md
         overall: pass
-        notes: "UJ-020/021 Playwright 2/2 PASS vs local dev stack; live unstubbed decode-tac summary + lint-tac info/fix verified; T2 H1-H5 + T3 deferred to 13"
+        notes: "UJ-020/021 Playwright 2/2 PASS vs local dev stack; live unstubbed decode-tac summary + lint-tac info/fix verified;
+          T2 H1-H5 + T3 deferred to 13"
       11-verify-impl:
         status: completed
         mode: full
@@ -8456,7 +8889,8 @@ evolve_cycles:
         completed: "2026-07-17"
         report: docs/sessions/S013-live-decode-preview-ux/reports/verify-impl.md
         overall: pass
-        notes: "F9 + F10 user-approved ('1 / 1'); 8/8 acceptance criteria PASS; UJ-020/021 signed off (T3 waiver — QA-002 live pre-deploy H0c/H4/H5 PASS, re-run at 13); 0 scope creep/gaps"
+        notes: "F9 + F10 user-approved ('1 / 1'); 8/8 acceptance criteria PASS; UJ-020/021 signed off (T3 waiver — QA-002
+          live pre-deploy H0c/H4/H5 PASS, re-run at 13); 0 scope creep/gaps"
       12-verify-deploy:
         status: completed
         mode: delta
@@ -8464,7 +8898,8 @@ evolve_cycles:
         completed: "2026-07-17"
         report: docs/sessions/S013-live-decode-preview-ux/reports/deploy-checklist.md
         overall: approved
-        notes: "Checklist + rollback approved (D-S013-EV009-deploy-check-A); no infra/env/migration delta; H0c 6/6 fresh; PR-EV-009=#723 CI green; merge + deploy approved"
+        notes: "Checklist + rollback approved (D-S013-EV009-deploy-check-A); no infra/env/migration delta; H0c 6/6 fresh;
+          PR-EV-009=#723 CI green; merge + deploy approved"
       13-deploy-smoke:
         status: completed
         mode: delta
@@ -8472,7 +8907,8 @@ evolve_cycles:
         completed: "2026-07-17"
         report: docs/sessions/S013-live-decode-preview-ux/reports/deploy-smoke.md
         overall: pass
-        notes: "PR #723 merged 4660602; API dep-d9da4kbtqb8s73cvrkog + FE dep-d9da4l58nd3s73drqo00 live; H1/H0c/H3 21/21 / H4 2/2 / H5 / H6' UJ-020/021 PASS"
+        notes: "PR #723 merged 4660602; API dep-d9da4kbtqb8s73cvrkog + FE dep-d9da4l58nd3s73drqo00 live; H1/H0c/H3 21/21 /
+          H4 2/2 / H5 / H6' UJ-020/021 PASS"
     gates:
       a_to_b: passed
       b_to_c: passed
@@ -8508,11 +8944,15 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: docs/EV-012-deploy-smoke
-  ahead_of_origin: 1
-  pushed: true
-  pending_commit:
+  current_branch: docs/EV-012-close
+  ahead_of_origin: 0
+  pushed: false
+  pending_commit: '[S016] docs: close EV-012 / S016 (Manual TAC Input modes)'
   notes:
+    - '2026-07-20 S016/EV-012 — Phase 4 closed (D-S016-EV012-phase4-close-1); issue #730 CLOSED; branch docs/EV-012-close
+      for close docs + workflow-state'
+    - '2026-07-20 S016/EV-012 — PR #747 merged dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73 (docs: 13-deploy-smoke PASS)'
+    - '2026-07-20 S016/EV-012 — PR #746 merged 37be5f877bd50d9ef1d1208e78f99c12ca59f092 (feature: Manual TAC Input modes)'
     - >-
       2026-07-20 S016/EV-012 — PR #746 merged 37be5f8; 13-deploy-smoke PASS; docs branch
       docs/EV-012-deploy-smoke for deploy-smoke.md + workflow-state; Phase D close pending
@@ -8540,8 +8980,10 @@ git_history:
       2026-07-20 S016/EV-012 git — recorded 143670ac6d6e912aa16c8ea175a3e04e4695fb64
       (143670a) docs(S016): add UJ-025 and TC-F7-007 for Manual TAC Input modes;
       01-requirements; local tip on evolve/EV-012-manual-tac-input-modes; not pushed
-    - 2026-07-20 S016/EV-012 open — branch evolve/EV-012-manual-tac-input-modes recorded active (base main); Phase 0 complete; lean+13 routing approved
-    - '2026-07-20 S015/EV-011 — PR #742 merged b405a96; T5.10 deploy-smoke PASS; docs a73bbe0 on docs/EV-011-deploy-smoke; EV-011 open pending Phase D close'
+    - 2026-07-20 S016/EV-012 open — branch evolve/EV-012-manual-tac-input-modes recorded active (base main); Phase 0 
+      complete; lean+13 routing approved
+    - '2026-07-20 S015/EV-011 — PR #742 merged b405a96; T5.10 deploy-smoke PASS; docs a73bbe0 on docs/EV-011-deploy-smoke;
+      EV-011 open pending Phase D close'
     - >-
       2026-07-20 S015/EV-011 M1 complete — commits e0189d4/ac0a282/a1abc7c/79aa67c
       (T1.1–T1.4); tip 79aa67c ahead of origin by 11; not pushed; next 08@M1 then T2.1
@@ -8603,7 +9045,8 @@ git_history:
     - "2026-07-19 S014/EV-010 T6.2 PASS (09+10); next T6.3 after Phase D checkpoint"
     - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED; C→D pending; git commit d3dbbfb recorded"
     - "2026-07-19 S014/EV-010 M6 started — T6.1 08-verify-build in_progress"
-    - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task T6.1 pending"
+    - "2026-07-19 S014/EV-010 M5 complete (T5.1–T5.6; 59d89af/4202392/2abd4a0/93a67f2); active_milestone M6; active_task T6.1
+      pending"
     - "2026-07-19 S014/EV-010 T5.1–T5.2 completed (54a7180 / 6186888); active_task T5.3 in_progress"
     - "2026-07-19 S014/EV-010 M4 complete (T4.1–T4.5); next M5 T5.1"
     - "M3 complete (T3.1–T3.9; b044871) — awaiting 08-verify-build / M3 minor PR then M4"
@@ -8618,51 +9061,76 @@ git_history:
     - "2026-07-18 S014/EV-010 T3.2 complete — F13 parity suite stubs vs lxml golden corpus (947020b); active_task T3.3 pending"
     - "2026-07-18 S014/EV-010 M3 T3.1–T3.2 complete (1770086 / 947020b); next T3.3 Rust validate_iwxxm"
     - "2026-07-18 S014/EV-010 T3.1 complete — iwxxm-validate rust/maturin scaffold; hatch pure path retained"
-    - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin scaffold)"
-    - "2026-07-18 S014/EV-010 M1 complete — commits 59a65bd/9f9f67b/3ad66cd/70d157b; next M2 T2.1; ci-cd.yml only triggers on main/dev — push alone did not run GHA; local format-check + perf tests green"
+    - "2026-07-18 S014/EV-010 M2 complete (T2.1–T2.5 through 866ca20); advance to M3 T3.1 in_progress (iwxxm-validate Rust/maturin
+      scaffold)"
+    - "2026-07-18 S014/EV-010 M1 complete — commits 59a65bd/9f9f67b/3ad66cd/70d157b; next M2 T2.1; ci-cd.yml only triggers
+      on main/dev — push alone did not run GHA; local format-check + perf tests green"
     - "2026-07-18 D-S014-EV010-b-to-c-push — B→C passed (50B); push to origin about to happen; Phase C 07-build M1 T1.1 starting"
     - "2026-07-18 S014/EV-010 — 6c3fd7a 06-tech-tooling done (49A); phase_b passed; current_stage=07-build pending B→C"
     - "2026-07-18 S014/EV-010 — 5dbfeb9 Phase B commit; 06-tech-tooling in_progress"
     - "2026-07-18 S014/EV-010 — Phase A commits 1711e75 + 0717f13; 04-tech-plan in_progress on evolve/EV-010-package-publish-validation"
     - "2026-07-18 S013/EV-009 closed — user approved deploy results (option 1); active_session cleared; F9/F10 Done (#723)"
-    - "2026-07-17 S013/EV-009 T4.5 done — #723 merged 4660602; Render live; H1/H0c/H3/H4/H5 + H6' UJ-020/021 PASS; EV-009 completed; awaiting session close"
-    - "2026-07-17 S013/EV-009 T4.4 done — checklist + merge/deploy approved (D-S013-EV009-deploy-check-A); deploy gate passed; #723 CI green; current_stage=13-deploy-smoke (T4.5)"
-    - "2026-07-17 S013/EV-009 T4.4 in_progress — deploy-checklist.md ready; PR-EV-009=#723 open (evolve→main; NO merge/deploy); awaiting sign-off + CI"
-    - "2026-07-17 S013/EV-009 T4.3 done — F9/F10 approved ('1 / 1'); verify-impl.md; phase_d passed; current_stage=12-verify-deploy (T4.4)"
+    - "2026-07-17 S013/EV-009 T4.5 done — #723 merged 4660602; Render live; H1/H0c/H3/H4/H5 + H6' UJ-020/021 PASS; EV-009
+      completed; awaiting session close"
+    - "2026-07-17 S013/EV-009 T4.4 done — checklist + merge/deploy approved (D-S013-EV009-deploy-check-A); deploy gate passed;
+      #723 CI green; current_stage=13-deploy-smoke (T4.5)"
+    - "2026-07-17 S013/EV-009 T4.4 in_progress — deploy-checklist.md ready; PR-EV-009=#723 open (evolve→main; NO merge/deploy);
+      awaiting sign-off + CI"
+    - "2026-07-17 S013/EV-009 T4.3 done — F9/F10 approved ('1 / 1'); verify-impl.md; phase_d passed; current_stage=12-verify-deploy
+      (T4.4)"
     - "2026-07-17 S013/EV-009 QA-001/QA-002 resolved (0cf2a28); 11-verify-impl awaiting F9/F10 sign-off"
-    - "2026-07-17 S013/EV-009 T4.2 done — 09-qa pass_with_advisories + 10-e2e PASS (UJ-020/021); current_stage=11-verify-impl (T4.3)"
+    - "2026-07-17 S013/EV-009 T4.2 done — 09-qa pass_with_advisories + 10-e2e PASS (UJ-020/021); current_stage=11-verify-impl
+      (T4.3)"
     - "2026-07-17 S013/EV-009 C→D passed (D-S013-EV009-c-to-d-pass); 09-qa + 10-e2e in_progress (T4.2)"
-    - "2026-07-16 S013/EV-009 T4.1 08-verify-build PASS (verification-report.md); active_task T4.2 pending; Phase C checkpoint pending"
+    - "2026-07-16 S013/EV-009 T4.1 08-verify-build PASS (verification-report.md); active_task T4.2 pending; Phase C checkpoint
+      pending"
     - "2026-07-16 S013 open — branch evolve/S013-live-decode-preview-ux; EV-009 allocated (F9/F10); routing approved"
     - "2026-07-15 S012 closed — BUG resolved; PR #721 merged 6412b21; production verified; active_session cleared"
     - "2026-07-15 S012-empty-bearer-lint-tac open — branch fix/S012-empty-bearer-lint-tac; S011 paused (PR #716 remains open)"
-    - "2026-07-14 S011/EV-008 PR-EV-008=#716 open (evolve→main; NO merge, NO deploy); tip dc32d47; T6.4 in_progress (12 done / 13 pending)"
+    - "2026-07-14 S011/EV-008 PR-EV-008=#716 open (evolve→main; NO merge, NO deploy); tip dc32d47; T6.4 in_progress (12 done
+      / 13 pending)"
     - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first)"
     - "2026-07-14 S011/EV-008 M5 complete (T5.1–T5.6); PR-M5 #720 open; active_milestone M6 active_task T6.1 pending"
     - "2026-07-14 S011/EV-008 M3 complete (T3.1–T3.4); PR-M3 #717 open; active_milestone M4 active_task T4.1"
-    - "2026-07-13 S011/EV-008 M2 complete (T2.1–T2.8); PR-M2 #716; current_stage=07-build; active_milestone M3 active_task T3.1"
+    - "2026-07-13 S011/EV-008 M2 complete (T2.1–T2.8); PR-M2 #716; current_stage=07-build; active_milestone M3 active_task
+      T3.1"
     - "2026-07-13 D-S011-EV008-b-to-c-pass — Phase B / B→C passed; current_stage=07-build; M1 T1.1 in_progress"
-    - "2026-07-13 D-S011-05-pass — 05-verify-tech completed; audit PASS; current_stage=05 awaiting Phase B / B→C; phase_b pending"
+    - "2026-07-13 D-S011-05-pass — 05-verify-tech completed; audit PASS; current_stage=05 awaiting Phase B / B→C; phase_b
+      pending"
     - "2026-07-13 D-S011-04-plan-approve-A — 04 complete; current_stage=05-verify-tech; phase_b pending"
     - "2026-07-13 D-S011-EV008-open — abandon EV-004 orphan; allocate EV-008 for S011; current_branch=evolve/S011-f7-operator-ui"
     - "2026-07-13 D-S010-close — S010/EV-007 closed; #655 / PR #715 / prod smoke PASS; current_branch=main"
-    - "2026-07-12 D-S008-evolve-main-18-19 — on-demand 18+19 for PR #711; PRM-015 commits ecdeac5 + 79af006; head_sha 79af006; squash-merge when CI green"
+    - "2026-07-12 D-S008-evolve-main-18-19 — on-demand 18+19 for PR #711; PRM-015 commits ecdeac5 + 79af006; head_sha 79af006;
+      squash-merge when CI green"
     - "2026-07-12 D-S008-EV006-close — close commit 2ac4093 recorded; pushed (or will be pushed with this follow-up)"
-    - "2026-07-12 D-S008-EV006-merge-m4-m7 — feat/S008-M4-us-metar (#706), M5-products (#707), M6-worker (#708), M7-live (#709) merged into evolve"
+    - "2026-07-12 D-S008-EV006-merge-m4-m7 — feat/S008-M4-us-metar (#706), M5-products (#707), M6-worker (#708), M7-live (#709)
+      merged into evolve"
     - "2026-07-12 PR-M8 #710 MERGED into evolve (PRM-014; merge_sha e4fe492); M8 complete"
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: docs/EV-012-close
+      base: main
+      created_at: '2026-07-20'
+      evolve_cycle_id: EV-012
+      session_id: S016-manual-tac-input-modes
+      purpose: EV-012 / S016 Phase 4 close docs + workflow-state
+      status: active
+      pushed: false
+      note: Phase 4 close (D-S016-EV012-phase4-close-1)
     - name: docs/EV-012-deploy-smoke
       purpose: EV-012 / S016 13-deploy-smoke report + workflow-state
       base: main
-      status: active
+      status: merged
       created_at: '2026-07-20'
       session_id: S016-manual-tac-input-modes
       evolve_cycle_id: EV-012
       tip_sha: 704be17
       pushed: true
-      note: '[S016] docs: 13-deploy-smoke PASS — tip 704be17'
+      note: 'PR #747 merged dd305ba — 13-deploy-smoke docs'
+      pr_number: 747
+      pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/747
+      merge_sha: dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73
     - name: evolve/EV-012-manual-tac-input-modes
       purpose: EV-012 / S016 Validate Manual TAC Input modes (#730 / ADR-024 under F7)
       base: main
@@ -8927,6 +9395,34 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: PENDING
+      short: PENDING
+      branch: docs/EV-012-close
+      message: '[S016] docs: close EV-012 / S016 (Manual TAC Input modes)'
+      stage: 16-evolve
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      timestamp: '2026-07-20'
+      note: 'Phase 4 close docs + workflow-state (D-S016-EV012-phase4-close-1); #730 CLOSED'
+      files_changed:
+        - workflow-state.yaml
+        - docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md
+        - docs/evolve-report-EV-012.md
+        - docs/CHANGELOG.md
+        - docs/deploy-state.md
+        - docs/decisions/evolve-decisions.md
+      pushed: false
+    - sha: dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73
+      short: dd305ba
+      branch: main
+      message: 'Merge pull request #747 from joseph-c-mcguire/docs/EV-012-deploy-smoke'
+      stage: 13-deploy-smoke
+      session_id: S016-manual-tac-input-modes
+      evolve_cycle_id: EV-012
+      timestamp: '2026-07-20'
+      note: 'PR #747 merged — deploy-smoke.md + workflow-state; #730 still open until Phase 4 close'
+      pr_number: 747
+      pushed: true
     - sha: 704be17788b3cf9ec18c5d15868bddcdbe326477
       short: 704be17
       branch: docs/EV-012-deploy-smoke
@@ -9427,7 +9923,9 @@ git_history:
       stage: "07-build"
       session_id: S014-package-publish-validation
       evolve_cycle_id: EV-010
-      files_changed: scripts/codegen/iwxxm_xsd.py, tests/codegen/test_tc_f11_codegen_regen_smoke.py, docs/sessions/S014-package-publish-validation/reports/t37a-codegen-regen-smoke.md, docs/sessions/S014-package-publish-validation/reports/execution-plan.md
+      files_changed: scripts/codegen/iwxxm_xsd.py, tests/codegen/test_tc_f11_codegen_regen_smoke.py, 
+        docs/sessions/S014-package-publish-validation/reports/t37a-codegen-regen-smoke.md, 
+        docs/sessions/S014-package-publish-validation/reports/execution-plan.md
       timestamp: "2026-07-18T23:35:51Z"
     - sha: 3056e4cb7e793a3e092b6391806f7e9538f924fa
       branch: evolve/EV-010-package-publish-validation
@@ -9475,7 +9973,8 @@ git_history:
       stage: "07-build"
       session_id: S014-package-publish-validation
       evolve_cycle_id: EV-010
-      files_changed: packages/iwxxm-validate/rust/*, native.py, test_native_scaffold.py, pyproject.toml, README, Makefile, .gitignore, execution-plan, workflow-state
+      files_changed: packages/iwxxm-validate/rust/*, native.py, test_native_scaffold.py, pyproject.toml, README, 
+        Makefile, .gitignore, execution-plan, workflow-state
       timestamp: "2026-07-18T21:28:00Z"
     - sha: 866ca20
       branch: evolve/EV-010-package-publish-validation
@@ -9957,7 +10456,8 @@ git_history:
       evolve_cycle_id: EV-006
       files_changed: 4
       timestamp: "2026-07-12T16:09:13Z"
-      note: "T2.1 completed; T2.2 completed (implement iwxxm-validate) but T2.2 commit SHA not yet on HEAD when this entry was recorded"
+      note: "T2.1 completed; T2.2 completed (implement iwxxm-validate) but T2.2 commit SHA not yet on HEAD when this entry
+        was recorded"
     - sha: .inf
       branch: feat/S008-M2-validate
       message: "[T2.2] feat: implement iwxxm-validate XSD/Schematron engine"

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -8945,9 +8945,9 @@ evolve_cycles:
 
 git_history:
   current_branch: docs/EV-012-close
-  ahead_of_origin: 0
-  pushed: false
-  pending_commit: '[S016] docs: close EV-012 / S016 (Manual TAC Input modes)'
+  ahead_of_origin: 1
+  pushed: true
+  pending_commit:
   notes:
     - '2026-07-20 S016/EV-012 — Phase 4 closed (D-S016-EV012-phase4-close-1); issue #730 CLOSED; branch docs/EV-012-close
       for close docs + workflow-state'
@@ -9116,8 +9116,9 @@ git_history:
       session_id: S016-manual-tac-input-modes
       purpose: EV-012 / S016 Phase 4 close docs + workflow-state
       status: active
-      pushed: false
-      note: Phase 4 close (D-S016-EV012-phase4-close-1)
+      pushed: true
+      note: '[S016] docs: close EV-012 / S016 — tip 9a63ecf'
+      tip_sha: 9a63ecf
     - name: docs/EV-012-deploy-smoke
       purpose: EV-012 / S016 13-deploy-smoke report + workflow-state
       base: main
@@ -9395,8 +9396,8 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
-    - sha: PENDING
-      short: PENDING
+    - sha: 9a63ecfec153630252c063543e3d77634e15a288
+      short: 9a63ecf
       branch: docs/EV-012-close
       message: '[S016] docs: close EV-012 / S016 (Manual TAC Input modes)'
       stage: 16-evolve


### PR DESCRIPTION
## Summary
- **Phase 4 closed** for EV-012 / S016 (Manual TAC Input modes) per **D-S016-EV012-phase4-close-1** (user option 1).
- Archives session `S016-manual-tac-input-modes` (`active_session: null`); marks **EV-012 completed** (`2026-07-20`); `checkpoints.phase_d: passed`.
- Records feature merge [#746](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/746) @ `37be5f877bd50d9ef1d1208e78f99c12ca59f092` and docs merge [#747](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/747) @ `dd305baa4fa6f8f5e85ae2fd451276c0d68b6c73`.
- GitHub issue [#730](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/730) **CLOSED**.
- Close artifacts: [evolve-summary](docs/sessions/S016-manual-tac-input-modes/reports/evolve-summary.md), [evolve-report-EV-012](docs/evolve-report-EV-012.md), CHANGELOG / deploy-state / evolve-decisions updates.

## Test plan
- [ ] Confirm `workflow-state.yaml`: `active_session` is `null`, EV-012 `status: completed`, S016 in `sessions[]` with close note citing D-S016-EV012-phase4-close-1
- [ ] Skim evolve-summary + evolve-report for accuracy vs #746 / #747 / #730
- [ ] Docs-only PR — no runtime/deploy smoke required


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Close EV-012 / S016 by recording completion of the Manual TAC Input modes validation cycle and its deployment, updating workflow state, evolve metadata, and documentation accordingly.

Enhancements:
- Archive session S016 in workflow-state, marking EV-012 as completed with Phase 4 and Phase D checkpoints passed and issue #730 closed.
- Refresh evolve-decisions to mark EV-012 as completed and capture final Phase 4 close decisions and routing outcomes.

Deployment:
- Record the latest production deployment details for EV-012, including commit, Render deploy IDs, and smoke test coverage for Manual TAC Input modes.

Documentation:
- Document completion of EV-012 / S016 with an evolve report and session evolve-summary for Manual TAC Input modes validation.
- Update changelog and deploy-state docs to reflect the EV-012 production deploy and associated smoke tests.