### PR TITLE
[T3.3] docker-compose wis2box harness + CI service (S019/EV-014)

### DIFF
--- a/.cursor/rules/optional/dissemination-coverage-compose.mdc
+++ b/.cursor/rules/optional/dissemination-coverage-compose.mdc
@@ -19,12 +19,13 @@ Traces to ADR-007, ADR-030, E14-04, E14-09, execution-plan T0.1 / T3.3.
 
 ## wis2box Compose harness (F17)
 
-- Overlay file: `docker-compose.wis2box.yml` (profile `wis2box`).
-- **Not** a long-lived Render web service (E14-04=B).
-- CI/Makefile: `make compose-wis2box-up` / `scripts/ci/run_wis2box_harness.sh`.
-- Harness script skips until a `wis2box:` service exists (T3.3).
-- Staging allowlist may list Compose/CI hosts when the harness runs
-  (`DISSEMINATION_EGRESS_ALLOWLIST` — ADR-029).
+- Overlay file: `docker-compose.wis2box.yml` (profile `wis2box`) — service `wis2box`.
+- Image: `packages/dissemination/docker/wis2box-harness` (MQTT + HTTP dataset
+  stand-in; **not** the full WMO wis2box stack; **not** a Render web service — E14-04=B).
+- CI/Makefile: `make compose-wis2box-up` / `scripts/ci/run_wis2box_harness.sh`
+  (integration job in `ci-cd.yml`).
+- Staging allowlist must list Compose/CI hosts when the harness runs
+  (`DISSEMINATION_EGRESS_ALLOWLIST=wis2box,127.0.0.1,localhost` — ADR-029).
 
 ## Package boundary
 

--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,10 @@ INGEST_POLL_INTERVAL_SEC=30
 # F16–F19 dissemination egress (ADR-029). Comma-separated hostnames and/or CIDRs.
 # Empty = fail-closed (no user-URI / user-host egress). Never put secrets here —
 # pasted BYOC credentials are memory-only on preflight/send.
+# For local/CI wis2box harness (F17 / T3.3), include loopback + compose DNS, e.g.:
+#   DISSEMINATION_EGRESS_ALLOWLIST=wis2box,127.0.0.1,localhost
 DISSEMINATION_EGRESS_ALLOWLIST=
+
+# F17 wis2box Compose harness host ports (docker-compose.wis2box.yml profile wis2box).
+WIS2BOX_MQTT_HOST_PORT=1883
+WIS2BOX_HTTP_HOST_PORT=9080

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -221,7 +221,7 @@ jobs:
           cd apps/backend && uv run pytest tests/infrastructure/test_smoke.py -k "cor or conversion or workflow" -q --no-cov
           docker compose down
 
-      # F17 / E14-04 — wis2box Compose harness hook (skips until T3.3 defines wis2box service).
+      # F17 / E14-04 / T3.3 — wis2box Compose harness (MQTT + HTTP dataset smoke).
       - name: Run wis2box Compose harness hook
         if: matrix.package == 'integration'
         run: bash scripts/ci/run_wis2box_harness.sh

--- a/Makefile
+++ b/Makefile
@@ -227,16 +227,13 @@ test-integration-dissemination:
 	$(UV) run pytest packages/dissemination/tests \
 		-m integration -v --tb=short --no-cov
 
-# F17 / E14-04 — wis2box Compose harness (overlay); real service in T3.3.
+# F17 / E14-04 — wis2box Compose harness (MQTT + HTTP dataset overlay; T3.3).
 compose-wis2box-up:
-	@if ! grep -Eq '^[[:space:]]*wis2box:[[:space:]]*$$' docker-compose.wis2box.yml 2>/dev/null; then \
-		echo "skip: wis2box service not defined yet (T3.3) — see docker-compose.wis2box.yml"; \
-	else \
-		$(COMPOSE) -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box up -d; \
-	fi
+	$(COMPOSE) -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box up -d --build --wait wis2box
 
 compose-wis2box-down:
-	@$(COMPOSE) -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box down --remove-orphans || true
+	@$(COMPOSE) -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box stop wis2box || true
+	@$(COMPOSE) -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box rm -f wis2box || true
 
 compose-wis2box-harness:
 	bash scripts/ci/run_wis2box_harness.sh

--- a/docker-compose.wis2box.yml
+++ b/docker-compose.wis2box.yml
@@ -1,12 +1,44 @@
 # F17 / E14-04 / ADR-030 — wis2box test harness overlay (Compose / CI only).
-# Not a Render web service. Real `wis2box` service + image pin land in T3.3.
+# Not a Render web service. Lightweight MQTT + HTTP dataset stand-in (T3.3);
+# full WMO wis2box stack is out of scope for CI cost (Q17 testing-only).
 #
-# Usage (after T3.3):
+# Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.wis2box.yml --profile wis2box up -d
 #   make compose-wis2box-up
 #   bash scripts/ci/run_wis2box_harness.sh
 #
-# Readiness probe for tooling: scripts/ci/run_wis2box_harness.sh looks for a
-# top-level `wis2box:` service key. Until then the script exits 0 (skip).
+# Host ports (override via .env):
+#   WIS2BOX_MQTT_HOST_PORT (default 1883)
+#   WIS2BOX_HTTP_HOST_PORT (default 9080)
+# Dataset URL example (host): http://127.0.0.1:9080/datasets/example.xml
+# Dataset URL example (compose net): http://wis2box:8080/datasets/example.xml
 
