### PR TITLE
[M5] F19 AMHS/SWIM/AFS staging stubs (S019 / EV-014 T5.1–T5.3)

### DIFF
--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -11,7 +11,7 @@
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
 | Merged | #761–#767 (through **M4** / handoff) |
-| Open PR | M5 F19 stubs — `cursor/s019-t51-adapter-stubs-584b` (T5.1–T5.3) |
+| Open PR | [#768](https://github.com/joseph-c-mcguire/metar-to-IWXXM/pull/768) M5 F19 stubs (T5.1–T5.3) — CI green |
 | Done | M1; M2; M3; M4; **M5 complete** (F19 staging stubs) |
 | Next | **T6.1** Vitest: drawer sink chooser + preflight diff + block Send |
 | Branch for next work | create `cursor/s019-t61-…-584b` off **`main`** after M5 PR merges (or continue on tip) |

--- a/docs/sessions/S019-dissemination-upload/HANDOFF.md
+++ b/docs/sessions/S019-dissemination-upload/HANDOFF.md
@@ -3,21 +3,22 @@
 ## Resume in next chat
 
 ```
-/16-evolve continue S019/EV-014 — 07-build M5 T5.1
+/16-evolve continue S019/EV-014 — 07-build M6 T6.1
 ```
 
 | Field | Value |
 |-------|-------|
 | Session | `S019-dissemination-upload` |
 | Cycle | `EV-014` |
-| Merged | #761–#766 (through **M4** / T4.3 EDIS SMTP preflight) |
-| Latest merges | #765 (T4.1–T4.2), #766 (T4.3) → `main` |
-| Done | M1; M2; M3; **M4 complete** (F18 EDIS) |
-| Next | **T5.1** Adapter interface + staging stub behaviors (F19) |
-| Branch for next work | create `cursor/s019-t51-…-ac66` (or repo convention) off **`main`** |
+| Merged | #761–#767 (through **M4** / handoff) |
+| Open PR | M5 F19 stubs — `cursor/s019-t51-adapter-stubs-584b` (T5.1–T5.3) |
+| Done | M1; M2; M3; M4; **M5 complete** (F19 staging stubs) |
+| Next | **T6.1** Vitest: drawer sink chooser + preflight diff + block Send |
+| Branch for next work | create `cursor/s019-t61-…-584b` off **`main`** after M5 PR merges (or continue on tip) |
 
 ## Do not skip
 
 - Live BYOC close gate before cycle close (Postgres + WIS2 + EDIS)
 - TC-F18-002 live EDIS remains cycle-close only
 - F19 live demo optional (evidence or waive); does not block EV-014 close
+- M6 ships FE drawer + H4–H5 (E14-10)

--- a/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
+++ b/docs/sessions/S019-dissemination-upload/reports/execution-plan.md
@@ -14,10 +14,11 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — **07-build** M4 complete; next M5 |
-| **Active milestone** | M5 — AMHS / SWIM / AFS (F19) |
-| **Active task** | T5.1 (next) |
-| **Tasks** | 20 / **29** completed (through T4.3) |
+| **Active phase** | Phase C — **07-build** M5 complete; next M6 |
+| **Active milestone** | M6 — FE drawer + connectivity + verify |
+| **Active task** | T6.1 (next) |
+| **Tasks** | 23 / **29** completed (through T5.3) |
+| **Branch** | `cursor/s019-t51-adapter-stubs-584b` (M5; PR → `main`) |
 | **Last updated** | 2026-07-21 |
 
 ## Tech Stack Summary
@@ -91,9 +92,9 @@
 
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
-| T5.1 | Test | Adapter interface + staging stub behaviors | F19; S-EV014-M2 | T2.4 | pending |
-| T5.2 | Code | AMHS/SWIM/AFS sink stubs + drawer-ready sink_type enums | ADR-030; E14-05 | T5.1 | pending |
-| T5.3 | Test | Staging/test path green for each adapter (mocked transport OK) | TC-F19; E14-09 | T5.2 | pending |
+| T5.1 | Test | Adapter interface + staging stub behaviors | F19; S-EV014-M2 | T2.4 | **completed** |
+| T5.2 | Code | AMHS/SWIM/AFS sink stubs + drawer-ready sink_type enums | ADR-030; E14-05 | T5.1 | **completed** |
+| T5.3 | Test | Staging/test path green for each adapter (mocked transport OK) | TC-F19; E14-09 | T5.2 | **completed** |
 
 ### M6 — FE drawer + connectivity + verify (F16–F19 UI)
 

--- a/packages/dissemination/README.md
+++ b/packages/dissemination/README.md
@@ -65,6 +65,14 @@ Deploy / image notes (CI skip policy, stock API Dockerfile without `msodbcsql18`
 - `dissemination.transports.AiosmtpClient` — `aiosmtplib` SMTP client; preflight is
   connect/login only (never `send_message` in CI)
 
+**F19 AMHS / SWIM / AFS (T5.1–T5.2 / S-EV014-M2)**
+
+- `dissemination.sink.SinkAdapter` — shared preflight/send Protocol (E14-05)
+- `dissemination.f19_stubs` — staging stubs (`get_staging_sink`); allowlist only,
+  no live AMHS/SWIM/AFS libraries this cycle
+- `dissemination.models.DRAWER_SINK_TYPES` — drawer-ready sink enum tuple (F16–F19)
+- Live F19 demo optional at cycle close; staging/test path required
+
 - Env: `DISSEMINATION_EGRESS_ALLOWLIST` (see `.env.example`, ADR-029)
 - Empty ⇒ fail-closed
 - Compose wis2box harness: `make compose-wis2box-up` / `compose-wis2box-harness`

--- a/packages/dissemination/src/dissemination/f19_stubs.py
+++ b/packages/dissemination/src/dissemination/f19_stubs.py
@@ -1,0 +1,173 @@
+"""AMHS / SWIM / AFS staging sink stubs (F19 / S-EV014-M2 / E14-05).
+
+Staging/test path is required this cycle; live AMHS/SWIM/AFS demos are optional.
+Stubs enforce the shared ``SinkAdapter`` contract + ADR-029 allowlist without
+calling live protocol libraries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+from uuid import uuid4
+
+from dissemination.allowlist import Allowlist, validate_egress_host
+from dissemination.models import PreflightResponse, SendResponse, SinkType
+from dissemination.redact import redact_secrets
+
+F19SinkName = Literal["amhs", "swim", "afs"]
+
+F19_SINK_TYPES: Final[tuple[F19SinkName, ...]] = ("amhs", "swim", "afs")
+
+
+@dataclass(frozen=True, slots=True)
+class F19Params:
+    """BYOC connection parameters for F19 adapters (memory-only; never logged raw)."""
+
+    sink_type: F19SinkName
+    host: str
+    port: int = 0
+    username: str | None = None
+    password: str | None = None
+    endpoint: str | None = None
+
+
+def _redact_exc(exc: BaseException, params: F19Params) -> str:
+    text = redact_secrets(str(exc))
+    if params.password:
+        text = text.replace(params.password, "***")
+    if params.username:
+        text = text.replace(params.username, "***")
+    return text
+
+
+def _require_host(params: F19Params) -> str:
+    host = (params.host or "").strip()
+    if not host:
+        raw = f"F19 host is required; password={params.password}; username={params.username}"
+        raise ValueError(_redact_exc(ValueError(raw), params))
+    return host
+
+
+def _validate_f19_egress(params: F19Params, allowlist: Allowlist) -> None:
+    validate_egress_host(_require_host(params), allowlist=allowlist)
+
+
+def _require_payload(
+    *,
+    iwxxm_xml: str | bytes | None,
+    tac_text: str | None,
+) -> None:
+    has_xml = iwxxm_xml is not None and (len(iwxxm_xml) > 0 if isinstance(iwxxm_xml, (bytes, str)) else True)
+    has_tac = tac_text is not None and len(tac_text) > 0
+    if not has_xml and not has_tac:
+        raise ValueError("F19 staging send requires an IWXXM or TAC payload")
+
+
+class StagingSinkAdapter:
+    """
+    Staging/test-path sink for AMHS, SWIM, or AFS.
+
+    Performs allowlist checks and returns green preflight/send markers without
+    live protocol egress (S-EV014-M2).
+    """
+
+    mode: Final[str] = "staging"
+
+    def __init__(self, sink_type: F19SinkName) -> None:
+        if sink_type not in F19_SINK_TYPES:
+            raise ValueError(f"sink_type {sink_type!r} is not an F19 staging adapter")
+        self._sink_type: SinkType = sink_type
+
+    @property
+    def sink_type(self) -> SinkType:
+        return self._sink_type
+
+    async def preflight(
+        self,
+        *,
+        params: F19Params,
+        allowlist: Allowlist,
+    ) -> PreflightResponse:
+        """
+        Allowlist-only preflight for the F19 staging stub.
+
+        Raises
+        ------
+        EgressDenied
+            When ``params.host`` is not allowlisted.
+        ValueError
+            When ``host`` is missing (secrets redacted).
+        """
+        if params.sink_type != self._sink_type:
+            raise ValueError(f"params.sink_type {params.sink_type!r} does not match adapter {self._sink_type!r}")
+        _validate_f19_egress(params, allowlist)
+        return PreflightResponse(
+            ok=True,
+            connectivity_ok=True,
+            diffs=[],
+            detail=f"staging stub ({self._sink_type})",
+        )
+
+    async def send(
+        self,
+        *,
+        params: F19Params,
+        allowlist: Allowlist,
+        iwxxm_xml: str | bytes | None = None,
+        tac_text: str | None = None,
+    ) -> SendResponse:
+        """
+        Record a staging delivery marker after allowlist + payload checks.
+
+        Raises
+        ------
+        EgressDenied
+            When ``params.host`` is not allowlisted.
+        ValueError
+            When host or payload is missing (secrets redacted).
+        """
+        if params.sink_type != self._sink_type:
+            raise ValueError(f"params.sink_type {params.sink_type!r} does not match adapter {self._sink_type!r}")
+        _validate_f19_egress(params, allowlist)
+        _require_payload(iwxxm_xml=iwxxm_xml, tac_text=tac_text)
+
+        key = f"staging:{self._sink_type}:{uuid4().hex}"
+        return SendResponse(
+            ok=True,
+            kv_upload_key=key,
+            detail=f"staging stub ({self._sink_type})",
+        )
+
+
+def get_staging_sink(sink_type: F19SinkName | str) -> StagingSinkAdapter:
+    """
+    Return the staging ``SinkAdapter`` for an F19 sink type.
+
+    Parameters
+    ----------
+    sink_type :
+        One of ``amhs``, ``swim``, ``afs``.
+
+    Returns
+    -------
+    StagingSinkAdapter
+        Staging stub implementing ``SinkAdapter``.
+
+    Raises
+    ------
+    ValueError
+        When ``sink_type`` is not an F19 adapter.
+    """
+    if sink_type not in F19_SINK_TYPES:
+        raise ValueError(f"sink_type {sink_type!r} is not an F19 staging adapter")
+    return StagingSinkAdapter(sink_type=sink_type)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "F19_SINK_TYPES",
+    "F19Params",
+    "F19SinkName",
+    "StagingSinkAdapter",
+    "get_staging_sink",
+]

--- a/packages/dissemination/src/dissemination/models.py
+++ b/packages/dissemination/src/dissemination/models.py
@@ -18,6 +18,19 @@ SinkType = Literal[
     "afs",
 ]
 
+# Drawer chooser order — keep FE enums aligned (T5.2 / E14-05 / E14-10).
+DRAWER_SINK_TYPES: tuple[SinkType, ...] = (
+    "postgres",
+    "mysql",
+    "sqlserver",
+    "sqlite",
+    "wis2",
+    "edis",
+    "amhs",
+    "swim",
+    "afs",
+)
+
 
 class SchemaDiffItem(msgspec.Struct, frozen=True):
     kind: str

--- a/packages/dissemination/src/dissemination/sink.py
+++ b/packages/dissemination/src/dissemination/sink.py
@@ -1,0 +1,65 @@
+"""Shared sink adapter Protocol for F16–F19 dissemination (E14-05 / ADR-030).
+
+Concrete sinks (DB, WIS2, EDIS, F19 staging stubs) expose the same preflight/send
+shape so the drawer and thin backend routers can dispatch by ``sink_type``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from dissemination.allowlist import Allowlist
+from dissemination.models import PreflightResponse, SendResponse, SinkType
+
+
+@runtime_checkable
+class SinkAdapter(Protocol):
+    """
+    Common preflight + send contract for operator dissemination sinks.
+
+    Parameters for both methods are sink-specific (URI, MQTT, SMTP, AMHS, …) and
+    must never be logged raw; allowlist/SSRF checks apply before egress.
+    """
+
+    @property
+    def sink_type(self) -> SinkType:
+        """Drawer / API sink discriminator."""
+
+    async def preflight(
+        self,
+        *,
+        params: Any,
+        allowlist: Allowlist,
+    ) -> PreflightResponse:
+        """
+        Connectivity / schema preflight without committing the payload.
+
+        Raises
+        ------
+        EgressDenied
+            When destination hosts are not allowlisted.
+        ValueError
+            When params or transport checks fail (secrets redacted).
+        """
+
+    async def send(
+        self,
+        *,
+        params: Any,
+        allowlist: Allowlist,
+        iwxxm_xml: str | bytes | None = None,
+        tac_text: str | None = None,
+    ) -> SendResponse:
+        """
+        Deliver IWXXM and/or TAC to the sink after allowlist checks.
+
+        Raises
+        ------
+        EgressDenied
+            When destination hosts are not allowlisted.
+        ValueError
+            When params, payload, or transport fail (secrets redacted).
+        """
+
+
+__all__ = ["SinkAdapter"]

--- a/packages/dissemination/tests/test_f19_sink_stubs.py
+++ b/packages/dissemination/tests/test_f19_sink_stubs.py
@@ -1,0 +1,167 @@
+"""F19 adapter interface + staging stub behaviors (T5.1 / S-EV014-M2 / E14-05).
+
+Defines the shared ``SinkAdapter`` contract (same interface as WIS2/EDIS) and the
+staging/test-path behaviors for AMHS, SWIM, and AFS. Live F19 transport is optional
+this cycle; T5.2 implements the stubs these tests describe.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+from unittest.mock import patch
+
+import pytest
+
+from dissemination.allowlist import EgressDenied, parse_allowlist
+from dissemination.f19_stubs import (
+    F19_SINK_TYPES,
+    F19Params,
+    StagingSinkAdapter,
+    get_staging_sink,
+)
+from dissemination.models import DRAWER_SINK_TYPES, SinkType
+from dissemination.sink import SinkAdapter
+
+
+@pytest.fixture(autouse=True)
+def _public_dns_for_example_hosts():
+    """Allowlist checks resolve hosts; map test FQDNs to a public address."""
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        yield
+
+
+def _params(sink_type: str = "amhs", **overrides: Any) -> F19Params:
+    base = dict(
+        sink_type=sink_type,
+        host="gateway.example.test",
+        port=8080,
+        username="operator",
+        password="super-secret-token",
+        endpoint="/submit",
+    )
+    base.update(overrides)
+    return F19Params(**base)
+
+
+def _allowlist(*hosts: str):
+    return parse_allowlist(",".join(hosts))
+
+
+@pytest.mark.parametrize("sink_type", ["amhs", "swim", "afs"])
+def test_f19_sink_types_are_drawer_ready(sink_type: str) -> None:
+    assert sink_type in get_args(SinkType)
+    assert sink_type in F19_SINK_TYPES
+    assert sink_type in DRAWER_SINK_TYPES
+
+
+def test_drawer_sink_types_cover_f16_through_f19() -> None:
+    expected = {
+        "postgres",
+        "mysql",
+        "sqlserver",
+        "sqlite",
+        "wis2",
+        "edis",
+        "amhs",
+        "swim",
+        "afs",
+    }
+    assert set(DRAWER_SINK_TYPES) == expected
+    assert set(F19_SINK_TYPES) == {"amhs", "swim", "afs"}
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+def test_staging_sink_implements_shared_adapter_interface(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    assert isinstance(adapter, SinkAdapter)
+    assert isinstance(adapter, StagingSinkAdapter)
+    assert adapter.sink_type == sink_type
+    assert adapter.mode == "staging"
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_preflight_ok_without_live_transport(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    result = await adapter.preflight(
+        params=_params(sink_type),
+        allowlist=_allowlist("gateway.example.test"),
+    )
+    assert result.ok is True
+    assert result.connectivity_ok is True
+    assert result.diffs == []
+    assert result.detail is None or "staging" in (result.detail or "").lower()
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_preflight_denies_host_not_allowlisted(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    with pytest.raises(EgressDenied):
+        await adapter.preflight(
+            params=_params(sink_type),
+            allowlist=_allowlist("other.example.test"),
+        )
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_send_ok_returns_staging_marker(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    result = await adapter.send(
+        params=_params(sink_type),
+        allowlist=_allowlist("gateway.example.test"),
+        iwxxm_xml=b"<iwxxm/>",
+    )
+    assert result.ok is True
+    assert result.kv_upload_key is not None
+    assert sink_type in result.kv_upload_key
+    assert "staging" in result.kv_upload_key.lower() or (
+        result.detail is not None and "staging" in result.detail.lower()
+    )
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_send_denies_host_not_allowlisted(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    with pytest.raises(EgressDenied):
+        await adapter.send(
+            params=_params(sink_type),
+            allowlist=_allowlist("other.example.test"),
+            iwxxm_xml="<iwxxm/>",
+        )
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_send_requires_payload(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    with pytest.raises(ValueError, match="payload"):
+        await adapter.send(
+            params=_params(sink_type),
+            allowlist=_allowlist("gateway.example.test"),
+        )
+
+
+@pytest.mark.parametrize("sink_type", list(F19_SINK_TYPES))
+@pytest.mark.asyncio
+async def test_staging_errors_redact_password(sink_type: str) -> None:
+    adapter = get_staging_sink(sink_type)
+    params = _params(sink_type, host="")
+    with pytest.raises(ValueError) as exc_info:
+        await adapter.preflight(
+            params=params,
+            allowlist=_allowlist("gateway.example.test"),
+        )
+    message = str(exc_info.value)
+    assert "super-secret-token" not in message
+    assert "***" in message or "host" in message.lower()
+
+
+def test_get_staging_sink_rejects_unknown_type() -> None:
+    with pytest.raises(ValueError, match="sink_type"):
+        get_staging_sink("wis2")  # type: ignore[arg-type]

--- a/packages/dissemination/tests/test_f19_sink_stubs.py
+++ b/packages/dissemination/tests/test_f19_sink_stubs.py
@@ -165,3 +165,63 @@ async def test_staging_errors_redact_password(sink_type: str) -> None:
 def test_get_staging_sink_rejects_unknown_type() -> None:
     with pytest.raises(ValueError, match="sink_type"):
         get_staging_sink("wis2")  # type: ignore[arg-type]
+
+
+def test_staging_adapter_init_rejects_unknown_type() -> None:
+    with pytest.raises(ValueError, match="sink_type"):
+        StagingSinkAdapter("wis2")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_staging_preflight_rejects_mismatched_sink_type() -> None:
+    adapter = get_staging_sink("amhs")
+    with pytest.raises(ValueError, match="does not match"):
+        await adapter.preflight(
+            params=_params("swim"),
+            allowlist=_allowlist("gateway.example.test"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_staging_send_rejects_mismatched_sink_type() -> None:
+    adapter = get_staging_sink("swim")
+    with pytest.raises(ValueError, match="does not match"):
+        await adapter.send(
+            params=_params("amhs"),
+            allowlist=_allowlist("gateway.example.test"),
+            iwxxm_xml="<iwxxm/>",
+        )
+
+
+@pytest.mark.asyncio
+async def test_staging_send_accepts_tac_text_only() -> None:
+    adapter = get_staging_sink("afs")
+    result = await adapter.send(
+        params=_params("afs"),
+        allowlist=_allowlist("gateway.example.test"),
+        tac_text="METAR KJFK 121251Z ...",
+    )
+    assert result.ok is True
+    assert "afs" in (result.kv_upload_key or "")
+
+
+@pytest.mark.asyncio
+async def test_staging_preflight_without_credentials() -> None:
+    adapter = get_staging_sink("amhs")
+    params = _params("amhs", username=None, password=None)
+    result = await adapter.preflight(
+        params=params,
+        allowlist=_allowlist("gateway.example.test"),
+    )
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_staging_missing_host_without_password_still_mentions_host() -> None:
+    adapter = get_staging_sink("amhs")
+    params = _params("amhs", host="", username=None, password=None)
+    with pytest.raises(ValueError, match="host"):
+        await adapter.preflight(
+            params=params,
+            allowlist=_allowlist("gateway.example.test"),
+        )

--- a/packages/dissemination/tests/test_f19_staging_path.py
+++ b/packages/dissemination/tests/test_f19_staging_path.py
@@ -1,0 +1,61 @@
+"""TC-F19-001..003 — staging/test path green per F19 adapter (T5.3 / E14-09).
+
+One case per AMHS / SWIM / AFS adapter with mocked (no-live) transport via the
+staging stubs. Live F19 demos remain optional at cycle close (S-EV014-M2).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dissemination.allowlist import parse_allowlist
+from dissemination.f19_stubs import F19Params, get_staging_sink
+
+
+@pytest.fixture(autouse=True)
+def _public_dns_for_example_hosts():
+    with patch(
+        "dissemination.allowlist.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("tc_id", "sink_type"),
+    [
+        ("TC-F19-001", "amhs"),
+        ("TC-F19-002", "swim"),
+        ("TC-F19-003", "afs"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_f19_staging_preflight_and_send_green(tc_id: str, sink_type: str) -> None:
+    """Staging path: allowlisted preflight + send without live protocol egress."""
+    del tc_id  # retained in parametrize id for test-plan traceability
+    adapter = get_staging_sink(sink_type)
+    params = F19Params(
+        sink_type=sink_type,  # type: ignore[arg-type]
+        host="f19-staging.example.test",
+        port=443,
+        username="byoc-user",
+        password="byoc-secret",
+        endpoint="/v1/submit",
+    )
+    allowlist = parse_allowlist("f19-staging.example.test")
+
+    pre = await adapter.preflight(params=params, allowlist=allowlist)
+    assert pre.ok is True
+    assert pre.connectivity_ok is True
+
+    send = await adapter.send(
+        params=params,
+        allowlist=allowlist,
+        iwxxm_xml=b'<?xml version="1.0"?><iwxxm:METAR/>',
+    )
+    assert send.ok is True
+    assert send.kv_upload_key is not None
+    assert sink_type in send.kv_upload_key
+    assert "staging" in send.kv_upload_key.lower() or (send.detail is not None and "staging" in send.detail.lower())

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -10,12 +10,12 @@ active_session:
   type: feature
   intent: 'Dissemination epic: F16 multi-DB upload (#729) URI one-shot + preflight + DDL + drag-drop; F17 WIS2 (#2) staging test + live BYOC; F18 EDIS (#6) RTH Washington BYOC SMTP; F19 AMHS/SWIM/AFS adapters. Credentials never persisted. Phase 0 approved (Q23=A–D, Q24=A Full); F16–F19 Planned in feature-list.'
   status: in_progress
-  branch: main
+  branch: cursor/s019-t51-adapter-stubs-584b
   orchestrator: 16-evolve
   evolve_cycle_id: EV-014
   artifacts_dir: docs/sessions/S019-dissemination-upload/
   current_stage: 07-build
-  note: 'M4 merged via #765+#766; next T5.1 off main'
+  note: 'M5 complete (T5.1–T5.3 F19 staging stubs). Next M6 T6.1 Vitest drawer. Progress 23/29.'
   started_at: '2026-07-20'
   context_briefs: []
   standing_docs_touched:
@@ -69,7 +69,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-20'
-      note: "Phase C — 07-build M4 merged (#765+#766→main); next M5 T5.1 off main; progress 20/29"
+      note: "Phase C — 07-build M6 T6.1 pending (cursor/s019-t51-adapter-stubs-584b); progress 23/29; M5 done"
     - stage: 01-requirements
       required: true
       mode: delta
@@ -124,7 +124,7 @@ active_session:
       status: in_progress
       skip_rationale:
       started: '2026-07-21'
-      note: 'M4 merged via #765 (4cc4b58) + #766 (df34500)→main; next T5.1 off main; progress 20/29'
+      note: 'M6 T6.1 pending on cursor/s019-t51-adapter-stubs-584b; tip a8f2cb0; progress 23/29; M5 done (T5.1–T5.3)'
     - stage: 08-verify-build
       required: true
       mode: full
@@ -2387,9 +2387,10 @@ stages:
         started_at: '2026-07-21'
         started: '2026-07-21'
         mode: full
-        note: 'M4 merged via #765+#766→main; next T5.1 off main; progress 20/29'
-        active_milestone: M5
-        active_task: T5.1
+        note: 'M5 complete (T5.1–T5.3 F19 staging stubs). Next M6 T6.1 Vitest drawer. Progress 23/29.'
+        progress: '23/29'
+        active_milestone: M6
+        active_task: T6.1
         active_task_status: pending
       - id: S015-metar-lint-quality
         session_id: S015-metar-lint-quality
@@ -2441,6 +2442,8 @@ stages:
         active_task_status: completed
         completed_at: '2026-07-19'
     notes:
+      - '2026-07-21 S019/EV-014 M5 complete (T5.1–T5.3 F19 staging stubs @ 33705dd/17b1094/a8f2cb0). Next M6 T6.1 Vitest drawer. Progress 23/29.'
+      - '2026-07-21 S019/EV-014 T5.1 in_progress — adapter interface + staging stub behaviors (F19) on cursor/s019-t51-adapter-stubs-584b off origin/main; progress 20/29'
       - '2026-07-21 S019/EV-014 M4 MERGED to main — #765 @ 4cc4b58 (12:55:49Z) then #766 @ df34500 (12:55:59Z). Next T5.1 off main. Progress 20/29. Session/cycle remain open.'
       - '2026-07-21 S019/EV-014 #766 ready_for_review (CI green) @ tip 1002baa; recorded coverage fix + CI trigger + 07edc63 chore. Prefer merge #765 then #766. T5.1 still pending; 20/29.'
       - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open draft (base t41). M4 complete (20/29). Next M5 T5.1. #765 ready for review.'
@@ -2570,9 +2573,10 @@ stages:
       status: in_progress
       mode: full
       started_at: '2026-07-21'
-      note: 'M4 merged via #765+#766→main; next T5.1 off main; progress 20/29'
-      active_milestone: M5
-      active_task: T5.1
+      note: 'M5 complete (T5.1–T5.3 F19 staging stubs). Next M6 T6.1 Vitest drawer. Progress 23/29.'
+      progress: '23/29'
+      active_milestone: M6
+      active_task: T6.1
       active_task_status: pending
   09-qa:
     status: completed
@@ -3140,7 +3144,7 @@ stages:
     started_at: '2026-07-20'
     current_stage: 07-build
     note: >-
-      Phase C — 07-build M4 merged (#765+#766→main); next T5.1 off main; progress 20/29
+      Phase C — 07-build M6 T6.1 pending (cursor/s019-t51-adapter-stubs-584b); progress 23/29; M5 done
 
 stages_pending: []
 
@@ -7728,12 +7732,15 @@ evolve_cycles:
       skipped_stages: []
       note: Full routing approved (Q24=A / D-S019-EV014-phase0-approve); 01 completed → 02-verify-plan
     current_stage: 07-build
-    active_milestone: M5
-    active_task: T5.1
+    active_milestone: M6
+    active_task: T6.1
     active_task_status: pending
-    branch: main
-    note: 'M4 merged via #765+#766; next T5.1 off main; progress 20/29'
+    progress: '23/29'
+    branch: cursor/s019-t51-adapter-stubs-584b
+    note: 'M5 complete (T5.1–T5.3 F19 staging stubs). Next M6 T6.1 Vitest drawer.'
     notes:
+      - '2026-07-21 S019/EV-014 M5 complete (T5.1–T5.3 F19 staging stubs @ 33705dd/17b1094/a8f2cb0). Next M6 T6.1 Vitest drawer. Progress 23/29.'
+      - '2026-07-21 S019/EV-014 T5.1 in_progress — adapter interface + staging stub behaviors (F19) on cursor/s019-t51-adapter-stubs-584b off origin/main; progress 20/29'
       - '2026-07-21 S019/EV-014 M4 MERGED to main — #765 @ 4cc4b5840e6451587718c7fdccb40f3516988079 (12:55:49Z) then #766 @ df3450043bbbaf85f4bed9949e1b657483e4a06e (12:55:59Z). Next T5.1 off main. Progress 20/29. Session/cycle remain open.'
       - '2026-07-21 S019/EV-014 #766 ready_for_review (CI green) @ tip 1002baa (coverage + CI trigger + 07edc63). Prefer merge #765 then #766. T5.1 pending; session/cycle open; 20/29.'
       - '2026-07-21 S019/EV-014 T4.3 completed — SMTP preflight (no live send) @ ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base cursor/s019-t41-edis-format-c6f7). M4 complete (20/29). Next M5 T5.1. #765 undrafted / ready_for_review (CI green). Session/cycle remain open.'
@@ -7882,9 +7889,10 @@ evolve_cycles:
         status: in_progress
         mode: full
         started: '2026-07-21'
-        note: 'M4 merged via #765+#766→main; next T5.1 off main; progress 20/29'
-        active_milestone: M5
-        active_task: T5.1
+        note: 'M5 complete (T5.1–T5.3 F19 staging stubs). Next M6 T6.1 Vitest drawer. Progress 23/29.'
+        progress: '23/29'
+        active_milestone: M6
+        active_task: T6.1
         active_task_status: pending
     gates:
       a_to_b: passed
@@ -10445,14 +10453,16 @@ evolve_cycles:
     merge_sha: "4660602"
 
 git_history:
-  current_branch: main
+  current_branch: cursor/s019-t51-adapter-stubs-584b
   ahead_of_origin: 0
   pushed: true
   pending_commit: null
-  tip_sha: df3450043bbbaf85f4bed9949e1b657483e4a06e
-  tip_sha_full: df3450043bbbaf85f4bed9949e1b657483e4a06e
-  note: 'Next work (T5.1) should branch from main @ df34500 (#766 merge tip)'
+  tip_sha: a8f2cb05c0129405d84fcf1d4cfe85a20094dfaf
+  tip_sha_full: a8f2cb05c0129405d84fcf1d4cfe85a20094dfaf
+  note: 'M5 complete (T5.1–T5.3) on cursor/s019-t51-adapter-stubs-584b; tip a8f2cb0; next M6 T6.1; progress 23/29'
   notes:
+    - '2026-07-21 S019/EV-014 M5 complete (T5.1–T5.3 @ 33705dd/17b1094/a8f2cb0) on cursor/s019-t51-adapter-stubs-584b; next M6 T6.1 Vitest drawer; progress 23/29'
+    - '2026-07-21 S019/EV-014 T5.1 in_progress — adapter interface + staging stub behaviors (F19) on cursor/s019-t51-adapter-stubs-584b off origin/main; progress 20/29; tip 58cc427'
     - '2026-07-21 S019/EV-014 M4 MERGED to main — #765 @ 4cc4b58 (12:55:49Z) then #766 @ df34500 (12:55:59Z). Branches t41+t43 merged. Next T5.1 off main. Progress 20/29.'
     - '2026-07-21 S019/EV-014 tip 1002baa on t43 — coverage fix + d903085 CI trigger + 07edc63 chore; #766 ready_for_review (CI green). Prefer merge #765 then #766. T5.1 pending; 20/29.'
     - '2026-07-21 S019/EV-014 T4.3 completed — ab62daf on cursor/s019-t43-smtp-preflight-ac66; PR #766 open_draft (base t41). M4 done (20/29); next T5.1. #765 ready_for_review / CI green.'
@@ -10650,6 +10660,18 @@ git_history:
     - "2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)"
     - "2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl"
   branches:
+    - name: cursor/s019-t51-adapter-stubs-584b
+      status: open
+      base: main
+      created: '2026-07-21'
+      created_at: '2026-07-21'
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      purpose: S019/EV-014 07-build M5 T5.1–T5.3 F19 adapter stubs; next M6 T6.1
+      tip_sha: a8f2cb05c0129405d84fcf1d4cfe85a20094dfaf
+      tip_sha_full: a8f2cb05c0129405d84fcf1d4cfe85a20094dfaf
+      pushed: true
+      note: 'M5 complete (T5.1–T5.3 F19 staging stubs @ 33705dd/17b1094/a8f2cb0); next M6 T6.1 Vitest drawer'
     - name: cursor/s019-t43-smtp-preflight-ac66
       status: merged
       base: cursor/s019-t41-edis-format-c6f7
@@ -11179,6 +11201,30 @@ git_history:
       pr_number: 716
       note: "PR-EV-008=#716 open (retitled/updated evolve→main); NO merge, NO deploy"
   commits:
+    - sha: a8f2cb05c0129405d84fcf1d4cfe85a20094dfaf
+      short: a8f2cb0
+      branch: cursor/s019-t51-adapter-stubs-584b
+      message: '[T5.3] test: TC-F19-001..003 staging path green per adapter'
+      stage: 07-build
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+    - sha: 17b109444aa0cdc0f80115d6bf4374e6574cfd9e
+      short: 17b1094
+      branch: cursor/s019-t51-adapter-stubs-584b
+      message: '[T5.2] feat: F19 SinkAdapter + AMHS/SWIM/AFS staging stubs'
+      stage: 07-build
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
+    - sha: 33705dda8da6cb94592fb702e7208190cf8e640c
+      short: 33705dd
+      branch: cursor/s019-t51-adapter-stubs-584b
+      message: '[T5.1] test: F19 adapter interface + staging stub behaviors'
+      stage: 07-build
+      session_id: S019-dissemination-upload
+      evolve_cycle_id: EV-014
+      timestamp: '2026-07-21'
     - sha: df3450043bbbaf85f4bed9949e1b657483e4a06e
       short: df34500
       branch: main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **M5 — AMHS / SWIM / AFS adapters (F19)** for S019 / EV-014:

- **T5.1** — Contract tests for shared `SinkAdapter` + staging stub behaviors
- **T5.2** — `dissemination.sink.SinkAdapter`, `dissemination.f19_stubs` staging adapters, `DRAWER_SINK_TYPES`
- **T5.3** — TC-F19-001..003 staging preflight+send green (mocked / no live transport)

## Spec

- F19; S-EV014-M2; E14-05 / ADR-030 (same sink interface as WIS2/EDIS)
- Staging/test path required; F19 live demo optional at cycle close

## Test plan

- [x] `bash scripts/ci/run_dissemination_coverage.sh` — 124 passed, 96% (≥95%)
- [x] CI `ci-cd.yml` green on branch
- [ ] Merge → continue **M6 T6.1** (Vitest drawer sink chooser)

## Checklist

- [x] Atomic commits `[T5.1]` / `[T5.2]` / `[T5.3]`
- [x] No FastAPI/Supabase imports in `packages/dissemination`
- [x] Allowlist/SSRF posture on F19 staging stubs
- [x] Execution plan + HANDOFF updated (next: M6 T6.1)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f84d3-a8bd-7979-9d5b-1f9c55ca584b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f84d3-a8bd-7979-9d5b-1f9c55ca584b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

