### PR TITLE
[T4.3] EDIS SMTP preflight connectivity (no live send in CI)

### DIFF
--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,6 +11,7 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-t41-edis-format-c6f7` (T4.1–T4.2) |
+| PR (T4.1–T4.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765 (CI green) |
 | Merged | #761–#764 (through M3 / T3.4) |
 | Done | M1; M2; M3; M4 through **T4.2** (EDIS format + sink) |
 | Next | **T4.3** Preflight connectivity check for SMTP params |

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,8 +11,8 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Branch | `cursor/s019-t43-smtp-preflight-ac66` (T4.3) |
-| PR (T4.1–T4.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765 (draft; stack base) |
-| PR (T4.3) | (open after push) |
+| PR (T4.1–T4.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765 (ready for review; CI green) |
+| PR (T4.3) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/766 (draft; stacks on #765) |
 | Merged | #761–#764 (through M3 / T3.4) |
 | Done | M1; M2; M3; **M4 complete** (T4.1–T4.3 EDIS format + sink + SMTP preflight) |
 | Next | **T5.1** Adapter interface + staging stub behaviors (F19) |

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,20 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M4 T4.1
+/16-evolve continue S019/EV-014 — 07-build M4 T4.3
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Branch | `cursor/s019-t34-wis2box-publish-c6f7` (T3.4) |
-| PR (T3.3) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/763 (merged) |
-| PR (T3.4) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/764 (CI green) |
-| Done | M1; M2; **M3 complete** (through T3.4 TC-F17-001 harness publish) |
-| Next | **T4.1** EDIS SMTP format fixtures (F18) |
+| Branch | `cursor/s019-t41-edis-format-c6f7` (T4.1–T4.2) |
+| Merged | #761–#764 (through M3 / T3.4) |
+| Done | M1; M2; M3; M4 through **T4.2** (EDIS format + sink) |
+| Next | **T4.3** Preflight connectivity check for SMTP params |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close (Postgres + WIS2 + EDIS)
-- After M3 PR merges: run **08-verify-build** only at M6 (T6.4); continue M4 without waiting
+- TC-F18-002 live EDIS remains cycle-close only

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,18 +3,19 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M4 T4.3
+/16-evolve continue S019/EV-014 — 07-build M5 T5.1
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Branch | `cursor/s019-t41-edis-format-c6f7` (T4.1–T4.2) |
-| PR (T4.1–T4.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765 (CI green) |
+| Branch | `cursor/s019-t43-smtp-preflight-ac66` (T4.3) |
+| PR (T4.1–T4.2) | https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765 (draft; stack base) |
+| PR (T4.3) | (open after push) |
 | Merged | #761–#764 (through M3 / T3.4) |
-| Done | M1; M2; M3; M4 through **T4.2** (EDIS format + sink) |
-| Next | **T4.3** Preflight connectivity check for SMTP params |
+| Done | M1; M2; M3; **M4 complete** (T4.1–T4.3 EDIS format + sink + SMTP preflight) |
+| Next | **T5.1** Adapter interface + staging stub behaviors (F19) |
 
 ## Do not skip
 

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — **07-build** M4 next |
-| **Active milestone** | M3 — WIS2 + Compose wis2box harness (**complete**) |
-| **Active task** | T4.1 (next) |
-| **Tasks** | 17 / **29** completed (through T3.4) |
+| **Active phase** | Phase C — **07-build** M4 in progress |
+| **Active milestone** | M4 — EDIS SMTP (F18) |
+| **Active task** | T4.3 (next) |
+| **Tasks** | 19 / **29** completed (through T4.2) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -83,8 +83,8 @@
 
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
-| T4.1 | Test | EDIS message formatting + mocked aiosmtplib submit | TC-F18; E14-05/09 | T2.4 | pending |
-| T4.2 | Code | EDIS sink + RTH header helpers | F18; #6 | T4.1 | pending |
+| T4.1 | Test | EDIS message formatting + mocked aiosmtplib submit | TC-F18; E14-05/09 | T2.4 | **completed** |
+| T4.2 | Code | EDIS sink + RTH header helpers | F18; #6 | T4.1 | **completed** |
 | T4.3 | Test | Preflight connectivity check for SMTP params (no live send in CI) | TC-F18; E14-09 | T4.2 | pending |
 
 ### M5 — AMHS / SWIM / AFS adapters (F19)

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — **07-build** M4 in progress |
-| **Active milestone** | M4 — EDIS SMTP (F18) |
-| **Active task** | T4.3 (next) |
-| **Tasks** | 19 / **29** completed (through T4.2) |
+| **Active phase** | Phase C — **07-build** M4 complete; next M5 |
+| **Active milestone** | M5 — AMHS / SWIM / AFS (F19) |
+| **Active task** | T5.1 (next) |
+| **Tasks** | 20 / **29** completed (through T4.3) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -85,7 +85,7 @@
 |------|------|-------------|-------------|------------|--------|
 | T4.1 | Test | EDIS message formatting + mocked aiosmtplib submit | TC-F18; E14-05/09 | T2.4 | **completed** |
 | T4.2 | Code | EDIS sink + RTH header helpers | F18; #6 | T4.1 | **completed** |
-| T4.3 | Test | Preflight connectivity check for SMTP params (no live send in CI) | TC-F18; E14-09 | T4.2 | pending |
+| T4.3 | Test | Preflight connectivity check for SMTP params (no live send in CI) | TC-F18; E14-09 | T4.2 | **completed** |
 
 ### M5 — AMHS / SWIM / AFS adapters (F19)
 

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -58,10 +58,12 @@ Deploy / image notes (CI skip policy, stock API Dockerfile without `msodbcsql18`
 - Staging publish: `make compose-wis2box-harness` runs TC-F17-001 pytest
 - Live BYOC remains the cycle-close gate (TC-F17-002)
 
-**EDIS sink (T4.1–T4.2 / F18)**
+**EDIS sink (T4.1–T4.3 / F18)**
 
 - `dissemination.edis` — WMO AHL formatting (ASCII-only) + `edis_preflight` /
   `edis_submit` with injectable SMTP (mocked in unit tests; live BYOC = TC-F18-002)
+- `dissemination.transports.AiosmtpClient` — `aiosmtplib` SMTP client; preflight is
+  connect/login only (never `send_message` in CI)
 
 - Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)
 - Empty ⇒ fail-closed

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -58,7 +58,10 @@ Deploy / image notes (CI skip policy, stock API Dockerfile without `msodbcsql18`
 - Staging publish: `make compose-wis2box-harness` runs TC-F17-001 pytest
 - Live BYOC remains the cycle-close gate (TC-F17-002)
 
-**Egress allowlist**
+**EDIS sink (T4.1–T4.2 / F18)**
+
+- `dissemination.edis` — WMO AHL formatting (ASCII-only) + `edis_preflight` /
+  `edis_submit` with injectable SMTP (mocked in unit tests; live BYOC = TC-F18-002)
 
 - Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)
 - Empty ⇒ fail-closed

--- a/packages/dissemination/src/dissemination/edis.py
+++ b/packages/dissemination/src/dissemination/edis.py
@@ -1,0 +1,246 @@
+"""EDIS → RTH Washington sink — WMO AHL formatting + SMTP submit (F18 / E14-05).
+
+Messages are ASCII-only with a WMO abbreviated heading (``T1T2A1A2ii CCCC YYGGgg [BBB]``).
+SMTP transport is injected for unit tests; live BYOC remains TC-F18-002.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Protocol
+
+from dissemination.allowlist import Allowlist, EgressDenied, validate_egress_host
+from dissemination.models import PreflightResponse
+from dissemination.redact import redact_secrets
+
+_AHL_TT = re.compile(r"^[A-Z]{2}$")
+_AHL_AA = re.compile(r"^[A-Z]{2}$")
+_AHL_II = re.compile(r"^\d{2}$")
+_AHL_CCCC = re.compile(r"^[A-Z]{4}$")
+_AHL_YYGGGG = re.compile(r"^\d{6}$")
+_AHL_BBB = re.compile(r"^[ACR]{2}[A-Z]$")
+
+
+class SmtpClient(Protocol):
+    """Minimal async SMTP client used by the EDIS sink."""
+
+    async def connect(self) -> None: ...
+
+    async def login(self, username: str, password: str) -> None: ...
+
+    async def send_message(self, message: EmailMessage) -> object: ...
+
+    async def quit(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EdisParams:
+    """BYOC EDIS/SMTP parameters (memory-only; never logged raw)."""
+
+    smtp_host: str
+    mail_from: str
+    mail_to: str
+    tt: str
+    aa: str
+    ii: str
+    cccc: str
+    yygggg: str
+    smtp_port: int = 587
+    username: str | None = None
+    password: str | None = None
+    use_tls: bool = True
+    bbb: str | None = None
+    subject: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EdisSubmitResult:
+    """Result of an EDIS SMTP submit."""
+
+    ok: bool
+    ahl: str
+    detail: str | None = None
+
+
+def _require_ascii(value: str, *, field: str) -> str:
+    if not value.isascii():
+        raise ValueError(f"EDIS {field} must be ASCII-only")
+    return value
+
+
+def format_wmo_ahl(
+    *,
+    tt: str,
+    aa: str,
+    ii: str,
+    cccc: str,
+    yygggg: str,
+    bbb: str | None = None,
+) -> str:
+    """
+    Format a WMO abbreviated heading line (Manual on the GTS / WMO-No. 386 shape).
+
+    Parameters
+    ----------
+    tt, aa, ii, cccc, yygggg :
+        AHL designators (``T1T2``, ``A1A2``, ``ii``, originating centre, time group).
+    bbb :
+        Optional BBB amendment indicator (e.g. ``CCA``).
+
+    Returns
+    -------
+    str
+        Single AHL line, ASCII.
+
+    Raises
+    ------
+    ValueError
+        When a field is non-ASCII or fails the AHL shape.
+    """
+    tt_u = _require_ascii(tt.strip().upper(), field="tt")
+    aa_u = _require_ascii(aa.strip().upper(), field="aa")
+    ii_u = _require_ascii(ii.strip().upper(), field="ii")
+    cccc_u = _require_ascii(cccc.strip().upper(), field="cccc")
+    yy_u = _require_ascii(yygggg.strip().upper(), field="yygggg")
+    for name, text, pattern in (
+        ("tt", tt_u, _AHL_TT),
+        ("aa", aa_u, _AHL_AA),
+        ("ii", ii_u, _AHL_II),
+        ("cccc", cccc_u, _AHL_CCCC),
+        ("yygggg", yy_u, _AHL_YYGGGG),
+    ):
+        if not pattern.match(text):
+            raise ValueError(f"invalid WMO AHL {name}: {text!r}")
+    line = f"{tt_u}{aa_u}{ii_u} {cccc_u} {yy_u}"
+    if bbb:
+        bbb_u = _require_ascii(bbb.strip().upper(), field="bbb")
+        if not _AHL_BBB.match(bbb_u):
+            raise ValueError(f"invalid WMO AHL bbb: {bbb!r}")
+        line = f"{line} {bbb_u}"
+    return line
+
+
+def build_edis_message(params: EdisParams, *, tac_body: str) -> str:
+    """
+    Build an ASCII EDIS bulletin body: AHL line, blank line, TAC text.
+
+    Raises
+    ------
+    ValueError
+        When any part is non-ASCII or AHL fields are invalid.
+    """
+    ahl = format_wmo_ahl(
+        tt=params.tt,
+        aa=params.aa,
+        ii=params.ii,
+        cccc=params.cccc,
+        yygggg=params.yygggg,
+        bbb=params.bbb,
+    )
+    body = _require_ascii(tac_body, field="tac_body").strip()
+    if not body:
+        raise ValueError("EDIS tac_body must be non-empty")
+    return f"{ahl}\n\n{body}\n"
+
+
+def _redact_exc(exc: BaseException, params: EdisParams) -> str:
+    text = redact_secrets(str(exc))
+    if params.password:
+        text = text.replace(params.password, "REDACTED")
+    if params.username:
+        text = text.replace(params.username, "REDACTED")
+    return text
+
+
+def _validate_edis_egress(params: EdisParams, allowlist: Allowlist) -> None:
+    validate_egress_host(params.smtp_host, allowlist=allowlist)
+
+
+async def edis_preflight(
+    params: EdisParams,
+    *,
+    allowlist: Allowlist,
+    smtp: SmtpClient,
+) -> PreflightResponse:
+    """
+    Check allowlist + SMTP connect/login (no message send).
+
+    Raises
+    ------
+    EgressDenied
+        When the SMTP host is not allowlisted.
+    ValueError
+        When transport checks fail (secrets redacted).
+    """
+    _validate_edis_egress(params, allowlist)
+    try:
+        await smtp.connect()
+        try:
+            if params.username is not None and params.password is not None:
+                await smtp.login(params.username, params.password)
+        finally:
+            await smtp.quit()
+    except Exception as exc:
+        raise ValueError(_redact_exc(exc, params)) from exc
+    return PreflightResponse(
+        ok=True,
+        connectivity_ok=True,
+        diffs=[],
+        detail=None,
+    )
+
+
+async def edis_submit(
+    params: EdisParams,
+    *,
+    tac_body: str,
+    allowlist: Allowlist,
+    smtp: SmtpClient,
+) -> EdisSubmitResult:
+    """
+    Format an ASCII EDIS message and submit via SMTP.
+
+    Raises
+    ------
+    EgressDenied
+        When the SMTP host is not allowlisted.
+    ValueError
+        When format or transport fails (secrets redacted).
+    """
+    _validate_edis_egress(params, allowlist)
+    bulletin = build_edis_message(params, tac_body=tac_body)
+    ahl = bulletin.split("\n", 1)[0]
+    message = EmailMessage()
+    message["From"] = _require_ascii(params.mail_from, field="mail_from")
+    message["To"] = _require_ascii(params.mail_to, field="mail_to")
+    subject = params.subject or f"EDIS {ahl}"
+    message["Subject"] = _require_ascii(subject, field="subject")
+    message.set_content(bulletin, subtype="plain", charset="us-ascii")
+
+    try:
+        await smtp.connect()
+        try:
+            if params.username is not None and params.password is not None:
+                await smtp.login(params.username, params.password)
+            await smtp.send_message(message)
+        finally:
+            await smtp.quit()
+    except EgressDenied:
+        raise
+    except Exception as exc:
+        raise ValueError(_redact_exc(exc, params)) from exc
+
+    return EdisSubmitResult(ok=True, ahl=ahl, detail=None)
+
+
+__all__ = [
+    "EdisParams",
+    "EdisSubmitResult",
+    "SmtpClient",
+    "build_edis_message",
+    "edis_preflight",
+    "edis_submit",
+    "format_wmo_ahl",
+]

--- a/packages/dissemination/src/dissemination/edis.py
+++ b/packages/dissemination/src/dissemination/edis.py
@@ -1,7 +1,9 @@
 """EDIS → RTH Washington sink — WMO AHL formatting + SMTP submit (F18 / E14-05).
 
 Messages are ASCII-only with a WMO abbreviated heading (``T1T2A1A2ii CCCC YYGGgg [BBB]``).
-SMTP transport is injected for unit tests; live BYOC remains TC-F18-002.
+``edis_preflight`` is connect/login only (no ``send_message``). Inject
+``dissemination.transports.AiosmtpClient`` or a test double; live BYOC remains
+TC-F18-002.
 """
 
 from __future__ import annotations

--- a/packages/dissemination/src/dissemination/transports.py
+++ b/packages/dissemination/src/dissemination/transports.py
@@ -1,14 +1,17 @@
-"""Concrete MQTT + HTTP transports for the WIS2 sink (F17 / T3.4).
+"""Concrete transports for WIS2 + EDIS sinks (F17 / F18).
 
-Implements the Protocols in ``dissemination.wis2`` using ``httpx`` and ``aiomqtt``.
+Implements the Protocols in ``dissemination.wis2`` / ``dissemination.edis`` using
+``httpx``, ``aiomqtt``, and ``aiosmtplib``.
 """
 
 from __future__ import annotations
 
 import asyncio
+from email.message import EmailMessage
 from typing import Self
 
 import aiomqtt
+import aiosmtplib
 import httpx
 
 
@@ -137,7 +140,79 @@ class AiomqttClient:
         await self.disconnect()
 
 
+class AiosmtpClient:
+    """``SmtpClient`` backed by ``aiosmtplib`` (EDIS / F18).
+
+    Prefers STARTTLS on submission ports (e.g. 587); uses implicit TLS on 465.
+    """
+
+    def __init__(
+        self,
+        *,
+        hostname: str,
+        port: int = 587,
+        use_tls: bool = True,
+        timeout: float = 30.0,
+    ) -> None:
+        self._hostname = hostname
+        self._port = port
+        self._use_tls = use_tls
+        self._timeout = timeout
+        self._client: aiosmtplib.SMTP | None = None
+
+    def _tls_kwargs(self) -> dict[str, bool]:
+        if not self._use_tls:
+            return {"use_tls": False, "start_tls": False}
+        if self._port == 465:
+            return {"use_tls": True, "start_tls": False}
+        return {"use_tls": False, "start_tls": True}
+
+    async def connect(self) -> None:
+        """Open an SMTP connection (STARTTLS or implicit TLS per port)."""
+        if self._client is not None and self._client.is_connected:
+            return
+        client = aiosmtplib.SMTP(
+            hostname=self._hostname,
+            port=self._port,
+            timeout=self._timeout,
+            **self._tls_kwargs(),
+        )
+        await client.connect()
+        self._client = client
+
+    async def login(self, username: str, password: str) -> None:
+        """Authenticate with the SMTP server."""
+        if self._client is None:
+            raise RuntimeError("smtp client is not connected")
+        await self._client.login(username, password)
+
+    async def send_message(self, message: EmailMessage) -> object:
+        """Submit ``message`` via SMTP DATA."""
+        if self._client is None:
+            raise RuntimeError("smtp client is not connected")
+        return await self._client.send_message(message)
+
+    async def quit(self) -> None:
+        """Close the SMTP connection if open."""
+        client = self._client
+        self._client = None
+        if client is None:
+            return
+        if client.is_connected:
+            await client.quit()
+        else:
+            await client.close()
+
+    async def __aenter__(self) -> Self:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.quit()
+
+
 __all__ = [
     "AiomqttClient",
+    "AiosmtpClient",
     "HttpxDatasetClient",
 ]

--- a/packages/dissemination/tests/test_edis_format.py
+++ b/packages/dissemination/tests/test_edis_format.py
@@ -1,0 +1,155 @@
+"""EDIS message format + mocked SMTP submit tests (T4.1 / TC-F18-001 / E14-05).
+
+Format fixtures define the T4.2 API surface; mocked aiosmtplib proves submit wiring
+without live RTH Washington (TC-F18-002 remains live BYOC close gate).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dissemination.allowlist import EgressDenied, parse_allowlist
+from dissemination.edis import (
+    EdisParams,
+    EdisSubmitResult,
+    build_edis_message,
+    edis_preflight,
+    edis_submit,
+    format_wmo_ahl,
+)
+
+
+def _params(**overrides: Any) -> EdisParams:
+    base = dict(
+        smtp_host="smtp.gateway.example.test",
+        smtp_port=587,
+        mail_from="publisher@example.test",
+        mail_to="rth@gateway.example.test",
+        username="edis-user",
+        password="secret-edis-token",
+        use_tls=True,
+        tt="SA",
+        aa="US",
+        ii="31",
+        cccc="KZNY",
+        yygggg="121200",
+    )
+    base.update(overrides)
+    return EdisParams(**base)
+
+
+def _allowlist(*hosts: str):
+    return parse_allowlist(",".join(hosts))
+
+
+def test_format_wmo_ahl_metar_shape() -> None:
+    assert format_wmo_ahl(tt="SA", aa="US", ii="31", cccc="KZNY", yygggg="121200") == ("SAUS31 KZNY 121200")
+
+
+def test_format_wmo_ahl_optional_bbb() -> None:
+    assert (
+        format_wmo_ahl(tt="SA", aa="US", ii="31", cccc="KZNY", yygggg="121200", bbb="CCA") == "SAUS31 KZNY 121200 CCA"
+    )
+
+
+def test_build_edis_message_ascii_with_ahl_and_body() -> None:
+    params = _params()
+    body = "METAR KJFK 121151Z 18008KT 10SM FEW250 22/12 A3012="
+    msg = build_edis_message(params, tac_body=body)
+    assert msg.startswith("SAUS31 KZNY 121200\n")
+    assert body in msg
+    assert msg.isascii()
+
+
+def test_build_edis_message_rejects_non_ascii() -> None:
+    params = _params()
+    with pytest.raises(ValueError, match="ASCII"):
+        build_edis_message(params, tac_body="METAR KJFK 121151Z café=")
+
+
+def test_build_edis_message_rejects_non_ascii_ahl_fields() -> None:
+    params = _params(cccc="KJN¥")
+    with pytest.raises(ValueError, match="ASCII"):
+        build_edis_message(params, tac_body="METAR KJFK 121151Z 18008KT=")
+
+
+@pytest.mark.asyncio
+async def test_edis_preflight_ok_with_mocked_smtp() -> None:
+    params = _params()
+    smtp = AsyncMock()
+    smtp.connect = AsyncMock()
+    smtp.login = AsyncMock()
+    smtp.quit = AsyncMock()
+    result = await edis_preflight(
+        params,
+        allowlist=_allowlist("smtp.gateway.example.test"),
+        smtp=smtp,
+    )
+    assert result.ok is True
+    assert result.connectivity_ok is True
+    smtp.connect.assert_awaited_once()
+    smtp.login.assert_awaited_once()
+    smtp.quit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edis_preflight_denies_host_not_allowlisted() -> None:
+    params = _params()
+    smtp = AsyncMock()
+    with pytest.raises(EgressDenied):
+        await edis_preflight(params, allowlist=_allowlist("other.example.test"), smtp=smtp)
+    smtp.connect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edis_submit_sends_ascii_message_via_mocked_smtp() -> None:
+    params = _params()
+    smtp = AsyncMock()
+    smtp.connect = AsyncMock()
+    smtp.login = AsyncMock()
+    smtp.send_message = AsyncMock()
+    smtp.quit = AsyncMock()
+    tac = "METAR KJFK 121151Z 18008KT 10SM FEW250 22/12 A3012="
+    result = await edis_submit(
+        params,
+        tac_body=tac,
+        allowlist=_allowlist("smtp.gateway.example.test"),
+        smtp=smtp,
+    )
+    assert isinstance(result, EdisSubmitResult)
+    assert result.ok is True
+    assert result.ahl == "SAUS31 KZNY 121200"
+    smtp.send_message.assert_awaited_once()
+    sent = smtp.send_message.await_args.args[0]
+    payload = sent.as_string()
+    assert "SAUS31 KZNY 121200" in payload
+    assert tac in payload
+    assert payload.isascii()
+
+
+@pytest.mark.asyncio
+async def test_edis_submit_redacts_password_in_errors() -> None:
+    params = _params()
+    smtp = AsyncMock()
+    smtp.connect = AsyncMock(side_effect=RuntimeError("auth failed secret-edis-token"))
+    with pytest.raises(ValueError) as excinfo:
+        await edis_submit(
+            params,
+            tac_body="METAR KJFK 121151Z 18008KT=",
+            allowlist=_allowlist("smtp.gateway.example.test"),
+            smtp=smtp,
+        )
+    assert "secret-edis-token" not in str(excinfo.value)
+    assert "REDACTED" in str(excinfo.value)
+
+
+@pytest.fixture(autouse=True)
+def _public_dns_for_example_hosts():
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        yield

--- a/packages/dissemination/tests/test_edis_preflight.py
+++ b/packages/dissemination/tests/test_edis_preflight.py
@@ -1,0 +1,180 @@
+"""EDIS SMTP preflight connectivity tests (T4.3 / TC-F18 / E14-09).
+
+Proves connect/login (or connect-only) without ``send_message`` — no live SMTP
+in CI. Live RTH BYOC remains TC-F18-002.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dissemination.allowlist import EgressDenied, parse_allowlist
+from dissemination.edis import EdisParams, edis_preflight
+from dissemination.transports import AiosmtpClient
+
+
+def _params(**overrides: Any) -> EdisParams:
+    base = dict(
+        smtp_host="smtp.gateway.example.test",
+        smtp_port=587,
+        mail_from="publisher@example.test",
+        mail_to="rth@gateway.example.test",
+        username="edis-user",
+        password="secret-edis-token",
+        use_tls=True,
+        tt="SA",
+        aa="US",
+        ii="31",
+        cccc="KZNY",
+        yygggg="121200",
+    )
+    base.update(overrides)
+    return EdisParams(**base)
+
+
+def _allowlist(*hosts: str):
+    return parse_allowlist(",".join(hosts))
+
+
+@pytest.fixture(autouse=True)
+def _public_dns_for_example_hosts():
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        yield
+
+
+def _smtp_mock(*, login_side_effect: Exception | None = None) -> AsyncMock:
+    smtp = AsyncMock()
+    smtp.connect = AsyncMock()
+    smtp.login = AsyncMock(side_effect=login_side_effect)
+    smtp.send_message = AsyncMock()
+    smtp.quit = AsyncMock()
+    return smtp
+
+
+@pytest.mark.asyncio
+async def test_preflight_connect_login_quit_never_sends() -> None:
+    smtp = _smtp_mock()
+    result = await edis_preflight(
+        _params(),
+        allowlist=_allowlist("smtp.gateway.example.test"),
+        smtp=smtp,
+    )
+    assert result.ok is True
+    assert result.connectivity_ok is True
+    assert result.diffs == []
+    smtp.connect.assert_awaited_once()
+    smtp.login.assert_awaited_once_with("edis-user", "secret-edis-token")
+    smtp.quit.assert_awaited_once()
+    smtp.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preflight_skips_login_when_credentials_absent() -> None:
+    smtp = _smtp_mock()
+    result = await edis_preflight(
+        _params(username=None, password=None),
+        allowlist=_allowlist("smtp.gateway.example.test"),
+        smtp=smtp,
+    )
+    assert result.ok is True
+    assert result.connectivity_ok is True
+    smtp.connect.assert_awaited_once()
+    smtp.login.assert_not_awaited()
+    smtp.quit.assert_awaited_once()
+    smtp.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preflight_denies_host_not_allowlisted() -> None:
+    smtp = _smtp_mock()
+    with pytest.raises(EgressDenied):
+        await edis_preflight(
+            _params(),
+            allowlist=_allowlist("other.example.test"),
+            smtp=smtp,
+        )
+    smtp.connect.assert_not_awaited()
+    smtp.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preflight_connect_failure_redacts_password() -> None:
+    smtp = _smtp_mock()
+    smtp.connect = AsyncMock(side_effect=RuntimeError("connect failed secret-edis-token"))
+    with pytest.raises(ValueError) as excinfo:
+        await edis_preflight(
+            _params(),
+            allowlist=_allowlist("smtp.gateway.example.test"),
+            smtp=smtp,
+        )
+    assert "secret-edis-token" not in str(excinfo.value)
+    assert "REDACTED" in str(excinfo.value)
+    smtp.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preflight_login_failure_redacts_and_quits() -> None:
+    smtp = _smtp_mock(login_side_effect=RuntimeError("auth failed secret-edis-token"))
+    with pytest.raises(ValueError) as excinfo:
+        await edis_preflight(
+            _params(),
+            allowlist=_allowlist("smtp.gateway.example.test"),
+            smtp=smtp,
+        )
+    assert "secret-edis-token" not in str(excinfo.value)
+    assert "REDACTED" in str(excinfo.value)
+    smtp.quit.assert_awaited_once()
+    smtp.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_connect_login_quit_no_send_via_mocked_lib() -> None:
+    """AiosmtpClient wires aiosmtplib without ever calling send_message in preflight."""
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.login = AsyncMock()
+    inner.send_message = AsyncMock()
+    inner.quit = AsyncMock()
+    smtp_ctor = MagicMock(return_value=inner)
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(
+            hostname="smtp.gateway.example.test",
+            port=587,
+            use_tls=True,
+        )
+        result = await edis_preflight(
+            _params(),
+            allowlist=_allowlist("smtp.gateway.example.test"),
+            smtp=client,
+        )
+    assert result.ok is True
+    smtp_ctor.assert_called_once()
+    kwargs = smtp_ctor.call_args.kwargs
+    assert kwargs["hostname"] == "smtp.gateway.example.test"
+    assert kwargs["port"] == 587
+    assert kwargs.get("start_tls") is True
+    inner.connect.assert_awaited_once()
+    inner.login.assert_awaited_once_with("edis-user", "secret-edis-token")
+    inner.quit.assert_awaited_once()
+    inner.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_smtps_port_uses_implicit_tls() -> None:
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.quit = AsyncMock()
+    smtp_ctor = MagicMock(return_value=inner)
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(hostname="smtp.example.test", port=465, use_tls=True)
+        await client.connect()
+        await client.quit()
+    kwargs = smtp_ctor.call_args.kwargs
+    assert kwargs["use_tls"] is True
+    assert kwargs.get("start_tls") is False

--- a/packages/dissemination/tests/test_edis_preflight.py
+++ b/packages/dissemination/tests/test_edis_preflight.py
@@ -169,6 +169,7 @@ async def test_aiosmtp_client_connect_login_quit_no_send_via_mocked_lib() -> Non
 async def test_aiosmtp_client_smtps_port_uses_implicit_tls() -> None:
     inner = AsyncMock()
     inner.connect = AsyncMock()
+    inner.is_connected = True
     inner.quit = AsyncMock()
     smtp_ctor = MagicMock(return_value=inner)
     with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
@@ -178,3 +179,89 @@ async def test_aiosmtp_client_smtps_port_uses_implicit_tls() -> None:
     kwargs = smtp_ctor.call_args.kwargs
     assert kwargs["use_tls"] is True
     assert kwargs.get("start_tls") is False
+    inner.quit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_plain_no_tls() -> None:
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.is_connected = True
+    inner.quit = AsyncMock()
+    smtp_ctor = MagicMock(return_value=inner)
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(hostname="smtp.example.test", port=25, use_tls=False)
+        await client.connect()
+        await client.quit()
+    kwargs = smtp_ctor.call_args.kwargs
+    assert kwargs["use_tls"] is False
+    assert kwargs["start_tls"] is False
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_connect_is_idempotent_when_connected() -> None:
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.is_connected = True
+    smtp_ctor = MagicMock(return_value=inner)
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(hostname="smtp.example.test")
+        await client.connect()
+        await client.connect()
+    assert smtp_ctor.call_count == 1
+    assert inner.connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_login_and_send_require_connect() -> None:
+    from email.message import EmailMessage
+
+    client = AiosmtpClient(hostname="smtp.example.test")
+    with pytest.raises(RuntimeError, match="not connected"):
+        await client.login("u", "p")
+    with pytest.raises(RuntimeError, match="not connected"):
+        await client.send_message(EmailMessage())
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_send_message_and_quit_close_paths() -> None:
+    from email.message import EmailMessage
+
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.is_connected = False
+    inner.send_message = AsyncMock(return_value=({}, "ok"))
+    inner.close = AsyncMock()
+    inner.quit = AsyncMock()
+    smtp_ctor = MagicMock(return_value=inner)
+    msg = EmailMessage()
+    msg["From"] = "a@example.test"
+    msg["To"] = "b@example.test"
+    msg.set_content("x")
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(hostname="smtp.example.test")
+        await client.connect()
+        # Force not-connected so quit uses close()
+        inner.is_connected = False
+        result = await client.send_message(msg)
+        await client.quit()
+    assert result == ({}, "ok")
+    inner.send_message.assert_awaited_once()
+    inner.close.assert_awaited_once()
+    inner.quit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aiosmtp_client_quit_noop_and_context_manager() -> None:
+    inner = AsyncMock()
+    inner.connect = AsyncMock()
+    inner.is_connected = True
+    inner.quit = AsyncMock()
+    smtp_ctor = MagicMock(return_value=inner)
+    with patch("dissemination.transports.aiosmtplib.SMTP", smtp_ctor):
+        client = AiosmtpClient(hostname="smtp.example.test")
+        await client.quit()  # never connected
+        async with AiosmtpClient(hostname="smtp.example.test") as opened:
+            assert opened is not None
+    inner.connect.assert_awaited()
+    inner.quit.assert_awaited()

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 'M4 complete via T4.3/#766; next T5.1; lingering #765 ready for review'
+  note: 'M4 complete (20/29); T5.1 pending; #765+#766 ready_for_review (CI green); prefer merge #765 then #766'
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -69,7 +69,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-20'
-      note: "Phase C — 07-build M4 complete (T4.3/#766); next M5 T5.1; #765 ready for review"
+      note: "Phase C — 07-build M4 complete (20/29); T5.1 pending; #765+#766 ready_for_review; prefer merge #765 then #766"
     - stage: 01-requirements
       required: true
       mode: delta
@@ -124,7 +124,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-21'
-      note: 'M4 complete via T4.3 @ ab62daf / PR #766 draft; next T5.1; #765 ready for review (CI green); progress 20/29'
+      note: 'M4 complete @ tip 1002baa / PR #766 ready_for_review (CI green); next T5.1; #765 ready_for_review; prefer merge #765 then #766; progress 20/29'
     - stage: 08-verify-build
       required: true
       mode: full
@@ -2387,7 +2387,7 @@ stages:
         started_at: '2026-07-21'
         started: '2026-07-21'
         mode: full
-        note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+        note: 'M4 complete @ tip 1002baa / #766 ready_for_review (CI green); T5.1 pending; prefer merge #765 then #766; progress 20/29'
         active_milestone: M5
         active_task: T5.1
         active_task_status: pending
@@ -2441,6 +2441,7 @@ stages:
         active_task_status: completed
         completed_at: '2026-07-19'
     notes:
+      - '2026-07-21 S019/EV-014 #766 ready_for_review (CI green) @ tip 1002baa; recorded coverage fix + CI trigger + 07edc63 chore. Prefer merge #765 then #766. T5.1 still pending; 20/29.'
       - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open draft (base t41). M4 complete (20/29). Next M5 T5.1. #765 ready for review.'
       - '2026-07-21 S019/EV-014 T4.3 STARTED — SMTP preflight connectivity (no live send in CI) on cursor/s019-t43-smtp-preflight-ac66; lingering PR #765 draft (T4.1–T4.2) on cursor/s019-t41-edis-format-c6f7 — CI nearly green'
       - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2 on cursor/s019-t41-edis-format-c6f7. PR #764 merged (T3.4). Next T4.3.'
@@ -2568,7 +2569,7 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+      note: 'M4 complete @ tip 1002baa / #766 ready_for_review (CI green); T5.1 pending; prefer merge #765 then #766; progress 20/29'
       active_milestone: M5
       active_task: T5.1
       active_task_status: pending
@@ -3138,8 +3139,8 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M4 complete (T4.3/#766 @ ab62daf); next M5 T5.1;
-      #765 ready for review
+      Phase C — 07-build M4 complete (20/29) tip 1002baa; #765+#766 ready_for_review
+      (CI green); prefer merge #765 then #766; next T5.1
 
 stages_pending: []
 
@@ -7731,8 +7732,9 @@ evolve_cycles:
     active_task: T5.1
     active_task_status: pending
     branch: cursor/s019-t43-smtp-preflight-ac66
-    note: 'M4 complete via T4.3/#766; next T5.1; lingering #765 ready for review; progress 20/29'
+    note: 'M4 complete (20/29); T5.1 pending; #765+#766 ready_for_review (CI green); prefer merge #765 then #766'
     notes:
+      - '2026-07-21 S019/EV-014 #766 ready_for_review (CI green) @ tip 1002baa (coverage + CI trigger + 07edc63). Prefer merge #765 then #766. T5.1 pending; session/cycle open; 20/29.'
       - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base cursor/s019-t41-edis-format-c6f7). M4 complete (20/29). Next M5 T5.1. #765 undrafted / ready_for_review (CI green). Session/cycle remain open.'
       - '2026-07-21 S019/EV-014 T4.3 STARTED — SMTP preflight connectivity (no live send in CI) on cursor/s019-t43-smtp-preflight-ac66; lingering PR #765 draft (T4.1–T4.2) CI nearly green. T4.3 not completed.'
       - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2. PR #764 merged (T3.4). Next T4.3.'
@@ -7802,7 +7804,7 @@ evolve_cycles:
       16-evolve:
         status: in_progress
         started: '2026-07-20'
-        note: "Phase C — 07-build M4 complete (T4.3/#766); next M5 T5.1; #765 ready for review"
+        note: "Phase C — 07-build M4 complete (20/29); T5.1 pending; #765+#766 ready_for_review; prefer merge #765 then #766"
       01-requirements:
         status: completed
         mode: delta
@@ -7879,7 +7881,7 @@ evolve_cycles:
         status: in_progress
         mode: full
         started: '2026-07-21'
-        note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+        note: 'M4 complete @ tip 1002baa / #766 ready_for_review (CI green); T5.1 pending; prefer merge #765 then #766; progress 20/29'
         active_milestone: M5
         active_task: T5.1
         active_task_status: pending
@@ -10446,9 +10448,10 @@ git_history:
   ahead_of_origin: 0
   pushed: true
   pending_commit: null
-  tip_sha: ab62daf6f9391c74fedc9afd5c3326130da40855
-  tip_sha_full: ab62daf6f9391c74fedc9afd5c3326130da40855
+  tip_sha: 1002baaae781aa37f1ebc75276522cc106b3310b
+  tip_sha_full: 1002baaae781aa37f1ebc75276522cc106b3310b
   notes:
+    - '2026-07-21 S019/EV-014 tip 1002baa on t43 — coverage fix + d903085 CI trigger + 07edc63 chore; #766 ready_for_review (CI green). Prefer merge #765 then #766. T5.1 pending; 20/29.'
     - '2026-07-21 S019/EV-014 T4.3 completed — ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base t41). M4 done (20/29); next T5.1. #765 ready_for_review / CI green.'
     - '2026-07-21 S019/EV-014 T4.3 STARTED — working branch cursor/s019-t43-smtp-preflight-ac66 (build agent); lingering PR #765 draft (T4.1–T4.2) on cursor/s019-t41-edis-format-c6f7 — CI nearly green. T4.3 not completed.'
     - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink on cursor/s019-t41-edis-format-c6f7 @ 67f73d2. PR #765 open draft; #764 merged (T3.4). Next T4.3.'
@@ -10652,16 +10655,16 @@ git_history:
       session_id: S019-dissemination-upload
       evolve_cycle_id: EV-014
       purpose: S019/EV-014 07-build M4 T4.3 SMTP preflight connectivity (no live send in CI)
-      tip_sha: ab62daf6f9391c74fedc9afd5c3326130da40855
-      tip_sha_full: ab62daf6f9391c74fedc9afd5c3326130da40855
+      tip_sha: 1002baaae781aa37f1ebc75276522cc106b3310b
+      tip_sha_full: 1002baaae781aa37f1ebc75276522cc106b3310b
       pushed: true
       pr_number: 766
       pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/766
       pr_title: '[T4.3] EDIS SMTP preflight connectivity (no live send in CI)'
-      pr_base: cursor/s019-t41-edis-format-c6f7
+      pr_base: main
       pr_head: cursor/s019-t43-smtp-preflight-ac66
-      pr_status: open_draft
-      note: 'T4.3 complete @ ab62daf; PR #766 open draft; M4 done → next T5.1'
+      pr_status: ready_for_review
+      note: 'T4.3 complete tip 1002baa; PR #766 ready_for_review (CI green); prefer merge #765 then #766'
     - name: cursor/s019-t41-edis-format-c6f7
       status: open
       base: main
@@ -10679,7 +10682,7 @@ git_history:
       pr_base: main
       pr_head: cursor/s019-t41-edis-format-c6f7
       pr_status: ready_for_review
-      note: 'T4.1–T4.2 complete; PR #765 undrafted / ready_for_review — CI green; lingering stack base for #766'
+      note: 'T4.1–T4.2 complete; PR #765 ready_for_review (CI green); merge before #766'
     - name: cursor/s019-t34-wis2box-publish-c6f7
       status: merged
       base: main
@@ -11167,6 +11170,37 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 1002baaae781aa37f1ebc75276522cc106b3310b
+      short: 1002baa
+      branch: cursor/s019-t43-smtp-preflight-ac66
+      message: '[T4.3] test: cover AiosmtpClient branches for 95% gate'
+      stage: 07-build / 16-evolve
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+      files_changed:
+        - packages/dissemination/tests/test_edis_preflight.py
+    - sha: d90308513fed6fcca7139e2f7bc56584eb280215
+      short: d903085
+      branch: cursor/s019-t43-smtp-preflight-ac66
+      message: 'chore: trigger CI for T4.3 PR #766'
+      stage: 07-build / 16-evolve
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+      files_changed: []
+      note: empty commit
+    - sha: 07edc6361f2c8269d0695155368cd3e2566c338e
+      short: 07edc63
+      branch: cursor/s019-t43-smtp-preflight-ac66
+      message: '[S019] chore: record T4.3/#766; next M5 T5.1 in workflow-state'
+      stage: 07-build / 16-evolve
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+      files_changed:
+        - docs/sessions/S019-dissemination-upload/HANDOFF.md
+        - workflow-state.yaml
     - sha: ab62daf6f9391c74fedc9afd5c3326130da40855
       short: ab62daf
       branch: cursor/s019-t43-smtp-preflight-ac66

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -10,12 +10,12 @@ active_session:
   type: feature
   intent: 'Dissemination epic: F16 multi-DB upload (#729) URI one-shot + preflight + DDL + drag-drop; F17 WIS2 (#2) staging test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase 0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-t34-wis2box-publish-c6f7
+  branch: cursor/s019-t41-edis-format-c6f7
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 'T3.4 done; M3 complete; next T4.1; PR for T3.4'
+  note: 'T4.1–T4.2 done; M4 in progress; next T4.3; PR for EDIS'
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -69,7 +69,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-20'
-      note: "Phase C — 07-build M3 complete (T3.4 TC-F17-001); #763 merged; next M4 T4.1"
+      note: "Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3"
     - stage: 01-requirements
       required: true
       mode: delta
@@ -124,7 +124,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-21'
-      note: 'T3.4 done on cursor/s019-t34-wis2box-publish-c6f7 (@ f3ba8e7); M3 complete; next T4.1; PR for T3.4; #763 merged'
+      note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
     - stage: 08-verify-build
       required: true
       mode: full
@@ -2387,9 +2387,9 @@ stages:
         started_at: '2026-07-21'
         started: '2026-07-21'
         mode: full
-        note: 'T3.4 done on cursor/s019-t34-wis2box-publish-c6f7 (@ f3ba8e7); M3 complete; next T4.1; PR for T3.4; #763 merged'
+        note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
         active_milestone: M4
-        active_task: T4.1
+        active_task: T4.3
         active_task_status: pending
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
@@ -2441,6 +2441,7 @@ stages:
         active_task_status: completed
         completed_at: '2026-07-19'
     notes:
+      - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2 on cursor/s019-t41-edis-format-c6f7. PR #764 merged (T3.4). Next T4.3.'
       - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 wis2box harness publish green @ f3ba8e7. PR #763 merged. M3 complete. Next M4 T4.1.'
       - >-
         2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness; PR #763 open @ f222f90. #761+#762 merged to main. Next T3.4 staging harness publish green (TC-F17-001).
@@ -2565,9 +2566,9 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: 'T3.4 done on cursor/s019-t34-wis2box-publish-c6f7 (@ f3ba8e7); M3 complete; next T4.1; PR for T3.4; #763 merged'
+      note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
       active_milestone: M4
-      active_task: T4.1
+      active_task: T4.3
       active_task_status: pending
   09-qa:
     status: completed
@@ -3135,7 +3136,7 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M3 complete (T3.4 TC-F17-001); #763 merged; next M4 T4.1
+      Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3
 
 stages_pending: []
 
@@ -7724,11 +7725,12 @@ evolve_cycles:
       note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
     current_stage: 07-build
     active_milestone: M4
-    active_task: T4.1
+    active_task: T4.3
     active_task_status: pending
-    branch: cursor/s019-t34-wis2box-publish-c6f7
-    note: 'T3.4 completed (TC-F17-001); #763 merged; M3→M4 gate green'
+    branch: cursor/s019-t41-edis-format-c6f7
+    note: 'T4.1–T4.2 done; EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
     notes:
+      - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2. PR #764 merged (T3.4). Next T4.3.'
       - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 wis2box harness publish green @ f3ba8e7. PR #763 merged. M3 complete; M3→M4 gate green. Next M4 T4.1 EDIS SMTP format fixtures.'
       - >-
         2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness; PR #763 open @ f222f90. #761+#762 merged to main. Next T3.4 staging harness publish green (TC-F17-001).
@@ -7795,7 +7797,7 @@ evolve_cycles:
       16-evolve:
         status: in_progress
         started: '2026-07-20'
-        note: "Phase C — 07-build M3 complete (T3.4 TC-F17-001); #763 merged; next M4 T4.1"
+        note: "Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3"
       01-requirements:
         status: completed
         mode: delta
@@ -7872,9 +7874,9 @@ evolve_cycles:
         status: in_progress
         mode: full
         started: '2026-07-21'
-        note: 'T3.4 done on cursor/s019-t34-wis2box-publish-c6f7 (@ f3ba8e7); M3 complete; next T4.1; PR for T3.4; #763 merged'
+        note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
         active_milestone: M4
-        active_task: T4.1
+        active_task: T4.3
         active_task_status: pending
     gates:
       a_to_b: passed
@@ -10435,14 +10437,15 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-t34-wis2box-publish-c6f7
+  current_branch: cursor/s019-t41-edis-format-c6f7
   ahead_of_origin: 0
   pushed: true
   pending_commit: null
-  tip_sha: f3ba8e7ae8c91ce77418f18a9154f7c0c0ff8061
-  tip_sha_full: f3ba8e7ae8c91ce77418f18a9154f7c0c0ff8061
+  tip_sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
+  tip_sha_full: 67f73d2cfb49c511f0eb550a01ddf793e3978021
   notes:
-    - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 harness publish on cursor/s019-t34-wis2box-publish-c6f7 @ f3ba8e7. PR #763 merged. M3 complete; next M4 T4.1.'
+    - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink on cursor/s019-t41-edis-format-c6f7 @ 67f73d2. PR #764 merged (T3.4). Next T4.3; PR for EDIS pending.'
+    - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 harness publish on cursor/s019-t34-wis2box-publish-c6f7 @ f3ba8e7. PR #764 merged. M3 complete; next M4 T4.1.'
     - >-
       2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90). #761+#762 merged to main. Next T3.4.
       tip f222f90 on cursor/s019-t33-wis2box-harness-c6f7; PR #763 open; #761+#762 merged to main
@@ -10634,18 +10637,37 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
-    - name: cursor/s019-t34-wis2box-publish-c6f7
+    - name: cursor/s019-t41-edis-format-c6f7
       status: open
       base: main
       created: '2026-07-21'
       created_at: '2026-07-21'
       session_id: S019-dissemination-upload
       evolve_cycle_id: EV-014
+      purpose: S019/EV-014 07-build M4 T4.1–T4.2 EDIS WMO AHL format + mocked SMTP sink
+      tip_sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
+      tip_sha_full: 67f73d2cfb49c511f0eb550a01ddf793e3978021
+      pushed: true
+      note: 'T4.1–T4.2 complete; PR for EDIS pending'
+    - name: cursor/s019-t34-wis2box-publish-c6f7
+      status: merged
+      base: main
+      created: '2026-07-21'
+      created_at: '2026-07-21'
+      merged_at: '2026-07-21'
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
       purpose: S019/EV-014 07-build M3 T3.4 TC-F17-001 wis2box harness publish
       tip_sha: f3ba8e7ae8c91ce77418f18a9154f7c0c0ff8061
       tip_sha_full: f3ba8e7ae8c91ce77418f18a9154f7c0c0ff8061
       pushed: true
-      note: 'T3.4 complete; PR for T3.4 pending; #763 merged'
+      pr_number: 764
+      pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/764
+      pr_title: '[T3.4] test: TC-F17-001 wis2box harness publish green (S019/EV-014)'
+      pr_base: main
+      pr_head: cursor/s019-t34-wis2box-publish-c6f7
+      pr_status: merged
+      note: 'T3.4 merged via PR #764 to main'
     - name: cursor/s019-t33-wis2box-harness-c6f7
       status: merged
       base: main
@@ -11114,6 +11136,20 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
+      short: 67f73d2
+      branch: cursor/s019-t41-edis-format-c6f7
+      message: '[T4.1–T4.2] feat: EDIS WMO AHL format + mocked SMTP sink'
+      stage: 07-build / 16-evolve
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+      files_changed:
+        - docs/sessions/S019-dissemination-upload/HANDOFF.md
+        - docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+        - packages/dissemination/README.md
+        - packages/dissemination/src/dissemination/edis.py
+        - packages/dissemination/tests/test_edis_format.py
     - sha: f3ba8e7ae8c91ce77418f18a9154f7c0c0ff8061
       short: f3ba8e7
       branch: cursor/s019-t34-wis2box-publish-c6f7

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -10,12 +10,12 @@ active_session:
   type: feature
   intent: 'Dissemination epic: F16 multi-DB upload (#729) URI one-shot + preflight + DDL + drag-drop; F17 WIS2 (#2) staging test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase 0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: cursor/s019-t41-edis-format-c6f7
+  branch: cursor/s019-t43-smtp-preflight-ac66
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 'T4.1–T4.2 done; M4 in progress; next T4.3; PR for EDIS'
+  note: 'M4 complete via T4.3/#766; next T5.1; lingering #765 ready for review'
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -69,7 +69,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-20'
-      note: "Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3"
+      note: "Phase C — 07-build M4 complete (T4.3/#766); next M5 T5.1; #765 ready for review"
     - stage: 01-requirements
       required: true
       mode: delta
@@ -124,7 +124,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-21'
-      note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
+      note: 'M4 complete via T4.3 @ ab62daf / PR #766 draft; next T5.1; #765 ready for review (CI green); progress 20/29'
     - stage: 08-verify-build
       required: true
       mode: full
@@ -2387,9 +2387,9 @@ stages:
         started_at: '2026-07-21'
         started: '2026-07-21'
         mode: full
-        note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
-        active_milestone: M4
-        active_task: T4.3
+        note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+        active_milestone: M5
+        active_task: T5.1
         active_task_status: pending
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
@@ -2441,6 +2441,8 @@ stages:
         active_task_status: completed
         completed_at: '2026-07-19'
     notes:
+      - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open draft (base t41). M4 complete (20/29). Next M5 T5.1. #765 ready for review.'
+      - '2026-07-21 S019/EV-014 T4.3 STARTED — SMTP preflight connectivity (no live send in CI) on cursor/s019-t43-smtp-preflight-ac66; lingering PR #765 draft (T4.1–T4.2) on cursor/s019-t41-edis-format-c6f7 — CI nearly green'
       - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2 on cursor/s019-t41-edis-format-c6f7. PR #764 merged (T3.4). Next T4.3.'
       - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 wis2box harness publish green @ f3ba8e7. PR #763 merged. M3 complete. Next M4 T4.1.'
       - >-
@@ -2566,9 +2568,9 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
-      active_milestone: M4
-      active_task: T4.3
+      note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+      active_milestone: M5
+      active_task: T5.1
       active_task_status: pending
   09-qa:
     status: completed
@@ -3136,7 +3138,8 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3
+      Phase C — 07-build M4 complete (T4.3/#766 @ ab62daf); next M5 T5.1;
+      #765 ready for review
 
 stages_pending: []
 
@@ -7724,12 +7727,14 @@ evolve_cycles:
       skipped_stages: []
       note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
     current_stage: 07-build
-    active_milestone: M4
-    active_task: T4.3
+    active_milestone: M5
+    active_task: T5.1
     active_task_status: pending
-    branch: cursor/s019-t41-edis-format-c6f7
-    note: 'T4.1–T4.2 done; EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
+    branch: cursor/s019-t43-smtp-preflight-ac66
+    note: 'M4 complete via T4.3/#766; next T5.1; lingering #765 ready for review; progress 20/29'
     notes:
+      - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base cursor/s019-t41-edis-format-c6f7). M4 complete (20/29). Next M5 T5.1. #765 undrafted / ready_for_review (CI green). Session/cycle remain open.'
+      - '2026-07-21 S019/EV-014 T4.3 STARTED — SMTP preflight connectivity (no live send in CI) on cursor/s019-t43-smtp-preflight-ac66; lingering PR #765 draft (T4.1–T4.2) CI nearly green. T4.3 not completed.'
       - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink @ 67f73d2. PR #764 merged (T3.4). Next T4.3.'
       - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 wis2box harness publish green @ f3ba8e7. PR #763 merged. M3 complete; M3→M4 gate green. Next M4 T4.1 EDIS SMTP format fixtures.'
       - >-
@@ -7797,7 +7802,7 @@ evolve_cycles:
       16-evolve:
         status: in_progress
         started: '2026-07-20'
-        note: "Phase C — 07-build M4 T4.1–T4.2 EDIS format+sink; #764 merged; next T4.3"
+        note: "Phase C — 07-build M4 complete (T4.3/#766); next M5 T5.1; #765 ready for review"
       01-requirements:
         status: completed
         mode: delta
@@ -7874,9 +7879,9 @@ evolve_cycles:
         status: in_progress
         mode: full
         started: '2026-07-21'
-        note: 'T4.1–T4.2 done on cursor/s019-t41-edis-format-c6f7 (@ 67f73d2); EDIS format+sink landed; #764 merged; next T4.3; PR for EDIS'
-        active_milestone: M4
-        active_task: T4.3
+        note: 'M4 complete via T4.3 @ ab62daf / PR #766; next T5.1 pending; #765 ready for review; progress 20/29'
+        active_milestone: M5
+        active_task: T5.1
         active_task_status: pending
     gates:
       a_to_b: passed
@@ -10437,14 +10442,16 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: cursor/s019-t41-edis-format-c6f7
+  current_branch: cursor/s019-t43-smtp-preflight-ac66
   ahead_of_origin: 0
   pushed: true
   pending_commit: null
-  tip_sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
-  tip_sha_full: 67f73d2cfb49c511f0eb550a01ddf793e3978021
+  tip_sha: ab62daf6f9391c74fedc9afd5c3326130da40855
+  tip_sha_full: ab62daf6f9391c74fedc9afd5c3326130da40855
   notes:
-    - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink on cursor/s019-t41-edis-format-c6f7 @ 67f73d2. PR #764 merged (T3.4). Next T4.3; PR for EDIS pending.'
+    - '2026-07-21 S019/EV-014 T4.3 completed — ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base t41). M4 done (20/29); next T5.1. #765 ready_for_review / CI green.'
+    - '2026-07-21 S019/EV-014 T4.3 STARTED — working branch cursor/s019-t43-smtp-preflight-ac66 (build agent); lingering PR #765 draft (T4.1–T4.2) on cursor/s019-t41-edis-format-c6f7 — CI nearly green. T4.3 not completed.'
+    - '2026-07-21 S019/EV-014 T4.1–T4.2 completed — EDIS WMO AHL format + mocked SMTP sink on cursor/s019-t41-edis-format-c6f7 @ 67f73d2. PR #765 open draft; #764 merged (T3.4). Next T4.3.'
     - '2026-07-21 S019/EV-014 T3.4 completed — TC-F17-001 harness publish on cursor/s019-t34-wis2box-publish-c6f7 @ f3ba8e7. PR #764 merged. M3 complete; next M4 T4.1.'
     - >-
       2026-07-21 S019/EV-014 T3.3 completed — wis2box Compose harness on cursor/s019-t33-wis2box-harness-c6f7 (PR #763 open @ f222f90). #761+#762 merged to main. Next T3.4.
@@ -10637,6 +10644,24 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: cursor/s019-t43-smtp-preflight-ac66
+      status: open
+      base: cursor/s019-t41-edis-format-c6f7
+      created: '2026-07-21'
+      created_at: '2026-07-21'
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      purpose: S019/EV-014 07-build M4 T4.3 SMTP preflight connectivity (no live send in CI)
+      tip_sha: ab62daf6f9391c74fedc9afd5c3326130da40855
+      tip_sha_full: ab62daf6f9391c74fedc9afd5c3326130da40855
+      pushed: true
+      pr_number: 766
+      pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/766
+      pr_title: '[T4.3] EDIS SMTP preflight connectivity (no live send in CI)'
+      pr_base: cursor/s019-t41-edis-format-c6f7
+      pr_head: cursor/s019-t43-smtp-preflight-ac66
+      pr_status: open_draft
+      note: 'T4.3 complete @ ab62daf; PR #766 open draft; M4 done → next T5.1'
     - name: cursor/s019-t41-edis-format-c6f7
       status: open
       base: main
@@ -10648,7 +10673,13 @@ git_history:
       tip_sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
       tip_sha_full: 67f73d2cfb49c511f0eb550a01ddf793e3978021
       pushed: true
-      note: 'T4.1–T4.2 complete; PR for EDIS pending'
+      pr_number: 765
+      pr_url: https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765
+      pr_title: '[T4.1–T4.2] EDIS WMO AHL format + mocked SMTP sink (S019/EV-014)'
+      pr_base: main
+      pr_head: cursor/s019-t41-edis-format-c6f7
+      pr_status: ready_for_review
+      note: 'T4.1–T4.2 complete; PR #765 undrafted / ready_for_review — CI green; lingering stack base for #766'
     - name: cursor/s019-t34-wis2box-publish-c6f7
       status: merged
       base: main
@@ -11136,6 +11167,21 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: ab62daf6f9391c74fedc9afd5c3326130da40855
+      short: ab62daf
+      branch: cursor/s019-t43-smtp-preflight-ac66
+      message: '[T4.3] test: SMTP preflight connectivity without live send'
+      stage: 07-build / 16-evolve
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+      files_changed:
+        - docs/sessions/S019-dissemination-upload/HANDOFF.md
+        - docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+        - packages/dissemination/README.md
+        - packages/dissemination/src/dissemination/edis.py
+        - packages/dissemination/src/dissemination/transports.py
+        - packages/dissemination/tests/test_edis_preflight.py
     - sha: 67f73d2cfb49c511f0eb550a01ddf793e3978021
       short: 67f73d2
       branch: cursor/s019-t41-edis-format-c6f7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **M4 / T4.3** (S019 / EV-014 / F18): SMTP preflight connectivity checks that never call `send_message` in CI.

- Dedicated `test_edis_preflight.py`: connect/login/quit only; allowlist deny; secret redaction; no-credentials path; `AiosmtpClient` branch coverage for the 95% gate
- `AiosmtpClient` in `dissemination.transports` (`aiosmtplib`) — STARTTLS on 587, implicit TLS on 465, plain when `use_tls=False`
- Live RTH BYOC remains **TC-F18-002** (cycle-close gate)

## Related

- Prefer merging **[#765](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/765)** first (T4.1–T4.2; ready for review, CI green). This PR includes those commits until #765 lands, then shrinks to T4.3-only.
- Base: `main` (so CI/CD Pipeline runs)

## Test plan

- [x] Local dissemination coverage gate ≥95% (95.78%)
- [x] Full unit path green in CI — Test (dissemination) pass
- [x] CI/CD Pipeline green on this branch
- [ ] Merge after #765 (or together if preferred)

## Spec

- Spec source: TC-F18; E14-09
- Next after merge: **T5.1** (F19 adapter stubs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f84a1-70f0-7608-a9bf-c6c86efdac66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f84a1-70f0-7608-a9bf-c6c86efdac66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