-services: {}
+services:
+  wis2box:
+    profiles: ["wis2box"]
+    build:
+      context: ./packages/dissemination/docker/wis2box-harness
+      dockerfile: Dockerfile
+    image: metar-iwxxm-wis2box-harness:local
+    container_name: metar-iwxxm-wis2box
+    ports:
+      - "${WIS2BOX_MQTT_HOST_PORT:-1883}:1883"
+      - "${WIS2BOX_HTTP_HOST_PORT:-9080}:8080"
+    environment:
+      - WIS2BOX_HTTP_PORT=8080
+      - WIS2BOX_DATASET_DIR=/var/lib/wis2box-harness/datasets
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-sf",
+          "http://127.0.0.1:8080/health",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    networks:
+      - metar-network
+    restart: unless-stopped

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -157,6 +157,16 @@ template-conformance, api-contract Planned routes, dependency-inventory Planned 
 - Assumed PASS (cloud AQ waived): 05 audited; 06 T0.1 installed; B→C open.
 - Next: **07-build** M1 T1.1.
 
+### T3.3 wis2box harness image (D-S019-EV014-T33-harness)
+
+- **A — Lightweight MQTT + HTTP dataset stand-in** under
+  `packages/dissemination/docker/wis2box-harness` (`python:3.12.11-slim-bookworm` + Debian
+  `mosquitto`); Compose overlay `docker-compose.wis2box.yml` profile `wis2box`; CI hook
+  `scripts/ci/run_wis2box_harness.sh` on integration matrix.
+- Reject full WMO wis2box-release multi-container stack for CI cost/ops (E14-04 / Q17
+  testing-only). Live WIS2 remains BYOC (TC-F17-002).
+- Merged session stack before T3.3: PR #761 (T2.7), #762 (T3.1–T3.2) → `main`.
+
 ### Notes
 
 - Prior: S018/EV-013 closed 2026-07-20 (Q0=A waive leftover 08/09/11/12); #750 remarks live

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -40,6 +40,7 @@
 | Package | Purpose | License | Source |
 |---------|---------|---------|--------|
 | testcontainers[mysql,postgres] | PG/MySQL Testcontainers for TC-F16-003 (T2.5) | MIT | PyPI (`>=4.8`); workspace `dev` + package optional `integration` |
+| python:3.12.11-slim-bookworm + mosquitto (apt) | F17 wis2box Compose harness image (T3.3) — MQTT + HTTP dataset stand-in | PSF / EPL-2.0 (mosquitto) | Docker Hub / Debian; build context `packages/dissemination/docker/wis2box-harness` |
 
 Package license: **MIT**. No FastAPI/Supabase imports. Backend already has `sqlalchemy` +
 `asyncpg` + `psycopg`; package may declare overlapping pins via workspace.
@@ -182,3 +183,6 @@ New dependencies require `[Decision]` + back-add to this file per plan-adherence
   tests **skip when no ODBC driver** (E14-06)
 - S019 / EV-014 T2.7 (2026-07-21): ODBC driver install/verify notes in `docs/deploy.md` +
   `packages/dissemination/README.md` (E14-06); stock API image still omits `msodbcsql18`
+- S019 / EV-014 T3.3 (2026-07-21): wis2box Compose harness — **lightweight MQTT+HTTP image**
+  (`python:3.12.11-slim-bookworm` + Debian `mosquitto`); reject full WMO wis2box release stack
+  for CI cost (E14-04 / Q17); not a Render service

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Platform**: Render (Docker web service + static site + Background Worker)
-> **Last updated**: 2026-07-21 (S019 / EV-014 T2.7 — SQL Server ODBC driver notes)
+> **Last updated**: 2026-07-21 (S019 / EV-014 T3.3 — wis2box Compose harness)
 
 ## Topology (post-monorepo + F8)
 
@@ -150,6 +150,22 @@ E14-06). Default CI images may omit ODBC — that is expected.
 `msodbcsql18`. Stock Render **metar-api** cannot open SQL Server BYOC URIs until the image
 (or base) gains a system ODBC SQL Server driver. Postgres / MySQL / SQLite sinks do not need
 ODBC. Package README: [`packages/dissemination/README.md`](../packages/dissemination/README.md).
