### PR TITLE
[T2.6] SQL Server aioodbc writer-contract path (S019/EV-014)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ test-unit-dissemination:
 
 # F16 / T2.5 — TC-F16-003 multi-DB (SQLite always; PG/MySQL via Testcontainers when Docker up).
 test-integration-dissemination:
-	$(UV) run pytest packages/dissemination/tests/test_writer_contract_engines.py \
+	$(UV) run pytest packages/dissemination/tests \
 		-m integration -v --tb=short --no-cov
 
 # F17 / E14-04 — wis2box Compose harness (overlay); real service in T3.3.

--- a/apps/backend/docker/Dockerfile
+++ b/apps/backend/docker/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/auth/pyproject.toml packages/auth/pyproject.toml
 COPY packages/tac2iwxxm/pyproject.toml packages/tac2iwxxm/pyproject.toml
 COPY packages/iwxxm-validate/pyproject.toml packages/iwxxm-validate/pyproject.toml
 COPY packages/tac-validate/pyproject.toml packages/tac-validate/pyproject.toml
+COPY packages/dissemination/pyproject.toml packages/dissemination/pyproject.toml
 COPY apps/backend/pyproject.toml apps/backend/pyproject.toml
 
 # Workspace sources required at runtime
@@ -33,6 +34,7 @@ COPY packages/auth packages/auth
 COPY packages/tac2iwxxm packages/tac2iwxxm
 COPY packages/iwxxm-validate packages/iwxxm-validate
 COPY packages/tac-validate packages/tac-validate
