### PR TITLE
[S019/EV-014] 07-build M1: dissemination package + egress allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 INGEST_POLLER_URL=
 INGEST_POLL_INTERVAL_SEC=30
+
+# F16–F19 dissemination egress (ADR-029). Comma-separated hostnames and/or CIDRs.
+# Empty = fail-closed (no user-URI / user-host egress). Never put secrets here —
+# pasted BYOC credentials are memory-only on preflight/send.
+DISSEMINATION_EGRESS_ALLOWLIST=

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PY_LINT := apps/backend/src apps/backend/tests \
 	packages/tac2iwxxm/src packages/tac2iwxxm/tests \
 	packages/iwxxm-validate/src packages/iwxxm-validate/tests \
 	packages/tac-validate/src packages/tac-validate/tests \
+	packages/dissemination/src packages/dissemination/tests \
 	tests
 
 .PHONY: install test test-unit vendor-sync \
@@ -114,13 +115,9 @@ lint-iwxxm-validate:
 lint-tac-validate:
 	$(UV) run ruff check --force-exclude packages/tac-validate/src packages/tac-validate/tests
 
-# F16–F19 — skip until T1.1/T1.2 scaffolds packages/dissemination.
+# F16–F19 — package present after T1.1; keep target for scoped lint.
 lint-dissemination:
-	@if [ -d packages/dissemination/src ]; then \
-		$(UV) run ruff check --force-exclude packages/dissemination/src packages/dissemination/tests; \
-	else \
-		echo "skip: packages/dissemination not scaffolded (T1.1/T1.2)"; \
-	fi
+	$(UV) run ruff check --force-exclude packages/dissemination/src packages/dissemination/tests
 
 lint-frontend:
 	$(PNPM) --filter @metar/frontend run lint

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "tac2iwxxm",
     "tac-validate",
     "iwxxm-validate",
+    "dissemination",
     "fastapi>=0.110",
     "uvicorn>=0.23",
     "python-multipart>=0.0.20",
@@ -123,3 +124,4 @@ metar-auth = { workspace = true }
 metar-shared = { workspace = true }
 tac-validate = { workspace = true }
 iwxxm-validate = { workspace = true }
+dissemination = { workspace = true }

--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -23,7 +23,7 @@ try:
     # Try relative imports first (when run as module in Docker)
     from .config.icao_opmet import get_icao_region, get_translation_centre_info
     from .msgspec_http import msgspec_json_response