+
+### wis2box Compose harness (F17 / E14-04)
+
+Staging WIS2 uses a **Docker Compose / CI harness** — not a Render web service. Image build
+context: `packages/dissemination/docker/wis2box-harness` (MQTT `:1883` + HTTP dataset
+`:8080` / host `:9080`). Overlay: `docker-compose.wis2box.yml` (profile `wis2box`).
+
+```bash
+make compose-wis2box-up
+curl -s http://127.0.0.1:9080/health
+make compose-wis2box-harness   # CI hook: up + probe + PUT/GET smoke
+make compose-wis2box-down
+```
+
+Set `DISSEMINATION_EGRESS_ALLOWLIST=wis2box,127.0.0.1,localhost` when exercising the sink
+against the harness. Live WIS2 acceptance remains operator BYOC (TC-F17-002).
 
 ## Docker Build Context
 

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,20 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M3 T3.3
+/16-evolve continue S019/EV-014 — 07-build M3 T3.4
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Branch | `cursor/s019-t31-wis2-unit-tests-ee99` (T3.1–T3.2; includes T2.7 tip) |
-| PR (T2.7) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/761 (CI green) |
-| PR (T3.1–T3.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/762 (CI green) |
-| Done | M1; M2; M3 through **T3.2** (WIS2 sink + mocked unit tests) |
-| Next | **T3.3** `docker-compose` wis2box harness + CI service/job |
+| Branch | `cursor/s019-t33-wis2box-harness-c6f7` (T3.3) |
+| Merged into `main` | #761 (T2.7), #762 (T3.1–T3.2) |
+| Done | M1; M2; M3 through **T3.3** (Compose wis2box harness + CI hook) |
+| Next | **T3.4** Staging harness publish green (TC-F17-001) |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close
-- Merge #761 then #762 (or squash stack) before T3.3 lands on `main`
+- T3.4 should use the harness MQTT + HTTP surfaces (allowlist `wis2box,127.0.0.1,localhost`)

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,6 +11,7 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-t33-wis2box-harness-c6f7` (T3.3) |
+| PR (T3.3) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/763 (CI green) |
 | Merged into `main` | #761 (T2.7), #762 (T3.1–T3.2) |
 | Done | M1; M2; M3 through **T3.3** (Compose wis2box harness + CI hook) |
 | Next | **T3.4** Staging harness publish green (TC-F17-001) |

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -16,8 +16,8 @@
 |-------|-------|
 | **Active phase** | Phase C — **07-build** M3 in progress |
 | **Active milestone** | M3 — WIS2 + Compose wis2box harness |
-| **Active task** | T3.3 (next) |
-| **Tasks** | 15 / **29** completed (through T3.2) |
+| **Active task** | T3.4 (next) |
+| **Tasks** | 16 / **29** completed (through T3.3) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -40,7 +40,7 @@
 
 | Asset | Staging | Needed By |
 |-------|---------|-----------|
-| Compose wis2box image/config | pending (M3) | T3.x / TC-F17-001 |
+| Compose wis2box image/config | staged (T3.3 harness image) | T3.4 / TC-F17-001 |
 | ODBC driver (CI/docs for SQL Server) | staged (skip-without-ODBC tests) | T2.6–T2.7 done |
 | Live BYOC creds (operator) | cycle close only | TC-F16/17/18 live gates |
 
@@ -76,7 +76,7 @@
 |------|------|-------------|-------------|------------|--------|
 | T3.1 | Test | WIS2 sink adapter unit tests (mocked MQTT/HTTP) | TC-F17-001; E14-09 | T2.4 | **completed** |
 | T3.2 | Code | WIS2 sink in `packages/dissemination` | F17; ADR-030 | T3.1 | **completed** |
-| T3.3 | Config | `docker-compose` wis2box harness + CI service/job | E14-04; TC-F17-001 | T3.2 | pending |
+| T3.3 | Config | `docker-compose` wis2box harness + CI service/job | E14-04; TC-F17-001 | T3.2 | **completed** |
 | T3.4 | Test | Staging harness publish green (TC-F17-001) | UJ-028 | T3.3 | pending |
 
 ### M4 — EDIS SMTP (F18)

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -542,8 +542,10 @@ Before closing S013 / EV-009:
 ### TC-F17-001: Staging wis2box publish (UJ-028)
 
 - **Level**: T2 / staging
-- **Objective**: Publish IWXXM to project wis2box harness (Render/Docker)
-- **Pass criteria**: MQTT notify + HTTP dataset retrievable
+- **Objective**: Publish IWXXM to project wis2box Compose harness (E14-04; not Render)
+- **Harness (T3.3)**: `docker-compose.wis2box.yml` profile `wis2box` — MQTT + HTTP dataset
+  stand-in; CI hook `scripts/ci/run_wis2box_harness.sh` (up + health + PUT/GET smoke)
+- **Pass criteria**: MQTT notify + HTTP dataset retrievable (publish path = T3.4)
 - **Source**: F17; #2; Q12=B / Q17
 
 ### TC-F17-002: Live WIS2 BYOC close gate (UJ-028)
@@ -798,7 +800,7 @@ pre-commit fast hooks where applicable. Scheduled workflows (`vendor-sync`, load
 | Trigger | Workflow | Jobs | Checks |
 |---------|----------|------|--------|
 | PR / push `main`, `dev` | `ci-cd.yml` | **validate** | ruff format/check, prettier, eslint, basedpyright, tsc, gitleaks, actionlint/yamllint, config-guard (`tests/test_config_placeholders.py`), frontend npm audit |
-| PR / push `main`, `dev` | `ci-cd.yml` | **test** | matrix unit+coverage (backend, auth, **tac2iwxxm**, **tac-validate**, **iwxxm-validate**, **dissemination** (skip until scaffolded), frontend, shared @ 98% — **gifts removed at F6 cutover**), integration matrix (docker compose + wis2box harness hook skip-until-T3.3), Codecov upload (95% gate) |
+| PR / push `main`, `dev` | `ci-cd.yml` | **test** | matrix unit+coverage (backend, auth, **tac2iwxxm**, **tac-validate**, **iwxxm-validate**, **dissemination**, frontend, shared @ 98% — **gifts removed at F6 cutover**), integration matrix (docker compose + **wis2box Compose harness** T3.3 MQTT/HTTP smoke), Codecov upload (95% gate) |
 | push `main` only | `ci-cd.yml` | **deploy** | Docker build/push GHCR, Render deploy hooks |
 | Schedule | `vendor-sync.yml` | vendor-sync | wmo-im schema sync PR (M6) |
 | Manual / schedule | `load-tests.yml`, `e2e-tests.yml` | — | out of EV-002 scope |

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -52,10 +52,13 @@ Deploy / image notes (CI skip policy, stock API Dockerfile without `msodbcsql18`
 
 - `dissemination.wis2` — `wis2_preflight` / `wis2_publish` with injectable MQTT + HTTP
   clients (unit-tested with mocks; no broker required)
-- Compose wis2box harness lands in T3.3; live BYOC remains the cycle-close gate
+- Compose wis2box harness (T3.3): MQTT + HTTP dataset stand-in under
+  `packages/dissemination/docker/wis2box-harness` — see that README
+- Live BYOC remains the cycle-close gate (TC-F17-002)
 
 **Egress allowlist**
 
 - Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)
 - Empty ⇒ fail-closed
-- Compose wis2box harness: `make compose-wis2box-up` / `compose-wis2box-harness` (T3.3 fills service)
+- Compose wis2box harness: `make compose-wis2box-up` / `compose-wis2box-harness`
+  (allowlist `wis2box,127.0.0.1,localhost` when calling the sink)

--- a/packages/dissemination/docker/wis2box-harness/Dockerfile
+++ b/packages/dissemination/docker/wis2box-harness/Dockerfile
@@ -1,0 +1,23 @@
+# F17 / E14-04 — lightweight wis2box *test harness* (MQTT + HTTP dataset).
+# Not the full WMO wis2box stack (too heavy for CI). Live WIS2 remains BYOC.
+FROM python:3.12.11-slim-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    mosquitto \
+    curl \
+    netcat-openbsd \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY mosquitto.conf /etc/mosquitto/mosquitto.conf
+COPY dataset_server.py entrypoint.sh /opt/wis2box-harness/
+RUN chmod +x /opt/wis2box-harness/entrypoint.sh \
+  && mkdir -p /var/lib/wis2box-harness/datasets
+
+EXPOSE 1883 8080
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=12 \
+  CMD curl -sf http://127.0.0.1:8080/health \
+    && nc -z 127.0.0.1 1883
+
+ENTRYPOINT ["/opt/wis2box-harness/entrypoint.sh"]

--- a/packages/dissemination/docker/wis2box-harness/README.md
+++ b/packages/dissemination/docker/wis2box-harness/README.md
@@ -3,8 +3,8 @@
 Lightweight **test harness** for TC-F17-001 — MQTT broker + HTTP dataset PUT/GET.
 Not a long-lived Render service (E14-04=B). Not the full WMO wis2box release stack.
 
-| Surface | Port (container) | Host default |
-|---------|------------------|--------------|
+| Surface | Port (container) | Host default                    |
+| ------- | ---------------- | ------------------------------- |
 | MQTT    | 1883             | `WIS2BOX_MQTT_HOST_PORT` (1883) |
 | HTTP    | 8080             | `WIS2BOX_HTTP_HOST_PORT` (9080) |
 

--- a/packages/dissemination/docker/wis2box-harness/README.md
+++ b/packages/dissemination/docker/wis2box-harness/README.md
@@ -1,0 +1,20 @@
+# wis2box Compose harness (F17 / T3.3)
+
+Lightweight **test harness** for TC-F17-001 — MQTT broker + HTTP dataset PUT/GET.
+Not a long-lived Render service (E14-04=B). Not the full WMO wis2box release stack.
+
+| Surface | Port (container) | Host default |
+|---------|------------------|--------------|
+| MQTT    | 1883             | `WIS2BOX_MQTT_HOST_PORT` (1883) |
+| HTTP    | 8080             | `WIS2BOX_HTTP_HOST_PORT` (9080) |
+
+```bash
+# from repo root
+make compose-wis2box-up
+curl -s http://127.0.0.1:9080/health
+make compose-wis2box-harness   # CI hook (up + probe + optional wis2* pytest)
+make compose-wis2box-down
+```
+
+Allowlist Compose/CI hosts when exercising the sink (ADR-029), e.g.
+`DISSEMINATION_EGRESS_ALLOWLIST=wis2box,127.0.0.1,localhost`.

--- a/packages/dissemination/docker/wis2box-harness/dataset_server.py
+++ b/packages/dissemination/docker/wis2box-harness/dataset_server.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Minimal HTTP dataset store for the F17 Compose wis2box harness (T3.3).
+
+Supports GET/HEAD/PUT under ``/datasets/*`` plus ``GET /health``. Not a full
+wis2box stack — MQTT + HTTP surfaces only (E14-04 / Q17 test harness).
+"""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+class DatasetHandler(BaseHTTPRequestHandler):
+    """Serve PUT/GET dataset objects from an on-disk directory."""
+
+    storage_root: Path
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Quiet default access logs (compose healthchecks are noisy)."""
+        if self.path.startswith("/health"):
+            return
+        super().log_message(fmt, *args)
+
+    def _dataset_path(self) -> Path | None:
+        parsed = urlparse(self.path)
+        path = unquote(parsed.path)
+        if not path.startswith("/datasets/"):
+            return None
+        rel = path[len("/datasets/") :]
+        if not rel or ".." in Path(rel).parts:
+            return None
+        return self.storage_root / rel
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler API
+        if urlparse(self.path).path == "/health":
+            body = b'{"ok":true,"service":"wis2box-harness"}\n'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        target = self._dataset_path()
+        if target is None:
+            self.send_error(404, "not found")
+            return
+        if not target.is_file():
+            self.send_error(404, "dataset missing")
+            return
+        data = target.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_HEAD(self) -> None:  # noqa: N802
+        if urlparse(self.path).path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            return
+        target = self._dataset_path()
+        if target is None or not target.is_file():
+            self.send_error(404, "not found")
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(target.stat().st_size))
+        self.end_headers()
+
+    def do_PUT(self) -> None:  # noqa: N802
+        target = self._dataset_path()
+        if target is None:
+            self.send_error(404, "not found")
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length > 0 else b""
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(body)
+        self.send_response(201)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument(
+        "--storage",
+        default="/var/lib/wis2box-harness/datasets",
+        help="Directory for PUT/GET dataset objects",
+    )
+    args = parser.parse_args()
+    root = Path(args.storage)
+    root.mkdir(parents=True, exist_ok=True)
+    DatasetHandler.storage_root = root
+    server = ThreadingHTTPServer((args.host, args.port), DatasetHandler)
+    print(f"[wis2box-harness] HTTP dataset store on {args.host}:{args.port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/dissemination/docker/wis2box-harness/entrypoint.sh
+++ b/packages/dissemination/docker/wis2box-harness/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Start MQTT broker + HTTP dataset store for the F17 wis2box Compose harness.
+set -euo pipefail
+
+STORAGE="${WIS2BOX_DATASET_DIR:-/var/lib/wis2box-harness/datasets}"
+HTTP_PORT="${WIS2BOX_HTTP_PORT:-8080}"
+mkdir -p "${STORAGE}"
+
+mosquitto -c /etc/mosquitto/mosquitto.conf &
+MQTT_PID=$!
+
+python3 /opt/wis2box-harness/dataset_server.py \
+  --host 0.0.0.0 \
+  --port "${HTTP_PORT}" \
+  --storage "${STORAGE}" &
+HTTP_PID=$!
+
+cleanup() {
+  kill "${MQTT_PID}" "${HTTP_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Fail the container if either child exits.
+while kill -0 "${MQTT_PID}" 2>/dev/null && kill -0 "${HTTP_PID}" 2>/dev/null; do
+  sleep 2
+done
+echo "[wis2box-harness] child process exited unexpectedly" >&2
+exit 1

--- a/packages/dissemination/docker/wis2box-harness/mosquitto.conf
+++ b/packages/dissemination/docker/wis2box-harness/mosquitto.conf
@@ -1,0 +1,9 @@
+# F17 Compose wis2box harness — anonymous MQTT for CI/local test only (E14-04).
+# Not for live/BYOC WIS2 nodes.
+listener 1883
+allow_anonymous true
+persistence false
+connection_messages false
+log_dest stdout
+log_type error
+log_type warning

--- a/scripts/ci/run_wis2box_harness.sh
+++ b/scripts/ci/run_wis2box_harness.sh
@@ -1,43 +1,89 @@
 #!/usr/bin/env bash
-# S019 / EV-014 T0.1 — CI Compose hook for F17 wis2box harness (E14-04).
+# S019 / EV-014 T3.3 — CI Compose hook for F17 wis2box harness (E14-04).
 #
-# Overlay: docker-compose.wis2box.yml (profile wis2box). Real service lands in T3.3.
-# Until a `wis2box` service is defined, exit 0 with skip so the hook can ship in 06.
+# Overlay: docker-compose.wis2box.yml (profile wis2box). Brings up the harness,
+# probes MQTT + HTTP, optionally runs wis2* pytest (T3.4 fills publish cases).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="${ROOT}/docker-compose.wis2box.yml"
 COMPOSE=(docker compose -f "${ROOT}/docker-compose.yml" -f "${COMPOSE_FILE}")
+HTTP_PORT="${WIS2BOX_HTTP_HOST_PORT:-9080}"
+MQTT_PORT="${WIS2BOX_MQTT_HOST_PORT:-1883}"
 
 if [[ ! -f "${COMPOSE_FILE}" ]]; then
-  echo "[wis2box-harness] skip — docker-compose.wis2box.yml missing."
-  exit 0
+  echo "[wis2box-harness] error — docker-compose.wis2box.yml missing." >&2
+  exit 1
 fi
 
 if ! grep -Eq '^[[:space:]]*wis2box:[[:space:]]*$' "${COMPOSE_FILE}"; then
-  echo "[wis2box-harness] skip — no wis2box service yet (execution plan T3.3)."
-  exit 0
+  echo "[wis2box-harness] error — no wis2box service in overlay (T3.3 regression)." >&2
+  exit 1
 fi
 
 cd "${ROOT}"
 echo "[wis2box-harness] bringing up profile wis2box…"
-"${COMPOSE[@]}" --profile wis2box up -d --wait wis2box
+"${COMPOSE[@]}" --profile wis2box up -d --build --wait wis2box
 
 cleanup() {
-  "${COMPOSE[@]}" --profile wis2box down --remove-orphans || true
+  # Stop only the harness service — do not `down` the whole compose project
+  # (that would remove backend/frontend/db if they share the project name).
+  "${COMPOSE[@]}" --profile wis2box stop wis2box || true
+  "${COMPOSE[@]}" --profile wis2box rm -f wis2box || true
 }
 trap cleanup EXIT
 
+probe() {
+  local i
+  for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${HTTP_PORT}/health" >/dev/null \
+      && (echo >"/dev/tcp/127.0.0.1/${MQTT_PORT}") 2>/dev/null; then
+      echo "[wis2box-harness] ready — HTTP :${HTTP_PORT} + MQTT :${MQTT_PORT}"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[wis2box-harness] error — harness did not become ready" >&2
+  "${COMPOSE[@]}" --profile wis2box ps || true
+  "${COMPOSE[@]}" --profile wis2box logs --no-color wis2box || true
+  return 1
+}
+
+probe
+
+# Smoke PUT/GET so T3.3 CI proves the HTTP dataset surface (MQTT port already probed).
+SMOKE_URL="http://127.0.0.1:${HTTP_PORT}/datasets/ci-smoke.xml"
+SMOKE_BODY='<ci>wis2box-harness</ci>'
+curl -sf -X PUT -H 'Content-Type: application/xml' --data "${SMOKE_BODY}" "${SMOKE_URL}" >/dev/null
+GOT="$(curl -sf "${SMOKE_URL}")"
+if [[ "${GOT}" != "${SMOKE_BODY}" ]]; then
+  echo "[wis2box-harness] error — dataset PUT/GET mismatch" >&2
+  exit 1
+fi
+echo "[wis2box-harness] HTTP dataset PUT/GET smoke ok"
+
 # Optional pytest path when TC-F17-001 tests exist (T3.4).
+# Allowlist loopback/harness hosts for sink egress during those tests.
+export DISSEMINATION_EGRESS_ALLOWLIST="${DISSEMINATION_EGRESS_ALLOWLIST:-wis2box,127.0.0.1,localhost}"
+
 shopt -s nullglob
 wis2_tests=(
   "${ROOT}"/packages/dissemination/tests/**/*wis2*
   "${ROOT}"/tests/**/*wis2*
 )
-if ((${#wis2_tests[@]} > 0)); then
-  uv run pytest "${wis2_tests[@]}" \
+# Unit tests under test_wis2_sink.py are mocked — only run files tagged for harness
+# when T3.4 adds them. Prefer explicit *harness* / *staging* names if present.
+harness_tests=()
+for f in "${wis2_tests[@]}"; do
+  case "$(basename "${f}")" in
+    *harness*|*staging*|*compose*) harness_tests+=("${f}") ;;
+  esac
+done
+
+if ((${#harness_tests[@]} > 0)); then
+  uv run pytest "${harness_tests[@]}" \
     -m "not live and not live_api" \
     -v --no-cov
 else
-  echo "[wis2box-harness] compose profile wis2box is up (no wis2* tests found yet — T3.4)."
+  echo "[wis2box-harness] compose profile wis2box green (publish pytest deferred to T3.4)."
 fi

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -12,12 +12,12 @@ active_session:
     test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase
     0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-t31-wis2-unit-tests-ee99
+  branch: cursor/s019-t33-wis2box-harness-c6f7
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 'T3.1–T3.2 done; next T3.3; T2.7 PR #761 still open'
+  note: 'T3.3 done; next T3.4; #761+#762 merged to main; PR #763 open for T3.3'
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -71,7 +71,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-20'
-    note: "Phase C — 07-build M3 T3.1–T3.2 done (PR #762); next T3.3; T2.7 PR #761 still open"
+    note: "Phase C — 07-build M3 T3.3 done (PR #763); next T3.4; #761+#762 merged to main"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -126,7 +126,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-21'
-    note: 'T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762 open @ 8ebfa3a); next T3.3 wis2box Compose harness; T2.7 PR #761 still open (CI green)'
+    note: 'T3.3 done on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90); next T3.4 staging harness publish green; #761+#762 merged to main'
   - stage: 08-verify-build
     required: true
     mode: full
@@ -2548,9 +2548,9 @@ stages:
       started_at: '2026-07-21'
       started: '2026-07-21'
       mode: full
-      note: 'T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762 open @ 8ebfa3a); next T3.3 wis2box Compose harness; T2.7 PR #761 still open (CI green)'
+      note: 'T3.3 done on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90); next T3.4 staging harness publish green; #761+#762 merged to main'
       active_milestone: M3
-      active_task: T3.3
+      active_task: T3.4
       active_task_status: pending
     - id: S015-metar-lint-quality
       session_id: S015-metar-lint-quality
@@ -2603,6 +2603,8 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - >-
+      2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness; PR #763 open @ f222f90. #761+#762 merged to main. Next T3.4 staging harness publish green (TC-F17-001).
     - >-
       2026-07-21 S019/EV-014 T2.7 PR #761 open (CI green). T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762). Next T3.3 wis2box Compose harness.
       Tip 8ebfa3a; T3.1=32d8c83 T3.2=49fe476; next T3.3 pending.
@@ -2741,9 +2743,9 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: 'T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762 open @ 8ebfa3a); next T3.3 wis2box Compose harness; T2.7 PR #761 still open (CI green)'
+      note: 'T3.3 done on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90); next T3.4 staging harness publish green; #761+#762 merged to main'
       active_milestone: M3
-      active_task: T3.3
+      active_task: T3.4
       active_task_status: pending
   09-qa:
     status: completed
@@ -3337,7 +3339,7 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M3 T3.1–T3.2 done (PR #762); next T3.3; T2.7 PR #761 still open; Q15=A+Q8=C+Q21=A live BYOC hard close gate
+      Phase C — 07-build M3 T3.3 done (PR #763); next T3.4; #761+#762 merged to main; Q15=A+Q8=C+Q21=A live BYOC hard close gate
 
 stages_pending: []
 
@@ -3573,6 +3575,20 @@ issue_log:
   resolved_at: "2026-07-12"
 
 decisions_log:
+- id: D-S019-EV014-T33-harness
+  date: '2026-07-21'
+  session_id: S019-dissemination-upload
+  evolve_cycle_id: EV-014
+  stage: 07-build
+  skill_id: 07-build
+  status: confirmed
+  decision: >-
+    Lightweight MQTT + HTTP dataset stand-in for wis2box staging/CI (E14-04 / Q17 testing-only):
+    packages/dissemination/docker/wis2box-harness (python:3.12.11-slim-bookworm + Debian mosquitto);
+    docker-compose.wis2box.yml profile wis2box; scripts/ci/run_wis2box_harness.sh on integration matrix.
+    Reject full WMO wis2box-release multi-container stack for CI cost/ops; live WIS2 remains BYOC.
+    T3.3 complete @ f222f90; PR #763 open; #761+#762 merged to main; next T3.4 TC-F17-001 publish green.
+  related_pr: 763
 - id: N-S019-EV014-T31-T32-complete
   date: '2026-07-21'
   session_id: S019-dissemination-upload
@@ -8032,7 +8048,14 @@ evolve_cycles:
     skipped_stages: []
     note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
   current_stage: 07-build
+  active_milestone: M3
+  active_task: T3.4
+  active_task_status: pending
+  branch: cursor/s019-t33-wis2box-harness-c6f7
+  note: 'T3.3 completed; #761+#762 merged to main; PR #763 open for T3.3'
   notes:
+  - >-
+    2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness; PR #763 open @ f222f90. #761+#762 merged to main. Next T3.4 staging harness publish green (TC-F17-001).
   - >-
     2026-07-21 S019/EV-014 T2.7 PR #761 open (CI green). T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762). Next T3.3 wis2box Compose harness.
     Tip 8ebfa3a; next T3.3 pending.
@@ -8110,7 +8133,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-20'
-      note: "Phase C — 07-build M3 T3.1–T3.2 done (PR #762); next T3.3; T2.7 PR #761 still open"
+      note: "Phase C — 07-build M3 T3.3 done (PR #763); next T3.4; #761+#762 merged to main"
     01-requirements:
       status: completed
       mode: delta
@@ -8187,9 +8210,9 @@ evolve_cycles:
       status: in_progress
       mode: full
       started: '2026-07-21'
-      note: 'T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762 open @ 8ebfa3a); next T3.3 wis2box Compose harness; T2.7 PR #761 still open (CI green)'
+      note: 'T3.3 done on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90); next T3.4 staging harness publish green; #761+#762 merged to main'
       active_milestone: M3
-      active_task: T3.3
+      active_task: T3.4
       active_task_status: pending
   gates:
     a_to_b: passed
@@ -10852,13 +10875,16 @@ evolve_cycles:
   merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-t31-wis2-unit-tests-ee99
+  current_branch: cursor/s019-t33-wis2box-harness-c6f7
   ahead_of_origin: 0
   pushed: true
   pending_commit: null
-  tip_sha: 8ebfa3a86d9eb82ca0e673e9d0ead10cc267a282
-  tip_sha_full: 8ebfa3a86d9eb82ca0e673e9d0ead10cc267a282
+  tip_sha: f222f901917d65ad2bfb8be9a496d0b885c5e4c0
+  tip_sha_full: f222f901917d65ad2bfb8be9a496d0b885c5e4c0
   notes:
+  - >-
+    2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90). #761+#762 merged to main. Next T3.4.
+    tip f222f90 on cursor/s019-t33-wis2box-harness-c6f7; PR #763 open; #761+#762 merged to main
   - >-
     2026-07-21 S019/EV-014 T2.7 PR #761 open (CI green). T3.1+T3.2 done on cursor/s019-t31-wis2-unit-tests-ee99 (PR #762). Next T3.3 wis2box Compose harness.
     tip 8ebfa3a on cursor/s019-t31-wis2-unit-tests-ee99; PR #762 open; T2.7 PR #761 still open
@@ -11068,11 +11094,30 @@ git_history:
   - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
   - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+  - name: cursor/s019-t33-wis2box-harness-c6f7
+    status: open
+    base: main
+    created: '2026-07-21'
+    created_at: '2026-07-21'
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    purpose: S019/EV-014 07-build M3 T3.3 wis2box Compose harness
+    tip_sha: f222f901917d65ad2bfb8be9a496d0b885c5e4c0
+    tip_sha_full: f222f901917d65ad2bfb8be9a496d0b885c5e4c0
+    pushed: true
+    pr_number: 763
+    pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/763
+    pr_title: '[T3.3] docker-compose wis2box harness + CI service (S019/EV-014)'
+    pr_base: main
+    pr_head: cursor/s019-t33-wis2box-harness-c6f7
+    pr_status: open
+    note: T3.3 complete; PR #763 open; next T3.4
   - name: cursor/s019-t31-wis2-unit-tests-ee99
-    status: active
+    status: merged
     base: cursor/s019-t27-odbc-docs-ee99
     created: '2026-07-21'
     created_at: '2026-07-21'
+    merged_at: '2026-07-21'
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: S019/EV-014 07-build M3 T3.1–T3.2 WIS2 sink
@@ -11084,13 +11129,14 @@ git_history:
     pr_title: '[T3.1–T3.2] WIS2 sink adapter + mocked unit tests (S019/EV-014)'
     pr_base: main
     pr_head: cursor/s019-t31-wis2-unit-tests-ee99
-    pr_status: open
-    note: T3.1–T3.2 complete; PR #762 open; next T3.3
+    pr_status: merged
+    note: T3.1–T3.2 merged via PR #762 to main
   - name: cursor/s019-t27-odbc-docs-ee99
-    status: active
+    status: merged
     base: main
     created: '2026-07-21'
     created_at: '2026-07-21'
+    merged_at: '2026-07-21'
     session_id: S019-dissemination-upload
     evolve_cycle_id: EV-014
     purpose: S019/EV-014 07-build M2 T2.7 ODBC docs
@@ -11102,8 +11148,8 @@ git_history:
     pr_title: '[T2.7] ODBC driver docs for SQL Server aioodbc (S019/EV-014)'
     pr_base: main
     pr_head: cursor/s019-t27-odbc-docs-ee99
-    pr_status: open
-    note: T2.7 PR #761 still open (CI green); stacked under by T3.1–T3.2 branch
+    pr_status: merged
+    note: T2.7 merged via PR #761 to main
   - name: cursor/s019-t26-wf-state-4b72
     status: merged
     base: main
@@ -11515,6 +11561,29 @@ git_history:
     pr_number: 716
     note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+  - sha: f222f901917d65ad2bfb8be9a496d0b885c5e4c0
+    short: f222f90
+    branch: cursor/s019-t33-wis2box-harness-c6f7
+    message: "[T3.3] config: docker-compose wis2box harness + CI service"
+    stage: "07-build / 16-evolve"
+    session_id: S019-dissemination-upload
+    evolve_cycle_id: EV-014
+    timestamp: '2026-07-21'
+    files_changed:
+    - docker-compose.wis2box.yml
+    - packages/dissemination/docker/wis2box-harness/Dockerfile
+    - packages/dissemination/docker/wis2box-harness/README.md
+    - packages/dissemination/docker/wis2box-harness/dataset_server.py
+    - packages/dissemination/docker/wis2box-harness/entrypoint.sh
+    - scripts/ci/run_wis2box_harness.sh
+    - Makefile
+    - docs/deploy.md
+    - docs/dependency-inventory.md
+    - docs/decisions/evolve-decisions.md
+    - docs/sessions/S019-dissemination-upload/HANDOFF.md
+    - packages/dissemination/README.md
+    - .cursor/rules/optional/dissemination-coverage-compose.mdc
+    - workflow-state.yaml
   - sha: 8ebfa3a86d9eb82ca0e673e9d0ead10cc267a282
     short: 8ebfa3a
     branch: cursor/s019-t31-wis2-unit-tests-ee99


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **S019 / EV-014** milestone M3 task **T3.3**: Compose wis2box test harness + CI integration hook (E14-04 / TC-F17-001 harness surface).

Session cleanup: merged lingering PRs **#761** (T2.7) and **#762** (T3.1–T3.2) into `main` before this branch.

### What landed

- Lightweight harness image at `packages/dissemination/docker/wis2box-harness` (MQTT `:1883` + HTTP dataset PUT/GET `:8080`) — not the full WMO wis2box stack; not a Render service (Q17 / E14-04)
- `docker-compose.wis2box.yml` profile `wis2box` with healthcheck
- `scripts/ci/run_wis2box_harness.sh` — build/up/wait, MQTT+HTTP probe, PUT/GET smoke; publish pytest deferred to **T3.4**
- Makefile / `.env.example` / deploy + dependency docs / execution-plan + handoff updates

### Spec

- E14-04=B Compose/CI harness
- ADR-030 WIS2 test harness
- D-S019-EV014-T33-harness (lightweight stand-in)

### Test plan

- [x] Local `bash scripts/ci/run_wis2box_harness.sh` → ready + PUT/GET smoke
- [x] `make test-unit-dissemination` (58 passed, ≥95% coverage)
- [x] CI green — https://github.com/joseph-c-mcguire/metar-to-IWXXM/actions/runs/29827581148 (incl. Test integration harness hook)

### Next

**T3.4** — staging harness publish green (TC-F17-001)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8477-1ab4-7542-80e6-5cc414d7c6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8477-1ab4-7542-80e6-5cc414d7c6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

