### PR TITLE
[EV-013] Handle METAR remarks (#667)

### DIFF
--- a/docs/context/metar-remarks-667.md
+++ b/docs/context/metar-remarks-667.md
@@ -1,0 +1,31 @@
+---
+slug: metar-remarks-667
+topic: "Handle Remark Portion of METARs (#667)"
+status: active
+created: 2026-07-20
+session_id: S018-metar-remarks-667
+evolve_cycle_id: EV-013
+linked_features: [F6]
+---
+
+# Context — metar-remarks-667
+
+## Baseline (2026-07-20)
+
+| Profile | RMK behavior before EV-013 |
+|---------|----------------------------|
+| `iwxxm_us` | AO2 / SLP / PK WND → Addendum / peak-wind; malformed → `MALFORMED_REMARKS` |
+| `annex3` | **Silent drop** — no issue, no XML |
+| Unparsed (plain language, T…, P…) | Dropped from XML even on `iwxxm_us` |
+
+## Target (E13-1)
+
+1. `annex3` + `RMK` → `ConvertIssue(code=REMARKS_EXCLUDED, severity=info)` (convert still `ok`)
+2. `iwxxm_us` → keep structured emit; leftover RMK tokens → `iwxxm-us:humanReadableText`
+3. Parse `T########` / `P####` into IR; retain in free-text until structured codec lands (no invented NWS URIs)
+
+## Refs
+
+- Issue #667
+- `[Corpus: product]` F6; domain `IWXXM_CONVERSION.md` US REMARKS keep-list
+- Schema: Addendum.humanReadableText / Remarks.freeText

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -171,8 +171,12 @@
   8. **Bulletin split** required for package acceptance (single-report input still supported)
   9. **`tac-validate` + `iwxxm-validate`** library APIs + CI; backend **thin wrappers** for
      validate (and convert) call these packages
+- **S018 / EV-013 delta (#667 REMARKS)**: `annex3` emits `REMARKS_EXCLUDED` (info) when `RMK`
+  present; `iwxxm_us` retains unparsed RMK remainder as `humanReadableText` (AO2/SLP/PK WND
+  structured emit unchanged; T/P parsed to IR + free-text). Closes UJ-026.
 - **Limitations**: US AIRMET/SIGMET docs thinner than METAR/TAF — may gate fixture depth inside
   F6.d; F5 not extended to other products in v1; exact AHL dialect coverage TBD in fixtures.
+  Full FMH-1 remark catalog beyond AO/SLP/PK/T/P free-text is still scoped deepen work.
 - **S011 / F7 engine deltas** (packages stay under F6; operator UX under F7):
   - `POST /api/v1/decode-tac` — ordered segments with `start`/`end` (+ short explanations).
   - Optional integer `start`/`end` on lint-tac / validate issue objects (span highlight).

--- a/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
@@ -1,0 +1,8 @@
+# EV-013 execution plan (thin)
+
+| Task | Type | Status | Notes |
+|------|------|--------|-------|
+| T1.1 | Spec | completed | UJ-026, feature-list F6 delta, TC-F6-013 |
+| T1.2 | Test | completed | `test_issue_667_metar_remarks.py` |
+| T1.3 | Code | completed | parse free-text/T/P; annex3 REMARKS_EXCLUDED; humanReadableText emit |
+| T1.4 | Verify | pending | full package suite + format-check |

--- a/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
@@ -3,6 +3,6 @@
 | Task | Type | Status | Notes |
 |------|------|--------|-------|
 | T1.1 | Spec | completed | UJ-026, feature-list F6 delta, TC-F6-013 |
-| T1.2 | Test | completed | `test_issue_667_metar_remarks.py` |
+| T1.2 | Test | completed | `test_issue_667_metar_remarks.py` (12 cases: SPECI, PK+free-text, T-sign, escape) |
 | T1.3 | Code | completed | parse free-text/T/P; annex3 REMARKS_EXCLUDED; humanReadableText emit |
 | T1.4 | Verify | pending | full package suite + format-check |

--- a/docs/sessions/S018-metar-remarks-667/routing-plan.md
+++ b/docs/sessions/S018-metar-remarks-667/routing-plan.md
@@ -1,0 +1,27 @@
+# Routing plan — S018-metar-remarks-667
+
+| Stage | Required | Mode | Skip rationale |
+|-------|----------|------|----------------|
+| 00-context | yes | scoped | Session open + context brief |
+| 16-evolve | yes | orchestrator | EV-013 |
+| 01-requirements | yes | delta | UJ / feature-list / test-plan for #667 |
+| 02-verify-plan | yes | delta | Consistency vs F6 / IWXXM_CONVERSION never-drop |
+| 04-tech-plan | yes | delta | Short execution tasks in session reports |
+| 07-build | yes | delta | tac2iwxxm parse/emit/convert |
+| 08-verify-build | yes | delta | lint + scoped pytest |
+| 09-qa | yes | delta | package suite + format-check |
+| 11-verify-impl | yes | delta | Per-acceptance #667 |
+| 12-verify-deploy | yes | delta | Preflight readiness |
+| 13-deploy-smoke | yes | delta | H1–H3; H4–H5 if convert issues surface in UI |
+| 03-plan-tooling | no | — | No new guardrails |
+| 05-verify-tech | no | — | Thin 04; fold into 02 |
+| 06-tech-tooling | no | — | No stack change |
+| 10-e2e | no | — | Package/API convert issues; covered by unit + 13 |
+
+## Approved
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Scope | E13-1 Assumed (AskQuestion waived) | 2026-07-20 |
+| Routing | Standard subset above | 2026-07-20 |
+| Fn | F6 deepen; no new Fn | 2026-07-20 |

--- a/docs/sessions/S018-metar-remarks-667/session-brief.md
+++ b/docs/sessions/S018-metar-remarks-667/session-brief.md
@@ -1,0 +1,57 @@
+---
+session_id: S018-metar-remarks-667
+type: feature
+status: in_progress
+branch: cursor/metar-remarks-667-2e2e
+started_at: 2026-07-20
+intent: "Handle Remark Portion of METARs (#667)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-013
+context_briefs:
+  - docs/context/metar-remarks-667.md
+standing_docs_touched:
+  - docs/user-journeys.md
+  - docs/feature-list.md
+  - docs/test-plan.md
+---
+
+# Session S018 — metar-remarks-667
+
+## Intent
+
+Close [GitHub #667](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/667): METAR/SPECI
+`RMK` must not be silently ignored — retain/process where possible, or clearly state exclusion.
+
+## Intake decisions (Phase 0 — Assumed; AskQuestion UI waived)
+
+| ID | Decision |
+|----|----------|
+| E13-1 | Dual bar: `annex3` → `REMARKS_EXCLUDED` ConvertIssue; `iwxxm_us` → keep AO2/SLP/PK WND + never-drop remainder via `humanReadableText`; parse T/P into IR (free-text emit; no invented NWS URIs for processedQuantity) |
+| E13-2 | Routing **Standard** (needs 07-build): 00→16→01→02→04→07→08→09→11→12→13; skip 03/05/06/10 |
+| E13-3 | No new Fn — deepen **F6** |
+
+## Scope
+
+### In
+
+- `packages/tac2iwxxm` METAR/SPECI parse + convert issues + `iwxxm_us` Addendum emit
+- Unit tests / bug-style regression for #667
+- Corpus deltas: UJ + feature-list note + test-plan row
+
+### Out
+
+- Full FMH-1 remark catalog (WSHFT, PRESRR, snow, `$` structured, etc.)
+- Invented `codes.nws.noaa.gov` concept URIs for processedQuantity
+- Non-METAR/SPECI products; FE redesign
+
+## Feature mapping
+
+| Fn | Role |
+|----|------|
+| **F6** (deepen) | Remark retain / exclusion messaging |
+
+## Links
+
+- Issue: [#667](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/667)
+- Prior: S008 F6 US REMARKS; S015 R5 lint (closed)
+- Schema: `vendor/schemas/iwxxm-us/3.0/metarSpeci.xsd` Addendum.humanReadableText

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -586,6 +586,12 @@ Manual signoff before release — not a PR merge gate. Developer runs `make test
 - **Pass criteria**: Structured errors; no gifts fallback; no silent annex3 downgrade on US profile
 - **Plan ownership**: T5.6 (API/package); UJ-008 live smoke in T8.4 (D-S008-05-batch2)
 
+### TC-F6-013: METAR REMARKS retain / exclusion (#667 / UJ-026)
+
+- **Objectives**: annex3 `REMARKS_EXCLUDED`; iwxxm_us `humanReadableText` for unparsed RMK; T/P IR
+- **Pass criteria**: `packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py` green
+- **Source**: S018 / EV-013
+
 ### TC-F6-020: M-parse / M-xsd / M-sch on golden pack
 
 - **Level**: Package CI (`packages/tac2iwxxm` + **`packages/iwxxm-validate`** for M-xsd / M-sch)

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -38,6 +38,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-023 | PyPI release tag → install smoke | CI / maintainer | F12–F14 | CI |
 | UJ-024 | METAR/SPECI lint registry + convert→validate golden | UI / API / CI | F15 (+F6/F12) | T0 / T2 / **T3** |
 | UJ-025 | Manual TAC Input modes (TAC / AHL / COLLECT) | apps/frontend | F7 (ADR-024) | T2 / **T3** / H6′ |
+| UJ-026 | METAR REMARKS retain / exclusion (#667) | UI / API / package | F6 | T0 / T2 |
 | UJ-DEV-001 | Clone and run monorepo | `git clone` + `make dev` | M1, M5 | T0 |
 | UJ-DEV-002 | Sync vendor schemas | Scheduled Action / manual | M2, M6, F6 | CI |
 | UJ-DEV-003 | ~~Merge GIFTs upstream~~ | — | M3 | **Deprecated** (ADR-014) |
@@ -249,10 +250,26 @@ and **no** gifts fallback.
 
 **Goal**: Under `iwxxm_us`, malformed REMARKS yield structured diagnostics (not silent drop).
 
-**Acceptance**: Error/issues list non-empty; annex3 mode still ignores US-only remarks without
-failing international validation (profile isolation).
+**Acceptance**: Error/issues list non-empty (`MALFORMED_REMARKS`); annex3 still does not emit
+US extension XML (profile isolation). See also UJ-026 for annex3 exclusion messaging.
 
 **Tier**: T0 / T2 primarily.
+
+---
+
+### UJ-026: METAR REMARKS retain / exclusion (#667)
+
+**Goal**: Remark portion of METAR/SPECI is not silently ignored ([#667](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/667)).
+
+**Acceptance**:
+1. `profile=annex3` with `RMK` → convert succeeds with `ConvertIssue` code `REMARKS_EXCLUDED` (info).
+2. `profile=iwxxm_us` → structured AO2/SLP/PK WND still emitted; unparsed remainder retained in
+   `iwxxm-us:humanReadableText` (never drop).
+3. Additive `T########` / `P####` parsed into IR and retained in free-text until structured codecs land.
+
+**Tier**: T0 / T2 primarily.
+
+**Source**: S018 / EV-013
 
 ---
 

--- a/packages/tac2iwxxm/src/tac2iwxxm/convert.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/convert.py
@@ -35,6 +35,7 @@ _REMARK_SPAN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("malformed SLP", re.compile(r"\bSLP(?!\d{3}\b)\w*\b")),
     ("malformed PK WND", re.compile(r"\bPK\s+WND\b")),
 )
+_RMK_TOKEN = re.compile(r"\bRMK\b")
 
 
 _PREVIEW_ROOTS = frozenset({"METAR", "SPECI", "TAF", "SIGMET", "AIRMET", "VAA", "TCA"})
@@ -219,6 +220,21 @@ def convert(
         return _fail("PARSE_ERROR", str(exc), span=True)
 
     issues: list[ConvertIssue] = []
+    if profile_l == "annex3" and product_u in {"METAR", "SPECI"} and ir.get("remarks_present"):
+        rmk_match = _RMK_TOKEN.search(tac)
+        issues.append(
+            ConvertIssue(
+                severity="info",
+                code="REMARKS_EXCLUDED",
+                message=(
+                    "REMARKS (RMK) present in TAC but excluded from annex3 IWXXM output; "
+                    "use profile=iwxxm_us to retain US remarks"
+                ),
+                location="remarks",
+                start=rmk_match.start() if rmk_match else None,
+                end=rmk_match.end() if rmk_match else None,
+            )
+        )
     if profile_l == "iwxxm_us":
         raw_remarks: object = ir.get("remark_issues")
         if isinstance(raw_remarks, list):

--- a/packages/tac2iwxxm/src/tac2iwxxm/products/metar_speci.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/products/metar_speci.py
@@ -24,8 +24,12 @@ _RMK = re.compile(r"\bRMK\b(?P<rmk>.*)$")
 _AO = re.compile(r"\bAO(?P<ao>[12])\b")
 _SLP = re.compile(r"\bSLP(?P<code>\d{3})\b")
 _PK_WND = re.compile(r"\bPK\s+WND\s+(?P<dir>\d{3})(?P<spd>\d{2,3})/(?P<hhmm>\d{4})\b")
+_RMK_T = re.compile(r"\bT(?P<tsign>[01])(?P<tttt>\d{3})(?P<dsign>[01])(?P<dddd>\d{3})\b")
+_RMK_P = re.compile(r"\bP(?P<p>\d{4})\b")
 _COR_AFTER_TIME = re.compile(r"^\s*COR\b\s*")
 _OBS_SYSTEM_HREF = "https://codes.nws.noaa.gov/FMH-1/ObservingSystemType/AO{ao}"
+# Structured tokens removed before free-text retain (AO/SLP/PK only — T/P stay in free-text).
+_CONSUMED_REMARK = re.compile(r"\bAO[12]\b|\bSLP\d{3}\b|\bPK\s+WND\s+\d{3}\d{2,3}/\d{4}\b")
 
 
 def _celsius(token: str) -> int:
@@ -62,17 +66,38 @@ def _slp_code_to_hpa(code: int) -> float:
     return 900.0 + code / 10.0
 
 
+def _tenths_celsius(sign: str, digits: str) -> float:
+    """Decode FMH-1 additive T sign+three-digit tenths to Celsius."""
+    value = int(digits) / 10.0
+    return -value if sign == "1" else value
+
+
+def _remarks_free_text(remarks: str) -> str:
+    """
+    Return REMARKS remainder after removing structured AO/SLP/PK tokens.
+
+    Additive T/P and plain language stay so ``iwxxm_us`` can retain them in
+    ``humanReadableText`` (#667 / UJ-026 never-drop).
+    """
+    leftover = _CONSUMED_REMARK.sub(" ", remarks)
+    leftover = re.sub(r"\s+", " ", leftover).strip(" =")
+    return leftover
+
+
 def _parse_remarks(rest: str, ir: dict[str, Any]) -> None:
     """
-    Enrich IR with IWXXM-US REMARKS groups (AO2, SLP, PK WND).
+    Enrich IR with IWXXM-US REMARKS groups (AO2, SLP, PK WND, T, P).
 
     Malformed US REMARKS tokens append to ``ir['remark_issues']`` for UJ-010 /
-    TC-F6-012 diagnostics (profile isolation: annex3 emit ignores them).
+    TC-F6-012 diagnostics (profile isolation: annex3 emit ignores extensions).
+    Unparsed remainder is stored in ``remarks_free_text`` for never-drop emit.
     """
     rmk = _RMK.search(rest)
     if rmk is None:
         return
     remarks = rmk.group("rmk")
+    ir["remarks_present"] = True
+    ir["remarks_text"] = remarks.strip().rstrip("=").strip()
     issues: list[str] = list(ir.get("remark_issues") or [])
 
     if re.search(r"\bAO(?![12]\b)\w*\b", remarks):
@@ -97,6 +122,19 @@ def _parse_remarks(rest: str, ir: dict[str, Any]) -> None:
         hhmm = pk.group("hhmm")
         ir["peak_wind_hour"] = int(hhmm[0:2])
         ir["peak_wind_minute"] = int(hhmm[2:4])
+
+    temp_tenths = _RMK_T.search(remarks)
+    if temp_tenths is not None:
+        ir["remark_temp_tenths_c"] = _tenths_celsius(temp_tenths.group("tsign"), temp_tenths.group("tttt"))
+        ir["remark_dewpoint_tenths_c"] = _tenths_celsius(temp_tenths.group("dsign"), temp_tenths.group("dddd"))
+
+    precip = _RMK_P.search(remarks)
+    if precip is not None:
+        ir["precip_inches"] = int(precip.group("p")) / 100.0
+
+    free = _remarks_free_text(remarks)
+    if free:
+        ir["remarks_free_text"] = free
 
     if issues:
         ir["remark_issues"] = issues

--- a/packages/tac2iwxxm/src/tac2iwxxm/profiles/iwxxm_us.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/profiles/iwxxm_us.py
@@ -33,12 +33,15 @@ def _peak_timestamp(ir: dict[str, Any]) -> str:
 
 def _addendum_extension(ir: dict[str, Any]) -> str:
     """Serialize observation-level ``iwxxm-us:Addendum`` when REMARKS present."""
-    if not ir.get("observing_system_type") and ir.get("sea_level_pressure_hpa") is None:
+    free_text = str(ir.get("remarks_free_text") or "").strip()
+    if not ir.get("observing_system_type") and ir.get("sea_level_pressure_hpa") is None and not free_text:
         return ""
     parts: list[str] = ["      <iwxxm:extension>", "        <iwxxm-us:Addendum>"]
     if ir.get("observing_system_href"):
         href = escape(str(ir["observing_system_href"]))
         parts.append(f'          <iwxxm-us:observingSystemType xlink:href="{href}"/>')
+    if free_text:
+        parts.append(f"          <iwxxm-us:humanReadableText>{escape(free_text)}</iwxxm-us:humanReadableText>")
     if ir.get("sea_level_pressure_hpa") is not None:
         parts.append(
             f'          <iwxxm-us:seaLevelPressure uom="hPa">{ir["sea_level_pressure_hpa"]}</iwxxm-us:seaLevelPressure>'

--- a/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+++ b/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
@@ -1,4 +1,4 @@
-"""EV-013 / #667 — METAR remarks must not be silently ignored."""
+"""EV-013 / #667 — METAR remarks must not be silently ignored (TC-F6-013 / UJ-026)."""
 
 from __future__ import annotations
 
@@ -56,3 +56,89 @@ def test_iwxxm_us_structured_only_remarks_omit_empty_human_readable() -> None:
     assert "observingSystemType" in result.xml
     assert "seaLevelPressure" in result.xml
     assert "humanReadableText" not in result.xml
+
+
+def test_annex3_speci_emits_remarks_excluded_with_rmk_span() -> None:
+    """SPECI follows the same annex3 exclusion bar as METAR (UJ-026)."""
+    tac = "SPECI KJFK 231815Z 18015KT 3SM -RA BKN015 14/12 A2998 RMK AO2 P0003="
+    result = convert(tac, product="SPECI", profile="annex3", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:" not in result.xml
+    excluded = next(i for i in result.issues if i.code == "REMARKS_EXCLUDED")
+    assert excluded.severity == "info"
+    assert excluded.location == "remarks"
+    assert excluded.start is not None and excluded.end is not None
+    assert tac[excluded.start : excluded.end] == "RMK"
+
+
+def test_parse_strips_structured_tokens_from_remarks_free_text() -> None:
+    """AO/SLP/PK are consumed; T/P and plain language remain for never-drop emit."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 SLP176 PK WND 28045/1745 T01560070 P0001 WSHFT 1715="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_present") is True
+    assert ir.get("observing_system_type") == "AO2"
+    assert ir.get("sea_level_pressure_hpa") == 1017.6
+    assert ir.get("peak_wind_dir_deg") == 280
+    assert ir.get("peak_wind_speed_kt") == 45
+    free = ir.get("remarks_free_text") or ""
+    assert "AO2" not in free
+    assert "SLP176" not in free
+    assert "PK WND" not in free
+    assert "T01560070" in free
+    assert "P0001" in free
+    assert "WSHFT 1715" in free
+
+
+def test_iwxxm_us_peak_wind_and_free_text_coexist() -> None:
+    """Structured PK WND emit must not drop leftover REMARKS (never-drop)."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 PK WND 28045/1745 VIRGA NE="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_free_text") == "VIRGA NE"
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:AerodromePeakWind" in result.xml
+    assert '<iwxxm-us:windDirection uom="deg">280</iwxxm-us:windDirection>' in result.xml
+    assert "<iwxxm-us:humanReadableText>VIRGA NE</iwxxm-us:humanReadableText>" in result.xml
+
+
+def test_iwxxm_us_negative_tenths_temp_decoded_and_retained() -> None:
+    """FMH-1 T1… sign bit → negative °C IR; token stays in free-text."""
+    tac = "METAR KJFK 231751Z 27008KT 10SM CLR M02/M05 A3012 RMK AO2 T10221055="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remark_temp_tenths_c") == -2.2
+    assert ir.get("remark_dewpoint_tenths_c") == -5.5
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "T10221055" in result.xml
+
+
+def test_iwxxm_us_plain_language_only_remarks_emit_addendum() -> None:
+    """Remarks without AO/SLP/PK still get an Addendum via humanReadableText."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK TORNADO B13 12 NE="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_free_text") == "TORNADO B13 12 NE"
+    assert ir.get("observing_system_type") is None
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:Addendum" in result.xml
+    assert "TORNADO B13 12 NE" in result.xml
+    assert "observingSystemType" not in result.xml
+
+
+def test_iwxxm_us_escapes_special_chars_in_human_readable_text() -> None:
+    """Free-text emit must XML-escape reserved characters."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK FOG & HAZE <1SM="
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "FOG &amp; HAZE &lt;1SM" in result.xml
+    assert "FOG & HAZE <1SM" not in result.xml
+
+
+def test_speci_iwxxm_us_retains_unparsed_remarks() -> None:
+    """SPECI iwxxm_us never-drop path mirrors METAR."""
+    tac = "SPECI KJFK 231815Z 18015KT 2SM BR BKN008 14/13 A2995 RMK AO2 VIS 1V3="
+    result = convert(tac, product="SPECI", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:humanReadableText" in result.xml
+    assert "VIS 1V3" in result.xml
+    assert all(i.code != "REMARKS_EXCLUDED" for i in result.issues)

--- a/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+++ b/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
@@ -1,0 +1,58 @@
+"""EV-013 / #667 — METAR remarks must not be silently ignored."""
+
+from __future__ import annotations
+
+from tac2iwxxm import convert
+from tac2iwxxm.products.metar_speci import parse_metar_speci
+
+
+def test_annex3_emits_remarks_excluded_when_rmk_present() -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK AO2 SLP176="
+    result = convert(tac, product="METAR", profile="annex3", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:Addendum" not in result.xml
+    codes = [i.code for i in result.issues]
+    assert "REMARKS_EXCLUDED" in codes
+    excluded = next(i for i in result.issues if i.code == "REMARKS_EXCLUDED")
+    assert excluded.severity == "info"
+    assert "RMK" in (excluded.message or "").upper() or "remark" in (excluded.message or "").lower()
+
+
+def test_annex3_no_remarks_excluded_without_rmk() -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005="
+    result = convert(tac, product="METAR", profile="annex3", iwxxm_version="2025-2")
+    assert result.ok
+    assert all(i.code != "REMARKS_EXCLUDED" for i in result.issues)
+
+
+def test_iwxxm_us_retains_unparsed_remarks_as_human_readable_text() -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 WND DATA ESTMD="
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:Addendum" in result.xml
+    assert "iwxxm-us:humanReadableText" in result.xml
+    assert "WND DATA ESTMD" in result.xml
+    assert "REMARKS_EXCLUDED" not in [i.code for i in result.issues]
+
+
+def test_iwxxm_us_keeps_additive_t_and_p_in_free_text() -> None:
+    tac = "METAR KJFK 231751Z AUTO 18012KT 10SM CLR 15/07 A3005 RMK AO2 SLP176 T01560070 P0001="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remark_temp_tenths_c") == 15.6
+    assert ir.get("remark_dewpoint_tenths_c") == 7.0
+    assert ir.get("precip_inches") == 0.01
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "humanReadableText" in result.xml
+    assert "T01560070" in result.xml
+    assert "P0001" in result.xml
+    assert "seaLevelPressure" in result.xml
+
+
+def test_iwxxm_us_structured_only_remarks_omit_empty_human_readable() -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK AO2 SLP149="
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "observingSystemType" in result.xml
+    assert "seaLevelPressure" in result.xml
+    assert "humanReadableText" not in result.xml

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -16,7 +16,7 @@ active_session:
   orchestrator: 16-evolve
   evolve_cycle_id: EV-013
   artifacts_dir: docs/sessions/S018-metar-remarks-667/
-  current_stage: 16-evolve
+  current_stage: 08-verify-build
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched: []
@@ -38,18 +38,23 @@ active_session:
       started: '2026-07-20'
       skip_rationale:
       note: >-
-        Phase 0 intake complete via Assumed; moving to 01-requirements;
-        Standard routing (needs 07-build)
+        Implementation landed (07-build); 08-verify-build in_progress;
+        Standard routing
     - stage: 01-requirements
       required: true
       mode: delta
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
     - stage: 02-verify-plan
       required: true
       mode: delta
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
+      note: Delta consistency via corpus updates
     - stage: 03-plan-tooling
       required: false
       mode: skipped
@@ -58,8 +63,11 @@ active_session:
     - stage: 04-tech-plan
       required: true
       mode: delta
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
+      note: Thin execution-plan written
     - stage: 05-verify-tech
       required: false
       mode: skipped
@@ -73,12 +81,15 @@ active_session:
     - stage: 07-build
       required: true
       mode: full
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
     - stage: 08-verify-build
       required: true
       mode: full
-      status: pending
+      status: in_progress
+      started: '2026-07-20'
       skip_rationale:
     - stage: 09-qa
       required: true
@@ -6900,8 +6911,11 @@ evolve_cycles:
         - 05-verify-tech
         - 06-tech-tooling
         - 10-e2e
-    current_stage: 16-evolve
+    current_stage: 08-verify-build
     notes:
+      - >-
+        2026-07-20 S018/EV-013 — implementation landed (07-build); 08-verify-build
+        in_progress; commits 8ee3176 (docs scope) + 19d6684 (feat remarks)
       - >-
         2026-07-20 S018/EV-013 open — Phase 0 intake complete via Assumed (E13-1/E13-2/E13-3);
         AskQuestion UI waived (cloud); Standard routing; moving toward 01-requirements
@@ -6920,19 +6934,27 @@ evolve_cycles:
         status: in_progress
         started: '2026-07-20'
         note: >-
-          Phase 0 intake complete via Assumed; orchestrator in_progress; next 01-requirements
+          Orchestrator in_progress; implementation landed; verification next
       01-requirements:
-        status: pending
+        status: completed
         mode: delta
+        started: '2026-07-20'
+        completed: '2026-07-20'
       02-verify-plan:
-        status: pending
+        status: completed
         mode: delta
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: Delta consistency via corpus updates
       03-plan-tooling:
         status: skipped
         skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
       04-tech-plan:
-        status: pending
+        status: completed
         mode: delta
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        note: Thin execution-plan written
       05-verify-tech:
         status: skipped
         skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
@@ -6940,11 +6962,14 @@ evolve_cycles:
         status: skipped
         skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
       07-build:
-        status: pending
+        status: completed
         mode: full
+        started: '2026-07-20'
+        completed: '2026-07-20'
       08-verify-build:
-        status: pending
+        status: in_progress
         mode: full
+        started: '2026-07-20'
       09-qa:
         status: pending
         mode: full
@@ -6974,9 +6999,13 @@ evolve_cycles:
     adrs: []
     artifacts:
       - path: docs/sessions/S018-metar-remarks-667/session-brief.md
-        status: pending
+        status: present
       - path: docs/sessions/S018-metar-remarks-667/routing-plan.md
-        status: pending
+        status: present
+      - path: docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+        status: present
+      - path: packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+        status: present
       - path: docs/sessions/S018-metar-remarks-667/reports/evolve-summary.md
         status: pending
     issues: []
@@ -9392,9 +9421,13 @@ evolve_cycles:
 git_history:
   current_branch: cursor/metar-remarks-667-2e2e
   ahead_of_origin: 0
-  pushed: false
+  pushed: true
   pending_commit:
+  tip_sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
   notes:
+    - >-
+      2026-07-20 S018/EV-013 — commits 8ee3176 (docs scope) + 19d6684 (feat remarks);
+      tip 19d6684; current_stage 08-verify-build; branch synced with origin
     - >-
       2026-07-20 S018/EV-013 open — branch cursor/metar-remarks-667-2e2e recorded active
       (base main); Phase 0 Assumed (E13-1/E13-2/E13-3); AskQuestion UI waived (cloud)
@@ -9566,8 +9599,9 @@ git_history:
       session_id: S018-metar-remarks-667
       evolve_cycle_id: EV-013
       purpose: 'EV-013 / S018 Handle METAR remarks (#667) — annex3 + iwxxm_us T/P'
-      pushed: false
-      note: Cloud agent naming override; Standard routing; Phase 0 Assumed
+      pushed: true
+      tip_sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
+      note: Cloud agent naming override; Standard routing; 08-verify-build in_progress
     - name: chore/S017-skill-trim-retro
       base: main
       status: active
@@ -9864,6 +9898,38 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
+      short: 19d6684
+      branch: cursor/metar-remarks-667-2e2e
+      message: '[EV-013] feat: retain METAR remarks or report exclusion (#667)'
+      stage: 07-build
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      timestamp: '2026-07-20T19:31:15Z'
+      files_changed:
+        - packages/tac2iwxxm/src/tac2iwxxm/convert.py
+        - packages/tac2iwxxm/src/tac2iwxxm/products/metar_speci.py
+        - packages/tac2iwxxm/src/tac2iwxxm/profiles/iwxxm_us.py
+        - packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+      pushed: true
+    - sha: 8ee3176e598144feaeeefdcf1f1c4e04bbcd55b1
+      short: 8ee3176
+      branch: cursor/metar-remarks-667-2e2e
+      message: '[S018] docs: EV-013 scope for METAR remarks (#667)'
+      stage: 16-evolve
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      timestamp: '2026-07-20T19:31:15Z'
+      files_changed:
+        - docs/context/metar-remarks-667.md
+        - docs/feature-list.md
+        - docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+        - docs/sessions/S018-metar-remarks-667/routing-plan.md
+        - docs/sessions/S018-metar-remarks-667/session-brief.md
+        - docs/test-plan.md
+        - docs/user-journeys.md
+        - workflow-state.yaml
+      pushed: true
     - sha: 9a63ecfec153630252c063543e3d77634e15a288
       short: 9a63ecf
       branch: docs/EV-012-close

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -4,8 +4,107 @@ project:
   description: METAR/SPECI TAC to IWXXM XML converter — monorepo migration
   output_directory: docs/
 
-session_counter: 17
+session_counter: 18
 active_session:
+  id: S018-metar-remarks-667
+  type: feature
+  intent: >-
+    Handle Remark Portion of METARs (#667) — annex3 exclusion messaging + iwxxm_us
+    never-drop/freeText + T/P emit
+  status: in_progress
+  branch: cursor/metar-remarks-667-2e2e
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-013
+  artifacts_dir: docs/sessions/S018-metar-remarks-667/
+  current_stage: 16-evolve
+  started_at: '2026-07-20'
+  context_briefs: []
+  standing_docs_touched: []
+  routing_plan:
+    - stage: 00-context
+      required: true
+      mode: scoped
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
+      skip_rationale:
+      note: >-
+        Session open; Phase 0 intake locked Assumed (E13-1/E13-2/E13-3);
+        AskQuestion UI waived (cloud)
+    - stage: 16-evolve
+      required: true
+      mode: orchestrator
+      status: in_progress
+      started: '2026-07-20'
+      skip_rationale:
+      note: >-
+        Phase 0 intake complete via Assumed; moving to 01-requirements;
+        Standard routing (needs 07-build)
+    - stage: 01-requirements
+      required: true
+      mode: delta
+      status: pending
+      skip_rationale:
+    - stage: 02-verify-plan
+      required: true
+      mode: delta
+      status: pending
+      skip_rationale:
+    - stage: 03-plan-tooling
+      required: false
+      mode: skipped
+      status: skipped
+      skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+    - stage: 04-tech-plan
+      required: true
+      mode: delta
+      status: pending
+      skip_rationale:
+    - stage: 05-verify-tech
+      required: false
+      mode: skipped
+      status: skipped
+      skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+    - stage: 06-tech-tooling
+      required: false
+      mode: skipped
+      status: skipped
+      skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+    - stage: 07-build
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
+    - stage: 08-verify-build
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
+    - stage: 09-qa
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
+    - stage: 10-e2e
+      required: false
+      mode: skipped
+      status: skipped
+      skip_rationale: 'Standard routing for #667 — not in approved stage list (E13-2)'
+    - stage: 11-verify-impl
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
+    - stage: 12-verify-deploy
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
+    - stage: 13-deploy-smoke
+      required: true
+      mode: full
+      status: pending
+      skip_rationale:
 sessions:
 
   - id: S017-skill-trim-retro
@@ -1174,8 +1273,9 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: manual-tac-input-modes
-    session_id: S016-manual-tac-input-modes
+    scoped_slug: metar-remarks-667
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
     started_at: "2026-07-20"
     completed_at: "2026-07-20"
     substeps:
@@ -1187,6 +1287,8 @@ stages:
       phase3: completed
       phase4: completed
     artifacts:
+      - docs/sessions/S018-metar-remarks-667/session-brief.md
+      - docs/sessions/S018-metar-remarks-667/routing-plan.md
       - docs/context/issue-555-feedback.md
       - docs/sessions/S004-issue-555-feedback/session-brief.md
       - docs/sessions/S004-issue-555-feedback/routing-plan.md
@@ -1201,6 +1303,10 @@ stages:
       - docs/sessions/S016-manual-tac-input-modes/routing-plan.md
       - docs/context/manual-tac-input-modes.md
     notes:
+      - >-
+        2026-07-20 S018/EV-013 00-context completed — Phase 0 intake locked Assumed
+        (E13-1/E13-2/E13-3); AskQuestion UI waived (cloud); Standard routing; handoff
+        16-evolve → 01-requirements
       - 2026-07-20 S016/EV-012 00-context completed — Phase 0 intake locked; lean+13 routing approved 
         (D-S016-EV012-route-1); handoff to 01-requirements
       - "2026-07-19 S015/EV-011 00-context completed — routing approved (D-S015-EV011-route-1); max expansion scope (D-S015-EV011-research-1);
@@ -2777,6 +2883,17 @@ stages:
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; 
       RA-007/RA-008 remain open
 
+  16-evolve:
+    status: in_progress
+    mode: orchestrator
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    started_at: '2026-07-20'
+    current_stage: 16-evolve
+    note: >-
+      S018/EV-013 — Phase 0 intake complete via Assumed (E13-1/E13-2/E13-3); AskQuestion UI
+      waived (cloud); Standard routing; moving to 01-requirements
+
 stages_pending: []
 
 stages_pending: []
@@ -2884,6 +3001,89 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S018-aq-waive-cloud
+    stage: 00-context
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 00-context
+    skill_id: 00-context
+    topic: AskQuestion UI waived (cloud)
+    decision: >-
+      AskQuestion UI unavailable this cloud session — waived interactive AskQuestion;
+      record Assumed decisions in decisions_log (same pattern as S017). Parent proceeds
+      on written user intent + Assumed scope/routing.
+    status: confirmed
+    resolved_at: '2026-07-20'
+  - id: D-S018-EV013-E13-1-scope
+    stage: 00-context
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 00-context
+    skill_id: 00-context
+    topic: 'E13-1 scope Assumed — Handle METAR remarks (#667)'
+    decision: >-
+      Assumed scope (user: "great let's start building on this task" after #667 partial-done
+      verification). No new Fn — deepen F6 (convert) + touch F12/F15 lint codes only if needed.
+      Close #667 acceptance bar: (1) annex3 profile: when METAR/SPECI contains RMK, emit
+      structured ConvertIssue (e.g. REMARKS_EXCLUDED) so exclusion is not silent; (2) iwxxm_us
+      profile: keep AO2/SLP/PK WND emit; retain unparsed RMK remainder as iwxxm-us
+      Remarks/freeText or Addendum humanReadableText; (3) Map additive T######## / P#### into
+      iwxxm-us elements where schema supports (R5 convert gap). Out: full FMH-1 remark catalog
+      beyond T/P/AO/SLP/PK WND; non-METAR products; UI redesign.
+    status: confirmed
+    resolved_at: '2026-07-20'
+    note: Assumed — AskQuestion UI waived (cloud)
+  - id: D-S018-EV013-E13-2-routing
+    stage: 00-context
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 00-context
+    skill_id: 00-context
+    topic: E13-2 routing Standard Assumed
+    decision: >-
+      Assumed Standard routing preset (needs 07-build):
+      00 → 16 → 01 → 02 → 04 → 07 → 08 → 09 → 11 → 12 → 13; skip 03/05/06
+      (and 10-e2e not in approved list). Cycle EV-013; Session S018-metar-remarks-667;
+      branch cursor/metar-remarks-667-2e2e (cloud agent naming override); orchestrator 16-evolve.
+    status: confirmed
+    resolved_at: '2026-07-20'
+    note: Assumed — AskQuestion UI waived (cloud)
+  - id: D-S018-EV013-E13-3-no-new-fn
+    stage: 00-context
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 00-context
+    skill_id: 00-context
+    topic: E13-3 no new Fn — deepen F6
+    decision: >-
+      Assumed — no new feature id. Deepen F6 (TAC→IWXXM convert remarks handling);
+      touch F12/F15 lint codes only if needed for REMARKS_EXCLUDED / related codes.
+    status: confirmed
+    resolved_at: '2026-07-20'
+    note: Assumed — AskQuestion UI waived (cloud)
+  - id: D-S018-open
+    stage: 00-context
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 00-context
+    skill_id: 00-context
+    topic: 'Open S018 feature session for EV-013 / #667'
+    decision: >-
+      Opened S018-metar-remarks-667 (feature) with orchestrator 16-evolve; allocated EV-013;
+      branch cursor/metar-remarks-667-2e2e; artifacts_dir docs/sessions/S018-metar-remarks-667/;
+      session_counter 18.
+    status: confirmed
+    resolved_at: '2026-07-20'
   - id: D-S017-RET001-aq-waive
     stage: 17-retrospective
     date: '2026-07-20'
@@ -6663,6 +6863,123 @@ retrospective_cycles:
         status: completed
 
 evolve_cycles:
+  - id: EV-013
+    session_id: S018-metar-remarks-667
+    cycle_type: feature
+    feature_ids:
+      - F6
+    feature_id:
+    title: 'Handle METAR remarks (#667)'
+    status: in_progress
+    started: '2026-07-20'
+    completed:
+    scope_summary: >-
+      Assumed E13-1: No new Fn — deepen F6 (convert) + touch F12/F15 lint codes only if needed.
+      Close #667 acceptance bar: (1) annex3 — when METAR/SPECI contains RMK, emit structured
+      ConvertIssue (e.g. REMARKS_EXCLUDED) so exclusion is not silent; (2) iwxxm_us — keep
+      AO2/SLP/PK WND emit; retain unparsed RMK remainder as iwxxm-us Remarks/freeText or
+      Addendum humanReadableText; (3) Map additive T######## / P#### into iwxxm-us elements
+      where schema supports (R5 convert gap). Out: full FMH-1 remark catalog beyond
+      T/P/AO/SLP/PK WND; non-METAR products; UI redesign.
+    github_issue: 667
+    routing_plan:
+      required_stages:
+        - 00-context
+        - 16-evolve
+        - 01-requirements
+        - 02-verify-plan
+        - 04-tech-plan
+        - 07-build
+        - 08-verify-build
+        - 09-qa
+        - 11-verify-impl
+        - 12-verify-deploy
+        - 13-deploy-smoke
+      skipped_stages:
+        - 03-plan-tooling
+        - 05-verify-tech
+        - 06-tech-tooling
+        - 10-e2e
+    current_stage: 16-evolve
+    notes:
+      - >-
+        2026-07-20 S018/EV-013 open — Phase 0 intake complete via Assumed (E13-1/E13-2/E13-3);
+        AskQuestion UI waived (cloud); Standard routing; moving toward 01-requirements
+    stages:
+      00-context:
+        status: completed
+        mode: scoped
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        substeps:
+          phase0: locked
+        note: >-
+          Phase 0 intake locked Assumed (E13-1 scope, E13-2 Standard routing, E13-3 no new Fn);
+          AskQuestion UI waived (cloud)
+      16-evolve:
+        status: in_progress
+        started: '2026-07-20'
+        note: >-
+          Phase 0 intake complete via Assumed; orchestrator in_progress; next 01-requirements
+      01-requirements:
+        status: pending
+        mode: delta
+      02-verify-plan:
+        status: pending
+        mode: delta
+      03-plan-tooling:
+        status: skipped
+        skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+      04-tech-plan:
+        status: pending
+        mode: delta
+      05-verify-tech:
+        status: skipped
+        skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+      06-tech-tooling:
+        status: skipped
+        skip_rationale: Standard preset — skip 03/05/06 (E13-2 Assumed)
+      07-build:
+        status: pending
+        mode: full
+      08-verify-build:
+        status: pending
+        mode: full
+      09-qa:
+        status: pending
+        mode: full
+      10-e2e:
+        status: skipped
+        skip_rationale: Not in Standard approved stage list (E13-2)
+      11-verify-impl:
+        status: pending
+        mode: full
+      12-verify-deploy:
+        status: pending
+        mode: full
+      13-deploy-smoke:
+        status: pending
+        mode: full
+    gates:
+      a_to_b: pending
+      b_to_c: pending
+      c_to_d: pending
+      deploy: pending
+    checkpoints:
+      phase_a: pending
+      phase_b: pending
+      phase_c: pending
+      phase_d: pending
+      deploy: pending
+    adrs: []
+    artifacts:
+      - path: docs/sessions/S018-metar-remarks-667/session-brief.md
+        status: pending
+      - path: docs/sessions/S018-metar-remarks-667/routing-plan.md
+        status: pending
+      - path: docs/sessions/S018-metar-remarks-667/reports/evolve-summary.md
+        status: pending
+    issues: []
   - id: EV-012
     session_id: S016-manual-tac-input-modes
     cycle_type: general  # validation/acceptance under F7, no new Fn
@@ -9073,11 +9390,14 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: docs/EV-012-close
-  ahead_of_origin: 1
-  pushed: true
+  current_branch: cursor/metar-remarks-667-2e2e
+  ahead_of_origin: 0
+  pushed: false
   pending_commit:
   notes:
+    - >-
+      2026-07-20 S018/EV-013 open — branch cursor/metar-remarks-667-2e2e recorded active
+      (base main); Phase 0 Assumed (E13-1/E13-2/E13-3); AskQuestion UI waived (cloud)
     - '2026-07-20 S017/RET-001 — skill-trim applied; branch chore/S017-skill-trim-retro'
     - '2026-07-20 S016/EV-012 — Phase 4 closed (D-S016-EV012-phase4-close-1); issue #730 CLOSED; branch docs/EV-012-close
       for close docs + workflow-state'
@@ -9239,6 +9559,15 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: cursor/metar-remarks-667-2e2e
+      base: main
+      status: active
+      created_at: '2026-07-20'
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      purpose: 'EV-013 / S018 Handle METAR remarks (#667) — annex3 + iwxxm_us T/P'
+      pushed: false
+      note: Cloud agent naming override; Standard routing; Phase 0 Assumed
     - name: chore/S017-skill-trim-retro
       base: main
       status: active


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining gap for [#667](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/667) (S018 / EV-013, F6 deepen):

- **`annex3`**: when METAR/SPECI contains `RMK`, convert still succeeds and emits `ConvertIssue` code `REMARKS_EXCLUDED` (info) so exclusion is not silent.
- **`iwxxm_us`**: keeps AO2 / SLP / PK WND structured emit; unparsed remainder (plain language, additive `T########` / `P####`) retained as `iwxxm-us:humanReadableText`.
- Parses `T` / `P` into IR for downstream decode; does **not** invent NWS registry URIs for `processedQuantity` yet.

## Spec / session

- Session: `docs/sessions/S018-metar-remarks-667/`
- UJ-026 + TC-F6-013; F6 delta note in `docs/feature-list.md`

## Test plan

- [x] `uv run pytest packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py`
- [x] `uv run pytest packages/tac2iwxxm/tests` — 164 passed, 9 skipped
- [x] `make format-check`
- [x] CI green on `cursor/metar-remarks-667-2e2e` ([run](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29772473313))
- [ ] After merge: close #667; optional 13-deploy-smoke

## Notes

- AskQuestion UI unavailable in this cloud run — scope Assumed from issue text + prior verification (recorded in `workflow-state.yaml` decisions_log).
- Do **not** auto-merge — needs explicit approval.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f80f9-6832-7a78-a591-0fed8f672e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f80f9-6832-7a78-a591-0fed8f672e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Handle METAR/SPECI REMARKS so they are either explicitly reported as excluded in annex3 or retained in iwxxm_us output, with supporting docs, workflow metadata, and tests for issue #667.

New Features:
- Emit a REMARKS_EXCLUDED info-level ConvertIssue when METAR/SPECI contain RMK under the annex3 profile so remarks exclusion is visible to callers.
- Expose METAR/SPECI remarks free text, including additive T and P tokens and plain language, as iwxxm-us:humanReadableText in the iwxxm_us Addendum while keeping existing structured AO2/SLP/PK WND elements.
- Decode additive T######## temperature/dewpoint and P#### precipitation values from REMARKS into the internal representation for downstream use.

Documentation:
- Document the new METAR REMARKS retain/exclusion journey (UJ-026) with its acceptance criteria and link it into the user journeys, feature list, test plan, and session context.
- Add a new S018 session brief, routing plan, and execution plan describing the EV-013 cycle for handling METAR REMARKS.

Tests:
- Add a dedicated regression test module for issue #667 covering annex3 REMARKS_EXCLUDED behaviour, iwxxm_us humanReadableText retention, T/P decoding, structured-only remarks, SPECI handling, and XML escaping of free text.

Chores:
- Update workflow-state and git history metadata to track the new S018 session, EV-013 evolve cycle, routing, decisions, and active branch for the METAR REMARKS work.