+COPY packages/dissemination packages/dissemination
 COPY apps/backend apps/backend
 COPY config config
 COPY vendor/schemas vendor/schemas

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 source = ["src"]
+concurrency = ["thread", "greenlet"]
 omit = [
     "src/**/__main__.py",
     "src/__main__.py",

--- a/apps/backend/src/routers/dissemination.py
+++ b/apps/backend/src/routers/dissemination.py
@@ -7,9 +7,6 @@ import uuid
 from typing import Any
 
 import msgspec
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy.ext.asyncio import create_async_engine
-
 from dissemination.db_preflight import (
     EgressDenied,
     dialect_for_sink,
@@ -26,6 +23,8 @@ from dissemination.models import (
 from dissemination.rate_limit import RateLimitExceeded, default_rate_limiter
 from dissemination.redact import redact_secrets
 from dissemination.writer_contract import CONTRACT_TABLE, apply_writer_contract
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from ..msgspec_http import msgspec_json_response
 from ..utilities.security import verify_supabase_token

--- a/apps/backend/src/services/database.py
+++ b/apps/backend/src/services/database.py
@@ -170,7 +170,11 @@ async def close_db_engine():
 
     if _engine is not None:
         logger.info("Closing database engine")
-        await _engine.dispose()
+        dispose = getattr(_engine, "dispose", None)
+        if callable(dispose):
+            result = dispose()
+            if hasattr(result, "__await__"):
+                await result  # type: ignore[misc]
         _engine = None
         _async_session_maker = None
         logger.info("Database engine closed")

--- a/apps/backend/tests/unit/test_api_import_fallback_unit.py
+++ b/apps/backend/tests/unit/test_api_import_fallback_unit.py
@@ -185,6 +185,7 @@ def test_api_module_top_level_fallback_imports(monkeypatch):
     fake_router_module = _stub_module("router_mod", router=object())
     fake_routers = _stub_module(
         "routers",
+        dissemination=fake_router_module,
         evaluation=fake_router_module,
         icao_opmet=fake_router_module,
         validation=fake_router_module,

--- a/apps/backend/tests/unit/test_database_service_unit.py
+++ b/apps/backend/tests/unit/test_database_service_unit.py
@@ -285,9 +285,14 @@ async def test_create_tables_swallows_engine_errors() -> None:
 
             yield _Conn()
 
-    db._engine = _BrokenEngine()
+        async def dispose(self) -> None:
+            return None
 
-    await db.create_tables()
+    db._engine = _BrokenEngine()
+    try:
+        await db.create_tables()
+    finally:
+        db._engine = None
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/unit/test_dissemination_api.py
+++ b/apps/backend/tests/unit/test_dissemination_api.py
@@ -176,3 +176,147 @@ def test_send_without_uri_or_handle_rejected(client: TestClient) -> None:
         headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
     )
     assert resp.status_code == 400
+
+
+def test_preflight_value_error_becomes_400(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(_req):
+        raise ValueError("uri is required for DB sink preflight")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _boom)
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "sqlite", "uri": "sqlite+aiosqlite:///:memory:", "ddl": False}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 400
+
+
+def test_send_rate_limit_denies(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    lim = DisseminationRateLimiter(max_per_minute=0)
+    monkeypatch.setattr(diss_router, "default_rate_limiter", lim)
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps({"handle": "x", "iwxxm_xml": "<x/>", "product": "metar"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 429
+
+
+def test_send_unimplemented_sink_inline(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "sink_type": "wis2",
+                "uri": "mqtt://example.com",
+                "iwxxm_xml": "<x/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 501
+
+
+def test_send_egress_denied(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from dissemination.allowlist import EgressDenied
+
+    async def _deny(_req):
+        raise EgressDenied("fail-closed: empty allowlist")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _deny)
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "sink_type": "sqlite",
+                "uri": "sqlite+aiosqlite:///:memory:",
+                "iwxxm_xml": "<x/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 403
+
+
+def test_send_writer_contract_conflict(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from dissemination.models import PreflightResponse
+
+    async def _mismatch(_req):
+        return PreflightResponse(ok=False, connectivity_ok=True, diffs=[], detail="mismatch")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _mismatch)
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "sink_type": "sqlite",
+                "uri": "sqlite+aiosqlite:///:memory:",
+                "iwxxm_xml": "<x/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 409
+
+
+def test_preflight_unexpected_error_becomes_500(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(_req):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _boom)
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "sqlite", "uri": "sqlite+aiosqlite:///:memory:", "ddl": False}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 500
+
+
+def test_send_value_error_becomes_400(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(_req):
+        raise ValueError("bad sink")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _boom)
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "sink_type": "sqlite",
+                "uri": "sqlite+aiosqlite:///:memory:",
+                "iwxxm_xml": "<x/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 400
+
+
+def test_send_apply_failure_becomes_500(client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dissemination.models import PreflightResponse
+
+    async def _ok(_req):
+        return PreflightResponse(ok=True, connectivity_ok=True, diffs=[], detail=None)
+
+    async def _fail(*_a, **_k):
+        raise RuntimeError("apply failed")
+
+    monkeypatch.setattr(diss_router, "run_db_preflight", _ok)
+    monkeypatch.setattr(diss_router, "apply_writer_contract", _fail)
+    uri = _sqlite_uri(tmp_path)
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps(
+            {
+                "sink_type": "sqlite",
+                "uri": uri,
+                "iwxxm_xml": "<x/>",
+                "product": "metar",
+            }
+        ),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 500

--- a/apps/backend/tests/unit/test_dissemination_api.py
+++ b/apps/backend/tests/unit/test_dissemination_api.py
@@ -131,3 +131,48 @@ def test_send_invalid_handle_rejected(client: TestClient) -> None:
     )
     assert resp.status_code == 400
     assert "handle" in resp.text.lower()
+
+
+def test_preflight_rejects_invalid_json_body(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=b"{not-json",
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 422
+
+
+def test_preflight_unimplemented_sink(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "wis2", "uri": "mqtt://example.com"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 501
+
+
+def test_send_requires_iwxxm_xml(client: TestClient, tmp_path: Path) -> None:
+    uri = _sqlite_uri(tmp_path)
+    pre = client.post(
+        "/api/v1/dissemination/preflight",
+        content=json.dumps({"sink_type": "sqlite", "uri": uri, "ddl": True}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert pre.status_code == 200, pre.text
+    handle = pre.json()["handle"]
+    send = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps({"handle": handle, "iwxxm_xml": "", "product": "metar"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert send.status_code == 400
+    assert "iwxxm_xml" in send.text.lower()
+
+
+def test_send_without_uri_or_handle_rejected(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/dissemination/send",
+        content=json.dumps({"sink_type": "sqlite", "iwxxm_xml": "<x/>", "product": "metar"}),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 400

--- a/apps/backend/tests/unit/test_dissemination_api.py
+++ b/apps/backend/tests/unit/test_dissemination_api.py
@@ -6,10 +6,10 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi.testclient import TestClient
-
 from dissemination.handles import default_handle_store
 from dissemination.rate_limit import DisseminationRateLimiter
+from fastapi.testclient import TestClient
+
 from src import api as api_module
 from src.routers import dissemination as diss_router
 from src.utilities.security import verify_supabase_token

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -178,3 +178,5 @@ New dependencies require `[Decision]` + back-add to this file per plan-adherence
   aiosqlite / **aioodbc** (E14-06=A) + aiosmtplib; msgspec HTTP (E14-07=A); pins in M1
 - S019 / EV-014 T2.5 (2026-07-21): **testcontainers[mysql,postgres]≥4.8** — multi-DB writer-contract
   integration (TC-F16-003 / E14-09); SQLite in-process; PG/MySQL skip without Docker
+- S019 / EV-014 T2.6 (2026-07-21): SQL Server via **aioodbc** + Testcontainers; integration
+  tests **skip when no ODBC driver** (E14-06); ODBC install docs deferred to T2.7

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,19 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M2 T2.6
+/16-evolve continue S019/EV-014 — 07-build M2 T2.7
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Branch | `cursor/s019-t25-writer-contract-engines-ce70` (T2.5); base `cursor/s019-07-build-m1-9a92` |
-| PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/758 (T2.5 → base); umbrella #757 |
-| Done | M1; M2 through **T2.5** (PG+MySQL Testcontainers + SQLite) |
-| Next | **T2.6** SQL Server path via aioodbc (CI skip if no ODBC) |
+| Branch | `cursor/s019-t26-sqlserver-aioodbc-4b72` (T2.6); base `main` |
+| Merged to main | #755, #756, #757, #758 (session stack) |
+| Done | M1; M2 through **T2.6** (SQL Server aioodbc; skip without ODBC) |
+| Next | **T2.7** ODBC driver notes in deploy.md / package README |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close
-- T2.6 SQL Server (skip/document when ODBC absent) before M2 docs T2.7
+- T2.7 ODBC docs before M2→M3 gate

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,6 +11,7 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-t26-sqlserver-aioodbc-4b72` (T2.6); base `main` |
+| PR | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/759 (T2.6 → main) |
 | Merged to main | #755, #756, #757, #758 (session stack) |
 | Done | M1; M2 through **T2.6** (SQL Server aioodbc; skip without ODBC) |
 | Next | **T2.7** ODBC driver notes in deploy.md / package README |

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -16,8 +16,8 @@
 |-------|-------|
 | **Active phase** | Phase C — **07-build** M2 in progress |
 | **Active milestone** | M2 — Multi-DB writer-contract + preflight/send API |
-| **Active task** | T2.6 (next) |
-| **Tasks** | 11 / **29** completed (through T2.5) |
+| **Active task** | T2.7 (next) |
+| **Tasks** | 12 / **29** completed (through T2.6) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -41,7 +41,7 @@
 | Asset | Staging | Needed By |
 |-------|---------|-----------|
 | Compose wis2box image/config | pending (M3) | T3.x / TC-F17-001 |
-| ODBC driver (CI/docs for SQL Server) | pending (M2) | T2.x SQL Server path |
+| ODBC driver (CI/docs for SQL Server) | staged (skip-without-ODBC tests) | T2.6 done; T2.7 docs |
 | Live BYOC creds (operator) | cycle close only | TC-F16/17/18 live gates |
 
 ## Milestones & Tasks (TDD order)
@@ -67,7 +67,7 @@
 | T2.3 | Test | API tests: preflight/send msgspec shapes; secret redaction; handle memory-only; per-user rate-limit deny (ADR-029 §5) | api-contract; TC-F16-002; ADR-029 | T2.2 | **completed** |
 | T2.4 | Code | Thin backend routers `/dissemination/preflight` + `/send` (+ rate limit) | api-contract; E14-03/07; ADR-029 | T2.3 | **completed** |
 | T2.5 | Test | Compose/Testcontainers integration PG+MySQL+SQLite happy + mismatch | TC-F16-003; E14-09 | T2.4 | **completed** |
-| T2.6 | Test | SQL Server path via aioodbc (CI skip if no ODBC; document) | E14-06; TC-F16-003 | T2.4 | pending |
+| T2.6 | Test | SQL Server path via aioodbc (CI skip if no ODBC; document) | E14-06; TC-F16-003 | T2.4 | **completed** |
 | T2.7 | Docs | ODBC driver notes in deploy.md / package README | E14-06 | T2.6 | pending |
 
 ### M3 — WIS2 + Compose wis2box harness (F17)

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -12,11 +12,14 @@ sink adapters, and SSRF/allowlist helpers ([ADR-030](../../docs/adr/ADR-030-diss
 
 - Local/CI: `make test-unit-dissemination` (95% branch gate)
 
-**Multi-DB integration (T2.5 / TC-F16-003)**
+**Multi-DB integration (T2.5–T2.6 / TC-F16-003)**
 
-- `pytest packages/dissemination/tests/test_writer_contract_engines.py -m integration`
+- `make test-integration-dissemination` (or `pytest packages/dissemination/tests -m integration`)
 - Postgres + MySQL via Testcontainers (requires Docker); SQLite in-process
-- Without Docker, PG/MySQL cases skip; SQLite still runs
+- SQL Server via Testcontainers + **aioodbc** (requires Docker **and** a system ODBC
+  SQL Server driver, e.g. Microsoft ODBC Driver 18). Without ODBC, SQL Server cases
+  **skip** (E14-06; CI may omit ODBC — see deploy notes in T2.7)
+- Without Docker, PG/MySQL/SQL Server cases skip; SQLite still runs
 
 **Egress allowlist**
 

--- a/packages/dissemination/pyproject.toml
+++ b/packages/dissemination/pyproject.toml
@@ -33,7 +33,7 @@ pythonpath = ["src"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
-  "integration: Compose/Testcontainers multi-DB engine tests (T2.5 / E14-09)",
+  "integration: Compose/Testcontainers multi-DB engine tests (T2.5–T2.6 / E14-09)",
 ]
 
 [tool.coverage.run]

--- a/packages/dissemination/src/dissemination/allowlist.py
+++ b/packages/dissemination/src/dissemination/allowlist.py
@@ -203,7 +203,10 @@ def _ip_on_allowlist(
 
 
 def _resolve_ips(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    infos = socket.getaddrinfo(host, None)
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return []
     out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
     seen: set[str] = set()
     for info in infos:

--- a/packages/dissemination/src/dissemination/db_preflight.py
+++ b/packages/dissemination/src/dissemination/db_preflight.py
@@ -41,6 +41,15 @@ def normalize_sqlalchemy_uri(uri: str, sink_type: str) -> str:
         return "mysql+aiomysql://" + uri.removeprefix("mysql://")
     if sink_type == "sqlite" and uri.startswith("sqlite://"):
         return "sqlite+aiosqlite://" + uri.removeprefix("sqlite://")
+    if sink_type == "sqlserver":
+        for prefix in (
+            "mssql+aioodbc://",
+            "mssql+pyodbc://",
+            "mssql+pymssql://",
+            "mssql://",
+        ):
+            if uri.startswith(prefix):
+                return "mssql+aioodbc://" + uri.removeprefix(prefix)
     return uri
 
 

--- a/packages/dissemination/src/dissemination/odbc.py
+++ b/packages/dissemination/src/dissemination/odbc.py
@@ -1,0 +1,58 @@
+"""ODBC driver probes for SQL Server (aioodbc / E14-06).
+
+CI and developer machines without an ODBC SQL Server driver skip live
+engine tests; package code still normalizes URIs to ``mssql+aioodbc://``.
+"""
+
+from __future__ import annotations
+
+
+def _is_sqlserver_odbc_driver(name: str) -> bool:
+    lower = name.lower()
+    if "freetds" in lower:
+        return True
+    if "sql server" in lower:
+        return True
+    # Microsoft "ODBC Driver 17/18 for SQL Server"
+    return "odbc driver" in lower and "sql" in lower
+
+
+def list_sqlserver_odbc_drivers() -> list[str]:
+    """
+    Return installed ODBC driver names usable with SQL Server.
+
+    Returns
+    -------
+    list[str]
+        Empty when ``pyodbc`` is missing or no SQL Server–capable driver is
+        registered with the system ODBC manager.
+    """
+    try:
+        import pyodbc
+    except ImportError:
+        return []
+    return [d for d in pyodbc.drivers() if _is_sqlserver_odbc_driver(d)]
+
+
+def odbc_sqlserver_available() -> bool:
+    """Return True when at least one SQL Server ODBC driver is installed."""
+    return bool(list_sqlserver_odbc_drivers())
+
+
+def preferred_sqlserver_odbc_driver() -> str | None:
+    """
+    Prefer Microsoft ODBC Driver 18, then 17, then any SQL Server driver.
+
+    Returns
+    -------
+    str | None
+        Driver name for a SQLAlchemy ``driver=`` query parameter, or ``None``.
+    """
+    drivers = list_sqlserver_odbc_drivers()
+    if not drivers:
+        return None
+    for needle in ("ODBC Driver 18 for SQL Server", "ODBC Driver 17 for SQL Server"):
+        for d in drivers:
+            if d == needle:
+                return d
+    return drivers[0]

--- a/packages/dissemination/src/dissemination/writer_contract.py
+++ b/packages/dissemination/src/dissemination/writer_contract.py
@@ -51,7 +51,7 @@ def writer_contract_ddl(dialect: str) -> str:
     Parameters
     ----------
     dialect :
-        ``postgresql``, ``mysql``, or ``sqlite`` (SQL Server via ``mssql`` later).
+        ``postgresql``, ``mysql``, ``sqlite``, or ``mssql`` / ``sqlserver`` (aioodbc).
 
     Returns
     -------

--- a/packages/dissemination/tests/test_allowlist.py
+++ b/packages/dissemination/tests/test_allowlist.py
@@ -130,6 +130,16 @@ def test_validate_denies_when_dns_returns_no_addresses() -> None:
             validate_egress_host("empty.example.com", allowlist=al)
 
 
+def test_validate_denies_when_dns_raises_oserror() -> None:
+    al = parse_allowlist("nx.example.com")
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        side_effect=OSError("name resolution failed"),
+    ):
+        with pytest.raises(EgressDenied, match="did not resolve"):
+            validate_egress_host("nx.example.com", allowlist=al)
+
+
 def test_iter_allowlist_entries_and_default_env_load(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/dissemination/tests/test_db_preflight_handles.py
+++ b/packages/dissemination/tests/test_db_preflight_handles.py
@@ -47,9 +47,7 @@ def test_handle_store_create_get_pop_and_user_isolation() -> None:
 
 def test_handle_store_expires_and_clear() -> None:
     store = HandleStore(ttl_seconds=10)
-    h = store.create(
-        user_id="a", sink_type="sqlite", uri="sqlite:///:memory:", now=1000.0
-    )
+    h = store.create(user_id="a", sink_type="sqlite", uri="sqlite:///:memory:", now=1000.0)
     assert store.get(h, user_id="a", now=1005.0) is not None
     assert store.get(h, user_id="a", now=1020.0) is None
     store.create(user_id="a", sink_type="sqlite", uri="x", now=2000.0)
@@ -57,11 +55,17 @@ def test_handle_store_expires_and_clear() -> None:
     assert store.pop("missing", user_id="a") is None
 
 
-def test_normalize_mysql_and_sqlite_prefixes() -> None:
+def test_normalize_mysql_sqlite_and_sqlserver_prefixes() -> None:
     assert normalize_sqlalchemy_uri("mysql://h/db", "mysql").startswith("mysql+aiomysql://")
-    assert normalize_sqlalchemy_uri("sqlite:///tmp/x.db", "sqlite").startswith(
-        "sqlite+aiosqlite://"
-    )
+    assert normalize_sqlalchemy_uri("sqlite:///tmp/x.db", "sqlite").startswith("sqlite+aiosqlite://")
+    assert dialect_for_sink("sqlserver") == "mssql"
+    assert normalize_sqlalchemy_uri("mssql://h/db", "sqlserver").startswith("mssql+aioodbc://")
+    assert normalize_sqlalchemy_uri("mssql+pymssql://h/db", "sqlserver").startswith("mssql+aioodbc://")
+    assert normalize_sqlalchemy_uri("mssql+pyodbc://h/db", "sqlserver").startswith("mssql+aioodbc://")
+    already = "mssql+aioodbc://h/db?driver=ODBC+Driver+18+for+SQL+Server"
+    assert normalize_sqlalchemy_uri(already, "sqlserver") == already
+    # Non-mssql scheme left unchanged for sqlserver sink
+    assert normalize_sqlalchemy_uri("postgresql://h/db", "sqlserver") == "postgresql://h/db"
 
 
 @pytest.mark.asyncio

--- a/packages/dissemination/tests/test_db_preflight_handles.py
+++ b/packages/dissemination/tests/test_db_preflight_handles.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import create_async_engine
 
 from dissemination.db_preflight import (
     dialect_for_sink,

--- a/packages/dissemination/tests/test_odbc.py
+++ b/packages/dissemination/tests/test_odbc.py
@@ -1,0 +1,73 @@
+"""Unit tests for SQL Server ODBC probes (T2.6 / E14-06)."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from dissemination import odbc as odbc_mod
+
+
+def test_is_sqlserver_odbc_driver_names() -> None:
+    assert odbc_mod._is_sqlserver_odbc_driver("ODBC Driver 18 for SQL Server")
+    assert odbc_mod._is_sqlserver_odbc_driver("ODBC Driver 17 for SQL Server")
+    assert odbc_mod._is_sqlserver_odbc_driver("FreeTDS")
+    assert odbc_mod._is_sqlserver_odbc_driver("SQL Server")
+    assert not odbc_mod._is_sqlserver_odbc_driver("PostgreSQL Unicode")
+    assert not odbc_mod._is_sqlserver_odbc_driver("MySQL ODBC 8.0 Driver")
+
+
+def test_list_drivers_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "pyodbc", raising=False)
+    real_import = __import__
+
+    def _no_pyodbc(name: str, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if name == "pyodbc" or name.startswith("pyodbc."):
+            raise ImportError("no pyodbc")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _no_pyodbc)
+    assert odbc_mod.list_sqlserver_odbc_drivers() == []
+    assert odbc_mod.odbc_sqlserver_available() is False
+    assert odbc_mod.preferred_sqlserver_odbc_driver() is None
+
+
+def test_preferred_driver_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        odbc_mod,
+        "list_sqlserver_odbc_drivers",
+        lambda: [
+            "FreeTDS",
+            "ODBC Driver 17 for SQL Server",
+            "ODBC Driver 18 for SQL Server",
+        ],
+    )
+    assert odbc_mod.preferred_sqlserver_odbc_driver() == "ODBC Driver 18 for SQL Server"
+
+    monkeypatch.setattr(
+        odbc_mod,
+        "list_sqlserver_odbc_drivers",
+        lambda: ["FreeTDS", "ODBC Driver 17 for SQL Server"],
+    )
+    assert odbc_mod.preferred_sqlserver_odbc_driver() == "ODBC Driver 17 for SQL Server"
+
+    monkeypatch.setattr(odbc_mod, "list_sqlserver_odbc_drivers", lambda: ["FreeTDS"])
+    assert odbc_mod.preferred_sqlserver_odbc_driver() == "FreeTDS"
+    assert odbc_mod.odbc_sqlserver_available() is True
+
+
+def test_list_drivers_filters_pyodbc(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = ModuleType("pyodbc")
+    fake.drivers = lambda: [  # type: ignore[attr-defined]
+        "PostgreSQL Unicode",
+        "ODBC Driver 18 for SQL Server",
+        "MySQL ODBC 8.0 Driver",
+        "FreeTDS",
+    ]
+    monkeypatch.setitem(sys.modules, "pyodbc", fake)
+    assert odbc_mod.list_sqlserver_odbc_drivers() == [
+        "ODBC Driver 18 for SQL Server",
+        "FreeTDS",
+    ]

--- a/packages/dissemination/tests/test_writer_contract_sqlserver.py
+++ b/packages/dissemination/tests/test_writer_contract_sqlserver.py
@@ -1,0 +1,119 @@
+"""SQL Server writer-contract via aioodbc (T2.6 / TC-F16-003 / E14-06).
+
+Live engine tests require Docker (Testcontainers) **and** a system ODBC SQL Server
+driver (e.g. Microsoft ODBC Driver 18). Without ODBC, cases skip — document that
+CI may omit ODBC; full driver notes are T2.7.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from dissemination.db_preflight import dialect_for_sink, normalize_sqlalchemy_uri
+from dissemination.odbc import (
+    odbc_sqlserver_available,
+    preferred_sqlserver_odbc_driver,
+)
+from dissemination.writer_contract import DiffKind, apply_writer_contract, diff_writer_contract
+
+pytestmark = pytest.mark.integration
+
+
+def _docker_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        return False
+
+
+requires_docker_and_odbc = pytest.mark.skipif(
+    not (_docker_available() and odbc_sqlserver_available()),
+    reason=("Docker + SQL Server ODBC driver required for aioodbc path (T2.6 / E14-06; CI skips when ODBC absent)"),
+)
+
+
+def _with_odbc_driver(url: str) -> str:
+    """Attach preferred ODBC driver + TrustServerCertificate for container TLS."""
+    driver = preferred_sqlserver_odbc_driver()
+    if driver is None:
+        return url
+    parsed = urlparse(url)
+    q = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    q.setdefault("driver", driver)
+    q.setdefault("TrustServerCertificate", "yes")
+    return urlunparse(parsed._replace(query=urlencode(q)))
+
+
+def _to_aioodbc_url(url: str) -> str:
+    return _with_odbc_driver(normalize_sqlalchemy_uri(url, "sqlserver"))
+
+
+@contextmanager
+def _mssql_async_url() -> Iterator[str]:
+    from testcontainers.mssql import SqlServerContainer
+
+    with SqlServerContainer("mcr.microsoft.com/mssql/server:2022-latest") as mssql:
+        yield _to_aioodbc_url(mssql.get_connection_url())
+
+
+@pytest.fixture
+async def mssql_engine() -> AsyncIterator[AsyncEngine]:
+    with _mssql_async_url() as url:
+        engine = create_async_engine(url)
+        try:
+            yield engine
+        finally:
+            await engine.dispose()
+
+
+def test_normalize_sqlserver_uri_to_aioodbc() -> None:
+    assert dialect_for_sink("sqlserver") == "mssql"
+    assert normalize_sqlalchemy_uri("mssql://SA:x@h:1433/db", "sqlserver").startswith("mssql+aioodbc://")
+    assert normalize_sqlalchemy_uri("mssql+pymssql://SA:x@h:1433/db", "sqlserver").startswith("mssql+aioodbc://")
+    assert normalize_sqlalchemy_uri("mssql+pyodbc://SA:x@h:1433/db", "sqlserver").startswith("mssql+aioodbc://")
+    already = "mssql+aioodbc://SA:x@h:1433/db?driver=ODBC+Driver+18+for+SQL+Server"
+    assert normalize_sqlalchemy_uri(already, "sqlserver") == already
+
+
+def test_odbc_probe_returns_bool() -> None:
+    assert isinstance(odbc_sqlserver_available(), bool)
+
+
+@requires_docker_and_odbc
+@pytest.mark.asyncio
+async def test_mssql_happy_apply_then_empty_diff(mssql_engine: AsyncEngine) -> None:
+    await apply_writer_contract(mssql_engine, dialect="mssql")
+    assert await diff_writer_contract(mssql_engine, dialect="mssql") == []
+
+
+@requires_docker_and_odbc
+@pytest.mark.asyncio
+async def test_mssql_mismatch_missing_table(mssql_engine: AsyncEngine) -> None:
+    diffs = await diff_writer_contract(mssql_engine, dialect="mssql")
+    assert any(d.kind == DiffKind.MISSING_TABLE for d in diffs)
+
+
+@requires_docker_and_odbc
+@pytest.mark.asyncio
+async def test_mssql_mismatch_missing_column(mssql_engine: AsyncEngine) -> None:
+    await apply_writer_contract(mssql_engine, dialect="mssql")
+    async with mssql_engine.begin() as conn:
+        await conn.execute(text("ALTER TABLE iwxxm_reports DROP COLUMN upload_key"))
+    diffs = await diff_writer_contract(mssql_engine, dialect="mssql")
+    assert any(d.kind == DiffKind.MISSING_COLUMN and d.column == "upload_key" for d in diffs)

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,12 +12,12 @@ active_session:
     test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase
     0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-t25-writer-contract-engines-ce70
+  branch: cursor/s019-t26-sqlserver-aioodbc-4b72
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 07-build M2 T2.5 done; next T2.6
+  note: M2 T2.6 done; next T2.7
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -71,7 +71,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-20'
-    note: "Phase C — 07-build M2 T2.5 done; next T2.6"
+    note: "Phase C — 07-build M2 T2.6 done; next T2.7; PRs #755–#758 merged to main"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -126,7 +126,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-21'
-    note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+    note: T2.6 completed; next T2.7 ODBC driver docs
   - stage: 08-verify-build
     required: true
     mode: full
@@ -2548,9 +2548,9 @@ stages:
       started_at: '2026-07-21'
       started: '2026-07-21'
       mode: full
-      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+      note: T2.6 completed; next T2.7 ODBC driver docs
       active_milestone: M2
-      active_task: T2.6
+      active_task: T2.7
       active_task_status: pending
     - id: S015-metar-lint-quality
       session_id: S015-metar-lint-quality
@@ -2603,6 +2603,13 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - >-
+      2026-07-21 S019/EV-014 07-build M2 T2.6 done — SQL Server aioodbc path + ODBC skip;
+      next T2.7 ODBC driver docs; branch cursor/s019-t26-sqlserver-aioodbc-4b72
+      (commit pending append after git)
+    - >-
+      2026-07-21 S019/EV-014 open PR stack #755 #756 #757 #758 merged to main
+      (7a9cb37/4afa313/1b9ac97/77a37c7)
     - >-
       2026-07-21 S019/EV-014 07-build M2 T2.5 done (aa5ea23) — Compose/Testcontainers
       PG+MySQL+SQLite writer-contract; next T2.6 SQL Server aioodbc
@@ -2722,9 +2729,9 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+      note: T2.6 completed; next T2.7 ODBC driver docs
       active_milestone: M2
-      active_task: T2.6
+      active_task: T2.7
       active_task_status: pending
   09-qa:
     status: completed
@@ -3318,7 +3325,8 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M2 T2.5 done; next T2.6; Q15=A+Q8=C+Q21=A live BYOC hard close gate
+      Phase C — 07-build M2 T2.6 done; next T2.7; PRs #755–#758 merged to main;
+      Q15=A+Q8=C+Q21=A live BYOC hard close gate
 
 stages_pending: []
 
@@ -3554,6 +3562,29 @@ issue_log:
   resolved_at: "2026-07-12"
 
 decisions_log:
+- id: N-S019-EV014-T26-complete
+  date: '2026-07-21'
+  session_id: S019-dissemination-upload
+  evolve_cycle_id: EV-014
+  stage: 07-build
+  skill_id: 07-build
+  status: noted
+  decision: >-
+    T2.6 completed — SQL Server aioodbc path + ODBC skip when driver absent;
+    next T2.7 ODBC driver docs. Branch cursor/s019-t26-sqlserver-aioodbc-4b72;
+    [T2.6] commit pending append after git. No user decision; progress note.
+- id: N-S019-EV014-prs-755-758-merged
+  date: '2026-07-21'
+  session_id: S019-dissemination-upload
+  evolve_cycle_id: EV-014
+  stage: 07-build
+  skill_id: 07-build
+  status: noted
+  decision: >-
+    S019 open PR stack #755 #756 #757 #758 merged to main (2026-07-21) —
+    #755 cursor/s019-05-verify-tech-b45b (7a9cb37); #756 cursor/s019-06-tech-tooling-9a92
+    (4afa313); #757 cursor/s019-07-build-m1-9a92 (1b9ac97); #758
+    cursor/s019-t25-writer-contract-engines-ce70 (77a37c7). Progress note.
 - id: N-S019-EV014-T25-complete
   date: '2026-07-21'
   session_id: S019-dissemination-upload
@@ -7947,6 +7978,12 @@ evolve_cycles:
     note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
   current_stage: 07-build
   notes:
+  - >-
+    2026-07-21 S019/EV-014 07-build M2 T2.6 completed — SQL Server aioodbc path + ODBC skip;
+    next T2.7 ODBC driver docs; branch cursor/s019-t26-sqlserver-aioodbc-4b72
+  - >-
+    2026-07-21 S019/EV-014 open PR stack #755 #756 #757 #758 merged to main
+    (7a9cb37/4afa313/1b9ac97/77a37c7)
   - 2026-07-21 S019/EV-014 07-build M2 T2.5 completed (aa5ea23); next T2.6 SQL Server aioodbc
   - 2026-07-21 S019/EV-014 07-build M2 T2.5 in_progress — Compose/Testcontainers PG+MySQL+SQLite (TC-F16-003)
   - 2026-07-21 S019/EV-014 07-build M1 complete (T1.1–T1.5; 4b523db/2a47a87/5c2be0c/f0332cf/66f1177); next M2 T2.1
@@ -8007,7 +8044,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-20'
-      note: "Phase C — 07-build M2 T2.5 done; next T2.6"
+      note: "Phase C — 07-build M2 T2.6 done; next T2.7; PRs #755–#758 merged to main"
     01-requirements:
       status: completed
       mode: delta
@@ -8084,9 +8121,9 @@ evolve_cycles:
       status: in_progress
       mode: full
       started: '2026-07-21'
-      note: M2 T2.5 done; next T2.6 SQL Server aioodbc
+      note: T2.6 completed; next T2.7 ODBC driver docs
       active_milestone: M2
-      active_task: T2.6
+      active_task: T2.7
       active_task_status: pending
   gates:
     a_to_b: passed
@@ -10749,12 +10786,18 @@ evolve_cycles:
   merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-t25-writer-contract-engines-ce70
+  current_branch: cursor/s019-t26-sqlserver-aioodbc-4b72
   ahead_of_origin: 0
   pushed: true
-  pending_commit: 'docs(S019): Phase 0 approve + 01-requirements delta (F16–F19)'
-  tip_sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
+  pending_commit: '[T2.6] SQL Server aioodbc path + ODBC skip (append after git)'
+  tip_sha: 77a37c7a9aefb3d38ec5a3728851921ad1a7fd05
   notes:
+  - >-
+    2026-07-21 S019/EV-014 tip 77a37c7 on cursor/s019-t26-sqlserver-aioodbc-4b72 (tracks main
+    after #755–#758); T2.6 work uncommitted — [T2.6] commit pending append after git; next T2.7
+  - >-
+    2026-07-21 S019/EV-014 PR stack merged to main — #755 (7a9cb37), #756 (4afa313),
+    #757 (1b9ac97), #758 (77a37c7)
   - "2026-07-21 S019/EV-014 tip aa5ea23 — [T2.5] Compose/Testcontainers PG+MySQL+SQLite writer-contract; next T2.6"
   - "2026-07-21 S019/EV-014 branch cursor/s019-t25-writer-contract-engines-ce70 — M2 T2.5 in_progress"
   - "2026-07-21 S019/EV-014 tip 3e8a10a — [T0.1] chore: dissemination coverage paths + CI Compose wis2box hooks; Phase B Assumed PASS"
@@ -10946,8 +10989,18 @@ git_history:
   - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
   - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
-  - name: cursor/s019-t25-writer-contract-engines-ce70
+  - name: cursor/s019-t26-sqlserver-aioodbc-4b72
     status: active
+    base: main
+    created: '2026-07-21'
+    created_at: '2026-07-21'
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    purpose: S019/EV-014 07-build M2 T2.6 SQL Server aioodbc
+    tip_sha: 77a37c7a9aefb3d38ec5a3728851921ad1a7fd05
+    note: T2.6 completed (uncommitted); next T2.7 ODBC docs; [T2.6] commit pending append after git
+  - name: cursor/s019-t25-writer-contract-engines-ce70
+    status: merged
     base: cursor/s019-07-build-m1-9a92
     created: '2026-07-21'
     created_at: '2026-07-21'
@@ -10955,33 +11008,39 @@ git_history:
     evolve_cycle_id: EV-014
     purpose: S019 EV-014 07-build M2 T2.5 multi-DB integration
     tip_sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
-    note: T2.5 completed; next T2.6 SQL Server aioodbc
+    pr_number: 758
+    note: merged to main via PR #758 (77a37c7)
   - name: cursor/s019-07-build-m1-9a92
-    status: active
+    status: merged
     base: cursor/s019-06-tech-tooling-9a92
     created: '2026-07-21'
     created_at: '2026-07-21'
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: S019 EV-014 07-build M1
+    pr_number: 757
+    note: merged to main via PR #757 (1b9ac97)
   - name: cursor/s019-06-tech-tooling-9a92
-    status: active
+    status: merged
     base: cursor/s019-05-verify-tech-b45b
     created: '2026-07-21'
     created_at: '2026-07-21'
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: S019/EV-014 06-tech-tooling T0.1
+    pr_number: 756
+    note: merged to main via PR #756 (4afa313)
   - name: cursor/s019-05-verify-tech-b45b
     base: main
-    status: in_progress
+    status: merged
     created_at: "2026-07-21"
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: "S019/EV-014 05-verify-tech PASS for dissemination plan"
     pushed: true
     tip_sha: 4abb451
-    note: "[S019] docs: 05-verify-tech PASS — tip 4abb451"
+    pr_number: 755
+    note: merged to main via PR #755 (7a9cb37)
   - name: cursor/dissemination-upload-e25c
     base: cursor/metar-remarks-live-e2e-2e2e
     status: active

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -2606,7 +2606,7 @@ stages:
     - >-
       2026-07-21 S019/EV-014 07-build M2 T2.6 done — SQL Server aioodbc path + ODBC skip;
       next T2.7 ODBC driver docs; branch cursor/s019-t26-sqlserver-aioodbc-4b72
-      (commit pending append after git)
+      tip 50d213d; PR #759 open
     - >-
       2026-07-21 S019/EV-014 open PR stack #755 #756 #757 #758 merged to main
       (7a9cb37/4afa313/1b9ac97/77a37c7)
@@ -3572,7 +3572,7 @@ decisions_log:
   decision: >-
     T2.6 completed — SQL Server aioodbc path + ODBC skip when driver absent;
     next T2.7 ODBC driver docs. Branch cursor/s019-t26-sqlserver-aioodbc-4b72;
-    [T2.6] commit pending append after git. No user decision; progress note.
+    tip 50d213d (50d213d277b7d66bc1afeca928b9d47b3e46b9f2); PR #759 open. No user decision; progress note.
 - id: N-S019-EV014-prs-755-758-merged
   date: '2026-07-21'
   session_id: S019-dissemination-upload
@@ -10789,12 +10789,13 @@ git_history:
   current_branch: cursor/s019-t26-sqlserver-aioodbc-4b72
   ahead_of_origin: 0
   pushed: true
-  pending_commit: '[T2.6] SQL Server aioodbc path + ODBC skip (append after git)'
-  tip_sha: 77a37c7a9aefb3d38ec5a3728851921ad1a7fd05
+  pending_commit: null
+  tip_sha: 50d213d277b7d66bc1afeca928b9d47b3e46b9f2
+  tip_sha_full: 50d213d277b7d66bc1afeca928b9d47b3e46b9f2
   notes:
   - >-
-    2026-07-21 S019/EV-014 tip 77a37c7 on cursor/s019-t26-sqlserver-aioodbc-4b72 (tracks main
-    after #755–#758); T2.6 work uncommitted — [T2.6] commit pending append after git; next T2.7
+    2026-07-21 S019/EV-014 tip 50d213d (50d213d277b7d66bc1afeca928b9d47b3e46b9f2) on
+    cursor/s019-t26-sqlserver-aioodbc-4b72; [T2.6] recorded; PR #759 open; next T2.7
   - >-
     2026-07-21 S019/EV-014 PR stack merged to main — #755 (7a9cb37), #756 (4afa313),
     #757 (1b9ac97), #758 (77a37c7)
@@ -10997,8 +10998,16 @@ git_history:
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: S019/EV-014 07-build M2 T2.6 SQL Server aioodbc
-    tip_sha: 77a37c7a9aefb3d38ec5a3728851921ad1a7fd05
-    note: T2.6 completed (uncommitted); next T2.7 ODBC docs; [T2.6] commit pending append after git
+    tip_sha: 50d213d277b7d66bc1afeca928b9d47b3e46b9f2
+    tip_sha_full: 50d213d277b7d66bc1afeca928b9d47b3e46b9f2
+    pushed: true
+    pr_number: 759
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/759
+    pr_title: '[T2.6] SQL Server aioodbc writer-contract path (S019/EV-014)'
+    pr_base: main
+    pr_head: cursor/s019-t26-sqlserver-aioodbc-4b72
+    pr_status: open
+    note: T2.6 committed (50d213d); PR #759 open; next T2.7 ODBC driver docs
   - name: cursor/s019-t25-writer-contract-engines-ce70
     status: merged
     base: cursor/s019-07-build-m1-9a92
@@ -11370,6 +11379,29 @@ git_history:
     pr_number: 716
     note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+  - sha: 50d213d277b7d66bc1afeca928b9d47b3e46b9f2
+    short: 50d213d
+    branch: cursor/s019-t26-sqlserver-aioodbc-4b72
+    message: "[T2.6] test: SQL Server aioodbc path with ODBC skip"
+    stage: 07-build
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    timestamp: '2026-07-21T03:56:00Z'
+    files_changed_note: odbc.py, sqlserver tests, URI normalize, README, Makefile, workflow-state, handoff
+    files_changed:
+    - Makefile
+    - docs/dependency-inventory.md
+    - docs/sessions/S019-dissemination-upload/HANDOFF.md
+    - docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+    - packages/dissemination/README.md
+    - packages/dissemination/pyproject.toml
+    - packages/dissemination/src/dissemination/db_preflight.py
+    - packages/dissemination/src/dissemination/odbc.py
+    - packages/dissemination/src/dissemination/writer_contract.py
+    - packages/dissemination/tests/test_db_preflight_handles.py
+    - packages/dissemination/tests/test_odbc.py
+    - packages/dissemination/tests/test_writer_contract_sqlserver.py
+    - workflow-state.yaml
   - sha: aa5ea23a19acfac0e55adca903bb21ecdd0841d7
     short: aa5ea23
     branch: cursor/s019-t25-writer-contract-engines-ce70


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues **S019 / EV-014** 07-build **M2 T2.6**: SQL Server writer-contract via **aioodbc**, with CI-friendly skip when no ODBC driver is installed (E14-06 / TC-F16-003).

Also merges the prior session stack into `main` (done in this session): **#755, #756, #757, #758**.

## Changes

- `normalize_sqlalchemy_uri(..., "sqlserver")` → `mssql+aioodbc://`
- `dissemination.odbc` — probe/list preferred SQL Server ODBC drivers
- Integration tests (`test_writer_contract_sqlserver.py`) via Testcontainers; **skip without ODBC**
- Unit coverage for ODBC helpers (95% gate maintained)
- README / dependency-inventory note ODBC skip; Makefile runs all `-m integration` dissemination tests
- **CI follow-ups:** COPY `packages/dissemination` into backend Dockerfile; BrokenEngine teardown isolation; api fallback stub; DNS `OSError` → allowlist deny; coverage concurrency + dissemination API branch tests

## Test plan

- [x] `make test-unit-dissemination` (coverage ≥95%)
- [x] `make test-integration-dissemination` (SQL Server cases skipped without ODBC; PG/MySQL/SQLite green)
- [x] Backend unit dissemination + fallback + BrokenEngine teardown
- [x] CI green on this branch (https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29800844346)

## Next

**T2.7** — ODBC driver notes in `docs/deploy.md` / package README.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82c2-e85d-77cf-bbc0-9d9584914b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82c2-e85d-77cf-bbc0-9d9584914b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add SQL Server aioodbc writer-contract support with ODBC-aware integration tests and CI/docs updates, plus backend robustness and dissemination API error-handling improvements.

New Features:
- Add SQL Server writer-contract path using aioodbc, including URI normalization for the sqlserver sink.
- Introduce ODBC driver probing utilities for SQL Server and expose availability and preferred-driver selection.
- Extend multi-DB integration test suite to cover SQL Server via Testcontainers with conditional skipping when no ODBC driver is installed.

Bug Fixes:
- Ensure database engine teardown safely handles engines without an async dispose method and clears engine state after failures.
- Treat DNS resolution failures that raise OSError as egress-denied in the allowlist logic.
- Improve dissemination API error handling so invalid JSON, missing fields, writer-contract mismatches, allowlist denials, rate-limit hits, and unexpected errors map to appropriate HTTP status codes.

Enhancements:
- Update writer-contract support to recognize the mssql/sqlserver dialect and document SQL Server support.
- Make backend API import fallback tests cover the dissemination router to guard against missing imports.
- Configure backend coverage to use thread and greenlet concurrency for more accurate reporting.

Build:
- Include the dissemination package and its pyproject in the backend Docker image build so dissemination functionality is available at runtime.
- Run all dissemination integration tests via the test-integration-dissemination make target instead of a single engines test file.

Documentation:
- Update dissemination package README and dependency inventory to document SQL Server aioodbc integration and skip behavior when no ODBC driver is present.
- Refresh workflow-state, handoff, and execution-plan docs to record completion of task T2.6 and the next ODBC docs task T2.7.

Tests:
- Add SQL Server-specific writer-contract integration tests that exercise happy-path and mismatch scenarios using aioodbc against a containerized SQL Server.
- Add unit tests for ODBC driver probing functions, including driver filtering, preference order, and behavior when pyodbc is absent.
- Expand dissemination API unit tests to cover preflight/send validation, error mapping, and rate-limit behavior.
- Add an allowlist test case to verify that DNS OSError leads to egress denial.
- Adjust database service unit tests to verify BrokenEngine teardown isolation and cleanup.