### PR TITLE
[T2.5] Compose/Testcontainers multi-DB writer-contract (S019/EV-014)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -186,6 +186,11 @@ jobs:
         if: matrix.package == 'dissemination'
         run: bash scripts/ci/run_dissemination_coverage.sh
 
+      # F16 / T2.5 — TC-F16-003 PG+MySQL Testcontainers + SQLite (skip PG/MySQL if no Docker).
+      - name: Run dissemination multi-DB integration tests
+        if: matrix.package == 'dissemination'
+        run: make test-integration-dissemination
+
       - name: Run frontend tests with coverage
         if: matrix.package == 'frontend'
         run: pnpm --filter @metar/frontend run test:coverage

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PY_LINT := apps/backend/src apps/backend/tests \
 	test-unit-backend test-unit-auth test-unit-frontend \
 	test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate \
 	test-unit-dissemination test-unit-worker test-bugs \
+	test-integration-dissemination \
 	compose-wis2box-up compose-wis2box-down compose-wis2box-harness \
 	format format-check typecheck typecheck-py typecheck-js \
 	lint lint-py lint-js lint-backend lint-auth lint-frontend lint-shared \
@@ -220,6 +221,11 @@ test-unit-tac-validate:
 # F16–F19 / T0.1 — coverage paths; skips until packages/dissemination exists (T1.1/T1.2).
 test-unit-dissemination:
 	bash scripts/ci/run_dissemination_coverage.sh
+
+# F16 / T2.5 — TC-F16-003 multi-DB (SQLite always; PG/MySQL via Testcontainers when Docker up).
+test-integration-dissemination:
+	$(UV) run pytest packages/dissemination/tests/test_writer_contract_engines.py \
+		-m integration -v --tb=short --no-cov
 
 # F17 / E14-04 — wis2box Compose harness (overlay); real service in T3.3.
 compose-wis2box-up:

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -35,6 +35,12 @@
 | aiosmtplib | EDIS SMTP submit | MIT | PyPI (`>=3.0.0`) |
 | msgspec | Preflight/send models + HTTP encode | Apache-2.0 | PyPI (`>=0.19`) |
 
+#### packages/dissemination — test / integration (E14-09)
+
+| Package | Purpose | License | Source |
+|---------|---------|---------|--------|
+| testcontainers[mysql,postgres] | PG/MySQL Testcontainers for TC-F16-003 (T2.5) | MIT | PyPI (`>=4.8`); workspace `dev` + package optional `integration` |
+
 Package license: **MIT**. No FastAPI/Supabase imports. Backend already has `sqlalchemy` +
 `asyncpg` + `psycopg`; package may declare overlapping pins via workspace.
 
@@ -170,3 +176,5 @@ New dependencies require `[Decision]` + back-add to this file per plan-adherence
   export from existing `tac-validate` / msgspec stack (E11-30)
 - S019 / EV-014 (2026-07-21): Planned `packages/dissemination` — SQLAlchemy async + aiomysql /
   aiosqlite / **aioodbc** (E14-06=A) + aiosmtplib; msgspec HTTP (E14-07=A); pins in M1
