### PR TITLE
[EV-013] test: expand TC-F6-013 METAR remarks coverage (#667)

### DIFF
--- a/docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
@@ -1,0 +1,61 @@
+# E2E Behavior Report — S018 / EV-013 (#667)
+
+> Generated: 2026-07-20  
+> Mechanism: **library** (tac2iwxxm) + package edge TCs  
+> Scope: UJ-026 (new), UJ-010 (regression)  
+> Journeys tested: 2 (cycle-scoped)
+
+## Summary
+
+| # | Journey | Mechanism | T0 | T2 connectivity | T3 browser | Status |
+|---|---------|-----------|----|-----------------|------------|--------|
+| 1 | UJ-026 METAR REMARKS retain / exclusion | library | PASS | deferred → 13 | N/A | PASS (T0) |
+| 2 | UJ-010 Malformed US REMARKS | library | PASS | deferred → 13 | N/A | PASS (T0) |
+
+Mocks/package T0 ≠ production UI connected — T2/T3 recorded separately per connectivity-gates §Stage 10.
+
+## Journey → test mapping
+
+| Journey | Test module | Notes |
+|---------|-------------|-------|
+| UJ-026 | `packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py` | TC-F6-013; no `tests/e2e/test_uj026.py` (library journey — package tests are SoT) |
+| UJ-010 | `packages/tac2iwxxm/tests/test_tc_f6_010_011_012_edge.py::test_tc_f6_012_*` | Malformed REMARKS → `MALFORMED_REMARKS` |
+
+**Waiver:** Repo uses `apps/e2e/` Playwright for UI UJs and package pytest for F6 convert journeys.
+No `tests/e2e/test_uj*.py` tree. Documented here instead of inventing a parallel harness.
+
+## Journey details
+
+### UJ-026: METAR REMARKS retain / exclusion (#667)
+
+- **Feature**: F6 deepen (EV-013)
+- **Mechanism**: library (`tac2iwxxm.convert` / `parse_metar_speci`)
+- **Steps**:
+  1. annex3 + RMK → `ok` + `REMARKS_EXCLUDED` (info) — PASS
+  2. annex3 without RMK → no `REMARKS_EXCLUDED` — PASS
+  3. iwxxm_us unparsed remainder → `humanReadableText` — PASS
+  4. T/P parsed to IR + retained in free-text — PASS
+  5. structured-only AO2/SLP → no empty `humanReadableText` — PASS
+  6. SPECI annex3 exclusion + span — PASS
+  7. plain-language-only / escape / peak-wind coexistence — PASS
+- **Evidence**: 12/12 in `test_issue_667_metar_remarks.py`; live REPL: `annex3 True ['REMARKS_EXCLUDED']`, us XML contains `VIRGA`
+
+### UJ-010: Malformed US REMARKS
+
+- **Feature**: F6
+- **Mechanism**: library
+- **Steps**:
+  1. iwxxm_us + malformed AO/SLP/PK → `MALFORMED_REMARKS` — PASS (`test_tc_f6_012`)
+- **Evidence**: included in 15/15 combined UJ-026+edge run
+
+## T2 / T3
+
+| Tier | Status | Notes |
+|------|--------|-------|
+| T2 (H1–H5) | **Deferred** | Owned by 13-deploy-smoke after merge; convert issues surface via `/api/v1/convert` |
+| T3 live browser | **Not run** | No UI-only acceptance for #667 this cycle |
+
+## Playwright
+
+Not required for UJ-026 T0 (package). Full `make test-e2e-playwright` not executed in this stage
+(no local stack spun). CI E2E Smoke on feat branch #750: SUCCESS.

--- a/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
@@ -3,6 +3,6 @@
 | Task | Type | Status | Notes |
 |------|------|--------|-------|
 | T1.1 | Spec | completed | UJ-026, feature-list F6 delta, TC-F6-013 |
-| T1.2 | Test | completed | `test_issue_667_metar_remarks.py` |
+| T1.2 | Test | completed | `test_issue_667_metar_remarks.py` (12 cases: SPECI, PK+free-text, T-sign, escape) |
 | T1.3 | Code | completed | parse free-text/T/P; annex3 REMARKS_EXCLUDED; humanReadableText emit |
 | T1.4 | Verify | pending | full package suite + format-check |

--- a/docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/qa-report.md
@@ -1,0 +1,79 @@
+# QA Report — S018 / EV-013 (#667 remarks)
+
+> Generated: 2026-07-20  
+> Branch: `cursor/metar-remarks-667-tests-1fe0` (includes feat #750 tip + TC-F6-013 expansion)  
+> Mode: **delta** (F6 deepen / EV-013)  
+> Overall: **PASS** (one advisory FE flake under concurrent load)
+
+```text
+QA Results:
+  Lint:           PASS — 0 issues
+  Format:         PASS — 0 files
+  Typecheck:      PASS — 0 errors (py + js)
+  Tests (Python): PASS — see table (CI-style make targets)
+  Tests (FE):     PASS — 644 / 644 on clean re-run (2 timeouts under concurrent load; advisory)
+  Security:       PASS — gitleaks --no-git: no leaks; pip-audit: no known vulns
+  H0c CORS:       PASS — 6 passed (tests/unit/test_cors_policy.py)
+  H0i:            PASS — 10 passed (apps/backend integration, --no-cov)
+  Cross-file:     PASS — ruff clean on apps/packages/tests
+  Template:       PASS — no layout drift in this delta
+  Staging H4–H5:  ADVISORY — deferred to 13-deploy-smoke
+```
+
+## Executive summary
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Format | PASS | `make format-check` |
+| Lint | PASS | `make lint` |
+| Typecheck | PASS | `make typecheck` |
+| tac2iwxxm | PASS | 171 passed, 9 skipped (≥95% cov) |
+| tac-validate | PASS | 296 passed |
+| iwxxm-validate | PASS | 76 passed, 1 skipped |
+| backend unit | PASS | 1216 passed |
+| auth | PASS | 228 passed, 31 skipped |
+| shared / workspace | PASS | 76 + 44 passed |
+| worker | PASS | 11 passed |
+| bugs | PASS | 44 passed, 1 deselected |
+| frontend | PASS | 644 passed (re-run); see QA-001 |
+| H0c | PASS | blocking connectivity |
+| H0i | PASS | blocking connectivity |
+| Security tree | PASS | gitleaks no-git; pip-audit clean |
+
+## Commands run (reproducible)
+
+```bash
+make format-check
+make lint
+make typecheck
+make test-unit-tac2iwxxm
+make test-unit-tac-validate
+make test-unit-iwxxm-validate
+make test-unit-backend
+make test-unit-auth
+make test-unit-shared-py
+make test-unit-workspace-py
+make test-unit-worker
+make test-bugs
+make test-unit-frontend   # clean re-run after flake
+uv run pytest tests/unit/test_cors_policy.py -q
+cd apps/backend && uv run pytest tests/integration/test_h0i_connectivity.py -q --no-cov
+gitleaks detect --no-git --config .gitleaks.toml
+uv run pip-audit
+```
+
+**Note:** Do not collect multiple packages in one root `pytest` invocation — basename collisions
+(`test_issue_spans`, `test_native_scaffold`) cause import-file mismatches. Use Make targets / CI jobs.
+
+## Findings for 11-verify-impl
+
+| ID | Severity | Finding | Suggested action |
+|----|----------|---------|------------------|
+| QA-001 | Advisory | First `make test-unit-frontend` under concurrent QA load: 2 Vitest timeouts (`bug-2026-07-12-result-card-dismiss`, `FileConverter` row remove). Isolated + full re-run: **644/644 PASS**. | Treat as load flake; no code change required for EV-013. Optional: raise testTimeout on those two cases. |
+| QA-002 | Advisory | Staging H4–H5 not run in this 09 pass. | 13-deploy-smoke after merge of #750/#751. |
+| QA-003 | Advisory | `scripts/check_secrets.sh` not present; used gitleaks `--no-git` instead. | None for this cycle. |
+
+## Phase / plan alignment
+
+- EV-013 implementation + TC-F6-013 expansion covered by local suite + CI green on `cursor/metar-remarks-667-2e2e` ([run](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29773115125)).
+- Related PRs: [#750](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/750) (feat), [#751](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/751) (test expansion).

--- a/docs/sessions/S018-metar-remarks-667/routing-plan.md
+++ b/docs/sessions/S018-metar-remarks-667/routing-plan.md
@@ -16,7 +16,7 @@
 | 03-plan-tooling | no | — | No new guardrails |
 | 05-verify-tech | no | — | Thin 04; fold into 02 |
 | 06-tech-tooling | no | — | No stack change |
-| 10-e2e | no | — | Package/API convert issues; covered by unit + 13 |
+| 10-e2e | yes | delta | Amended 2026-07-20 (user request); UJ-026/UJ-010 T0 library |
 
 ## Approved
 

--- a/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+++ b/packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
@@ -1,4 +1,4 @@
-"""EV-013 / #667 — METAR remarks must not be silently ignored."""
+"""EV-013 / #667 — METAR remarks must not be silently ignored (TC-F6-013 / UJ-026)."""
 
 from __future__ import annotations
 
@@ -56,3 +56,89 @@ def test_iwxxm_us_structured_only_remarks_omit_empty_human_readable() -> None:
     assert "observingSystemType" in result.xml
     assert "seaLevelPressure" in result.xml
     assert "humanReadableText" not in result.xml
+
+
+def test_annex3_speci_emits_remarks_excluded_with_rmk_span() -> None:
+    """SPECI follows the same annex3 exclusion bar as METAR (UJ-026)."""
+    tac = "SPECI KJFK 231815Z 18015KT 3SM -RA BKN015 14/12 A2998 RMK AO2 P0003="
+    result = convert(tac, product="SPECI", profile="annex3", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:" not in result.xml
+    excluded = next(i for i in result.issues if i.code == "REMARKS_EXCLUDED")
+    assert excluded.severity == "info"
+    assert excluded.location == "remarks"
+    assert excluded.start is not None and excluded.end is not None
+    assert tac[excluded.start : excluded.end] == "RMK"
+
+
+def test_parse_strips_structured_tokens_from_remarks_free_text() -> None:
+    """AO/SLP/PK are consumed; T/P and plain language remain for never-drop emit."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 SLP176 PK WND 28045/1745 T01560070 P0001 WSHFT 1715="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_present") is True
+    assert ir.get("observing_system_type") == "AO2"
+    assert ir.get("sea_level_pressure_hpa") == 1017.6
+    assert ir.get("peak_wind_dir_deg") == 280
+    assert ir.get("peak_wind_speed_kt") == 45
+    free = ir.get("remarks_free_text") or ""
+    assert "AO2" not in free
+    assert "SLP176" not in free
+    assert "PK WND" not in free
+    assert "T01560070" in free
+    assert "P0001" in free
+    assert "WSHFT 1715" in free
+
+
+def test_iwxxm_us_peak_wind_and_free_text_coexist() -> None:
+    """Structured PK WND emit must not drop leftover REMARKS (never-drop)."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 PK WND 28045/1745 VIRGA NE="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_free_text") == "VIRGA NE"
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:AerodromePeakWind" in result.xml
+    assert '<iwxxm-us:windDirection uom="deg">280</iwxxm-us:windDirection>' in result.xml
+    assert "<iwxxm-us:humanReadableText>VIRGA NE</iwxxm-us:humanReadableText>" in result.xml
+
+
+def test_iwxxm_us_negative_tenths_temp_decoded_and_retained() -> None:
+    """FMH-1 T1… sign bit → negative °C IR; token stays in free-text."""
+    tac = "METAR KJFK 231751Z 27008KT 10SM CLR M02/M05 A3012 RMK AO2 T10221055="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remark_temp_tenths_c") == -2.2
+    assert ir.get("remark_dewpoint_tenths_c") == -5.5
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "T10221055" in result.xml
+
+
+def test_iwxxm_us_plain_language_only_remarks_emit_addendum() -> None:
+    """Remarks without AO/SLP/PK still get an Addendum via humanReadableText."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK TORNADO B13 12 NE="
+    ir = parse_metar_speci(tac, product="METAR")
+    assert ir.get("remarks_free_text") == "TORNADO B13 12 NE"
+    assert ir.get("observing_system_type") is None
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:Addendum" in result.xml
+    assert "TORNADO B13 12 NE" in result.xml
+    assert "observingSystemType" not in result.xml
+
+
+def test_iwxxm_us_escapes_special_chars_in_human_readable_text() -> None:
+    """Free-text emit must XML-escape reserved characters."""
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK FOG & HAZE <1SM="
+    result = convert(tac, product="METAR", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "FOG &amp; HAZE &lt;1SM" in result.xml
+    assert "FOG & HAZE <1SM" not in result.xml
+
+
+def test_speci_iwxxm_us_retains_unparsed_remarks() -> None:
+    """SPECI iwxxm_us never-drop path mirrors METAR."""
+    tac = "SPECI KJFK 231815Z 18015KT 2SM BR BKN008 14/13 A2995 RMK AO2 VIS 1V3="
+    result = convert(tac, product="SPECI", profile="iwxxm_us", iwxxm_version="2025-2")
+    assert result.ok and result.xml
+    assert "iwxxm-us:humanReadableText" in result.xml
+    assert "VIS 1V3" in result.xml
+    assert all(i.code != "REMARKS_EXCLUDED" for i in result.issues)

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -16,7 +16,7 @@ active_session:
   orchestrator: 16-evolve
   evolve_cycle_id: EV-013
   artifacts_dir: docs/sessions/S018-metar-remarks-667/
-  current_stage: 08-verify-build
+  current_stage: 11-verify-impl
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched: []
@@ -38,8 +38,8 @@ active_session:
       started: '2026-07-20'
       skip_rationale:
       note: >-
-        Implementation landed (07-build); 08-verify-build in_progress;
-        Standard routing
+        09-qa + 10-e2e completed (QA pass_with_advisories; e2e PASS);
+        current_stage 11-verify-impl pending
     - stage: 01-requirements
       required: true
       mode: delta
@@ -88,19 +88,32 @@ active_session:
     - stage: 08-verify-build
       required: true
       mode: full
-      status: in_progress
+      status: completed
       started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
+      note: CI already green — completed without re-run
     - stage: 09-qa
       required: true
       mode: full
-      status: pending
+      status: completed
+      started: '2026-07-20T19:54:52Z'
+      completed: '2026-07-20T20:18:31Z'
       skip_rationale:
+      note: >-
+        pass_with_advisories (QA-001 FE flake under load; clean re-run green);
+        report docs/sessions/S018-metar-remarks-667/reports/qa-report.md
     - stage: 10-e2e
-      required: false
-      mode: skipped
-      status: skipped
-      skip_rationale: 'Standard routing for #667 — not in approved stage list (E13-2)'
+      required: true
+      mode: full
+      status: completed
+      started: '2026-07-20T19:54:52Z'
+      completed: '2026-07-20T20:18:31Z'
+      skip_rationale:
+      note: >-
+        PASS T0 UJ-026/UJ-010; report
+        docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+        (amended routing D-S018-EV013-amend-10-e2e)
     - stage: 11-verify-impl
       required: true
       mode: full
@@ -2330,13 +2343,24 @@ stages:
       note: 'M1–M5 complete (T1.1–T5.10); PR #742 merged b405a96'
   09-qa:
     status: completed
-    started_at: "2026-06-24T14:55:00Z"
-    completed_at: "2026-06-24T15:10:00Z"
-    report: docs/sessions/S004-issue-555-feedback/reports/qa-report.md
-    overall: fail
-    session_id: S004-issue-555-feedback
-    evolve_cycle_id: EV-004
+    started_at: "2026-07-20T19:54:52Z"
+    completed_at: "2026-07-20T20:18:31Z"
+    report: docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+    overall: pass_with_advisories
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
     delta_substages:
+      - id: S018-metar-remarks-667
+        session_id: S018-metar-remarks-667
+        evolve_cycle_id: EV-013
+        status: completed
+        started_at: '2026-07-20T19:54:52Z'
+        completed_at: '2026-07-20T20:18:31Z'
+        overall: pass_with_advisories
+        mode: full
+        report: docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+        note: >-
+          pass_with_advisories (QA-001 FE flake under load; clean re-run green)
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
         evolve_cycle_id: EV-011
@@ -2387,6 +2411,10 @@ stages:
         report: docs/sessions/S011-f7-operator-ui/reports/qa-report.md
         note: "T6.2 pass_with_advisories; Playwright/compose SKIPPED host ports/disk; QA-001 api.py type narrow uncommitted"
     notes:
+      - >-
+        2026-07-20 S018/EV-013 09-qa completed — pass_with_advisories (QA-001 FE flake;
+        clean re-run green); qa-report.md; next 11-verify-impl
+      - 2026-07-20 S018/EV-013 09-qa in_progress (parallel 10-e2e; D-S018-EV013-amend-10-e2e)
       - 2026-07-20 S015/EV-011 09-qa completed — PASS — qa-report.md
       - "2026-07-19 S014/EV-010 09-qa completed — pass_with_advisories (QA-S014-001 H4–H5→13); see qa-report.md"
       - "2026-07-19 S014/EV-010 09-qa in_progress (T6.2; D-S014-EV010-c-to-d-pass)"
@@ -2495,11 +2523,12 @@ stages:
 
   10-e2e:
     status: completed
-    started_at: "2026-06-24T15:00:00Z"
-    completed_at: "2026-06-24T15:20:00Z"
-    report: docs/sessions/S004-issue-555-feedback/reports/e2e-report.md
-    overall: fail
-    session_id: S004-issue-555-feedback
+    started_at: "2026-07-20T19:54:52Z"
+    completed_at: "2026-07-20T20:18:31Z"
+    report: docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+    overall: pass
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
     substeps:
       extract_journeys:
         status: completed
@@ -2516,6 +2545,16 @@ stages:
         status: completed
         notes: "H3 13 pass 8 skip (legacy Supabase keys); T3 browser deferred"
     delta_substages:
+      - id: S018-metar-remarks-667
+        session_id: S018-metar-remarks-667
+        evolve_cycle_id: EV-013
+        status: completed
+        started_at: '2026-07-20T19:54:52Z'
+        completed_at: '2026-07-20T20:18:31Z'
+        overall: pass
+        mode: full
+        report: docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+        note: PASS T0 UJ-026/UJ-010 (amended routing D-S018-EV013-amend-10-e2e)
       - id: S016-manual-tac-input-modes
         session_id: S016-manual-tac-input-modes
         evolve_cycle_id: EV-012
@@ -2569,6 +2608,10 @@ stages:
         report: docs/sessions/S011-f7-operator-ui/reports/e2e-report.md
         note: "T6.2 pass_with_advisories; Playwright/compose SKIPPED host ports/disk"
     notes:
+      - >-
+        2026-07-20 S018/EV-013 10-e2e completed — PASS T0 UJ-026/UJ-010; e2e-report.md;
+        next 11-verify-impl
+      - 2026-07-20 S018/EV-013 10-e2e in_progress (amended from skipped; D-S018-EV013-amend-10-e2e)
       - 2026-07-20 S016/EV-012 10-e2e completed — PASS TC-F7-007 T1-T6 + Vitest; e2e-report.md; next 13-deploy-smoke 
         (pending)
       - 2026-07-20 S015/EV-011 10-e2e completed — PASS — e2e-report.md; UJ-024 catalog smoke
@@ -2584,9 +2627,11 @@ stages:
   08-verify-build:
     status: completed
     started_at: "2026-06-22T17:27:00Z"
-    completed_at: "2026-06-24T14:30:00Z"
+    completed_at: "2026-07-20T19:54:52Z"
     overall: fail
     report: docs/sessions/S004-issue-555-feedback/reports/verification-report.md
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
     substeps:
       lint:
         status: completed
@@ -2605,6 +2650,14 @@ stages:
       report:
         status: completed
     delta_substages:
+      - id: S018-metar-remarks-667
+        session_id: S018-metar-remarks-667
+        evolve_cycle_id: EV-013
+        status: completed
+        started_at: '2026-07-20'
+        completed_at: '2026-07-20'
+        mode: full
+        note: CI already green — completed without re-run; handoff 09-qa+10-e2e
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
         evolve_cycle_id: EV-011
@@ -2655,6 +2708,7 @@ stages:
         report: docs/sessions/S011-f7-operator-ui/reports/verification-report.md
         note: "T6.1 PASS; integration SKIPPED host ports/disk; C→D passed D-S011-EV008-c-to-d-pass"
     notes:
+      - 2026-07-20 S018/EV-013 08-verify-build completed — CI green; handoff 09-qa+10-e2e
       - 2026-07-20 S015/EV-011 08-verify-build completed — T5.1 PASS — verification-report.md; C→D passed
       - "2026-07-19 S014/EV-010 C→D passed (D-S014-EV010-c-to-d-pass); T6.2 09-qa+10-e2e in_progress"
       - "2026-07-19 S014/EV-010 T6.1 PASS (verification-report.md); integration SKIPPED (docker pull); C→D pending AskQuestion;
@@ -2900,10 +2954,10 @@ stages:
     session_id: S018-metar-remarks-667
     evolve_cycle_id: EV-013
     started_at: '2026-07-20'
-    current_stage: 16-evolve
+    current_stage: 11-verify-impl
     note: >-
-      S018/EV-013 — Phase 0 intake complete via Assumed (E13-1/E13-2/E13-3); AskQuestion UI
-      waived (cloud); Standard routing; moving to 01-requirements
+      S018/EV-013 — 09-qa + 10-e2e completed; current_stage 11-verify-impl
+      pending (QA pass_with_advisories; e2e PASS)
 
 stages_pending: []
 
@@ -3012,6 +3066,40 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S018-EV013-qa-001-fe-flake
+    stage: 09-qa
+    date: '2026-07-20'
+    timestamp: '2026-07-20T20:18:31Z'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 09-qa
+    skill_id: 09-qa
+    topic: QA-001 FE flake advisory under load
+    decision: >-
+      QA-001: frontend Vitest saw 2 timeouts under concurrent load; clean re-run
+      green (644/644). Recorded as advisory only — overall pass_with_advisories;
+      does not block 11-verify-impl.
+    status: noted
+    resolved_at: '2026-07-20'
+    note: Advisory from qa-report.md; clean re-run green
+  - id: D-S018-EV013-amend-10-e2e
+    stage: 09-qa
+    date: '2026-07-20'
+    timestamp: '2026-07-20T19:54:52Z'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 09-qa
+    skill_id: 09-qa
+    topic: Amend routing — include 10-e2e for EV-013 #667 remarks
+    decision: >-
+      User requested 10-e2e despite prior E13-2 Standard skip (10-e2e not in approved
+      stage list). Amend active_session.routing_plan and EV-013: 10-e2e skipped →
+      required/in_progress; run 09-qa + 10-e2e in parallel after 08-verify-build
+      completed (CI green). Intent: verify all tests passing + run 09-qa and 10-e2e
+      for EV-013 #667 remarks.
+    status: confirmed
+    resolved_at: '2026-07-20'
+    note: User-amended routing plan (amendment of D-S018-EV013-E13-2-routing)
   - id: D-S018-aq-waive-cloud
     stage: 00-context
     date: '2026-07-20'
@@ -5584,6 +5672,28 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+    type: report
+    kind: qa-report
+    stage: 09-qa
+    skill_id: 09-qa
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20T20:18:31Z'
+    status: completed
+    note: pass_with_advisories (QA-001 FE flake; clean re-run green)
+  - path: docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+    type: report
+    kind: e2e-report
+    stage: 10-e2e
+    skill_id: 10-e2e
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20T20:18:31Z'
+    status: completed
+    note: PASS T0 UJ-026/UJ-010
   - path: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
     type: report
     kind: e2e-report
@@ -6903,6 +7013,7 @@ evolve_cycles:
         - 07-build
         - 08-verify-build
         - 09-qa
+        - 10-e2e
         - 11-verify-impl
         - 12-verify-deploy
         - 13-deploy-smoke
@@ -6910,9 +7021,14 @@ evolve_cycles:
         - 03-plan-tooling
         - 05-verify-tech
         - 06-tech-tooling
-        - 10-e2e
-    current_stage: 08-verify-build
+    current_stage: 11-verify-impl
     notes:
+      - >-
+        2026-07-20 S018/EV-013 — 09-qa + 10-e2e completed (QA pass_with_advisories;
+        e2e PASS); current_stage 11-verify-impl pending
+      - >-
+        2026-07-20 S018/EV-013 — 08-verify-build completed (CI green); 09-qa + 10-e2e
+        in_progress parallel (D-S018-EV013-amend-10-e2e)
       - >-
         2026-07-20 S018/EV-013 — TC-F6-013 tests expanded (12 cases) on
         cursor/metar-remarks-667-tests-1fe0 / PR #751 (stacked on feature branch)
@@ -6937,7 +7053,7 @@ evolve_cycles:
         status: in_progress
         started: '2026-07-20'
         note: >-
-          Orchestrator in_progress; implementation landed; verification next
+          Orchestrator in_progress; 09+10 done; current_stage 11-verify-impl pending
       01-requirements:
         status: completed
         mode: delta
@@ -6970,15 +7086,28 @@ evolve_cycles:
         started: '2026-07-20'
         completed: '2026-07-20'
       08-verify-build:
-        status: in_progress
+        status: completed
         mode: full
         started: '2026-07-20'
+        completed: '2026-07-20'
+        note: CI already green — completed without re-run
       09-qa:
-        status: pending
+        status: completed
         mode: full
+        started: '2026-07-20T19:54:52Z'
+        completed: '2026-07-20T20:18:31Z'
+        overall: pass_with_advisories
+        report: docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+        note: >-
+          pass_with_advisories (QA-001 FE flake under load; clean re-run green)
       10-e2e:
-        status: skipped
-        skip_rationale: Not in Standard approved stage list (E13-2)
+        status: completed
+        mode: full
+        started: '2026-07-20T19:54:52Z'
+        completed: '2026-07-20T20:18:31Z'
+        overall: pass
+        report: docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
+        note: PASS T0 UJ-026/UJ-010 (amended routing)
       11-verify-impl:
         status: pending
         mode: full
@@ -7008,6 +7137,10 @@ evolve_cycles:
       - path: docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
         status: present
       - path: packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+        status: present
+      - path: docs/sessions/S018-metar-remarks-667/reports/qa-report.md
+        status: present
+      - path: docs/sessions/S018-metar-remarks-667/reports/e2e-report.md
         status: present
       - path: docs/sessions/S018-metar-remarks-667/reports/evolve-summary.md
         status: pending

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -6914,6 +6914,9 @@ evolve_cycles:
     current_stage: 08-verify-build
     notes:
       - >-
+        2026-07-20 S018/EV-013 — TC-F6-013 tests expanded (12 cases) on
+        cursor/metar-remarks-667-tests-1fe0 / PR #751 (stacked on feature branch)
+      - >-
         2026-07-20 S018/EV-013 — implementation landed (07-build); 08-verify-build
         in_progress; commits 8ee3176 (docs scope) + 19d6684 (feat remarks)
       - >-
@@ -9592,6 +9595,17 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: cursor/metar-remarks-667-tests-1fe0
+      base: cursor/metar-remarks-667-2e2e
+      status: active
+      created_at: '2026-07-20'
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      purpose: 'EV-013 / S018 expand TC-F6-013 targeted remark tests (#667)'
+      pushed: true
+      tip_sha: 3993cfcbe82ab1caadc1d82c5f94c8d38e0a9064
+      pr: 'https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/751'
+      note: Stacked test PR; local pytest 12/12 green
     - name: cursor/metar-remarks-667-2e2e
       base: main
       status: active
@@ -9898,6 +9912,19 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 3993cfcbe82ab1caadc1d82c5f94c8d38e0a9064
+      short: 3993cfc
+      branch: cursor/metar-remarks-667-tests-1fe0
+      message: '[EV-013] test: expand TC-F6-013 METAR remarks coverage (#667)'
+      stage: 08-verify-build
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      timestamp: '2026-07-20T19:42:00Z'
+      files_changed:
+        - packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
+        - docs/sessions/S018-metar-remarks-667/reports/execution-plan.md
+      pushed: true
+      pr: 'https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/751'
     - sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
       short: 19d6684
       branch: cursor/metar-remarks-667-2e2e


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands TC-F6-013 / UJ-026 coverage for [#667](https://github.com/joseph-c-mcguire/metar-to-IWXXM/issues/667) on top of the feat work in #750.

Also includes S018 **09-qa** + **10-e2e** verification reports:

- `docs/sessions/S018-metar-remarks-667/reports/qa-report.md` — overall PASS (advisory FE flake under concurrent load; clean re-run 644/644)
- `docs/sessions/S018-metar-remarks-667/reports/e2e-report.md` — UJ-026 / UJ-010 T0 PASS; T2 deferred to 13

## Test plan

- [x] Expanded `test_issue_667_metar_remarks.py`
- [x] Local `make` unit suite for packages/backend/auth/worker/bugs
- [x] Frontend 644/644 on clean re-run
- [x] H0c + H0i PASS
- [ ] Prefer merge order: #750 then #751 (or squash together)

## Notes

- Do **not** auto-merge — needs explicit approval.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f810a-a1ad-736d-9db9-c1299c8d1fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f810a-a1ad-736d-9db9-c1299c8d1fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Extend METAR/SPECI remarks handling tests and documentation for TC-F6-013 / UJ-026 coverage.

Documentation:
- Update the S018 METAR remarks session execution plan to document the expanded test coverage and case count for test_issue_667_metar_remarks.py.

Tests:
- Add regression tests for SPECI annex3 remarks exclusion, including tracking the RMK token span.
- Add parse-level tests ensuring AO/SLP/PK structured tokens are removed from remarks_free_text while T/P and plain language remain.
- Add iwxxm_us tests verifying coexistence of peak wind structured output with residual free-text and negative tenths temperature decoding/retention.
- Add iwxxm_us tests ensuring plain-language-only remarks still emit an Addendum and that humanReadableText escapes XML-reserved characters.
- Add SPECI iwxxm_us tests confirming unparsed remarks are retained and not flagged as REMARKS_EXCLUDED.