### PR TITLE
[EV-017] fix: omit disableAuth from FE Docker config bake

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -61,11 +61,9 @@ const cfg = { \
     baseUrl: process.env.VITE_API_BASE_URL || '', \
     frontendUrl: process.env.VITE_APP_URL || '', \
     corsOrigins: process.env.VITE_APP_URL ? [process.env.VITE_APP_URL] : [], \
-    disableAuth: false, \
   }, \
   supabase: { \
     url: process.env.VITE_SUPABASE_URL || '', \
-    publishableKey: process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || '', \
   }, \
 }; \
 fs.mkdirSync('public', { recursive: true }); \


### PR DESCRIPTION
## Summary
- FE Docker bake still wrote `api.disableAuth: false` (and Auth publishable key) into `/config.json`, which fails H5 after F21 public cutover.
- Omit retired `disableAuth` and Auth publishable key from the baked runtime config so live H4–H5 can pass.

## Test plan
- [x] Local `make validate-ci` + `make ci-prepush`
- [ ] Main CI Deploy rebuilds `frontend:main-latest`
- [ ] Live `/config.json` has no `disableAuth`
- [ ] `make test-live-connectivity` (T7.2 H4–H5)


Made with [Cursor](https://cursor.com)