+- S019 / EV-014 T2.5 (2026-07-21): **testcontainers[mysql,postgres]≥4.8** — multi-DB writer-contract
+  integration (TC-F16-003 / E14-09); SQLite in-process; PG/MySQL skip without Docker

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,7 +11,7 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-t25-writer-contract-engines-ce70` (T2.5); base `cursor/s019-07-build-m1-9a92` |
-| PR | T2.5 PR off base; umbrella https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/757 |
+| PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/758 (T2.5 → base); umbrella #757 |
 | Done | M1; M2 through **T2.5** (PG+MySQL Testcontainers + SQLite) |
 | Next | **T2.6** SQL Server path via aioodbc (CI skip if no ODBC) |
 

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,19 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M2 T2.5
+/16-evolve continue S019/EV-014 — 07-build M2 T2.6
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Branch | `cursor/s019-07-build-m1-9a92` |
-| PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/757 |
-| Done | M1; M2 through **T2.4** (preflight/send API) |
-| Next | **T2.5** Compose/Testcontainers PG+MySQL+SQLite |
+| Branch | `cursor/s019-t25-writer-contract-engines-ce70` (T2.5); base `cursor/s019-07-build-m1-9a92` |
+| PR | T2.5 PR off base; umbrella https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/757 |
+| Done | M1; M2 through **T2.5** (PG+MySQL Testcontainers + SQLite) |
+| Next | **T2.6** SQL Server path via aioodbc (CI skip if no ODBC) |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close
-- T2.5 integration before marking M2 complete
+- T2.6 SQL Server (skip/document when ODBC absent) before M2 docs T2.7

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -16,8 +16,8 @@
 |-------|-------|
 | **Active phase** | Phase C — **07-build** M2 in progress |
 | **Active milestone** | M2 — Multi-DB writer-contract + preflight/send API |
-| **Active task** | T2.5 (next) |
-| **Tasks** | 10 / **29** completed (through T2.4) |
+| **Active task** | T2.6 (next) |
+| **Tasks** | 11 / **29** completed (through T2.5) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -66,7 +66,7 @@
 | T2.2 | Code | Engine adapters + versioned writer-contract DDL | ADR-030; E14-02 | T2.1 | **completed** |
 | T2.3 | Test | API tests: preflight/send msgspec shapes; secret redaction; handle memory-only; per-user rate-limit deny (ADR-029 §5) | api-contract; TC-F16-002; ADR-029 | T2.2 | **completed** |
 | T2.4 | Code | Thin backend routers `/dissemination/preflight` + `/send` (+ rate limit) | api-contract; E14-03/07; ADR-029 | T2.3 | **completed** |
-| T2.5 | Test | Compose/Testcontainers integration PG+MySQL+SQLite happy + mismatch | TC-F16-003; E14-09 | T2.4 | pending |
+| T2.5 | Test | Compose/Testcontainers integration PG+MySQL+SQLite happy + mismatch | TC-F16-003; E14-09 | T2.4 | **completed** |
 | T2.6 | Test | SQL Server path via aioodbc (CI skip if no ODBC; document) | E14-06; TC-F16-003 | T2.4 | pending |
 | T2.7 | Docs | ODBC driver notes in deploy.md / package README | E14-06 | T2.6 | pending |
 

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -12,6 +12,12 @@ sink adapters, and SSRF/allowlist helpers ([ADR-030](../../docs/adr/ADR-030-diss
 
 - Local/CI: `make test-unit-dissemination` (95% branch gate)
 
+**Multi-DB integration (T2.5 / TC-F16-003)**
+
+- `pytest packages/dissemination/tests/test_writer_contract_engines.py -m integration`
+- Postgres + MySQL via Testcontainers (requires Docker); SQLite in-process
+- Without Docker, PG/MySQL cases skip; SQLite still runs
+
 **Egress allowlist**
 
 - Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)

--- a/packages/dissemination/pyproject.toml
+++ b/packages/dissemination/pyproject.toml
@@ -22,11 +22,19 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/dissemination"]
 
+[project.optional-dependencies]
+integration = [
+  "testcontainers[mysql,postgres]>=4.8",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+  "integration: Compose/Testcontainers multi-DB engine tests (T2.5 / E14-09)",
+]
 
 [tool.coverage.run]
 branch = true

--- a/packages/dissemination/tests/test_writer_contract_engines.py
+++ b/packages/dissemination/tests/test_writer_contract_engines.py
@@ -1,0 +1,178 @@
+"""Compose/Testcontainers multi-DB writer-contract (T2.5 / TC-F16-003 / E14-09).
+
+Happy path: apply DDL then empty schema diff.
+Mismatch path: missing table / missing column reported per engine.
+Postgres + MySQL use Testcontainers when Docker is available; SQLite is in-process.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dissemination.writer_contract import DiffKind, apply_writer_contract, diff_writer_contract
+
+pytestmark = pytest.mark.integration
+
+
+def _docker_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        return False
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker required for Postgres/MySQL Testcontainers (T2.5 / E14-09)",
+)
+
+
+def _to_asyncpg_url(url: str) -> str:
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    if url.startswith("postgresql+psycopg2://"):
+        return "postgresql+asyncpg://" + url.removeprefix("postgresql+psycopg2://")
+    if url.startswith("postgresql+psycopg://"):
+        return "postgresql+asyncpg://" + url.removeprefix("postgresql+psycopg://")
+    if url.startswith("postgresql://"):
+        return "postgresql+asyncpg://" + url.removeprefix("postgresql://")
+    return url
+
+
+def _to_aiomysql_url(url: str) -> str:
+    if url.startswith("mysql+aiomysql://"):
+        return url
+    if url.startswith("mysql+pymysql://"):
+        return "mysql+aiomysql://" + url.removeprefix("mysql+pymysql://")
+    if url.startswith("mysql://"):
+        return "mysql+aiomysql://" + url.removeprefix("mysql://")
+    return url
+
+
+@contextmanager
+def _postgres_async_url() -> Iterator[str]:
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine", driver=None) as pg:
+        yield _to_asyncpg_url(pg.get_connection_url())
+
+
+@contextmanager
+def _mysql_async_url() -> Iterator[str]:
+    from testcontainers.mysql import MySqlContainer
+
+    with MySqlContainer("mysql:8.4") as mysql:
+        yield _to_aiomysql_url(mysql.get_connection_url())
+
+
+@pytest.fixture
+async def sqlite_engine() -> AsyncIterator[AsyncEngine]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def postgres_engine() -> AsyncIterator[AsyncEngine]:
+    with _postgres_async_url() as url:
+        engine = create_async_engine(url)
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest.fixture
+async def mysql_engine() -> AsyncIterator[AsyncEngine]:
+    with _mysql_async_url() as url:
+        engine = create_async_engine(url)
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_happy_apply_then_empty_diff(sqlite_engine: AsyncEngine) -> None:
+    await apply_writer_contract(sqlite_engine, dialect="sqlite")
+    assert await diff_writer_contract(sqlite_engine, dialect="sqlite") == []
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mismatch_missing_table(sqlite_engine: AsyncEngine) -> None:
+    diffs = await diff_writer_contract(sqlite_engine, dialect="sqlite")
+    assert any(d.kind == DiffKind.MISSING_TABLE for d in diffs)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mismatch_missing_column(sqlite_engine: AsyncEngine) -> None:
+    await apply_writer_contract(sqlite_engine, dialect="sqlite")
+    async with sqlite_engine.begin() as conn:
+        await conn.execute(text("ALTER TABLE iwxxm_reports DROP COLUMN upload_key"))
+    diffs = await diff_writer_contract(sqlite_engine, dialect="sqlite")
+    assert any(d.kind == DiffKind.MISSING_COLUMN and d.column == "upload_key" for d in diffs)
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_postgres_happy_apply_then_empty_diff(postgres_engine: AsyncEngine) -> None:
+    await apply_writer_contract(postgres_engine, dialect="postgresql")
+    assert await diff_writer_contract(postgres_engine, dialect="postgresql") == []
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_postgres_mismatch_missing_table(postgres_engine: AsyncEngine) -> None:
+    diffs = await diff_writer_contract(postgres_engine, dialect="postgresql")
+    assert any(d.kind == DiffKind.MISSING_TABLE for d in diffs)
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_postgres_mismatch_missing_column(postgres_engine: AsyncEngine) -> None:
+    await apply_writer_contract(postgres_engine, dialect="postgresql")
+    async with postgres_engine.begin() as conn:
+        await conn.execute(text("ALTER TABLE iwxxm_reports DROP COLUMN upload_key"))
+    diffs = await diff_writer_contract(postgres_engine, dialect="postgresql")
+    assert any(d.kind == DiffKind.MISSING_COLUMN and d.column == "upload_key" for d in diffs)
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_mysql_happy_apply_then_empty_diff(mysql_engine: AsyncEngine) -> None:
+    await apply_writer_contract(mysql_engine, dialect="mysql")
+    assert await diff_writer_contract(mysql_engine, dialect="mysql") == []
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_mysql_mismatch_missing_table(mysql_engine: AsyncEngine) -> None:
+    diffs = await diff_writer_contract(mysql_engine, dialect="mysql")
+    assert any(d.kind == DiffKind.MISSING_TABLE for d in diffs)
+
+
+@requires_docker
+@pytest.mark.asyncio
+async def test_mysql_mismatch_missing_column(mysql_engine: AsyncEngine) -> None:
+    await apply_writer_contract(mysql_engine, dialect="mysql")
+    async with mysql_engine.begin() as conn:
+        await conn.execute(text("ALTER TABLE iwxxm_reports DROP COLUMN upload_key"))
+    diffs = await diff_writer_contract(mysql_engine, dialect="mysql")
+    assert any(d.kind == DiffKind.MISSING_COLUMN and d.column == "upload_key" for d in diffs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "iwxxm-validate",
   "tac-validate",
   "dissemination",
+  "testcontainers[mysql,postgres]>=4.8",
 ]
 
 [tool.uv.sources]

--- a/scripts/ci/run_dissemination_coverage.sh
+++ b/scripts/ci/run_dissemination_coverage.sh
@@ -17,7 +17,10 @@ if [[ ! -f "${PYPROJECT}" ]]; then
 fi
 
 cd "${ROOT}"
+# Unit coverage gate: exclude Testcontainers engine suite (T2.5) from the 95% path;
+# those tests are invoked via `make test-integration-dissemination` (Docker optional).
 exec uv run pytest packages/dissemination/tests \
+  -m "not integration" \
   --cov=dissemination \
   --cov-config=packages/dissemination/pyproject.toml \
   --cov-branch \

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,11 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
+[package.optional-dependencies]
+integration = [
+    { name = "testcontainers", extra = ["mysql"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiomysql", specifier = ">=0.2.0" },
@@ -609,7 +614,9 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "msgspec", specifier = ">=0.19" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "testcontainers", extras = ["mysql", "postgres"], marker = "extra == 'integration'", specifier = ">=4.8" },
 ]
+provides-extras = ["integration"]
 
 [[package]]
 name = "distlib"
@@ -627,6 +634,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]
@@ -1416,6 +1437,7 @@ dev = [
     { name = "ruff" },
     { name = "tac-validate" },
     { name = "tac2iwxxm" },
+    { name = "testcontainers", extra = ["mysql"] },
     { name = "xsdata", extra = ["cli"] },
     { name = "xsdata-pydantic" },
 ]
@@ -1442,6 +1464,7 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "tac-validate", editable = "packages/tac-validate" },
     { name = "tac2iwxxm", editable = "packages/tac2iwxxm" },
+    { name = "testcontainers", extras = ["mysql", "postgres"], specifier = ">=4.8" },
     { name = "xsdata", extras = ["cli"], specifier = ">=24.5" },
     { name = "xsdata-pydantic", specifier = ">=24.5" },
 ]
@@ -2236,6 +2259,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
 ]
 
+[package.optional-dependencies]
+rsa = [
+    { name = "cryptography" },
+]
+
 [[package]]
 name = "pyodbc"
 version = "5.3.0"
@@ -2812,6 +2840,28 @@ requires-dist = [
 provides-extras = ["validate"]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[package.optional-dependencies]
+mysql = [
+    { name = "pymysql", extra = ["rsa"] },
+    { name = "sqlalchemy" },
+]
+
+[[package]]
 name = "toposort"
 version = "1.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2946,6 +2996,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,12 +12,12 @@ active_session:
     test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase
     0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-07-build-m1-9a92
+  branch: cursor/s019-t25-writer-contract-engines-ce70
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 07-build M2 T2.1–T2.2 done; next T2.3 API tests
+  note: 07-build M2 T2.5 done; next T2.6
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -71,7 +71,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-20'
-    note: "Phase C — 07-build M1 done; next M2 T2.1"
+    note: "Phase C — 07-build M2 T2.5 done; next T2.6"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -126,7 +126,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-21'
-    note: M1 done; M2 T2.1–T2.2 done; next T2.3
+    note: M2 T2.5 done; next T2.6 SQL Server aioodbc
   - stage: 08-verify-build
     required: true
     mode: full
@@ -2548,9 +2548,9 @@ stages:
       started_at: '2026-07-21'
       started: '2026-07-21'
       mode: full
-      note: M1 complete (T1.1–T1.5); next M2 T2.1
+      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
       active_milestone: M2
-      active_task: T2.1
+      active_task: T2.6
       active_task_status: pending
     - id: S015-metar-lint-quality
       session_id: S015-metar-lint-quality
@@ -2603,6 +2603,12 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - >-
+      2026-07-21 S019/EV-014 07-build M2 T2.5 done (aa5ea23) — Compose/Testcontainers
+      PG+MySQL+SQLite writer-contract; next T2.6 SQL Server aioodbc
+    - >-
+      2026-07-21 S019/EV-014 07-build M2 T2.5 in_progress — Compose/Testcontainers
+      PG+MySQL+SQLite (TC-F16-003); branch cursor/s019-t25-writer-contract-engines-ce70
     - >-
       2026-07-21 S019/EV-014 07-build M1 complete (T1.1–T1.5; 4b523db/2a47a87/5c2be0c/f0332cf/66f1177);
       next M2 T2.1
@@ -2716,7 +2722,10 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: M1 T1.1 package layout + import smoke
+      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+      active_milestone: M2
+      active_task: T2.6
+      active_task_status: pending
   09-qa:
     status: completed
     started_at: "2026-06-24T14:55:00Z"
@@ -3309,7 +3318,7 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M1 complete; next M2 T2.1; Q15=A+Q8=C+Q21=A live BYOC hard close gate
+      Phase C — 07-build M2 T2.5 done; next T2.6; Q15=A+Q8=C+Q21=A live BYOC hard close gate
 
 stages_pending: []
 
@@ -3545,6 +3554,16 @@ issue_log:
   resolved_at: "2026-07-12"
 
 decisions_log:
+- id: N-S019-EV014-T25-complete
+  date: '2026-07-21'
+  session_id: S019-dissemination-upload
+  evolve_cycle_id: EV-014
+  stage: 07-build
+  skill_id: 07-build
+  status: noted
+  decision: >-
+    T2.5 completed (aa5ea23) — Compose/Testcontainers PG+MySQL+SQLite writer-contract;
+    next T2.6 SQL Server aioodbc. No user decision; progress note.
 - id: D-S019-EV014-Q37A-phase-b
   date: '2026-07-21'
   session_id: S019-dissemination-upload
@@ -7928,6 +7947,8 @@ evolve_cycles:
     note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
   current_stage: 07-build
   notes:
+  - 2026-07-21 S019/EV-014 07-build M2 T2.5 completed (aa5ea23); next T2.6 SQL Server aioodbc
+  - 2026-07-21 S019/EV-014 07-build M2 T2.5 in_progress — Compose/Testcontainers PG+MySQL+SQLite (TC-F16-003)
   - 2026-07-21 S019/EV-014 07-build M1 complete (T1.1–T1.5; 4b523db/2a47a87/5c2be0c/f0332cf/66f1177); next M2 T2.1
   - 2026-07-21 S019/EV-014 Phase B Assumed PASS (D-S019-EV014-Q37A-phase-b) — 06 T0.1 done; B→C passed; next 07-build M1 T1.1
   - 2026-07-21 S019/EV-014 06-tech-tooling COMPLETE (D-S019-EV014-Q37A-phase-b) — T0.1 coverage + CI Compose wis2box hooks
@@ -7986,7 +8007,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-20'
-      note: "Phase C — 07-build M1 done; next M2 T2.1"
+      note: "Phase C — 07-build M2 T2.5 done; next T2.6"
     01-requirements:
       status: completed
       mode: delta
@@ -8063,7 +8084,10 @@ evolve_cycles:
       status: in_progress
       mode: full
       started: '2026-07-21'
-      note: M1 T1.1 package layout + import smoke
+      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+      active_milestone: M2
+      active_task: T2.6
+      active_task_status: pending
   gates:
     a_to_b: passed
     b_to_c: passed
@@ -10725,12 +10749,14 @@ evolve_cycles:
   merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-07-build-m1-9a92
+  current_branch: cursor/s019-t25-writer-contract-engines-ce70
   ahead_of_origin: 0
   pushed: true
   pending_commit: 'docs(S019): Phase 0 approve + 01-requirements delta (F16–F19)'
-  tip_sha: 3e8a10a623b18ced8d0902f930fce61795185f08
+  tip_sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
   notes:
+  - "2026-07-21 S019/EV-014 tip aa5ea23 — [T2.5] Compose/Testcontainers PG+MySQL+SQLite writer-contract; next T2.6"
+  - "2026-07-21 S019/EV-014 branch cursor/s019-t25-writer-contract-engines-ce70 — M2 T2.5 in_progress"
   - "2026-07-21 S019/EV-014 tip 3e8a10a — [T0.1] chore: dissemination coverage paths + CI Compose wis2box hooks; Phase B Assumed PASS"
   - "2026-07-21 PR #753 merged to main @ 3c9ee81 — S019/EV-014 04 handoff"
   - >-
@@ -10920,6 +10946,16 @@ git_history:
   - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
   - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+  - name: cursor/s019-t25-writer-contract-engines-ce70
+    status: active
+    base: cursor/s019-07-build-m1-9a92
+    created: '2026-07-21'
+    created_at: '2026-07-21'
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    purpose: S019 EV-014 07-build M2 T2.5 multi-DB integration
+    tip_sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
+    note: T2.5 completed; next T2.6 SQL Server aioodbc
   - name: cursor/s019-07-build-m1-9a92
     status: active
     base: cursor/s019-06-tech-tooling-9a92
@@ -11275,6 +11311,24 @@ git_history:
     pr_number: 716
     note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+  - sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
+    short: aa5ea23
+    branch: cursor/s019-t25-writer-contract-engines-ce70
+    message: "[T2.5] test: Compose/Testcontainers PG+MySQL+SQLite writer-contract"
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    timestamp: '2026-07-21T03:37:00Z'
+    files_changed:
+    - .github/workflows/ci-cd.yml
+    - Makefile
+    - docs/dependency-inventory.md
+    - packages/dissemination/README.md
+    - packages/dissemination/pyproject.toml
+    - packages/dissemination/tests/test_writer_contract_engines.py
+    - pyproject.toml
+    - scripts/ci/run_dissemination_coverage.sh
+    - uv.lock
   - sha: f3506cdad61e9867d6e9c765bf056c5467386aee
     short: f3506cd
     branch: cursor/s019-07-build-m1-9a92


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S019 / EV-014 **07-build M2 T2.5** — Compose/Testcontainers integration for Postgres, MySQL, and SQLite writer-contract happy + mismatch paths (TC-F16-003 / E14-09).

## Changes

- New `packages/dissemination/tests/test_writer_contract_engines.py` (9 tests):
  - SQLite in-process: happy apply, missing table, missing column
  - Postgres + MySQL via Testcontainers (`postgres:16-alpine`, `mysql:8.4`); skip when Docker unavailable
- Dev dep: `testcontainers[mysql,postgres]>=4.8` (E14-09; inventory + optional `integration` extra)
- `make test-integration-dissemination`; CI dissemination matrix step
- Coverage script excludes `-m integration` so the 95% unit gate stays fast

## Verification

- `make test-unit-dissemination` — 41 passed, 95.34% coverage
- `make test-integration-dissemination` — 9 passed (incl. live PG + MySQL containers)

## Next

T2.6 — SQL Server path via aioodbc (CI skip if no ODBC)

## Spec

- Feature F16; ADR-030; E14-09; TC-F16-003

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82b7-1d2b-7d51-977f-87d79f5ace70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82b7-1d2b-7d51-977f-87d79f5ace70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add multi-database integration test coverage for the dissemination writer contract using SQLite in-process and Postgres/MySQL via Testcontainers, and wire it into the build, docs, and CI while marking task T2.5 complete in workflow metadata.

New Features:
- Introduce integration test suite validating writer-contract behavior across SQLite, Postgres, and MySQL engines, including happy and mismatch paths.

Enhancements:
- Document and expose dissemination multi-DB integration tests via README guidance and a dedicated make target.
- Add an optional dissemination `integration` dependency group for Testcontainers-based database testing and register a pytest `integration` marker.
- Update dissemination coverage execution to exclude integration-marked tests from the unit coverage gate to keep the fast 95% threshold focused on unit tests.
- Record completion of milestone M2 task T2.5 and update session/cycle workflow-state notes and handoff docs to point to upcoming T2.6 work.

Build:
- Extend dev dependencies with `testcontainers[mysql,postgres]>=4.8` for multi-DB integration testing.
- Add a `test-integration-dissemination` Makefile target to run the multi-DB writer-contract integration suite.

CI:
- Update the CI dissemination job to invoke the new multi-DB integration test target alongside existing unit coverage.

Documentation:
- Expand dependency inventory and session documentation to describe Testcontainers usage, multi-DB integration scope, and the transition from T2.5 to T2.6.
- Update dissemination package README with instructions and prerequisites for running multi-DB integration tests.

Tests:
- Add a new integration test module exercising writer-contract apply/diff behavior for SQLite, Postgres, and MySQL using Testcontainers where Docker is available, including missing table and missing column scenarios.