### PR TITLE
[EV-013] Echo REMARKS_EXCLUDED on convert API + UJ-026 e2e (#667)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/ci-cd.yml)
 [![E2E](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/workflows/e2e-tests.yml)
-[![E2E tests](https://img.shields.io/badge/E2E_tests-49-blue)](apps/e2e)
+[![E2E tests](https://img.shields.io/badge/E2E_tests-52-blue)](apps/e2e)
 [![codecov](https://codecov.io/gh/joseph-c-mcguire/metar-to-IWXXM/graph/badge.svg)](https://codecov.io/gh/joseph-c-mcguire/metar-to-IWXXM)
 [![Unit coverage gate](https://img.shields.io/badge/unit_coverage-%E2%89%A598%25-success)](docs/test-plan.md)
 

--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -1657,7 +1657,9 @@ async def convert(
         """Echo tac2iwxxm non-fatal convert issues (e.g. REMARKS_EXCLUDED) to the client."""
         for raw in soft.get("convert_issues") or []:
             data = raw.model_dump() if hasattr(raw, "model_dump") else dict(raw)
-            sev_raw = str(data.get("severity") or "info").lower()
+            sev_raw = str(data.get("severity") or "info").strip().lower()
+            if "." in sev_raw:
+                sev_raw = sev_raw.rsplit(".", 1)[-1]
             if sev_raw == "error":
                 severity = ConversionIssueSeverity.ERROR
             elif sev_raw == "warning":

--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -1653,14 +1653,40 @@ async def convert(
     preview_failed_spans: List[FailedSpan] = []
     preview_saw_soft_fail = False
 
-    def absorb_soft_preview(soft: dict, *, base_offset: int = 0) -> None:
+    def absorb_convert_issues(soft: dict, *, source: str) -> None:
+        """Echo tac2iwxxm non-fatal convert issues (e.g. REMARKS_EXCLUDED) to the client."""
+        for raw in soft.get("convert_issues") or []:
+            data = raw.model_dump() if hasattr(raw, "model_dump") else dict(raw)
+            sev_raw = str(data.get("severity") or "info").lower()
+            if sev_raw == "error":
+                severity = ConversionIssueSeverity.ERROR
+            elif sev_raw == "warning":
+                severity = ConversionIssueSeverity.WARNING
+            else:
+                severity = ConversionIssueSeverity.INFO
+            code = data.get("code") or None
+            add_issue(
+                source=source,
+                message=str(data.get("message") or code or "Convert issue"),
+                severity=severity,
+                hint=("Use profile=iwxxm_us to retain US REMARKS in IWXXM." if code == "REMARKS_EXCLUDED" else None),
+                code=code,
+                location=data.get("location"),
+            )
+
+    def absorb_soft_preview(soft: dict, *, base_offset: int = 0, source: str | None = None) -> None:
         """Merge soft-preview envelope fields from convert_metar_tac_with_metadata.
 
         ``base_offset`` shifts entry-local span offsets into the original
         ``manual_text`` buffer (multi-line editor documents).
+        Always absorbs ``convert_issues`` when ``source`` is provided (EV-013 / #667).
         """
         nonlocal preview_saw_soft_fail
-        if not preview or not soft:
+        if not soft:
+            return
+        if source:
+            absorb_convert_issues(soft, source=source)
+        if not preview:
             return
         if soft.get("ok") is False:
             preview_saw_soft_fail = True
@@ -1930,9 +1956,9 @@ async def convert(
                     product=product,
                     profile=profile,
                     preview=preview,
-                    soft_preview_out=soft_preview_buf if preview else None,
+                    soft_preview_out=soft_preview_buf,
                 )
-                absorb_soft_preview(soft_preview_buf)
+                absorb_soft_preview(soft_preview_buf, source=metar_name)
                 if preview and soft_preview_buf.get("ok") is False:
                     add_issue(
                         source=metar_name,
@@ -2187,9 +2213,9 @@ async def convert(
                 product=product,
                 profile=profile,
                 preview=preview,
-                soft_preview_out=soft_preview_buf if preview else None,
+                soft_preview_out=soft_preview_buf,
             )
-            absorb_soft_preview(soft_preview_buf, base_offset=entry_offset)
+            absorb_soft_preview(soft_preview_buf, base_offset=entry_offset, source=manual_source)
             if preview and soft_preview_buf.get("ok") is False:
                 add_issue(
                     source=manual_source,
@@ -2416,9 +2442,9 @@ async def convert(
                     product=product,
                     profile=profile,
                     preview=preview,
-                    soft_preview_out=soft_preview_buf if preview else None,
+                    soft_preview_out=soft_preview_buf,
                 )
-                absorb_soft_preview(soft_preview_buf)
+                absorb_soft_preview(soft_preview_buf, source=source_name)
                 if preview and soft_preview_buf.get("ok") is False:
                     add_issue(
                         source=source_name,

--- a/apps/backend/src/utilities/conversion.py
+++ b/apps/backend/src/utilities/conversion.py
@@ -44,6 +44,19 @@ def _load_service_validation_error() -> type[Exception]:
 ServiceValidationError = _load_service_validation_error()
 
 
+def _normalize_issue_severity(value: object) -> str:
+    """Return ``error`` / ``warning`` / ``info`` from str or enum-like severity."""
+    if value is None:
+        return "info"
+    raw = getattr(value, "value", value)
+    text = str(raw or "info").strip().lower()
+    if "." in text:
+        text = text.rsplit(".", 1)[-1]
+    if text in {"error", "warning", "info"}:
+        return text
+    return "info"
+
+
 class ConversionError(Exception):
     """Raised when METAR to IWXXM conversion fails."""
 
@@ -240,7 +253,7 @@ def convert_metar_tac_with_metadata(
     if soft_preview_out is not None:
         soft_preview_out["convert_issues"] = [
             {
-                "severity": str(getattr(issue, "severity", "") or "info"),
+                "severity": _normalize_issue_severity(getattr(issue, "severity", None)),
                 "code": str(getattr(issue, "code", "") or ""),
                 "message": str(getattr(issue, "message", "") or ""),
                 "location": getattr(issue, "location", None),

--- a/apps/backend/src/utilities/conversion.py
+++ b/apps/backend/src/utilities/conversion.py
@@ -174,8 +174,10 @@ def convert_metar_tac_with_metadata(
         Soft-preview mode (ADR-022): return best-effort XML instead of raising on
         parse/convert failure.
     soft_preview_out :
-        Optional mutable dict filled when ``preview=True`` with ``ok`` and
-        ``failed_spans`` for the API response envelope.
+        Optional mutable dict. When ``preview=True``, filled with ``ok`` and
+        ``failed_spans``. On any successful convert, also filled with
+        ``convert_issues`` (tac2iwxxm non-fatal issues such as ``REMARKS_EXCLUDED``)
+        when the caller passes a dict — including hard convert (EV-013 / #667).
 
     Returns
     -------
@@ -234,6 +236,19 @@ def convert_metar_tac_with_metadata(
         soft_preview_out.clear()
         soft_preview_out["ok"] = True
         soft_preview_out["failed_spans"] = []
+
+    if soft_preview_out is not None:
+        soft_preview_out["convert_issues"] = [
+            {
+                "severity": str(getattr(issue, "severity", "") or "info"),
+                "code": str(getattr(issue, "code", "") or ""),
+                "message": str(getattr(issue, "message", "") or ""),
+                "location": getattr(issue, "location", None),
+                "start": getattr(issue, "start", None),
+                "end": getattr(issue, "end", None),
+            }
+            for issue in (result.issues or [])
+        ]
 
     xml_string = result.xml
     if not xml_string.lstrip().startswith("<?xml"):

--- a/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
+++ b/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
@@ -76,3 +76,44 @@ def test_iwxxm_us_convert_retains_human_readable_text(client: TestClient) -> Non
     xml = (body.get("results") or [{}])[0].get("content") or ""
     assert "iwxxm-us:humanReadableText" in xml
     assert "WND DATA ESTMD" in xml
+
+
+def test_convert_absorbs_enum_like_and_warning_error_severities(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover absorb_convert_issues severity branches (enum-style / warning / error)."""
+
+    def _fake_convert(*_args, soft_preview_out=None, **_kwargs):
+        if soft_preview_out is not None:
+            soft_preview_out.clear()
+            soft_preview_out["ok"] = True
+            soft_preview_out["failed_spans"] = []
+            soft_preview_out["convert_issues"] = [
+                {
+                    "severity": "Severity.ERROR",
+                    "code": "FAKE_ERROR",
+                    "message": "error-ish",
+                },
+                {
+                    "severity": "warning",
+                    "code": "FAKE_WARN",
+                    "message": "warn-ish",
+                },
+                {
+                    "severity": "info",
+                    "code": "FAKE_INFO",
+                    "message": "info-ish",
+                },
+            ]
+        return ('<?xml version="1.0"?><iwxxm:METAR/>', None)
+
+    monkeypatch.setattr(api_module, "convert_metar_tac_with_metadata", _fake_convert)
+    body = _convert(
+        client,
+        tac="METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005=",
+        profile="annex3",
+    )
+    by_code = {i.get("code"): i.get("severity") for i in (body.get("issues") or [])}
+    assert by_code.get("FAKE_ERROR") == "error"
+    assert by_code.get("FAKE_WARN") == "warning"
+    assert by_code.get("FAKE_INFO") == "info"

--- a/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
+++ b/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 import pytest
 from fastapi.testclient import TestClient
 
 from src import api as api_module
+from src.utilities.conversion import _normalize_issue_severity
 from src.utilities.security import verify_supabase_token
+
+
+class _Severity(Enum):
+    ERROR = "error"
+    WARNING = "warning"
 
 
 @pytest.fixture
@@ -33,6 +41,21 @@ def _convert(client: TestClient, *, tac: str, profile: str) -> dict:
     )
     assert response.status_code == 200, response.text[:500]
     return response.json()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("info", "info"),
+        ("WARNING", "warning"),
+        (_Severity.ERROR, "error"),
+        ("Severity.WARNING", "warning"),
+        (None, "info"),
+        ("unknown", "info"),
+    ],
+)
+def test_normalize_issue_severity(raw: object, expected: str) -> None:
+    assert _normalize_issue_severity(raw) == expected
 
 
 def test_annex3_convert_echoes_remarks_excluded(client: TestClient) -> None:

--- a/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
+++ b/apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
@@ -1,0 +1,55 @@
+"""EV-013 / UJ-026 — convert API echoes REMARKS_EXCLUDED / retains iwxxm_us free text."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import api as api_module
+from src.utilities.security import verify_supabase_token
+
+
+@pytest.fixture
+def client():
+    async def override_verify_token():
+        return {"sub": "test-user", "aud": "test-aud"}
+
+    api_module.app.dependency_overrides[verify_supabase_token] = override_verify_token
+    test_client = TestClient(api_module.app)
+    yield test_client
+    api_module.app.dependency_overrides.clear()
+
+
+def _convert(client: TestClient, *, tac: str, profile: str) -> dict:
+    response = client.post(
+        "/api/v1/convert",
+        files={
+            "manual_text": (None, tac),
+            "product": (None, "METAR"),
+            "profile": (None, profile),
+            "iwxxm_version": (None, "2025-2"),
+            "lint": (None, "false"),
+        },
+    )
+    assert response.status_code == 200, response.text[:500]
+    return response.json()
+
+
+def test_annex3_convert_echoes_remarks_excluded(client: TestClient) -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK AO2 SLP176="
+    body = _convert(client, tac=tac, profile="annex3")
+    codes = [i.get("code") for i in (body.get("issues") or [])]
+    assert "REMARKS_EXCLUDED" in codes
+    assert body.get("successful", 0) >= 1
+    xml = (body.get("results") or [{}])[0].get("content") or ""
+    assert "iwxxm-us:Addendum" not in xml
+
+
+def test_iwxxm_us_convert_retains_human_readable_text(client: TestClient) -> None:
+    tac = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 WND DATA ESTMD="
+    body = _convert(client, tac=tac, profile="iwxxm_us")
+    codes = [i.get("code") for i in (body.get("issues") or [])]
+    assert "REMARKS_EXCLUDED" not in codes
+    xml = (body.get("results") or [{}])[0].get("content") or ""
+    assert "iwxxm-us:humanReadableText" in xml
+    assert "WND DATA ESTMD" in xml

--- a/apps/e2e/uj026-metar-remarks.e2e.spec.ts
+++ b/apps/e2e/uj026-metar-remarks.e2e.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * UJ-026 / #667 — METAR REMARKS retain / exclusion (API + UI smoke).
+ *
+ * Spec: docs/user-journeys.md UJ-026; docs/test-plan.md TC-F6-013.
+ * API assertions are the hard gate; UI checks soft-fail if issue chips are absent.
+ */
+import { expect, test } from '@playwright/test';
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  convertManualMetar,
+  loginAndOpenConverter,
+} from './playwright-e2e-helpers';
+
+const TAC_RMK = 'METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK AO2 SLP176=';
+const TAC_FREE =
+  'METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 WND DATA ESTMD=';
+
+function apiBase(): string {
+  return (
+    process.env.PLAYWRIGHT_API_BASE_URL ||
+    process.env.LIVE_API_URL ||
+    'https://metar-to-iwxxm-api.onrender.com'
+  ).replace(/\/$/, '');
+}
+
+test.describe('UJ-026: METAR REMARKS retain / exclusion', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !ADMIN_EMAIL || !ADMIN_PASSWORD,
+      'Requires PLAYWRIGHT_ADMIN_EMAIL / ADMIN_EMAIL credentials',
+    );
+  });
+
+  test('API: annex3 convert returns REMARKS_EXCLUDED', async ({ request }) => {
+    const login = await request.post(`${apiBase()}/auth/login`, {
+      data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    });
+    test.skip(!login.ok(), `live login failed: ${login.status()}`);
+    const body = await login.json();
+    const token = body.access_token || body.token || body.session?.access_token;
+    test.skip(!token, 'login missing access_token');
+
+    const convert = await request.post(`${apiBase()}/api/v1/convert`, {
+      headers: { Authorization: `Bearer ${token}` },
+      multipart: {
+        manual_text: TAC_RMK,
+        product: 'METAR',
+        profile: 'annex3',
+        iwxxm_version: '2025-2',
+        lint: 'false',
+      },
+    });
+    expect(convert.status()).toBe(200);
+    const payload = await convert.json();
+    const codes = (payload.issues || []).map((i: { code?: string }) => i.code);
+    expect(codes).toContain('REMARKS_EXCLUDED');
+    const xml = payload.results?.[0]?.content || '';
+    expect(xml).not.toContain('iwxxm-us:Addendum');
+  });
+
+  test('API: iwxxm_us convert retains humanReadableText', async ({ request }) => {
+    const login = await request.post(`${apiBase()}/auth/login`, {
+      data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    });
+    test.skip(!login.ok(), `live login failed: ${login.status()}`);
+    const body = await login.json();
+    const token = body.access_token || body.token || body.session?.access_token;
+    test.skip(!token, 'login missing access_token');
+
+    const convert = await request.post(`${apiBase()}/api/v1/convert`, {
+      headers: { Authorization: `Bearer ${token}` },
+      multipart: {
+        manual_text: TAC_FREE,
+        product: 'METAR',
+        profile: 'iwxxm_us',
+        iwxxm_version: '2025-2',
+        lint: 'false',
+      },
+    });
+    expect(convert.status()).toBe(200);
+    const payload = await convert.json();
+    const xml = payload.results?.[0]?.content || '';
+    expect(xml).toContain('iwxxm-us:humanReadableText');
+    expect(xml).toContain('WND DATA ESTMD');
+  });
+
+  test('UI: annex3 convert with RMK still yields results', async ({ page }) => {
+    await loginAndOpenConverter(page);
+    const product = page.locator('#param-product');
+    if (await product.isVisible().catch(() => false)) {
+      await page
+        .getByLabel(/Expand parameters/i)
+        .click()
+        .catch(() => undefined);
+      await page.locator('#param-product').selectOption('METAR');
+      await page.locator('#param-profile').selectOption('annex3');
+    }
+    await convertManualMetar(page, TAC_RMK);
+    await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
+      {
+        timeout: 30000,
+      },
+    );
+  });
+});

--- a/apps/e2e/uj026-metar-remarks.e2e.spec.ts
+++ b/apps/e2e/uj026-metar-remarks.e2e.spec.ts
@@ -88,14 +88,14 @@ test.describe('UJ-026: METAR REMARKS retain / exclusion', () => {
   test('UI: annex3 convert with RMK still yields results', async ({ page }) => {
     await loginAndOpenConverter(page);
     const product = page.locator('#param-product');
-    if (await product.isVisible().catch(() => false)) {
+    if (!(await product.isVisible().catch(() => false))) {
       await page
         .getByLabel(/Expand parameters/i)
         .click()
         .catch(() => undefined);
-      await page.locator('#param-product').selectOption('METAR');
-      await page.locator('#param-profile').selectOption('annex3');
     }
+    await page.locator('#param-product').selectOption('METAR');
+    await page.locator('#param-profile').selectOption('annex3');
     await convertManualMetar(page, TAC_RMK);
     await expect(page.getByRole('region', { name: /conversion results/i })).toBeVisible(
       {

--- a/docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
+++ b/docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
@@ -1,0 +1,62 @@
+# Deploy & Smoke — S018 / EV-013 (#667)
+
+> Date: 2026-07-20  
+> Mode: **validate-existing** + follow-up API fix PR  
+> Branch (fix): `cursor/metar-remarks-live-e2e-2e2e` → [#752](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/752)
+
+## Staging topology
+
+| Service | URL | Deployed image / note |
+|---------|-----|------------------------|
+| API | https://metar-to-iwxxm-api.onrender.com | `backend:…-ccfb8cc` (**#750** live) |
+| Frontend | https://metar-to-iwxxm-frontend-v4-web.onrender.com | `frontend:…-ccfb8cc` live |
+
+## Feature verification (#667)
+
+| Check | Live now (#750) | After #752 deploy |
+|-------|-----------------|-------------------|
+| `iwxxm_us` retains `humanReadableText` for unparsed RMK | **PASS** | PASS |
+| `annex3` emits `REMARKS_EXCLUDED` in `/api/v1/convert` `issues` | **FAIL** (dropped on success path) | **PASS** (unit green; awaiting merge) |
+| Package `tac2iwxxm` REMARKS_EXCLUDED | PASS (in #750 image) | PASS |
+
+**Root cause (live gap):** `convert_metar_tac_with_metadata` discarded tac2iwxxm success-path issues. Fixed in #752.
+
+## Smoke tiers
+
+| Tier | Status | Evidence |
+|------|--------|----------|
+| H0c | PASS | `test_cors_policy.py` 6/6 |
+| H1 | PASS | `/health` 200, `tac2iwxxm_available: true` |
+| H3 | PASS | live API health + convert/lint 24/24 |
+| H4 | PASS | CORS preflight allows FE origin |
+| H5 | PASS | `/config.json` → api.baseUrl = live API |
+| UJ-026 live (`iwxxm_us`) | PASS | `test_uj026_live_iwxxm_us_human_readable` |
+| UJ-026 live (`annex3`) | FAIL until #752 | empty `issues[]` |
+| Playwright UJ-026 | 2 PASS / 1 FAIL | fail = annex3 REMARKS_EXCLUDED (same gap) |
+
+## E2E added
+
+| File | Role |
+|------|------|
+| `apps/backend/tests/unit/test_uj026_remarks_convert_issues.py` | API unit (PASS locally) |
+| `tests/live/test_uj026_metar_remarks_live.py` | Live API gate |
+| `apps/e2e/uj026-metar-remarks.e2e.spec.ts` | Playwright API + UI (badge 49→52) |
+
+## Gate status
+
+- **Partial deploy smoke PASS** for connectivity + iwxxm_us retain.
+- **Full #667 acceptance on staging** blocked on merge/deploy of **#752**.
+- Recommend: merge #752 → wait for Render image `…-<sha>` → re-run live UJ-026 + Playwright annex3 test.
+
+## Commands
+
+```bash
+export LIVE_API_URL=https://metar-to-iwxxm-api.onrender.com
+export LIVE_FRONTEND_URL=https://metar-to-iwxxm-frontend-v4-web.onrender.com
+# + ADMIN_EMAIL / ADMIN_PASSWORD from .env
+bash scripts/deploy/verify_connectivity.sh
+uv run pytest apps/backend/tests/infrastructure/test_live_api_health.py \
+  tests/live/test_t72_h3_live_smoke.py tests/live/test_uj026_metar_remarks_live.py \
+  -m live_api -v --no-cov
+cd apps/e2e && DISABLE_AUTH=false pnpm exec playwright test uj026-metar-remarks.e2e.spec.ts
+```

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -269,6 +269,12 @@ US extension XML (profile isolation). See also UJ-026 for annex3 exclusion messa
 
 **Tier**: T0 / T2 primarily.
 
+**Automated tests**:
+- Package: `packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py`
+- API unit: `apps/backend/tests/unit/test_uj026_remarks_convert_issues.py`
+- Live API: `tests/live/test_uj026_metar_remarks_live.py`
+- Playwright: `apps/e2e/uj026-metar-remarks.e2e.spec.ts`
+
 **Source**: S018 / EV-013
 
 ---

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "overrides": {
       "vite": "6.4.3",
       "vitest": "4.1.9",
-      "@vitest/coverage-v8": "4.1.9"
+      "@vitest/coverage-v8": "4.1.9",
+      "brace-expansion@<1.1.16": ">=1.1.16 <2",
+      "brace-expansion@>=2.0.0 <2.1.2": ">=2.1.2 <3",
+      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "@vitest/coverage-v8": "4.1.9",
       "brace-expansion@<1.1.16": ">=1.1.16 <2",
       "brace-expansion@>=2.0.0 <2.1.2": ">=2.1.2 <3",
-      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7"
+      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7",
+      "js-yaml@>=4.0.0 <4.3.0": ">=4.3.0 <5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   vite: 6.4.3
   vitest: 4.1.9
   '@vitest/coverage-v8': 4.1.9
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
+  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
 
 importers:
 
@@ -2367,11 +2370,11 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -5781,12 +5784,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6519,11 +6522,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minipass@7.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   brace-expansion@<1.1.16: '>=1.1.16 <2'
   brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
   brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
+  js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5'
 
 importers:
 
@@ -2879,8 +2880,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@28.1.0:
@@ -4343,7 +4344,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6313,7 +6314,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 

--- a/tests/live/test_uj026_metar_remarks_live.py
+++ b/tests/live/test_uj026_metar_remarks_live.py
@@ -1,0 +1,90 @@
+"""Live UJ-026 / #667 — annex3 REMARKS_EXCLUDED + iwxxm_us humanReadableText.
+
+Requires LIVE_API_URL (or STAGING_API_URL) and ADMIN_EMAIL / ADMIN_PASSWORD.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+pytestmark = [pytest.mark.live, pytest.mark.live_api]
+
+TAC_RMK = "METAR KJFK 231751Z 18012KT 10SM FEW040 15/07 A3005 RMK AO2 SLP176="
+TAC_FREE = "METAR KJFK 231751Z 18012KT 10SM CLR 15/07 A3005 RMK AO2 WND DATA ESTMD="
+
+
+def _live_api_base() -> str | None:
+    return os.environ.get("LIVE_API_URL") or os.environ.get("STAGING_API_URL")
+
+
+@pytest.fixture(scope="module")
+def live_api() -> str:
+    base = _live_api_base()
+    if not base:
+        pytest.skip("LIVE_API_URL / STAGING_API_URL not set")
+    return base.rstrip("/")
+
+
+@pytest.fixture(scope="module")
+def live_headers(live_api: str) -> dict[str, str]:
+    email = os.environ.get("ADMIN_EMAIL")
+    password = os.environ.get("ADMIN_PASSWORD")
+    if not email or not password:
+        pytest.skip("ADMIN_EMAIL / ADMIN_PASSWORD required for live convert")
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(
+            f"{live_api}/auth/login",
+            json={"email": email, "password": password},
+        )
+        if resp.status_code != 200:
+            pytest.skip(f"live login failed: {resp.status_code}")
+        data = resp.json()
+        token = (
+            data.get("access_token")
+            or data.get("token")
+            or (data.get("session") or {}).get("access_token")
+        )
+        if not token:
+            pytest.skip("live login missing access_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _convert(live_api: str, headers: dict[str, str], *, tac: str, profile: str) -> dict:
+    with httpx.Client(timeout=120.0) as client:
+        resp = client.post(
+            f"{live_api}/api/v1/convert",
+            headers=headers,
+            data={
+                "manual_text": tac,
+                "product": "METAR",
+                "profile": profile,
+                "iwxxm_version": "2025-2",
+                "lint": "false",
+            },
+        )
+    assert resp.status_code == 200, resp.text[:500]
+    return resp.json()
+
+
+def test_uj026_live_annex3_remarks_excluded(
+    live_api: str, live_headers: dict[str, str]
+) -> None:
+    body = _convert(live_api, live_headers, tac=TAC_RMK, profile="annex3")
+    codes = [i.get("code") for i in (body.get("issues") or [])]
+    assert "REMARKS_EXCLUDED" in codes, f"issues={body.get('issues')!r}"
+    xml = (body.get("results") or [{}])[0].get("content") or ""
+    assert "iwxxm-us:Addendum" not in xml
+
+
+def test_uj026_live_iwxxm_us_human_readable(
+    live_api: str, live_headers: dict[str, str]
+) -> None:
+    body = _convert(live_api, live_headers, tac=TAC_FREE, profile="iwxxm_us")
+    codes = [i.get("code") for i in (body.get("issues") or [])]
+    assert "REMARKS_EXCLUDED" not in codes
+    xml = (body.get("results") or [{}])[0].get("content") or ""
+    assert "iwxxm-us:humanReadableText" in xml
+    assert "WND DATA ESTMD" in xml

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,11 +12,11 @@ active_session:
     Handle Remark Portion of METARs (#667) — annex3 exclusion messaging + iwxxm_us
     never-drop/freeText + T/P emit
   status: in_progress
-  branch: cursor/metar-remarks-667-2e2e
+  branch: cursor/metar-remarks-live-e2e-2e2e
   orchestrator: 16-evolve
   evolve_cycle_id: EV-013
   artifacts_dir: docs/sessions/S018-metar-remarks-667/
-  current_stage: 08-verify-build
+  current_stage: 13-deploy-smoke
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched: []
@@ -38,8 +38,8 @@ active_session:
       started: '2026-07-20'
       skip_rationale:
       note: >-
-        Implementation landed (07-build); 08-verify-build in_progress;
-        Standard routing
+        Implementation landed (07-build); 13-deploy-smoke completed
+        pass_with_advisories (#750 live; #752 pending)
     - stage: 01-requirements
       required: true
       mode: delta
@@ -114,8 +114,13 @@ active_session:
     - stage: 13-deploy-smoke
       required: true
       mode: full
-      status: pending
+      status: completed
+      started: '2026-07-20'
+      completed: '2026-07-20'
       skip_rationale:
+      note: >-
+        partial PASS — pass_with_advisories; full UJ-026 annex3 blocked on #752 deploy
+
 sessions:
 
   - id: S017-skill-trim-retro
@@ -2786,9 +2791,25 @@ stages:
   13-deploy-smoke:
     status: completed
     started_at: "2026-07-19"
-    completed_at: "2026-07-19"
-    session_id: S014-package-publish-validation
+    completed_at: "2026-07-20"
+    session_id: S018-metar-remarks-667
     delta_substages:
+      - id: S018-metar-remarks-667
+        session_id: S018-metar-remarks-667
+        evolve_cycle_id: EV-013
+        status: completed
+        started_at: '2026-07-20'
+        completed_at: '2026-07-20'
+        mode: full
+        note: >-
+          partial PASS — full UJ-026 annex3 blocked on #752 deploy; staging #750 live @
+          ccfb8cc; H1/H3/H4/H5 pass; REMARKS_EXCLUDED API echo needs #752
+        report: docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
+        overall: pass_with_advisories
+        merge_sha: ccfb8ccc01a7c99aa3e5b3895682a8b1b3e21126
+        pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/750
+        pr_number: 750
+        followup_pr: 752
       - id: S016-manual-tac-input-modes
         session_id: S016-manual-tac-input-modes
         evolve_cycle_id: EV-012
@@ -2835,6 +2856,10 @@ stages:
         report: docs/sessions/S014-package-publish-validation/reports/deploy-smoke.md
         hard_gates_report: docs/sessions/S014-package-publish-validation/reports/t66-hard-publish-gates.md
     notes:
+      - >-
+        2026-07-20 S018/EV-013 13-deploy-smoke COMPLETE / pass_with_advisories —
+        partial PASS; #750 live @ ccfb8cc; H1/H3/H4/H5 pass; full UJ-026 annex3 blocked
+        on #752 deploy
       - >-
         2026-07-20 S016/EV-012 13-deploy-smoke COMPLETE / PASS — PR #746 merged 37be5f8;
         CI/CD 29766213356 SUCCESS; Render LIVE; H0c/H3/H4/H5 + AHL 200 + COLLECT 501 +
@@ -2900,10 +2925,10 @@ stages:
     session_id: S018-metar-remarks-667
     evolve_cycle_id: EV-013
     started_at: '2026-07-20'
-    current_stage: 16-evolve
+    current_stage: 13-deploy-smoke
     note: >-
-      S018/EV-013 — Phase 0 intake complete via Assumed (E13-1/E13-2/E13-3); AskQuestion UI
-      waived (cloud); Standard routing; moving to 01-requirements
+      S018/EV-013 — 13-deploy-smoke completed pass_with_advisories; #750 live @
+      ccfb8cc; full UJ-026 annex3 blocked on #752
 
 stages_pending: []
 
@@ -2921,9 +2946,9 @@ deployment:
   staging:
     status: deployed
     last_verified: '2026-07-20'
-    commit_deployed: 37be5f8
-    commit_head: 37be5f8
-    drift: false
+    commit_deployed: ccfb8cc
+    commit_head: 99102ab
+    drift: true
     urls:
       api: https://metar-to-iwxxm-api.onrender.com
       frontend: https://metar-to-iwxxm-frontend-v4-web.onrender.com
@@ -2941,10 +2966,14 @@ deployment:
       H3: pass
       H4: pass
       H5: pass
+      UJ026_annex3: pending
       AHL_convert_bulletin: pass
       COLLECT_ingest_collect: expected_501
       Playwright_workbench: pass
     notes:
+      - S018/EV-013 #750 METAR remarks live @ ccfb8cc; 13-deploy-smoke pass_with_advisories
+      - uj026_annex3 pending #752 (REMARKS_EXCLUDED API echo); drift true until #752 lands (main tip will move)
+      - H1/H3/H4/H5 pass; iwxxm_us UJ-026 retain PASS on staging
       - S016/EV-012 Manual TAC Input modes live @ 37be5f8 (PR #746); 13-deploy-smoke PASS
       - CI/CD run 29766213356 SUCCESS including Deploy; images 20260720180925-37be5f8
       - H0c PASS; H3 21/21; H4 2/2; H5 PASS; AHL convert-bulletin 200; COLLECT ingest-collect 501; live Playwright 
@@ -3012,6 +3041,25 @@ issue_log:
     resolved_at: "2026-07-12"
 
 decisions_log:
+  - id: D-S018-EV013-13-partial
+    stage: 13-deploy-smoke
+    date: '2026-07-20'
+    timestamp: '2026-07-20'
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    skill: 13-deploy-smoke
+    skill_id: 13-deploy-smoke
+    topic: '13-deploy-smoke partial PASS — #750 live; #752 pending'
+    decision: >-
+      Staging #750 live @ ccfb8cc; H1/H3/H4/H5 pass; iwxxm_us UJ-026 retain PASS.
+      Full UJ-026 annex3 (REMARKS_EXCLUDED API echo) blocked on #752 merge/deploy.
+      Record 13-deploy-smoke completed with overall pass_with_advisories; drift true
+      until #752 lands.
+    status: confirmed
+    resolved_at: '2026-07-20'
+    summary: >-
+      partial PASS — #750 live; REMARKS_EXCLUDED API echo needs #752;
+      pass_with_advisories
   - id: D-S018-aq-waive-cloud
     stage: 00-context
     date: '2026-07-20'
@@ -5584,6 +5632,19 @@ decisions_log:
     status: confirmed
 
 artifacts:
+  - path: docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
+    type: report
+    kind: deploy-smoke
+    stage: 13-deploy-smoke
+    skill_id: 13-deploy-smoke
+    session_id: S018-metar-remarks-667
+    evolve_cycle_id: EV-013
+    created_at: '2026-07-20'
+    updated_at: '2026-07-20'
+    status: completed
+    overall: pass_with_advisories
+    note: >-
+      partial PASS — full UJ-026 annex3 blocked on #752 deploy; #750 live @ ccfb8cc
   - path: docs/sessions/S016-manual-tac-input-modes/reports/e2e-report.md
     type: report
     kind: e2e-report
@@ -6911,8 +6972,11 @@ evolve_cycles:
         - 05-verify-tech
         - 06-tech-tooling
         - 10-e2e
-    current_stage: 08-verify-build
+    current_stage: 13-deploy-smoke
     notes:
+      - >-
+        2026-07-20 S018/EV-013 13-deploy-smoke completed pass_with_advisories —
+        #750 live @ ccfb8cc; full UJ-026 annex3 blocked on #752
       - >-
         2026-07-20 S018/EV-013 — implementation landed (07-build); 08-verify-build
         in_progress; commits 8ee3176 (docs scope) + 19d6684 (feat remarks)
@@ -6934,7 +6998,8 @@ evolve_cycles:
         status: in_progress
         started: '2026-07-20'
         note: >-
-          Orchestrator in_progress; implementation landed; verification next
+          Orchestrator in_progress; 13-deploy-smoke completed pass_with_advisories;
+          #750 live; #752 pending for full UJ-026 annex3
       01-requirements:
         status: completed
         mode: delta
@@ -6983,19 +7048,25 @@ evolve_cycles:
         status: pending
         mode: full
       13-deploy-smoke:
-        status: pending
+        status: completed
         mode: full
+        started: '2026-07-20'
+        completed: '2026-07-20'
+        overall: pass_with_advisories
+        note: >-
+          partial PASS — full UJ-026 annex3 blocked on #752 deploy; #750 live @
+          ccfb8cc; report docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
     gates:
       a_to_b: pending
       b_to_c: pending
       c_to_d: pending
-      deploy: pending
+      deploy: pass_with_advisories
     checkpoints:
       phase_a: pending
       phase_b: pending
       phase_c: pending
       phase_d: pending
-      deploy: pending
+      deploy: pass_with_advisories
     adrs: []
     artifacts:
       - path: docs/sessions/S018-metar-remarks-667/session-brief.md
@@ -7006,6 +7077,9 @@ evolve_cycles:
         status: present
       - path: packages/tac2iwxxm/tests/test_issue_667_metar_remarks.py
         status: present
+      - path: docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
+        status: completed
+        kind: deploy-smoke
       - path: docs/sessions/S018-metar-remarks-667/reports/evolve-summary.md
         status: pending
     issues: []
@@ -9419,12 +9493,16 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/metar-remarks-667-2e2e
+  current_branch: cursor/metar-remarks-live-e2e-2e2e
   ahead_of_origin: 0
   pushed: true
   pending_commit:
-  tip_sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
+  tip_sha: 99102ab703efba985c976359ca06b3b4ed5844ac
   notes:
+    - >-
+      2026-07-20 S018/EV-013 — tip 99102ab on cursor/metar-remarks-live-e2e-2e2e
+      (deploy-smoke report); fix e13138f (#752); staging deployed ccfb8cc (#750);
+      drift until #752 lands
     - >-
       2026-07-20 S018/EV-013 — commits 8ee3176 (docs scope) + 19d6684 (feat remarks);
       tip 19d6684; current_stage 08-verify-build; branch synced with origin
@@ -9592,16 +9670,29 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
-    - name: cursor/metar-remarks-667-2e2e
+    - name: cursor/metar-remarks-live-e2e-2e2e
       base: main
       status: active
+      created_at: '2026-07-20'
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      purpose: 'EV-013 live e2e + REMARKS_EXCLUDED API echo (#752) after #750'
+      pushed: true
+      tip_sha: 99102ab703efba985c976359ca06b3b4ed5844ac
+      note: >-
+        13-deploy-smoke partial PASS; blocked on #752 deploy for full UJ-026 annex3
+    - name: cursor/metar-remarks-667-2e2e
+      base: main
+      status: superseded
       created_at: '2026-07-20'
       session_id: S018-metar-remarks-667
       evolve_cycle_id: EV-013
       purpose: 'EV-013 / S018 Handle METAR remarks (#667) — annex3 + iwxxm_us T/P'
       pushed: true
       tip_sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
-      note: Cloud agent naming override; Standard routing; 08-verify-build in_progress
+      note: >-
+        Cloud agent naming override; #750 merged to main; superseded by
+        cursor/metar-remarks-live-e2e-2e2e
     - name: chore/S017-skill-trim-retro
       base: main
       status: active
@@ -9898,6 +9989,35 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 99102ab703efba985c976359ca06b3b4ed5844ac
+      short: 99102ab
+      branch: cursor/metar-remarks-live-e2e-2e2e
+      message: '[S018] docs: EV-013 deploy-smoke report for #667 staging verify'
+      stage: 13-deploy-smoke
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      timestamp: '2026-07-20T20:39:48Z'
+      files_changed:
+        - docs/sessions/S018-metar-remarks-667/reports/deploy-smoke.md
+      pushed: true
+    - sha: e13138fb6b8e4444f62a3930585e5b0e7bb4ea71
+      short: e13138f
+      branch: cursor/metar-remarks-live-e2e-2e2e
+      message: '[EV-013] fix: echo REMARKS_EXCLUDED on convert API + UJ-026 e2e'
+      stage: 13-deploy-smoke
+      session_id: S018-metar-remarks-667
+      evolve_cycle_id: EV-013
+      timestamp: '2026-07-20T20:34:26Z'
+      files_changed:
+        - README.md
+        - apps/backend/src/api.py
+        - apps/backend/src/utilities/conversion.py
+        - apps/backend/tests/unit/test_uj026_remarks_convert_issues.py
+        - apps/e2e/uj026-metar-remarks.e2e.spec.ts
+        - docs/user-journeys.md
+        - tests/live/test_uj026_metar_remarks_live.py
+      pushed: true
+      note: 'PR #752 — REMARKS_EXCLUDED API echo; awaiting merge/deploy'
     - sha: 19d6684e5205bf46013a385ecf91d40b94bbb121
       short: 19d6684
       branch: cursor/metar-remarks-667-2e2e


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up for #667 / EV-013 after #750: staging still dropped `REMARKS_EXCLUDED` on successful `POST /api/v1/convert` because success-path tac2iwxxm issues were not absorbed into the HTTP response.

Also clears the Validate gate failures from newly published npm advisories (`brace-expansion`, `js-yaml`).

## Changes

- Echo `convert_issues` (e.g. `REMARKS_EXCLUDED`) from `convert_metar_tac_with_metadata` into `/api/v1/convert`
- Normalize issue severities (str / enum-like) before mapping to API severity
- UJ-026 coverage: backend unit, live API, Playwright (expand-when-collapsed fix)
- pnpm overrides for patched `brace-expansion` and `js-yaml` (frontend `audit:ci`)

## Test plan

- [x] Backend unit + severity absorb coverage
- [x] CI green on branch ([run](https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29781715075))
- [ ] After merge: re-verify staging annex3 returns `REMARKS_EXCLUDED`, then close #667

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f80f9-6832-7a78-a591-0fed8f672e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f80f9-6832-7a78-a591-0fed8f672e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure tac2iwxxm convert issues, including REMARKS_EXCLUDED, are surfaced via the convert API and validated end-to-end for UJ-026 METAR remarks.

New Features:
- Expose tac2iwxxm non-fatal convert issues (e.g., REMARKS_EXCLUDED) in /api/v1/convert responses for both preview and hard converts.
- Add UJ-026 METAR remarks end-to-end coverage across API unit, live API, and Playwright UI tests.

Enhancements:
- Update conversion utilities and API soft-preview handling to always capture and forward convert_issues for successful METAR converts.
- Expand UJ-026 user-journey documentation with explicit references to the new tests and coverage.

Documentation:
- Add a deploy-smoke report documenting partial PASS for EV-013 METAR remarks and the dependency on the follow-up REMARKS_EXCLUDED API fix PR.

Tests:
- Introduce apps/backend unit tests verifying REMARKS_EXCLUDED echoing and iwxxm_us free-text retention in convert responses.
- Add live API tests and a Playwright spec that gate UJ-026 behavior for annex3 exclusion and iwxxm_us retention.
- Update README test badges to reflect the additional Playwright e2e coverage.

Chores:
- Refresh workflow-state and evolve-cycle metadata to record EV-013 deploy-smoke completion, staging drift, and branch supersession for the METAR remarks work.