-    from .routers import evaluation, icao_opmet, validation, work_sessions
+    from .routers import dissemination, evaluation, icao_opmet, validation, work_sessions
     from .schemas.conversion import (
         ConversionIssue,
         ConversionIssueSeverity,
@@ -66,7 +66,7 @@ except ImportError:
     # Fall back to direct imports (when sys.path is set for local development)
     from config.icao_opmet import get_icao_region, get_translation_centre_info
     from msgspec_http import msgspec_json_response
-    from routers import evaluation, icao_opmet, validation, work_sessions
+    from routers import dissemination, evaluation, icao_opmet, validation, work_sessions
     from schemas.conversion import (
         ConversionIssue,
         ConversionIssueSeverity,
@@ -627,6 +627,12 @@ try:
     logger.info("DEBUG: included work sessions routers successfully")
 except Exception as e:  # pragma: no cover - defensive
     logger.error(f"DEBUG: Failed to include work sessions routers: {e}", exc_info=True)
+
+try:
+    app.include_router(dissemination.router)
+    logger.info("DEBUG: included dissemination router successfully")
+except Exception as e:  # pragma: no cover - defensive
+    logger.error(f"DEBUG: Failed to include dissemination router: {e}", exc_info=True)
 
 try:
     app.include_router(icao_opmet.router)

--- a/apps/backend/src/routers/dissemination.py
+++ b/apps/backend/src/routers/dissemination.py
@@ -1,0 +1,225 @@
+"""Thin FastAPI routers for dissemination preflight/send (F16–F19 / ADR-030)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import msgspec
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from dissemination.db_preflight import (
+    EgressDenied,
+    dialect_for_sink,
+    normalize_sqlalchemy_uri,
+    run_db_preflight,
+)
+from dissemination.handles import default_handle_store
+from dissemination.models import (
+    PreflightRequest,
+    PreflightResponse,
+    SendRequest,
+    SendResponse,
+)
+from dissemination.rate_limit import RateLimitExceeded, default_rate_limiter
+from dissemination.redact import redact_secrets
+from dissemination.writer_contract import CONTRACT_TABLE, apply_writer_contract
+
+from ..msgspec_http import msgspec_json_response
+from ..utilities.security import verify_supabase_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/dissemination", tags=["Dissemination"])
+
+_DB_SINKS = frozenset({"postgres", "mysql", "sqlserver", "sqlite"})
+_decoder_preflight = msgspec.json.Decoder(PreflightRequest)
+_decoder_send = msgspec.json.Decoder(SendRequest)
+
+
+def _user_id(user: dict[str, Any]) -> str:
+    return str(user.get("sub") or user.get("user_id") or "anonymous")
+
+
+async def _read_struct(request: Request, decoder: msgspec.json.Decoder) -> Any:
+    raw = await request.body()
+    try:
+        return decoder.decode(raw)
+    except msgspec.DecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=redact_secrets(f"invalid request body: {exc}"),
+        ) from exc
+
+
+@router.post("/preflight")
+async def dissemination_preflight(
+    request: Request,
+    user: dict[str, Any] = Depends(verify_supabase_token),
+):
+    """Run sink preflight; return schema diffs and optional memory-only handle."""
+    uid = _user_id(user)
+    try:
+        default_rate_limiter.check(uid)
+    except RateLimitExceeded as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    req: PreflightRequest = await _read_struct(request, _decoder_preflight)
+
+    if req.sink_type not in _DB_SINKS:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=f"sink_type {req.sink_type!r} not implemented in this milestone",
+        )
+
+    try:
+        result = await run_db_preflight(req)
+    except EgressDenied as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=redact_secrets(str(exc)),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=redact_secrets(str(exc)),
+        ) from exc
+    except Exception as exc:
+        logger.exception("dissemination preflight failed: %s", redact_secrets(str(exc)))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="preflight failed",
+        ) from exc
+
+    handle = None
+    if result.ok:
+        handle = default_handle_store.create(
+            user_id=uid,
+            sink_type=req.sink_type,
+            uri=req.uri,
+            params=dict(req.params),
+        )
+    resp = PreflightResponse(
+        ok=result.ok,
+        connectivity_ok=result.connectivity_ok,
+        diffs=result.diffs,
+        handle=handle,
+        detail=result.detail,
+    )
+    return msgspec_json_response(resp)
+
+
+@router.post("/send")
+async def dissemination_send(
+    request: Request,
+    user: dict[str, Any] = Depends(verify_supabase_token),
+):
+    """Send IWXXM via a green preflight handle or inline sink params."""
+    uid = _user_id(user)
+    try:
+        default_rate_limiter.check(uid)
+    except RateLimitExceeded as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    req: SendRequest = await _read_struct(request, _decoder_send)
+
+    sink_type = req.sink_type
+    uri = req.uri
+    if req.handle:
+        rec = default_handle_store.get(req.handle, user_id=uid)
+        if rec is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="invalid or expired preflight handle",
+            )
+        sink_type = rec.sink_type  # type: ignore[assignment]
+        uri = rec.uri
+
+    if sink_type not in _DB_SINKS:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=f"sink_type {sink_type!r} not implemented in this milestone",
+        )
+    if not uri:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="uri or valid handle required",
+        )
+    if not req.iwxxm_xml:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="iwxxm_xml is required",
+        )
+
+    # Re-check allowlist / contract before write.
+    try:
+        pre = await run_db_preflight(
+            PreflightRequest(sink_type=sink_type, uri=uri, ddl=True)  # type: ignore[arg-type]
+        )
+    except EgressDenied as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=redact_secrets(str(exc)),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=redact_secrets(str(exc)),
+        ) from exc
+
+    if not pre.ok:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="writer-contract not green; run preflight with ddl=true",
+        )
+
+    dialect = dialect_for_sink(sink_type)
+    sa_uri = normalize_sqlalchemy_uri(uri, sink_type)
+    engine = create_async_engine(sa_uri)
+    upload_key = f"kv_{uuid.uuid4().hex}"
+    try:
+        await apply_writer_contract(engine, dialect=dialect)
+        from sqlalchemy import text
+
+        insert_sql = text(
+            f"INSERT INTO {CONTRACT_TABLE} "
+            "(id, product, icao, observation_time, iwxxm_version, iwxxm_xml, "
+            "tac_text, upload_key) "
+            "VALUES (:id, :product, :icao, :observation_time, :iwxxm_version, "
+            ":iwxxm_xml, :tac_text, :upload_key)"
+        )
+        async with engine.begin() as conn:
+            await conn.execute(
+                insert_sql,
+                {
+                    "id": str(uuid.uuid4()),
+                    "product": req.product or "metar",
+                    "icao": None,
+                    "observation_time": None,
+                    "iwxxm_version": req.iwxxm_version or "2025-2",
+                    "iwxxm_xml": req.iwxxm_xml,
+                    "tac_text": req.tac_text,
+                    "upload_key": upload_key,
+                },
+            )
+    except Exception as exc:
+        logger.exception("dissemination send failed: %s", redact_secrets(str(exc)))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=redact_secrets(f"send failed: {exc}"),
+        ) from exc
+    finally:
+        await engine.dispose()
+
+    if req.handle:
+        default_handle_store.pop(req.handle, user_id=uid)
+
+    return msgspec_json_response(SendResponse(ok=True, kv_upload_key=upload_key, detail="uploaded"))

--- a/apps/backend/tests/unit/test_dissemination_api.py
+++ b/apps/backend/tests/unit/test_dissemination_api.py
@@ -1,0 +1,133 @@
+"""API tests for dissemination preflight/send (T2.3 / ADR-029 / api-contract)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dissemination.handles import default_handle_store
+from dissemination.rate_limit import DisseminationRateLimiter
+from src import api as api_module
+from src.routers import dissemination as diss_router
+from src.utilities.security import verify_supabase_token
+
+
+async def _auth_user() -> dict:
+    return {"sub": "user-dissemination-test", "user_id": "user-dissemination-test"}
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DISABLE_AUTH", "true")
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "")
+    lim = DisseminationRateLimiter(max_per_minute=1000)
+    monkeypatch.setattr(diss_router, "default_rate_limiter", lim)
+    default_handle_store.clear()
+    api_module.app.dependency_overrides[verify_supabase_token] = _auth_user
+    with TestClient(api_module.app) as c:
+        yield c
+    api_module.app.dependency_overrides.clear()
+    default_handle_store.clear()
+
+
+def _sqlite_uri(tmp_path: Path) -> str:
+    db = tmp_path / "dissem.db"
+    return f"sqlite+aiosqlite:///{db}"
+
+
+def test_preflight_msgspec_shape_and_handle_memory_only(client: TestClient, tmp_path: Path) -> None:
+    uri = _sqlite_uri(tmp_path)
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "sqlite", "uri": uri, "ddl": True, "product": "metar"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["connectivity_ok"] is True
+    assert body["diffs"] == []
+    assert body["handle"]
+    assert "password" not in resp.text.lower()
+    assert uri not in resp.text
+
+
+def test_preflight_redacts_secret_in_error_detail(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "db.example.com")
+    secret_uri = "postgresql://op:SuperSecretPass@db.example.com:5432/wx"
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "postgres", "uri": secret_uri, "ddl": False}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code in {400, 403, 500}
+    assert "SuperSecretPass" not in resp.text
+
+
+def test_preflight_fail_closed_remote_host_when_allowlist_empty(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps(
+            {
+                "sink_type": "postgres",
+                "uri": "postgresql://u:p@db.example.com/wx",
+                "ddl": False,
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 403
+    assert "fail-closed" in resp.text or "allowlist" in resp.text.lower()
+    assert ":p@" not in resp.text
+
+
+def test_rate_limit_denies_after_budget(client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lim = DisseminationRateLimiter(max_per_minute=3)
+    monkeypatch.setattr(diss_router, "default_rate_limiter", lim)
+    uri = _sqlite_uri(tmp_path)
+    payload = json.dumps({"sink_type": "sqlite", "uri": uri, "ddl": True})
+    headers = {"Content-Type": "application/json", "Authorization": "Bearer t"}
+    codes = [
+        client.post("/api/v1/dissemination/preflight", content=payload, headers=headers).status_code for _ in range(4)
+    ]
+    assert 429 in codes
+
+
+def test_send_with_handle_uploads_sqlite(client: TestClient, tmp_path: Path) -> None:
+    uri = _sqlite_uri(tmp_path)
+    pre = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "sqlite", "uri": uri, "ddl": True}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert pre.status_code == 200, pre.text
+    handle = pre.json()["handle"]
+    send = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "handle": handle,
+                "iwxxm_xml": "<iwxxm:METAR xmlns:iwxxm='http://icao.int/iwxxm/2025-2'/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert send.status_code == 200, send.text
+    body = send.json()
+    assert body["ok"] is True
+    assert body["kv_upload_key"]
+    assert "password" not in send.text.lower()
+
+
+def test_send_invalid_handle_rejected(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps({"handle": "not-a-real-handle", "iwxxm_xml": "<x/>", "product": "metar"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 400
+    assert "handle" in resp.text.lower()

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -21,19 +21,19 @@
 | tac-validate | TAC lint / rules | MIT | workspace path |
 | iwxxm-validate | XSD + Schematron (F2) | MIT | workspace path |
 | gifts | ~~Conversion~~ | — | **Removed at F6 cutover** (ADR-014) |
-| dissemination | F16–F19 sinks (Planned) | MIT | workspace path (ADR-030) |
+| dissemination | F16–F19 sinks | MIT | workspace path (ADR-030) |
 
-### packages/dissemination (Planned — S019 / EV-014)
+### packages/dissemination (S019 / EV-014 — M1)
 
 | Package | Purpose | License | Source |
 |---------|---------|---------|--------|
-| sqlalchemy | Async engine / DDL / writer-contract | MIT | PyPI (≥2.0; already on backend) |
-| asyncpg | Postgres async driver | Apache-2.0 | PyPI (already on backend) |
-| aiomysql | MySQL/MariaDB async | MIT | PyPI — **new** (`>=0.2.0`; pin in M1) |
-| aiosqlite | SQLite async | MIT | PyPI — **new** (`>=0.20.0`; pin in M1) |
-| aioodbc | SQL Server async (ODBC) | MIT | PyPI — **new** (`>=0.5.0`; E14-06=A); document ODBC driver in deploy |
-| aiosmtplib | EDIS SMTP submit | MIT | PyPI — **new** (`>=3.0.0`; pin in M1) |
-| msgspec | Preflight/send models + HTTP encode | Apache-2.0 | PyPI (E14-07=A) |
+| sqlalchemy[asyncio] | Async engine / DDL / writer-contract | MIT | PyPI (`>=2.0`) |
+| asyncpg | Postgres async driver | Apache-2.0 | PyPI (`>=0.29`) |
+| aiomysql | MySQL/MariaDB async | MIT | PyPI (`>=0.2.0`) |
+| aiosqlite | SQLite async | MIT | PyPI (`>=0.20.0`) |
+| aioodbc | SQL Server async (ODBC) | MIT | PyPI (`>=0.5.0`; E14-06=A) |
+| aiosmtplib | EDIS SMTP submit | MIT | PyPI (`>=3.0.0`) |
+| msgspec | Preflight/send models + HTTP encode | Apache-2.0 | PyPI (`>=0.19`) |
 
 Package license: **MIT**. No FastAPI/Supabase imports. Backend already has `sqlalchemy` +
 `asyncpg` + `psycopg`; package may declare overlapping pins via workspace.

--- a/docs/ops/staging-secrets-matrix.md
+++ b/docs/ops/staging-secrets-matrix.md
@@ -48,7 +48,7 @@ Set on Render static site build environment:
 | `DISABLE_AUTH` | `false` | Yes | Production auth enabled per 04-tech-plan |
 | `PORT` | Render-injected | Yes | Bind `0.0.0.0:$PORT` |
 | `DATABASE_URL` | *(dashboard)* | If used | Postgres connection |
-| `DISSEMINATION_EGRESS_ALLOWLIST` | *(dashboard — sync: false)* | Yes (F16–F19) | Host/CIDR allowlist; **empty = fail-closed** (ADR-029 / E14-08). Staging lists Compose/CI wis2box hosts when harness runs. |
+| `DISSEMINATION_EGRESS_ALLOWLIST` | *(dashboard — sync: false)* | Yes (F16–F19) | Host/CIDR allowlist; **empty = fail-closed** (ADR-029 / E14-08). Staging lists Compose/CI wis2box hosts when harness runs. Documented in `.env.example`; secrets never stored — hosts/CIDRs only. |
 
 ### Deprecated (remove after migration)
 

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,25 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M2 T2.1
+/16-evolve continue S019/EV-014 — 07-build M2 T2.3
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Features | F16–F19 Planned |
 | Branch | `cursor/s019-07-build-m1-9a92` |
-| Last completed | **M1** T1.1–T1.5 (package + allowlist) |
-| Next | **M2** T2.1 writer-contract schema diff tests |
-
-## M1 done
-
-- `packages/dissemination` workspace member + deps
-- ADR-029 allowlist fail-closed helpers
-- `.env.example` + Compose stub targets (from T0.1)
+| PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/757 |
+| Done | M1 complete; M2 T2.1–T2.2 (writer-contract) |
+| Next | **T2.3** API tests: preflight/send msgspec + redaction + rate-limit |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close
-- TDD on M2 (T2.1 before T2.2)
+- T2.3 before T2.4 routers

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,7 +3,7 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — start 07-build M1 T1.1
+/16-evolve continue S019/EV-014 — 07-build M2 T2.1
 ```
 
 | Field | Value |
@@ -11,19 +11,17 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Features | F16–F19 Planned |
-| Branch / tip | `cursor/s019-06-tech-tooling-9a92` (06 tooling); base `main` @ `#753` |
-| Last completed stage | **06-tech-tooling** + Phase B Assumed PASS |
-| Next | **07-build** M1 T1.1 |
+| Branch | `cursor/s019-07-build-m1-9a92` |
+| Last completed | **M1** T1.1–T1.5 (package + allowlist) |
+| Next | **M2** T2.1 writer-contract schema diff tests |
 
-## Approved artifacts
+## M1 done
 
-- [execution-plan.md](reports/execution-plan.md) — **29** tasks; **T0.1 completed**
-- [06-tech-tooling.md](reports/06-tech-tooling.md)
-- [05-verify-tech-audit.md](reports/05-verify-tech-audit.md) — PASS
-- [ADR-030](../../adr/ADR-030-dissemination-package-architecture.md)
-- [ADR-029](../../adr/ADR-029-dissemination-ssrf-allowlist.md)
+- `packages/dissemination` workspace member + deps
+- ADR-029 allowlist fail-closed helpers
+- `.env.example` + Compose stub targets (from T0.1)
 
 ## Do not skip
 
-- Live BYOC close gate (Postgres + WIS2 + EDIS) before cycle close
-- TDD order on M1 (T1.1 test before T1.2 config)
+- Live BYOC close gate before cycle close
+- TDD on M2 (T2.1 before T2.2)

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,7 +3,7 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M2 T2.3
+/16-evolve continue S019/EV-014 — 07-build M2 T2.5
 ```
 
 | Field | Value |
@@ -12,10 +12,10 @@
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-07-build-m1-9a92` |
 | PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/757 |
-| Done | M1 complete; M2 T2.1–T2.2 (writer-contract) |
-| Next | **T2.3** API tests: preflight/send msgspec + redaction + rate-limit |
+| Done | M1; M2 through **T2.4** (preflight/send API) |
+| Next | **T2.5** Compose/Testcontainers PG+MySQL+SQLite |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close
-- T2.3 before T2.4 routers
+- T2.5 integration before marking M2 complete

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — **07-build** M1 **complete**; next M2 T2.1 |
+| **Active phase** | Phase C — **07-build** M2 in progress |
 | **Active milestone** | M2 — Multi-DB writer-contract + preflight/send API |
-| **Active task** | T2.1 (next) |
-| **Tasks** | 6 / **29** completed (T0.1 + T1.1–T1.5) |
+| **Active task** | T2.3 (next) |
+| **Tasks** | 8 / **29** completed (T0.1 + T1.1–T1.5 + T2.1–T2.2) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -62,8 +62,8 @@
 
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
-| T2.1 | Test | Writer-contract schema diff fixtures (PG/MySQL/SQLite); DDL create-if-missing | TC-F16-001/003; F16-R4 | T1.4 | pending |
-| T2.2 | Code | Engine adapters + versioned writer-contract DDL | ADR-030; E14-02 | T2.1 | pending |
+| T2.1 | Test | Writer-contract schema diff fixtures (PG/MySQL/SQLite); DDL create-if-missing | TC-F16-001/003; F16-R4 | T1.4 | **completed** |
+| T2.2 | Code | Engine adapters + versioned writer-contract DDL | ADR-030; E14-02 | T2.1 | **completed** |
 | T2.3 | Test | API tests: preflight/send msgspec shapes; secret redaction; handle memory-only; per-user rate-limit deny (ADR-029 §5) | api-contract; TC-F16-002; ADR-029 | T2.2 | pending |
 | T2.4 | Code | Thin backend routers `/dissemination/preflight` + `/send` (+ rate limit) | api-contract; E14-03/07; ADR-029 | T2.3 | pending |
 | T2.5 | Test | Compose/Testcontainers integration PG+MySQL+SQLite happy + mismatch | TC-F16-003; E14-09 | T2.4 | pending |

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -16,8 +16,8 @@
 |-------|-------|
 | **Active phase** | Phase C — **07-build** M2 in progress |
 | **Active milestone** | M2 — Multi-DB writer-contract + preflight/send API |
-| **Active task** | T2.3 (next) |
-| **Tasks** | 8 / **29** completed (T0.1 + T1.1–T1.5 + T2.1–T2.2) |
+| **Active task** | T2.5 (next) |
+| **Tasks** | 10 / **29** completed (through T2.4) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -64,8 +64,8 @@
 |------|------|-------------|-------------|------------|--------|
 | T2.1 | Test | Writer-contract schema diff fixtures (PG/MySQL/SQLite); DDL create-if-missing | TC-F16-001/003; F16-R4 | T1.4 | **completed** |
 | T2.2 | Code | Engine adapters + versioned writer-contract DDL | ADR-030; E14-02 | T2.1 | **completed** |
-| T2.3 | Test | API tests: preflight/send msgspec shapes; secret redaction; handle memory-only; per-user rate-limit deny (ADR-029 §5) | api-contract; TC-F16-002; ADR-029 | T2.2 | pending |
-| T2.4 | Code | Thin backend routers `/dissemination/preflight` + `/send` (+ rate limit) | api-contract; E14-03/07; ADR-029 | T2.3 | pending |
+| T2.3 | Test | API tests: preflight/send msgspec shapes; secret redaction; handle memory-only; per-user rate-limit deny (ADR-029 §5) | api-contract; TC-F16-002; ADR-029 | T2.2 | **completed** |
+| T2.4 | Code | Thin backend routers `/dissemination/preflight` + `/send` (+ rate limit) | api-contract; E14-03/07; ADR-029 | T2.3 | **completed** |
 | T2.5 | Test | Compose/Testcontainers integration PG+MySQL+SQLite happy + mismatch | TC-F16-003; E14-09 | T2.4 | pending |
 | T2.6 | Test | SQL Server path via aioodbc (CI skip if no ODBC; document) | E14-06; TC-F16-003 | T2.4 | pending |
 | T2.7 | Docs | ODBC driver notes in deploy.md / package README | E14-06 | T2.6 | pending |

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — **07-build** M1 |
-| **Active milestone** | M1 — Package scaffold + SSRF/allowlist |
-| **Active task** | T1.1 (completing) |
-| **Tasks** | 1 / **29** completed (T0.1); M1 in progress |
+| **Active phase** | Phase C — **07-build** M1 **complete**; next M2 T2.1 |
+| **Active milestone** | M2 — Multi-DB writer-contract + preflight/send API |
+| **Active task** | T2.1 (next) |
+| **Tasks** | 6 / **29** completed (T0.1 + T1.1–T1.5) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase B — **06-tech-tooling** complete (T0.1); next Phase B checkpoint → **07-build** M1 T1.1 |
-| **Active milestone** | M1 — Package scaffold + SSRF/allowlist (start after B→C) |
-| **Active task** | — (07-build not started) |
-| **Tasks** | 1 / **29** completed (T0.1) |
+| **Active phase** | Phase C — **07-build** M1 |
+| **Active milestone** | M1 — Package scaffold + SSRF/allowlist |
+| **Active task** | T1.1 (completing) |
+| **Tasks** | 1 / **29** completed (T0.1); M1 in progress |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -52,11 +52,11 @@
 
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
-| T1.1 | Test | Package layout + import smoke; no FastAPI/Supabase imports | ADR-030; plan-adherence | — | pending |
-| T1.2 | Config | Add `packages/dissemination` workspace member + pyproject deps (sqlalchemy, asyncpg, aiomysql, aiosqlite, aioodbc, aiosmtplib, msgspec) | dependency-inventory; E14-06 | T1.1 | pending |
-| T1.3 | Test | Allowlist parse + fail-closed when empty; DNS/private-range deny unit tests | ADR-029; TC-F16-002 | T1.2 | pending |
-| T1.4 | Code | SSRF/allowlist helpers in package; env `DISSEMINATION_EGRESS_ALLOWLIST` | env-contract; E14-08 | T1.3 | pending |
-| T1.5 | Config | `.env.example` + staging-secrets note; Makefile target for Compose stub (placeholder) | config-spec F16–F19 | T1.4 | pending |
+| T1.1 | Test | Package layout + import smoke; no FastAPI/Supabase imports | ADR-030; plan-adherence | — | **completed** |
+| T1.2 | Config | Add `packages/dissemination` workspace member + pyproject deps (sqlalchemy, asyncpg, aiomysql, aiosqlite, aioodbc, aiosmtplib, msgspec) | dependency-inventory; E14-06 | T1.1 | **completed** |
+| T1.3 | Test | Allowlist parse + fail-closed when empty; DNS/private-range deny unit tests | ADR-029; TC-F16-002 | T1.2 | **completed** |
+| T1.4 | Code | SSRF/allowlist helpers in package; env `DISSEMINATION_EGRESS_ALLOWLIST` | env-contract; E14-08 | T1.3 | **completed** |
+| T1.5 | Config | `.env.example` + staging-secrets note; Makefile target for Compose stub (placeholder) | config-spec F16–F19 | T1.4 | **completed** |
 
 ### M2 — Multi-DB writer-contract + preflight/send API (F16)
 

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -11,3 +11,9 @@ sink adapters, and SSRF/allowlist helpers ([ADR-030](../../docs/adr/ADR-030-diss
 **Coverage**
 
 - Local/CI: `make test-unit-dissemination` (95% branch gate)
+
+**Egress allowlist**
+
+- Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)
+- Empty ⇒ fail-closed
+- Compose wis2box harness: `make compose-wis2box-up` / `compose-wis2box-harness` (T3.3 fills service)

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -1,0 +1,13 @@
+# dissemination
+
+MIT package for F16–F19 operator dissemination: multi-DB writer-contract, WIS2/EDIS/AMHS
+sink adapters, and SSRF/allowlist helpers ([ADR-030](../../docs/adr/ADR-030-dissemination-package-architecture.md)).
+
+**Boundaries**
+
+- No FastAPI or Supabase imports
+- HTTP routers stay in `apps/backend` (thin)
+
+**Coverage**
+
+- Local/CI: `make test-unit-dissemination` (95% branch gate)

--- a/packages/dissemination/pyproject.toml
+++ b/packages/dissemination/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "dissemination"
+version = "0.1.0"
+description = "Dissemination sinks, writer-contract DDL, and SSRF/allowlist helpers (F16–F19)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dissemination"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/dissemination"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = ["E501"]

--- a/packages/dissemination/pyproject.toml
+++ b/packages/dissemination/pyproject.toml
@@ -5,7 +5,15 @@ description = "Dissemination sinks, writer-contract DDL, and SSRF/allowlist help
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+  "sqlalchemy[asyncio]>=2.0",
+  "asyncpg>=0.29",
+  "aiomysql>=0.2.0",
+  "aiosqlite>=0.20.0",
+  "aioodbc>=0.5.0",
+  "aiosmtplib>=3.0.0",
+  "msgspec>=0.19",
+]
 
 [build-system]
 requires = ["hatchling>=1.25"]

--- a/packages/dissemination/pyproject.toml
+++ b/packages/dissemination/pyproject.toml
@@ -25,6 +25,8 @@ packages = ["src/dissemination"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 branch = true

--- a/packages/dissemination/src/dissemination/__init__.py
+++ b/packages/dissemination/src/dissemination/__init__.py
@@ -1,0 +1,10 @@
+"""Dissemination sinks, writer-contract, and SSRF/allowlist helpers (F16–F19).
+
+No FastAPI or Supabase imports (ADR-030). Thin HTTP routers live in ``apps/backend``.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/packages/dissemination/src/dissemination/__init__.py
+++ b/packages/dissemination/src/dissemination/__init__.py
@@ -5,6 +5,23 @@ No FastAPI or Supabase imports (ADR-030). Thin HTTP routers live in ``apps/backe
 
 from __future__ import annotations
 
+from dissemination.allowlist import (
+    Allowlist,
+    AllowlistError,
+    EgressDenied,
+    load_allowlist_from_env,
+    parse_allowlist,
+    validate_egress_host,
+)
+
 __version__ = "0.1.0"
 
-__all__ = ["__version__"]
+__all__ = [
+    "Allowlist",
+    "AllowlistError",
+    "EgressDenied",
+    "__version__",
+    "load_allowlist_from_env",
+    "parse_allowlist",
+    "validate_egress_host",
+]

--- a/packages/dissemination/src/dissemination/__init__.py
+++ b/packages/dissemination/src/dissemination/__init__.py
@@ -13,15 +13,31 @@ from dissemination.allowlist import (
     parse_allowlist,
     validate_egress_host,
 )
+from dissemination.writer_contract import (
+    CONTRACT_TABLE,
+    CONTRACT_VERSION,
+    DiffKind,
+    SchemaDiff,
+    apply_writer_contract,
+    diff_writer_contract,
+    writer_contract_ddl,
+)
 
 __version__ = "0.1.0"
 
 __all__ = [
     "Allowlist",
     "AllowlistError",
+    "CONTRACT_TABLE",
+    "CONTRACT_VERSION",
+    "DiffKind",
     "EgressDenied",
+    "SchemaDiff",
     "__version__",
+    "apply_writer_contract",
+    "diff_writer_contract",
     "load_allowlist_from_env",
     "parse_allowlist",
     "validate_egress_host",
+    "writer_contract_ddl",
 ]

--- a/packages/dissemination/src/dissemination/allowlist.py
+++ b/packages/dissemination/src/dissemination/allowlist.py
@@ -1,0 +1,221 @@
+"""Egress allowlist and SSRF guards for dissemination destinations (ADR-029).
+
+``DISSEMINATION_EGRESS_ALLOWLIST`` is a comma-separated list of hostnames and/or
+CIDRs. An empty allowlist is **fail-closed** — no user-host egress.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from dataclasses import dataclass
+from typing import Iterable
+
+ENV_ALLOWLIST = "DISSEMINATION_EGRESS_ALLOWLIST"
+
+# Always blocked — cloud instance metadata / link-local IMDS style targets.
+_BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local / AWS IMDS
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+    ipaddress.ip_network("fd00:ec2::/32"),  # AWS IPv6 IMDS prefix (common)
+)
+
+_BLOCKED_HOSTNAMES = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.goog",
+        "instance-data",
+    }
+)
+
+
+class AllowlistError(ValueError):
+    """Raised when an allowlist token cannot be parsed."""
+
+
+class EgressDenied(PermissionError):
+    """Raised when a destination host is not permitted for egress."""
+
+
+@dataclass(frozen=True, slots=True)
+class Allowlist:
+    """Parsed egress allowlist entries."""
+
+    hostnames: frozenset[str]
+    networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.hostnames and not self.networks
+
+    @property
+    def entries(self) -> tuple[str, ...]:
+        hosts = sorted(self.hostnames)
+        nets = [str(n) for n in self.networks]
+        return tuple(hosts + nets)
+
+
+def parse_allowlist(raw: str | None) -> Allowlist:
+    """
+    Parse a comma-separated host/CIDR allowlist string.
+
+    Parameters
+    ----------
+    raw :
+        Allowlist text, or ``None`` / blank for an empty (fail-closed) list.
+
+    Returns
+    -------
+    Allowlist
+        Parsed hostnames and networks.
+
+    Raises
+    ------
+    AllowlistError
+        If a token is neither a hostname nor a CIDR/IP.
+    """
+    if raw is None or not raw.strip():
+        return Allowlist(hostnames=frozenset(), networks=())
+
+    hostnames: set[str] = set()
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for token in raw.split(","):
+        item = token.strip().lower()
+        if not item:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(item, strict=False))
+            continue
+        except ValueError:
+            pass
+        if _is_hostname(item):
+            hostnames.add(item)
+            continue
+        raise AllowlistError(f"invalid allowlist token: {token!r}")
+    return Allowlist(hostnames=frozenset(hostnames), networks=tuple(networks))
+
+
+def load_allowlist_from_env(
+    *,
+    env_var: str = ENV_ALLOWLIST,
+    environ: os._Environ[str] | None = None,
+) -> Allowlist:
+    """Load and parse ``DISSEMINATION_EGRESS_ALLOWLIST`` from the process environment."""
+    env = environ if environ is not None else os.environ
+    return parse_allowlist(env.get(env_var))
+
+
+def validate_egress_host(
+    host: str,
+    *,
+    allowlist: Allowlist | None = None,
+) -> None:
+    """
+    Validate that ``host`` may be used for dissemination egress.
+
+    Empty allowlist ⇒ fail-closed. Hostname must appear on the allowlist (or
+    resolve into an allowlisted CIDR). Resolved addresses that fall in blocked
+    metadata/link-local ranges are always denied. Private resolved IPs require
+    an overlapping allowlisted CIDR (DNS-rebinding guard).
+
+    Parameters
+    ----------
+    host :
+        Destination hostname or literal IP.
+    allowlist :
+        Parsed allowlist; when ``None``, loaded from the environment.
+
+    Raises
+    ------
+    EgressDenied
+        If the host is not permitted.
+    """
+    al = allowlist if allowlist is not None else load_allowlist_from_env()
+    normalized = host.strip().lower().rstrip(".")
+    if not normalized:
+        raise EgressDenied("empty host denied")
+
+    if al.is_empty:
+        raise EgressDenied(f"egress fail-closed: {ENV_ALLOWLIST} is empty — no user-host egress")
+
+    if normalized in _BLOCKED_HOSTNAMES:
+        raise EgressDenied(f"blocked metadata hostname: {normalized}")
+
+    # Literal IP destination.
+    try:
+        addr = ipaddress.ip_address(normalized)
+    except ValueError:
+        addr = None
+
+    if addr is not None:
+        _deny_if_blocked_ip(addr)
+        if not _ip_on_allowlist(addr, al):
+            raise EgressDenied(f"IP {normalized} not on allowlist")
+        return
+
+    if normalized not in al.hostnames:
+        raise EgressDenied(f"host {normalized!r} not on allowlist")
+
+    resolved = _resolve_ips(normalized)
+    if not resolved:
+        raise EgressDenied(f"host {normalized!r} did not resolve")
+
+    for ip in resolved:
+        _deny_if_blocked_ip(ip)
+        # Private/loopback/link-local require an overlapping CIDR so a hostname
+        # allowlist entry cannot DNS-rebind into an unlisted LAN (ADR-029).
+        if (ip.is_private or ip.is_loopback or ip.is_link_local) and not _ip_on_allowlist(ip, al):
+            raise EgressDenied(
+                f"resolved private/reserved address {ip} for {normalized!r} not covered by allowlisted CIDR"
+            )
+
+
+def _is_hostname(value: str) -> bool:
+    if len(value) > 253 or " " in value or value.startswith("-"):
+        return False
+    labels = value.split(".")
+    if not labels:
+        return False
+    for label in labels:
+        if not label or len(label) > 63:
+            return False
+        if label.startswith("-") or label.endswith("-"):
+            return False
+        if not all(c.isalnum() or c == "-" for c in label):
+            return False
+    return True
+
+
+def _deny_if_blocked_ip(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    for net in _BLOCKED_NETWORKS:
+        if addr in net:
+            raise EgressDenied(f"blocked metadata/link-local address: {addr}")
+
+
+def _ip_on_allowlist(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    allowlist: Allowlist,
+) -> bool:
+    if str(addr) in allowlist.hostnames:
+        return True
+    return any(addr in net for net in allowlist.networks)
+
+
+def _resolve_ips(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    infos = socket.getaddrinfo(host, None)
+    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    seen: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        ip_s = sockaddr[0]
+        if ip_s in seen:
+            continue
+        seen.add(ip_s)
+        out.append(ipaddress.ip_address(ip_s))
+    return out
+
+
+def iter_allowlist_entries(allowlist: Allowlist) -> Iterable[str]:
+    """Yield human-readable allowlist entries (hosts then CIDRs)."""
+    yield from allowlist.entries

--- a/packages/dissemination/src/dissemination/db_preflight.py
+++ b/packages/dissemination/src/dissemination/db_preflight.py
@@ -1,0 +1,101 @@
+"""DB sink preflight orchestration (allowlist + writer-contract)."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dissemination.allowlist import EgressDenied, load_allowlist_from_env, validate_egress_host
+from dissemination.models import PreflightRequest, PreflightResponse, SchemaDiffItem
+from dissemination.redact import redact_secrets
+from dissemination.writer_contract import (
+    apply_writer_contract,
+    diff_writer_contract,
+)
+
+
+def uri_hostname(uri: str) -> str | None:
+    """Return hostname from ``uri``, or ``None`` for hostless schemes (e.g. sqlite memory)."""
+    parsed = urlparse(uri)
+    return parsed.hostname
+
+
+def dialect_for_sink(sink_type: str) -> str:
+    mapping = {
+        "postgres": "postgresql",
+        "mysql": "mysql",
+        "sqlserver": "mssql",
+        "sqlite": "sqlite",
+    }
+    if sink_type not in mapping:
+        raise ValueError(f"sink_type {sink_type!r} is not a DB sink")
+    return mapping[sink_type]
+
+
+def normalize_sqlalchemy_uri(uri: str, sink_type: str) -> str:
+    """Ensure async driver prefix for SQLAlchemy."""
+    if sink_type == "postgres" and uri.startswith("postgresql://"):
+        return "postgresql+asyncpg://" + uri.removeprefix("postgresql://")
+    if sink_type == "mysql" and uri.startswith("mysql://"):
+        return "mysql+aiomysql://" + uri.removeprefix("mysql://")
+    if sink_type == "sqlite" and uri.startswith("sqlite://"):
+        return "sqlite+aiosqlite://" + uri.removeprefix("sqlite://")
+    return uri
+
+
+async def run_db_preflight(req: PreflightRequest) -> PreflightResponse:
+    """
+    Validate egress + optional writer-contract against a DB URI.
+
+    Raises
+    ------
+    EgressDenied
+        When allowlist/SSRF checks fail.
+    ValueError
+        When the request is incomplete or unsupported.
+    """
+    if not req.uri:
+        raise ValueError("uri is required for DB sink preflight")
+
+    host = uri_hostname(req.uri)
+    if host:
+        validate_egress_host(host, allowlist=load_allowlist_from_env())
+
+    dialect = dialect_for_sink(req.sink_type)
+    sa_uri = normalize_sqlalchemy_uri(req.uri, req.sink_type)
+    engine: AsyncEngine = create_async_engine(sa_uri)
+    try:
+        if req.ddl:
+            await apply_writer_contract(engine, dialect=dialect)
+        diffs_raw = await diff_writer_contract(engine, dialect=dialect)
+        diffs = [
+            SchemaDiffItem(
+                kind=str(d.kind),
+                table=d.table,
+                detail=d.detail,
+                column=d.column,
+            )
+            for d in diffs_raw
+        ]
+        ok = len(diffs) == 0
+        return PreflightResponse(
+            ok=ok,
+            connectivity_ok=True,
+            diffs=diffs,
+            detail=None if ok else "writer-contract mismatches",
+        )
+    except Exception as exc:
+        raise ValueError(redact_secrets(str(exc))) from exc
+    finally:
+        await engine.dispose()
+
+
+# Re-export for callers that catch allowlist failures.
+__all__ = [
+    "EgressDenied",
+    "dialect_for_sink",
+    "normalize_sqlalchemy_uri",
+    "run_db_preflight",
+    "uri_hostname",
+]

--- a/packages/dissemination/src/dissemination/handles.py
+++ b/packages/dissemination/src/dissemination/handles.py
@@ -1,0 +1,89 @@
+"""Memory-only opaque handles for green preflight results (ADR-029 / ADR-030)."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class HandleRecord:
+    user_id: str
+    sink_type: str
+    uri: str | None
+    params: dict[str, Any]
+    expires_at: float
+
+
+class HandleStore:
+    """Process-local handle map — never persisted."""
+
+    def __init__(self, *, ttl_seconds: float = 300.0) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._items: dict[str, HandleRecord] = {}
+        self._lock = threading.Lock()
+
+    def create(
+        self,
+        *,
+        user_id: str,
+        sink_type: str,
+        uri: str | None,
+        params: dict[str, Any] | None = None,
+        now: float | None = None,
+    ) -> str:
+        token = secrets.token_urlsafe(24)
+        ts = time.time() if now is None else now
+        rec = HandleRecord(
+            user_id=user_id,
+            sink_type=sink_type,
+            uri=uri,
+            params=dict(params or {}),
+            expires_at=ts + self.ttl_seconds,
+        )
+        with self._lock:
+            self._purge(ts)
+            self._items[token] = rec
+        return token
+
+    def get(
+        self,
+        handle: str,
+        *,
+        user_id: str,
+        now: float | None = None,
+    ) -> HandleRecord | None:
+        ts = time.time() if now is None else now
+        with self._lock:
+            self._purge(ts)
+            rec = self._items.get(handle)
+            if rec is None:
+                return None
+            if rec.user_id != user_id:
+                return None
+            if rec.expires_at < ts:
+                self._items.pop(handle, None)
+                return None
+            return rec
+
+    def pop(self, handle: str, *, user_id: str) -> HandleRecord | None:
+        with self._lock:
+            rec = self._items.get(handle)
+            if rec is None or rec.user_id != user_id:
+                return None
+            return self._items.pop(handle)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+
+    def _purge(self, now: float) -> None:
+        expired = [k for k, v in self._items.items() if v.expires_at < now]
+        for k in expired:
+            del self._items[k]
+
+
+default_handle_store = HandleStore()

--- a/packages/dissemination/src/dissemination/models.py
+++ b/packages/dissemination/src/dissemination/models.py
@@ -1,0 +1,60 @@
+"""msgspec request/response models for dissemination preflight/send (F16–F19)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import msgspec
+
+SinkType = Literal[
+    "postgres",
+    "mysql",
+    "sqlserver",
+    "sqlite",
+    "wis2",
+    "edis",
+    "amhs",
+    "swim",
+    "afs",
+]
+
+
+class SchemaDiffItem(msgspec.Struct, frozen=True):
+    kind: str
+    table: str
+    detail: str
+    column: str | None = None
+
+
+class PreflightRequest(msgspec.Struct, frozen=True):
+    sink_type: SinkType
+    uri: str | None = None
+    ddl: bool = False
+    product: str | None = None
+    iwxxm_version: str | None = None
+    params: dict[str, Any] = msgspec.field(default_factory=dict)
+
+
+class PreflightResponse(msgspec.Struct, frozen=True):
+    ok: bool
+    connectivity_ok: bool
+    diffs: list[SchemaDiffItem]
+    handle: str | None = None
+    detail: str | None = None
+
+
+class SendRequest(msgspec.Struct, frozen=True):
+    handle: str | None = None
+    sink_type: SinkType | None = None
+    uri: str | None = None
+    iwxxm_xml: str | None = None
+    tac_text: str | None = None
+    product: str | None = None
+    iwxxm_version: str | None = None
+    params: dict[str, Any] = msgspec.field(default_factory=dict)
+
+
+class SendResponse(msgspec.Struct, frozen=True):
+    ok: bool
+    kv_upload_key: str | None = None
+    detail: str | None = None

--- a/packages/dissemination/src/dissemination/rate_limit.py
+++ b/packages/dissemination/src/dissemination/rate_limit.py
@@ -1,0 +1,64 @@
+"""In-memory per-user rate limiter for dissemination preflight/send (ADR-029)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import defaultdict, deque
+
+
+class RateLimitExceeded(PermissionError):
+    """Raised when a user exceeds the dissemination request budget."""
+
+
+class DisseminationRateLimiter:
+    """Sliding-window counter keyed by user id."""
+
+    def __init__(self, *, max_per_minute: int | None = None) -> None:
+        env = os.environ.get("DISSEMINATION_RATE_LIMIT_PER_MIN", "").strip()
+        if max_per_minute is not None:
+            self.max_per_minute = max_per_minute
+        elif env:
+            self.max_per_minute = int(env)
+        else:
+            self.max_per_minute = 30
+        self._hits: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(self, user_id: str, *, now: float | None = None) -> None:
+        """
+        Record a hit and raise if the user is over budget.
+
+        Parameters
+        ----------
+        user_id :
+            Authenticated subject id.
+        now :
+            Optional monotonic/unix timestamp override for tests.
+
+        Raises
+        ------
+        RateLimitExceeded
+            When the sliding one-minute window is full.
+        """
+        ts = time.time() if now is None else now
+        window_start = ts - 60.0
+        with self._lock:
+            q = self._hits[user_id]
+            while q and q[0] < window_start:
+                q.popleft()
+            if len(q) >= self.max_per_minute:
+                raise RateLimitExceeded(f"dissemination rate limit exceeded ({self.max_per_minute}/min)")
+            q.append(ts)
+
+    def reset(self, user_id: str | None = None) -> None:
+        """Clear counters for one user or all users (tests)."""
+        with self._lock:
+            if user_id is None:
+                self._hits.clear()
+            else:
+                self._hits.pop(user_id, None)
+
+
+default_rate_limiter = DisseminationRateLimiter()

--- a/packages/dissemination/src/dissemination/redact.py
+++ b/packages/dissemination/src/dissemination/redact.py
@@ -1,0 +1,44 @@
+"""Secret redaction for dissemination errors and logs (ADR-029)."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse, urlunparse
+
+_URI_USERINFO = re.compile(r"(://[^:/?#]+:)([^@/?#]+)(@)")
+_PASSWORD_JSON = re.compile(r'(?i)("?(?:password|passwd|secret|token|api[_-]?key)"?\s*[:=]\s*")([^"]*)(")')
+
+
+def redact_uri(uri: str) -> str:
+    """
+    Redact userinfo password in a connection URI.
+
+    Parameters
+    ----------
+    uri :
+        Possibly secret-bearing URI.
+
+    Returns
+    -------
+    str
+        URI with password replaced by ``***`` when present.
+    """
+    redacted = _URI_USERINFO.sub(r"\1***\3", uri)
+    try:
+        parsed = urlparse(redacted)
+        if parsed.password:
+            netloc = parsed.hostname or ""
+            if parsed.port:
+                netloc = f"{netloc}:{parsed.port}"
+            if parsed.username:
+                netloc = f"{parsed.username}:***@{netloc}"
+            return urlunparse(parsed._replace(netloc=netloc))
+    except Exception:
+        pass
+    return redacted
+
+
+def redact_secrets(text: str) -> str:
+    """Redact URI passwords and common secret JSON/key patterns from ``text``."""
+    out = redact_uri(text)
+    return _PASSWORD_JSON.sub(r"\1***\3", out)

--- a/packages/dissemination/src/dissemination/writer_contract.py
+++ b/packages/dissemination/src/dissemination/writer_contract.py
@@ -1,0 +1,211 @@
+"""Versioned IWXXM writer-contract DDL and schema-diff (F16 / ADR-030).
+
+Contract version ``1`` targets table ``iwxxm_reports`` used by multi-DB upload sinks.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import msgspec
+from sqlalchemy import inspect, text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+CONTRACT_VERSION = "1"
+CONTRACT_TABLE = "iwxxm_reports"
+
+# Logical column names required by contract v1 (types mapped per dialect).
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "id",
+    "product",
+    "icao",
+    "observation_time",
+    "iwxxm_version",
+    "iwxxm_xml",
+    "tac_text",
+    "upload_key",
+    "created_at",
+)
+
+
+class DiffKind(StrEnum):
+    MISSING_TABLE = "missing_table"
+    MISSING_COLUMN = "missing_column"
+    TYPE_MISMATCH = "type_mismatch"
+
+
+class SchemaDiff(msgspec.Struct, frozen=True):
+    """One actionable preflight schema difference."""
+
+    kind: DiffKind
+    table: str
+    detail: str
+    column: str | None = None
+
+
+def writer_contract_ddl(dialect: str) -> str:
+    """
+    Return CREATE TABLE DDL for the writer contract on ``dialect``.
+
+    Parameters
+    ----------
+    dialect :
+        ``postgresql``, ``mysql``, or ``sqlite`` (SQL Server via ``mssql`` later).
+
+    Returns
+    -------
+    str
+        Dialect-specific DDL statement(s).
+    """
+    d = dialect.lower()
+    if d in {"postgresql", "postgres"}:
+        return _ddl_postgres()
+    if d in {"mysql", "mariadb"}:
+        return _ddl_mysql()
+    if d == "sqlite":
+        return _ddl_sqlite()
+    if d in {"mssql", "sqlserver"}:
+        return _ddl_mssql()
+    raise ValueError(f"unsupported writer-contract dialect: {dialect}")
+
+
+async def diff_writer_contract(
+    engine: AsyncEngine,
+    *,
+    dialect: str | None = None,
+) -> list[SchemaDiff]:
+    """
+    Compare the live database to writer-contract v1.
+
+    Parameters
+    ----------
+    engine :
+        SQLAlchemy async engine.
+    dialect :
+        Optional override; defaults to ``engine.dialect.name``.
+
+    Returns
+    -------
+    list[SchemaDiff]
+        Empty when the schema matches the contract.
+    """
+    name = (dialect or engine.dialect.name).lower()
+    if name == "postgres":
+        name = "postgresql"
+
+    async with engine.connect() as conn:
+        return await _diff_on_connection(conn, dialect=name)
+
+
+async def apply_writer_contract(
+    engine: AsyncEngine,
+    *,
+    dialect: str | None = None,
+) -> None:
+    """Create the writer-contract table if missing (create-if-missing path)."""
+    name = (dialect or engine.dialect.name).lower()
+    if name == "postgres":
+        name = "postgresql"
+    ddl = writer_contract_ddl(name)
+    async with engine.begin() as conn:
+        for stmt in _split_statements(ddl):
+            await conn.execute(text(stmt))
+
+
+async def _diff_on_connection(conn: AsyncConnection, *, dialect: str) -> list[SchemaDiff]:
+    def _inspect(sync_conn: Any) -> list[SchemaDiff]:
+        insp = inspect(sync_conn)
+        if not insp.has_table(CONTRACT_TABLE):
+            return [
+                SchemaDiff(
+                    kind=DiffKind.MISSING_TABLE,
+                    table=CONTRACT_TABLE,
+                    detail=f"table {CONTRACT_TABLE!r} missing (contract v{CONTRACT_VERSION})",
+                )
+            ]
+        cols = {c["name"].lower() for c in insp.get_columns(CONTRACT_TABLE)}
+        out: list[SchemaDiff] = []
+        for required in REQUIRED_COLUMNS:
+            if required not in cols:
+                out.append(
+                    SchemaDiff(
+                        kind=DiffKind.MISSING_COLUMN,
+                        table=CONTRACT_TABLE,
+                        column=required,
+                        detail=f"column {required!r} missing on {CONTRACT_TABLE}",
+                    )
+                )
+        return out
+
+    return await conn.run_sync(_inspect)
+
+
+def _split_statements(ddl: str) -> list[str]:
+    parts = [p.strip() for p in ddl.split(";")]
+    return [p for p in parts if p]
+
+
+def _ddl_sqlite() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {CONTRACT_TABLE} (
+  id TEXT PRIMARY KEY,
+  product TEXT NOT NULL,
+  icao TEXT,
+  observation_time TEXT,
+  iwxxm_version TEXT NOT NULL,
+  iwxxm_xml TEXT NOT NULL,
+  tac_text TEXT,
+  upload_key TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+""".strip()
+
+
+def _ddl_postgres() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {CONTRACT_TABLE} (
+  id UUID PRIMARY KEY,
+  product TEXT NOT NULL,
+  icao TEXT,
+  observation_time TIMESTAMPTZ,
+  iwxxm_version TEXT NOT NULL,
+  iwxxm_xml TEXT NOT NULL,
+  tac_text TEXT,
+  upload_key TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+""".strip()
+
+
+def _ddl_mysql() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {CONTRACT_TABLE} (
+  id CHAR(36) PRIMARY KEY,
+  product VARCHAR(32) NOT NULL,
+  icao VARCHAR(8) NULL,
+  observation_time DATETIME(6) NULL,
+  iwxxm_version VARCHAR(32) NOT NULL,
+  iwxxm_xml LONGTEXT NOT NULL,
+  tac_text MEDIUMTEXT NULL,
+  upload_key VARCHAR(128) NULL,
+  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+);
+""".strip()
+
+
+def _ddl_mssql() -> str:
+    return f"""
+IF OBJECT_ID(N'{CONTRACT_TABLE}', N'U') IS NULL
+CREATE TABLE {CONTRACT_TABLE} (
+  id UNIQUEIDENTIFIER PRIMARY KEY,
+  product NVARCHAR(32) NOT NULL,
+  icao NVARCHAR(8) NULL,
+  observation_time DATETIMEOFFSET NULL,
+  iwxxm_version NVARCHAR(32) NOT NULL,
+  iwxxm_xml NVARCHAR(MAX) NOT NULL,
+  tac_text NVARCHAR(MAX) NULL,
+  upload_key NVARCHAR(128) NULL,
+  created_at DATETIMEOFFSET NOT NULL DEFAULT SYSDATETIMEOFFSET()
+);
+""".strip()

--- a/packages/dissemination/tests/test_allowlist.py
+++ b/packages/dissemination/tests/test_allowlist.py
@@ -1,0 +1,185 @@
+"""Allowlist / SSRF helpers — fail-closed + private/metadata deny (T1.3 / ADR-029)."""
+
+from __future__ import annotations
+
+import ipaddress
+from unittest.mock import patch
+
+import pytest
+
+from dissemination.allowlist import (
+    AllowlistError,
+    EgressDenied,
+    load_allowlist_from_env,
+    parse_allowlist,
+    validate_egress_host,
+)
+
+
+def test_parse_allowlist_empty_or_whitespace_is_empty() -> None:
+    assert parse_allowlist(None).entries == ()
+    assert parse_allowlist("").entries == ()
+    assert parse_allowlist("  , , ").entries == ()
+
+
+def test_parse_allowlist_hosts_and_cidrs() -> None:
+    al = parse_allowlist("example.com, 10.0.0.0/8, 2001:db8::/32")
+    assert "example.com" in al.hostnames
+    assert ipaddress.ip_network("10.0.0.0/8") in al.networks
+    assert ipaddress.ip_network("2001:db8::/32") in al.networks
+
+
+def test_load_allowlist_from_env_fail_closed_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISSEMINATION_EGRESS_ALLOWLIST", raising=False)
+    al = load_allowlist_from_env()
+    assert al.is_empty
+    with pytest.raises(EgressDenied, match="fail-closed|allowlist"):
+        validate_egress_host("example.com", allowlist=al)
+
+
+def test_load_allowlist_from_env_fail_closed_when_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "")
+    al = load_allowlist_from_env()
+    assert al.is_empty
+    with pytest.raises(EgressDenied):
+        validate_egress_host("db.example.com", allowlist=al)
+
+
+def test_validate_allows_listed_hostname_with_public_resolved_ip() -> None:
+    al = parse_allowlist("db.example.com")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        validate_egress_host("db.example.com", allowlist=al)
+
+
+def test_validate_denies_host_not_on_allowlist() -> None:
+    al = parse_allowlist("allowed.example.com")
+    with pytest.raises(EgressDenied, match="not on allowlist"):
+        validate_egress_host("other.example.com", allowlist=al)
+
+
+def test_validate_denies_cloud_metadata_even_if_allowlisted() -> None:
+    al = parse_allowlist("169.254.169.254, metadata.google.internal")
+    with pytest.raises(EgressDenied, match="metadata|blocked"):
+        validate_egress_host("169.254.169.254", allowlist=al)
+
+
+def test_validate_denies_dns_rebinding_to_private_when_not_in_cidr() -> None:
+    """Hostname allowlisted, but resolved A record is private and not in an allowlisted CIDR."""
+    al = parse_allowlist("tricky.example.com")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("10.1.2.3", 0))],
+    ):
+        with pytest.raises(EgressDenied, match="private|resolved"):
+            validate_egress_host("tricky.example.com", allowlist=al)
+
+
+def test_validate_allows_private_ip_when_cidr_allowlisted() -> None:
+    al = parse_allowlist("wis2box, 10.0.0.0/8")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("10.5.6.7", 0))],
+    ):
+        validate_egress_host("wis2box", allowlist=al)
+
+
+def test_parse_allowlist_rejects_garbage_token() -> None:
+    with pytest.raises(AllowlistError):
+        parse_allowlist("not a host!!!")
+
+
+def test_validate_denies_empty_host() -> None:
+    al = parse_allowlist("example.com")
+    with pytest.raises(EgressDenied, match="empty host"):
+        validate_egress_host("  ", allowlist=al)
+
+
+def test_validate_allows_literal_ip_on_allowlist() -> None:
+    al = parse_allowlist("203.0.113.10")
+    validate_egress_host("203.0.113.10", allowlist=al)
+
+
+def test_validate_denies_literal_ip_not_on_allowlist() -> None:
+    al = parse_allowlist("203.0.113.10")
+    with pytest.raises(EgressDenied, match="not on allowlist"):
+        validate_egress_host("198.51.100.1", allowlist=al)
+
+
+def test_validate_denies_blocked_metadata_hostname() -> None:
+    al = parse_allowlist("metadata.google.internal")
+    with pytest.raises(EgressDenied, match="metadata"):
+        validate_egress_host("metadata.google.internal", allowlist=al)
+
+
+def test_load_allowlist_from_env_parses_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "a.example,10.0.0.0/8")
+    al = load_allowlist_from_env()
+    assert "a.example" in al.hostnames
+    assert not al.is_empty
+
+
+def test_validate_denies_when_dns_returns_no_addresses() -> None:
+    al = parse_allowlist("empty.example.com")
+    with patch("dissemination.allowlist.socket.getaddrinfo", return_value=[]):
+        with pytest.raises(EgressDenied, match="did not resolve"):
+            validate_egress_host("empty.example.com", allowlist=al)
+
+
+def test_iter_allowlist_entries_and_default_env_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dissemination.allowlist import iter_allowlist_entries
+
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "z.example,10.1.0.0/16")
+    al = load_allowlist_from_env()
+    entries = list(iter_allowlist_entries(al))
+    assert "z.example" in entries
+    assert "10.1.0.0/16" in entries
+
+
+def test_validate_uses_env_allowlist_when_none_passed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "only.example.com")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.4.4", 0))],
+    ):
+        validate_egress_host("only.example.com")
+
+
+def test_parse_allowlist_rejects_bad_hostname_labels() -> None:
+    with pytest.raises(AllowlistError):
+        parse_allowlist("-bad.example.com")
+    with pytest.raises(AllowlistError):
+        parse_allowlist("has space.com")
+    with pytest.raises(AllowlistError):
+        parse_allowlist("bad-.example.com")
+    with pytest.raises(AllowlistError):
+        parse_allowlist("a.." + ("x" * 64))
+    with pytest.raises(AllowlistError):
+        parse_allowlist("empty..label.example.com")
+
+
+def test_validate_allows_ip_listed_as_hostname_entry() -> None:
+    from dissemination.allowlist import Allowlist
+
+    al = Allowlist(hostnames=frozenset({"8.8.8.8"}), networks=())
+    validate_egress_host("8.8.8.8", allowlist=al)
+
+
+def test_resolve_dedupes_duplicate_getaddrinfo_rows() -> None:
+    al = parse_allowlist("dup.example.com")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[
+            (None, None, None, None, ("8.8.8.8", 0)),
+            (None, None, None, None, ("8.8.8.8", 0)),
+        ],
+    ):
+        validate_egress_host("dup.example.com", allowlist=al)

--- a/packages/dissemination/tests/test_db_preflight_handles.py
+++ b/packages/dissemination/tests/test_db_preflight_handles.py
@@ -1,0 +1,70 @@
+"""Handle store + db_preflight unit tests (coverage for T2.3/T2.4 helpers)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from dissemination.db_preflight import (
+    dialect_for_sink,
+    normalize_sqlalchemy_uri,
+    run_db_preflight,
+    uri_hostname,
+)
+from dissemination.handles import HandleStore
+from dissemination.models import PreflightRequest
+
+
+def test_uri_hostname_and_dialect_helpers() -> None:
+    assert uri_hostname("postgresql://u:p@db.example.com:5432/wx") == "db.example.com"
+    assert uri_hostname("sqlite+aiosqlite:///:memory:") is None
+    assert dialect_for_sink("postgres") == "postgresql"
+    assert normalize_sqlalchemy_uri("postgresql://x", "postgres").startswith("postgresql+asyncpg://")
+    with pytest.raises(ValueError):
+        dialect_for_sink("wis2")
+
+
+@pytest.mark.asyncio
+async def test_run_db_preflight_sqlite_ddl(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISSEMINATION_EGRESS_ALLOWLIST", "")
+    db = tmp_path / "p.db"
+    uri = f"sqlite+aiosqlite:///{db}"
+    resp = await run_db_preflight(PreflightRequest(sink_type="sqlite", uri=uri, ddl=True))
+    assert resp.ok is True
+    assert resp.diffs == []
+
+
+def test_handle_store_create_get_pop_and_user_isolation() -> None:
+    store = HandleStore(ttl_seconds=60)
+    h = store.create(user_id="a", sink_type="sqlite", uri="sqlite:///:memory:")
+    assert store.get(h, user_id="b") is None
+    rec = store.get(h, user_id="a")
+    assert rec is not None
+    assert rec.sink_type == "sqlite"
+    assert store.pop(h, user_id="a") is not None
+    assert store.get(h, user_id="a") is None
+
+
+def test_handle_store_expires_and_clear() -> None:
+    store = HandleStore(ttl_seconds=10)
+    h = store.create(
+        user_id="a", sink_type="sqlite", uri="sqlite:///:memory:", now=1000.0
+    )
+    assert store.get(h, user_id="a", now=1005.0) is not None
+    assert store.get(h, user_id="a", now=1020.0) is None
+    store.create(user_id="a", sink_type="sqlite", uri="x", now=2000.0)
+    store.clear()
+    assert store.pop("missing", user_id="a") is None
+
+
+def test_normalize_mysql_and_sqlite_prefixes() -> None:
+    assert normalize_sqlalchemy_uri("mysql://h/db", "mysql").startswith("mysql+aiomysql://")
+    assert normalize_sqlalchemy_uri("sqlite:///tmp/x.db", "sqlite").startswith(
+        "sqlite+aiosqlite://"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_db_preflight_requires_uri() -> None:
+    with pytest.raises(ValueError, match="uri is required"):
+        await run_db_preflight(PreflightRequest(sink_type="sqlite", uri=None))

--- a/packages/dissemination/tests/test_package_layout.py
+++ b/packages/dissemination/tests/test_package_layout.py
@@ -1,0 +1,41 @@
+"""Package layout and boundary smoke tests for packages/dissemination (T1.1 / ADR-030)."""
+
+from __future__ import annotations
+
+import ast
+from importlib import metadata
+from pathlib import Path
+
+import dissemination
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_SRC = PACKAGE_ROOT / "src" / "dissemination"
+
+
+def test_package_importable_and_versioned() -> None:
+    assert dissemination.__version__
+    assert isinstance(dissemination.__version__, str)
+    dist = metadata.version("dissemination")
+    assert dist == dissemination.__version__
+
+
+def test_package_src_layout_exists() -> None:
+    assert PACKAGE_SRC.is_dir()
+    assert (PACKAGE_SRC / "__init__.py").is_file()
+    assert (PACKAGE_ROOT / "pyproject.toml").is_file()
+    assert (PACKAGE_ROOT / "README.md").is_file()
+
+
+def test_package_has_no_fastapi_or_supabase_imports() -> None:
+    """ADR-030 — sinks live in the package; FastAPI/Supabase stay in apps/backend."""
+    forbidden = {"fastapi", "supabase"}
+    py_files = list(PACKAGE_SRC.rglob("*.py"))
+    assert py_files, "expected dissemination package sources"
+    for path in py_files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name.split(".", 1)[0] not in forbidden, path
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module.split(".", 1)[0] not in forbidden, path

--- a/packages/dissemination/tests/test_redact_rate_limit.py
+++ b/packages/dissemination/tests/test_redact_rate_limit.py
@@ -1,0 +1,44 @@
+"""Unit tests for dissemination redaction and rate limit helpers (T2.3 support)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dissemination.rate_limit import DisseminationRateLimiter, RateLimitExceeded
+from dissemination.redact import redact_secrets, redact_uri
+
+
+def test_redact_uri_password() -> None:
+    uri = "postgresql://alice:s3cret@db.example.com:5432/wx"
+    out = redact_uri(uri)
+    assert "s3cret" not in out
+    assert "***" in out
+    assert "alice" in out
+    assert "db.example.com" in out
+
+
+def test_redact_secrets_json_password_field() -> None:
+    raw = '{"password": "hunter2", "host": "x"}'
+    out = redact_secrets(raw)
+    assert "hunter2" not in out
+    assert "***" in out
+
+
+def test_rate_limiter_allows_then_denies() -> None:
+    lim = DisseminationRateLimiter(max_per_minute=2)
+    lim.check("u1", now=1000.0)
+    lim.check("u1", now=1001.0)
+    with pytest.raises(RateLimitExceeded):
+        lim.check("u1", now=1002.0)
+    # Different user unaffected
+    lim.check("u2", now=1002.0)
+
+
+def test_rate_limiter_env_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISSEMINATION_RATE_LIMIT_PER_MIN", "5")
+    lim = DisseminationRateLimiter()
+    assert lim.max_per_minute == 5
+    lim.check("u", now=1.0)
+    lim.reset("u")
+    lim.check("u", now=1.0)
+    lim.reset()

--- a/packages/dissemination/tests/test_writer_contract.py
+++ b/packages/dissemination/tests/test_writer_contract.py
@@ -1,0 +1,71 @@
+"""Writer-contract schema diff and DDL create-if-missing tests (T2.1 / TC-F16-003)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dissemination.writer_contract import (
+    CONTRACT_VERSION,
+    DiffKind,
+    SchemaDiff,
+    apply_writer_contract,
+    diff_writer_contract,
+    writer_contract_ddl,
+)
+
+
+@pytest.fixture
+async def sqlite_engine() -> AsyncEngine:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_diff_missing_table_on_empty_sqlite(sqlite_engine: AsyncEngine) -> None:
+    diffs = await diff_writer_contract(sqlite_engine, dialect="sqlite")
+    assert any(d.kind == DiffKind.MISSING_TABLE for d in diffs)
+    assert CONTRACT_VERSION == "1"
+
+
+@pytest.mark.asyncio
+async def test_apply_then_diff_is_empty_sqlite(sqlite_engine: AsyncEngine) -> None:
+    await apply_writer_contract(sqlite_engine, dialect="sqlite")
+    diffs = await diff_writer_contract(sqlite_engine, dialect="sqlite")
+    assert diffs == []
+
+
+@pytest.mark.asyncio
+async def test_diff_reports_missing_column_sqlite(sqlite_engine: AsyncEngine) -> None:
+    await apply_writer_contract(sqlite_engine, dialect="sqlite")
+    async with sqlite_engine.begin() as conn:
+        await conn.exec_driver_sql("ALTER TABLE iwxxm_reports DROP COLUMN tac_text")
+    diffs = await diff_writer_contract(sqlite_engine, dialect="sqlite")
+    assert any(d.kind == DiffKind.MISSING_COLUMN and d.column == "tac_text" for d in diffs)
+
+
+def test_writer_contract_ddl_per_engine_mentions_core_columns() -> None:
+    for dialect in ("postgresql", "mysql", "sqlite", "mssql"):
+        ddl = writer_contract_ddl(dialect)
+        assert "iwxxm_reports" in ddl
+        assert "iwxxm_xml" in ddl
+        assert "upload_key" in ddl
+
+
+def test_writer_contract_ddl_rejects_unknown_dialect() -> None:
+    with pytest.raises(ValueError, match="unsupported"):
+        writer_contract_ddl("oracle")
+
+
+@pytest.mark.asyncio
+async def test_diff_uses_engine_dialect_name(sqlite_engine: AsyncEngine) -> None:
+    await apply_writer_contract(sqlite_engine)
+    diffs = await diff_writer_contract(sqlite_engine)
+    assert diffs == []
+
+
+def test_schema_diff_is_msgspec_friendly_struct() -> None:
+    d = SchemaDiff(kind=DiffKind.MISSING_TABLE, table="iwxxm_reports", detail="absent")
+    assert d.table == "iwxxm_reports"
+    assert d.kind == DiffKind.MISSING_TABLE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
   "tac2iwxxm",
   "iwxxm-validate",
   "tac-validate",
+  "dissemination",
 ]
 
 [tool.uv.sources]
@@ -40,6 +41,7 @@ metar-worker = { workspace = true }
 tac2iwxxm = { workspace = true }
 iwxxm-validate = { workspace = true }
 tac-validate = { workspace = true }
+dissemination = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -48,6 +50,7 @@ members = [
   "packages/tac2iwxxm",
   "packages/iwxxm-validate",
   "packages/tac-validate",
+  "packages/dissemination",
   "apps/backend",
   "apps/worker",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1318,6 +1318,7 @@ version = "0.1.0"
 source = { editable = "apps/backend" }
 dependencies = [
     { name = "asyncpg" },
+    { name = "dissemination" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "iwxxm-validate" },
@@ -1355,6 +1356,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "dissemination", editable = "packages/dissemination" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "iwxxm-validate", editable = "packages/iwxxm-validate" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.12"
 
 [manifest]
 members = [
+    "dissemination",
     "iwxxm-validate",
     "metar-auth",
     "metar-backend",
@@ -542,6 +543,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
 ]
+
+[[package]]
+name = "dissemination"
+version = "0.1.0"
+source = { editable = "packages/dissemination" }
 
 [[package]]
 name = "distlib"
@@ -1329,6 +1335,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "dissemination" },
     { name = "httpx" },
     { name = "httpx2" },
     { name = "iwxxm-validate" },
@@ -1354,6 +1361,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.29" },
+    { name = "dissemination", editable = "packages/dissemination" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx2", specifier = ">=2.0" },
     { name = "iwxxm-validate", editable = "packages/iwxxm-validate" },

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,48 @@ members = [
 ]
 
 [[package]]
+name = "aiomysql"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymysql" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a", size = 108311, upload-time = "2025-10-22T00:15:21.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2", size = 71834, upload-time = "2025-10-22T00:15:15.905Z" },
+]
+
+[[package]]
+name = "aioodbc"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyodbc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/87/3a7580938f217212a574ba0d1af78203fc278fc439815f3fc515a7fdc12b/aioodbc-0.5.0.tar.gz", hash = "sha256:cbccd89ce595c033a49c9e6b4b55bbace7613a104b8a46e3d4c58c4bc4f25075", size = 41298, upload-time = "2023-10-28T21:37:29.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/80/4d1565bc16b53cd603c73dc4bc770e2e6418d957417e05031314760dc28c/aioodbc-0.5.0-py3-none-any.whl", hash = "sha256:bcaf16f007855fa4bf0ce6754b1f72c6c5a3d544188849577ddd55c5dc42985e", size = 19449, upload-time = "2023-10-28T21:37:28.51Z" },
+]
+
+[[package]]
+name = "aiosmtplib"
+version = "5.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/25/d36d056e62a1dc3dd51ce76e7647c62966702193dc91eafa7fd4e1006a91/aiosmtplib-5.1.2.tar.gz", hash = "sha256:04a0ea3c678f5b719f998f290dce010ca512e1385836d3944206299df03b060f", size = 71031, upload-time = "2026-06-20T15:00:48.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/ec/c5a415cd1309eaac28ad3c599458194d25ba07189bb07a1bac2c6713c17e/aiosmtplib-5.1.2-py3-none-any.whl", hash = "sha256:070d467cc329dafd0af59108ba5d217d973cba10309910fed359a2a7bfb52d7a", size = 28394, upload-time = "2026-06-20T15:00:47.299Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -548,6 +590,26 @@ wheels = [
 name = "dissemination"
 version = "0.1.0"
 source = { editable = "packages/dissemination" }
+dependencies = [
+    { name = "aiomysql" },
+    { name = "aioodbc" },
+    { name = "aiosmtplib" },
+    { name = "aiosqlite" },
+    { name = "asyncpg" },
+    { name = "msgspec" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiomysql", specifier = ">=0.2.0" },
+    { name = "aioodbc", specifier = ">=0.5.0" },
+    { name = "aiosmtplib", specifier = ">=3.0.0" },
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "asyncpg", specifier = ">=0.29" },
+    { name = "msgspec", specifier = ">=0.19" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+]
 
 [[package]]
 name = "distlib"
@@ -2164,6 +2226,59 @@ crypto = [
 ]
 
 [[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
+]
+
+[[package]]
+name = "pyodbc"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/85/44b10070a769a56bd910009bb185c0c0a82daff8d567cd1a116d7d730c7d/pyodbc-5.3.0.tar.gz", hash = "sha256:2fe0e063d8fb66efd0ac6dc39236c4de1a45f17c33eaded0d553d21c199f4d05", size = 121770, upload-time = "2025-10-17T18:04:09.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/0c/7ecf8077f4b932a5d25896699ff5c394ffc2a880a9c2c284d6a3e6ea5949/pyodbc-5.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ebf6b5d989395efe722b02b010cb9815698a4d681921bf5db1c0e1195ac1bde", size = 72994, upload-time = "2025-10-17T18:03:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/03/78/9fbde156055d88c1ef3487534281a5b1479ee7a2f958a7e90714968749ac/pyodbc-5.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:197bb6ddafe356a916b8ee1b8752009057fce58e216e887e2174b24c7ab99269", size = 72535, upload-time = "2025-10-17T18:03:21.423Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f9/8c106dcd6946e95fee0da0f1ba58cd90eb872eebe8968996a2ea1f7ac3c1/pyodbc-5.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6ccb5315ec9e081f5cbd66f36acbc820ad172b8fa3736cf7f993cdf69bd8a96", size = 333565, upload-time = "2025-10-17T18:03:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/2c70f47a76a4fafa308d148f786aeb35a4d67a01d41002f1065b465d9994/pyodbc-5.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5dd3d5e469f89a3112cf8b0658c43108a4712fad65e576071e4dd44d2bd763c7", size = 340283, upload-time = "2025-10-17T18:03:23.691Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b2/0631d84731606bfe40d3b03a436b80cbd16b63b022c7b13444fb30761ca8/pyodbc-5.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b180bc5e49b74fd40a24ef5b0fe143d0c234ac1506febe810d7434bf47cb925b", size = 1302767, upload-time = "2025-10-17T18:03:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b9/707c5314cca9401081b3757301241c167a94ba91b4bd55c8fa591bf35a4a/pyodbc-5.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e3c39de3005fff3ae79246f952720d44affc6756b4b85398da4c5ea76bf8f506", size = 1361251, upload-time = "2025-10-17T18:03:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/97/7c/893036c8b0c8d359082a56efdaa64358a38dda993124162c3faa35d1924d/pyodbc-5.3.0-cp312-cp312-win32.whl", hash = "sha256:d32c3259762bef440707098010035bbc83d1c73d81a434018ab8c688158bd3bb", size = 63413, upload-time = "2025-10-17T18:03:27.903Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/70/5e61b216cc13c7f833ef87f4cdeab253a7873f8709253f5076e9bb16c1b3/pyodbc-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:fe77eb9dcca5fc1300c9121f81040cc9011d28cff383e2c35416e9ec06d4bc95", size = 70133, upload-time = "2025-10-17T18:03:28.746Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/85/e7d0629c9714a85eb4f85d21602ce6d8a1ec0f313fde8017990cf913e3b4/pyodbc-5.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:afe7c4ac555a8d10a36234788fc6cfc22a86ce37fc5ba88a1f75b3e6696665dc", size = 64700, upload-time = "2025-10-17T18:03:29.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1d/9e74cbcc1d4878553eadfd59138364b38656369eb58f7e5b42fb344c0ce7/pyodbc-5.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e9ab0b91de28a5ab838ac4db0253d7cc8ce2452efe4ad92ee6a57b922bf0c24", size = 72975, upload-time = "2025-10-17T18:03:30.466Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c7/27d83f91b3144d3e275b5b387f0564b161ddbc4ce1b72bb3b3653e7f4f7a/pyodbc-5.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6132554ffbd7910524d643f13ce17f4a72f3a6824b0adef4e9a7f66efac96350", size = 72541, upload-time = "2025-10-17T18:03:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/2bb24e7fc95e98a7b11ea5ad1f256412de35d2e9cc339be198258c1d9a76/pyodbc-5.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1629af4706e9228d79dabb4863c11cceb22a6dab90700db0ef449074f0150c0d", size = 343287, upload-time = "2025-10-17T18:03:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/24/88cde8b6dc07a93a92b6c15520a947db24f55db7bd8b09e85956642b7cf3/pyodbc-5.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ceaed87ba2ea848c11223f66f629ef121f6ebe621f605cde9cfdee4fd9f4b68", size = 350094, upload-time = "2025-10-17T18:03:33.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/99/53c08562bc171a618fa1699297164f8885e66cde38c3b30f454730d0c488/pyodbc-5.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3cc472c8ae2feea5b4512e23b56e2b093d64f7cbc4b970af51da488429ff7818", size = 1301029, upload-time = "2025-10-17T18:03:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/10/68a0b5549876d4b53ba4c46eed2a7aca32d589624ed60beef5bd7382619e/pyodbc-5.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c79df54bbc25bce9f2d87094e7b39089c28428df5443d1902b0cc5f43fd2da6f", size = 1361420, upload-time = "2025-10-17T18:03:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0f/9dfe4987283ffcb981c49a002f0339d669215eb4a3fe4ee4e14537c52852/pyodbc-5.3.0-cp313-cp313-win32.whl", hash = "sha256:c2eb0b08e24fe5c40c7ebe9240c5d3bd2f18cd5617229acee4b0a0484dc226f2", size = 63399, upload-time = "2025-10-17T18:03:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/56/03/15dcefe549d3888b649652af7cca36eda97c12b6196d92937ca6d11306e9/pyodbc-5.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:01166162149adf2b8a6dc21a212718f205cabbbdff4047dc0c415af3fd85867e", size = 70133, upload-time = "2025-10-17T18:03:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c1/c8b128ae59a14ecc8510e9b499208e342795aecc3af4c3874805c720b8db/pyodbc-5.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:363311bd40320b4a61454bebf7c38b243cd67c762ed0f8a5219de3ec90c96353", size = 64683, upload-time = "2025-10-17T18:03:39.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f2/c26d82a7ce1e90b8bbb8731d3d53de73814e2f6606b9db9d978303aa8d5f/pyodbc-5.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3f1bdb3ce6480a17afaaef4b5242b356d4997a872f39e96f015cabef00613797", size = 73513, upload-time = "2025-10-17T18:03:40.536Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d5/1ab1b7c4708cbd701990a8f7183c5bb5e0712d5e8479b919934e46dadab4/pyodbc-5.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7713c740a10f33df3cb08f49a023b7e1e25de0c7c99650876bbe717bc95ee780", size = 72631, upload-time = "2025-10-17T18:03:41.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/7e3831eeac2b09b31a77e6b3495491ce162035ff2903d7261b49d35aa3c2/pyodbc-5.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf18797a12e70474e1b7f5027deeeccea816372497e3ff2d46b15bec2d18a0cc", size = 344580, upload-time = "2025-10-17T18:03:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a6/71d26d626a3c45951620b7ff356ec920e420f0e09b0a924123682aa5e4ab/pyodbc-5.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:08b2439500e212625471d32f8fde418075a5ddec556e095e5a4ba56d61df2dc6", size = 350224, upload-time = "2025-10-17T18:03:43.731Z" },
+    { url = "https://files.pythonhosted.org/packages/93/14/f702c5e8c2d595776266934498505f11b7f1545baf21ffec1d32c258e9d3/pyodbc-5.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:729c535341bb09c476f219d6f7ab194bcb683c4a0a368010f1cb821a35136f05", size = 1301503, upload-time = "2025-10-17T18:03:45.013Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b2/ad92ebdd1b5c7fec36b065e586d1d34b57881e17ba5beec5c705f1031058/pyodbc-5.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c67e7f2ce649155ea89beb54d3b42d83770488f025cf3b6f39ca82e9c598a02e", size = 1361050, upload-time = "2025-10-17T18:03:46.298Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/dc84e232da07056cb5aaaf5f759ba4c874bc12f37569f7f1670fc71e7ae1/pyodbc-5.3.0-cp314-cp314-win32.whl", hash = "sha256:a48d731432abaee5256ed6a19a3e1528b8881f9cb25cb9cf72d8318146ea991b", size = 65670, upload-time = "2025-10-17T18:03:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/79/c48be07e8634f764662d7a279ac204f93d64172162dbf90f215e2398b0bd/pyodbc-5.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:58635a1cc859d5af3f878c85910e5d7228fe5c406d4571bffcdd281375a54b39", size = 72177, upload-time = "2025-10-17T18:03:57.296Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/79/e304574446b2263f428ce14df590ba52c2e0e0205e8d34b235b582b7d57e/pyodbc-5.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:754d052030d00c3ac38da09ceb9f3e240e8dd1c11da8906f482d5419c65b9ef5", size = 66668, upload-time = "2025-10-17T18:03:58.174Z" },
+    { url = "https://files.pythonhosted.org/packages/43/17/f4eabf443b838a2728773554017d08eee3aca353102934a7e3ba96fb0e31/pyodbc-5.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f927b440c38ade1668f0da64047ffd20ec34e32d817f9a60d07553301324b364", size = 75780, upload-time = "2025-10-17T18:03:47.273Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ea/e79e168c3d38c27d59d5d96273fd9e3c3ba55937cc944c4e60618f51de90/pyodbc-5.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:25c4cfb2c08e77bc6e82f666d7acd52f0e52a0401b1876e60f03c73c3b8aedc0", size = 75503, upload-time = "2025-10-17T18:03:48.171Z" },
+    { url = "https://files.pythonhosted.org/packages/90/81/d1d7c125ec4a20e83fdc28e119b8321192b2bd694f432cf63e1199b2b929/pyodbc-5.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc834567c2990584b9726cba365834d039380c9dbbcef3030ddeb00c6541b943", size = 398356, upload-time = "2025-10-17T18:03:49.131Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fc/f6be4b3cc3910f8c2aba37aa41671121fd6f37b402ae0fefe53a70ac7cd5/pyodbc-5.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8339d3094858893c1a68ee1af93efc4dff18b8b65de54d99104b99af6306320d", size = 397291, upload-time = "2025-10-17T18:03:50.18Z" },
+    { url = "https://files.pythonhosted.org/packages/03/2e/0610b1ed05a5625528d52f6cece9610e84617d35f475c89c2a52f66d13f7/pyodbc-5.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74528fe148980d0c735c0ebb4a4dc74643ac4574337c43c1006ac4d09593f92d", size = 1353900, upload-time = "2025-10-17T18:03:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f1/43497e1d37f9f71b43b2b3172e7b1bdf50851e278390c3fb6b46a3630c53/pyodbc-5.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d89a7f2e24227150c13be8164774b7e1f9678321a4248f1356a465b9cc17d31e", size = 1406062, upload-time = "2025-10-17T18:03:52.546Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/88a1277c2f7d9ab1cec0a71e074ba24fd4a1710a43974682546da90a1343/pyodbc-5.3.0-cp314-cp314t-win32.whl", hash = "sha256:af4d8c9842fc4a6360c31c35508d6594d5a3b39922f61b282c2b4c9d9da99514", size = 70132, upload-time = "2025-10-17T18:03:53.715Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c7/ee98c62050de4aa8bafb6eb1e11b95e0b0c898bd5930137c6dc776e06a9b/pyodbc-5.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bfeb3e34795d53b7d37e66dd54891d4f9c13a3889a8f5fe9640e56a82d770955", size = 79452, upload-time = "2025-10-17T18:03:54.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8f/d8889efd96bbe8e5d43ff9701f6b1565a8e09c3e1f58c388d550724f777b/pyodbc-5.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:13656184faa3f2d5c6f19b701b8f247342ed581484f58bf39af7315c054e69db", size = 70142, upload-time = "2025-10-17T18:03:55.551Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2571,6 +2686,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
     { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
     { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,13 +12,12 @@ active_session:
     test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase
     0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-06-tech-tooling-9a92
+  branch: cursor/s019-07-build-m1-9a92
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: >-
-    06-tech-tooling completed (T0.1); Phase B Assumed PASS (D-S019-EV014-Q37A-phase-b); next 07-build M1 T1.1
+  note: 07-build M1 complete (T1.1–T1.5); next M2 T2.1
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -51,6 +50,12 @@ active_session:
   - scripts/ci/run_dissemination_coverage.sh
   - scripts/ci/run_wis2box_harness.sh
   - docker-compose.wis2box.yml
+  - packages/dissemination/README.md
+  - packages/dissemination/pyproject.toml
+  - packages/dissemination/src/dissemination/__init__.py
+  - packages/dissemination/src/dissemination/allowlist.py
+  - packages/dissemination/tests/test_package_layout.py
+  - packages/dissemination/tests/test_allowlist.py
   routing_plan:
   - stage: 00-context
     required: true
@@ -66,7 +71,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-20'
-    note: "Phase B passed; next 07-build"
+    note: "Phase C — 07-build M1 done; next M2 T2.1"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -118,9 +123,10 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
-    status: pending
+    status: in_progress
     skip_rationale:
-    note: Full routing (Q24=A) — await prior stages
+    started: '2026-07-21'
+    note: M1 done; next M2 T2.1
   - stage: 08-verify-build
     required: true
     mode: full
@@ -2534,6 +2540,18 @@ stages:
         milestone: M11
         notes: "T11.4 complete — H0c+H4+H5 green on staging; TC-M001–M005 pass; Phase 4 gate criteria met on main"
     delta_substages:
+    - id: S019-dissemination-upload
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      skill_id: 07-build
+      status: in_progress
+      started_at: '2026-07-21'
+      started: '2026-07-21'
+      mode: full
+      note: M1 complete (T1.1–T1.5); next M2 T2.1
+      active_milestone: M2
+      active_task: T2.1
+      active_task_status: pending
     - id: S015-metar-lint-quality
       session_id: S015-metar-lint-quality
       evolve_cycle_id: EV-011
@@ -2585,6 +2603,12 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - >-
+      2026-07-21 S019/EV-014 07-build M1 complete (T1.1–T1.5; 4b523db/2a47a87/5c2be0c/f0332cf/66f1177);
+      next M2 T2.1
+    - >-
+      2026-07-21 S019/EV-014 07-build STARTED — M1 T1.1 package layout + import smoke;
+      historical greenfield status remains completed
     - '2026-07-20 S015/EV-011 07-build completed — M1–M5 complete (T1.1–T5.10); PR #742 merged b405a96'
     - >-
       2026-07-20 S015/EV-011 M1+M2 complete (T2.1 08af6d6, T2.2 da22b32, T2.2a 4233a7f,
@@ -2686,14 +2710,13 @@ stages:
     - "2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task
       T6.3 in_progress"
     active_session:
-      session_id: S015-metar-lint-quality
-      evolve_cycle_id: EV-011
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
       skill_id: 07-build
-      status: completed
+      status: in_progress
       mode: full
-      started_at: '2026-07-19'
-      completed_at: '2026-07-20'
-      note: 'M1–M5 complete (T1.1–T5.10); PR #742 merged b405a96'
+      started_at: '2026-07-21'
+      note: M1 T1.1 package layout + import smoke
   09-qa:
     status: completed
     started_at: "2026-06-24T14:55:00Z"
@@ -3286,8 +3309,7 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      S019/EV-014 Phase B Assumed PASS (D-S019-EV014-Q37A-phase-b); next 07-build M1 T1.1;
-      Q15=A+Q8=C+Q21=A live BYOC hard close gate
+      Phase C — 07-build M1 complete; next M2 T2.1; Q15=A+Q8=C+Q21=A live BYOC hard close gate
 
 stages_pending: []
 
@@ -7906,6 +7928,7 @@ evolve_cycles:
     note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
   current_stage: 07-build
   notes:
+  - 2026-07-21 S019/EV-014 07-build M1 complete (T1.1–T1.5; 4b523db/2a47a87/5c2be0c/f0332cf/66f1177); next M2 T2.1
   - 2026-07-21 S019/EV-014 Phase B Assumed PASS (D-S019-EV014-Q37A-phase-b) — 06 T0.1 done; B→C passed; next 07-build M1 T1.1
   - 2026-07-21 S019/EV-014 06-tech-tooling COMPLETE (D-S019-EV014-Q37A-phase-b) — T0.1 coverage + CI Compose wis2box hooks
   - 2026-07-21 S019/EV-014 06-tech-tooling STARTED (D-S019-EV014-Q36A-06) — T0.1 coverage + CI Compose wis2box hooks
@@ -7963,7 +7986,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-20'
-      note: "Phase B passed; next 07-build"
+      note: "Phase C — 07-build M1 done; next M2 T2.1"
     01-requirements:
       status: completed
       mode: delta
@@ -8036,6 +8059,11 @@ evolve_cycles:
       started: '2026-07-21'
       completed: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; report 06-tech-tooling.md
+    07-build:
+      status: in_progress
+      mode: full
+      started: '2026-07-21'
+      note: M1 T1.1 package layout + import smoke
   gates:
     a_to_b: passed
     b_to_c: passed
@@ -10697,7 +10725,7 @@ evolve_cycles:
   merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-06-tech-tooling-9a92
+  current_branch: cursor/s019-07-build-m1-9a92
   ahead_of_origin: 0
   pushed: true
   pending_commit: 'docs(S019): Phase 0 approve + 01-requirements delta (F16–F19)'
@@ -10892,6 +10920,14 @@ git_history:
   - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
   - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+  - name: cursor/s019-07-build-m1-9a92
+    status: active
+    base: cursor/s019-06-tech-tooling-9a92
+    created: '2026-07-21'
+    created_at: '2026-07-21'
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    purpose: S019 EV-014 07-build M1
   - name: cursor/s019-06-tech-tooling-9a92
     status: active
     base: cursor/s019-05-verify-tech-b45b
@@ -11239,6 +11275,64 @@ git_history:
     pr_number: 716
     note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+  - sha: 66f1177ef7134a418bc6fe93ccb33f037034d12e
+    short: 66f1177
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T1.5] config: document DISSEMINATION_EGRESS_ALLOWLIST and lint paths'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - .env.example
+    - Makefile
+    - docs/ops/staging-secrets-matrix.md
+    - docs/sessions/S019-dissemination-upload/HANDOFF.md
+    - docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+    - packages/dissemination/README.md
+  - sha: f0332cfabfc4e70aae37fecfa3c4d01d5a6fdc55
+    short: f0332cf
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T1.4] feat: dissemination egress allowlist helpers'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - packages/dissemination/src/dissemination/__init__.py
+    - packages/dissemination/src/dissemination/allowlist.py
+  - sha: 5c2be0c48cf3a084f7dfc9e5239e479142719a90
+    short: 5c2be0c
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T1.3] test: allowlist fail-closed and SSRF deny cases'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - packages/dissemination/tests/test_allowlist.py
+  - sha: 2a47a8719e29cd5bbdff165727761ff856d1b856
+    short: 2a47a87
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T1.2] config: pin dissemination workspace deps (ADR-030)'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - docs/dependency-inventory.md
+    - packages/dissemination/pyproject.toml
+    - uv.lock
+  - sha: 4b523dbc8e947d23f16fc4c774065f847e63691b
+    short: 4b523db
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T1.1] test: dissemination package layout + import smoke'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - packages/dissemination/README.md
+    - packages/dissemination/pyproject.toml
+    - packages/dissemination/src/dissemination/__init__.py
+    - packages/dissemination/tests/test_package_layout.py
+    - pyproject.toml
+    - uv.lock
   - sha: 5c1502ccbe90bcfd0806b3b360ca65f7d4ea0880
     short: 5c1502c
     branch: cursor/s019-06-tech-tooling-9a92

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -17,7 +17,7 @@ active_session:
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 07-build M1 complete (T1.1–T1.5); next M2 T2.1
+  note: 07-build M2 T2.1–T2.2 done; next T2.3 API tests
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -126,7 +126,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-21'
-    note: M1 done; next M2 T2.1
+    note: M1 done; M2 T2.1–T2.2 done; next T2.3
   - stage: 08-verify-build
     required: true
     mode: full
@@ -11275,6 +11275,26 @@ git_history:
     pr_number: 716
     note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+  - sha: f3506cdad61e9867d6e9c765bf056c5467386aee
+    short: f3506cd
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T2.2] feat: versioned iwxxm_reports writer-contract DDL + diff'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - packages/dissemination/pyproject.toml
+    - packages/dissemination/src/dissemination/__init__.py
+    - packages/dissemination/src/dissemination/writer_contract.py
+  - sha: c1957f65a7c0445556dba9c1936e6f92e0f77b19
+    short: c1957f6
+    branch: cursor/s019-07-build-m1-9a92
+    message: '[T2.1] test: writer-contract schema diff fixtures (SQLite)'
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    timestamp: '2026-07-21'
+    files_changed:
+    - packages/dissemination/tests/test_writer_contract.py
   - sha: 66f1177ef7134a418bc6fe93ccb33f037034d12e
     short: 66f1177
     branch: cursor/s019-07-build-m1-9a92


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S019 / EV-014 **07-build** — dissemination F16 through **T2.4**.

### M1 (complete)
T1.1–T1.5 — package scaffold, deps, ADR-029 allowlist, `.env.example`

### M2 (through T2.4)
- **T2.1–T2.2** — `iwxxm_reports` writer-contract v1 + schema diff
- **T2.3** — API tests: msgspec shapes, secret redaction, memory handles, rate-limit
- **T2.4** — `POST /api/v1/dissemination/preflight` + `/send` thin routers

### Verification
- `bash scripts/ci/run_dissemination_coverage.sh` — 41 passed, ≥95%
- `apps/backend/tests/unit/test_dissemination_api.py` — 6 passed

### Next
**T2.5** — Compose/Testcontainers PG+MySQL+SQLite integration

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f828e-f964-7b1e-b4be-8fa98e879a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f828e-f964-7b1e-b4be-8fa98e879a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce a dedicated dissemination package and backend API endpoints for preflight/send, wiring them into the workspace and workflow state with egress allowlist, writer-contract, and rate-limited handling plus supporting tests and docs.

New Features:
- Add a `dissemination` workspace package providing multi-DB writer-contract DDL, schema diffing, and SSRF/egress allowlist helpers for F16–F19 sinks.
- Expose msgspec-based request/response models and in-memory handle storage for dissemination preflight and send flows.
- Add thin FastAPI routers under `/api/v1/dissemination/preflight` and `/api/v1/dissemination/send` with per-user rate limiting and secret redaction for dissemination uploads.

Enhancements:
- Wire the `dissemination` package into the monorepo workspace, backend app dependencies, API router inclusion, and lint/test targets.
- Update workflow-state and execution-plan docs to reflect S019/EV-014 07-build progress through M1 and M2 (T2.4), including dependency inventory and env var documentation for `DISSEMINATION_EGRESS_ALLOWLIST`.
- Document dissemination package boundaries, coverage expectations, and egress allowlist behaviour in README and ops staging secrets matrix.

Build:
- Register `packages/dissemination` as a workspace member with pinned async DB and messaging dependencies and configure coverage, pytest, and Ruff lint settings for the new package.

Tests:
- Add unit tests for dissemination package layout, allowlist/SSRF guards, writer-contract DDL and schema diff, DB preflight helpers and handle store, redaction and rate limiter behaviour, and backend dissemination API flows (preflight/send, rate limiting, fail-closed allowlist, secret redaction).