### PR TITLE
[EV-017] docs: M7 T7.2/T7.4 closeout

### DIFF
--- a/docs/sessions/S023-public-app-privacy/reports/execution-plan.md
+++ b/docs/sessions/S023-public-app-privacy/reports/execution-plan.md
@@ -13,9 +13,9 @@
 | Field | Value |
 |-------|-------|
 | **Active phase** | Phase C — 07-build |
-| **Active milestone** | M7 — E2E / docs / connectivity gate |
-| **Active task** | T7.4 blocked on F21 image cutover (RENDER_API_KEY OK; inventory done) |
-| **Tasks** | 27 / ~28 completed |
+| **Active milestone** | M7 — E2E / docs / connectivity gate — **COMPLETE** |
+| **Active task** | M7 done — handoff 08-verify-build |
+| **Tasks** | 28 / ~28 completed |
 | **Last updated** | 2026-07-28 |
 
 ## Tech Stack Summary (S023 delta)
@@ -116,9 +116,9 @@
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
 | T7.1 | Test | Playwright: public UJ-001/004/013/018; Auth-gone negative; privacy smoke | test-plan; H6 | M2–M6 | completed |
-| T7.2 | Test | H4–H5 connectivity after FE/API deploy | connectivity-gates | T7.1 | pending |
+| T7.2 | Test | H4–H5 connectivity after FE/API deploy | connectivity-gates | T7.1 | completed — see reports/t7.2-h4-h5-connectivity.md |
 | T7.3 | Docs | Update deploy.md / CORPUS refs; session 04 report; CHANGELOG draft bullets | docs corpus | T5.4 | completed |
-| T7.4 | Config | Confirm Render env: remove Auth secrets from API if unused; keep F8 + allowlist | env-contract | T1.3 | blocked — live still Auth-era `main-latest`; delete env only after F21 image deploy; see reports/t7.4-render-env-checklist.md |
+| T7.4 | Config | Confirm Render env: remove Auth secrets from API if unused; keep F8 + allowlist | env-contract | T1.3 | completed — see reports/t7.4-render-env-checklist.md |
 
 ## Phase Gate Check (B→C)
 

--- a/docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
+++ b/docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
@@ -1,0 +1,28 @@
+# T7.2 — H4–H5 connectivity (post F21 deploy)
+
+**Session**: S023 / EV-017  
+**Status**: **completed** 2026-07-28  
+**Depends**: T7.1, T7.4 (live cutover)
+
+## Command
+
+```bash
+export LIVE_API_URL="https://metar-to-iwxxm-api.onrender.com"
+export LIVE_FRONTEND_URL="https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+export VITE_API_BASE_URL="${LIVE_API_URL}"
+make test-live-connectivity
+```
+
+## Results
+
+| Tier | Result |
+|------|--------|
+| H0c CORS policy unit | 6 passed |
+| H4 Live CORS preflight | 2 passed |
+| H5 Frontend `/config.json` | OK — `api.baseUrl` matches; no `disableAuth` |
+
+## Deploy train
+
+- [#786](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786) F21 public app merge
+- [#787](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/787) FE Docker config bake fix (omit `disableAuth`)
+- Live FE image: `frontend:20260728202600-0a03c00`

--- a/docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
+++ b/docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
@@ -1,7 +1,7 @@
 # T7.4 — Render env Auth secret cutover (checklist)
 
 **Session**: S023 / EV-017  
-**Status**: **unblocked on `RENDER_API_KEY`** — live inventory done; **blocked on F21 image cutover**  
+**Status**: **completed** 2026-07-28  
 **Spec**: env-contract F21; deploy.md secrets table (T7.3)
 
 ## Goal
@@ -10,79 +10,36 @@ Confirm Render **API** service (`metar-to-iwxxm-api`) no longer carries unused o
 Auth secrets; keep F8 worker + dissemination allowlist intact. Verify live
 `/auth/login` → 404 and `/health` → 200 after F21 code is on `main-latest`.
 
-## Live inventory (2026-07-28, after `RENDER_API_KEY` available)
+## Cutover executed
 
-**API** `srv-d69v688gjchc73cn9kg0` — image `ghcr.io/empiric2/tac-to-iwxxm/backend:main-latest`
+1. Merged [#786](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786) → `main` (`e96a937`).
+2. Main CI Deploy succeeded — API + FE `main-latest` redeployed via Render hooks.
+3. Live probes (post-image): `/health` 200, `/auth/login` **404**, public convert (multipart) **200**.
+4. Deleted API env: `SUPABASE_PUBLISHABLE_KEY`, `DISABLE_AUTH`; redeployed API (`dep-d9kgsdn10e5c73ev26rg` live).
+5. Follow-up [#787](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/787) — omit `disableAuth` from FE Docker bake so H5 passes.
 
-| Key | Present | Action |
-|-----|---------|--------|
-| `SUPABASE_PUBLISHABLE_KEY` | yes | **Delete after** F21 image deploy |
-| `DISABLE_AUTH` | yes (`false`) | **Delete after** F21 image deploy (no-op today) |
-| `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` | no | already gone |
-| `ADMIN_EMAIL` / `ADMIN_PASSWORD` | no | already gone |
-| `DISSEMINATION_EGRESS_ALLOWLIST` | yes | **keep** |
-| `METAR_CONFIG_ENV` | yes (`prod`) | **keep** |
-| `DATABASE_URL` | yes | **keep** (optional ops) |
-| `SUPABASE_URL` / `SUPABASE_SECRET_KEY` | yes | leave until F21 image; then drop if unused by public API |
+## Final API env (Auth-retired keys)
 
-**Probes (Auth-era `main`, pre-F21):**
+| Key | Status |
+|-----|--------|
+| `SUPABASE_PUBLISHABLE_KEY` | **deleted** |
+| `DISABLE_AUTH` | **deleted** |
+| `E2E_USER_*` / `ADMIN_*` | already absent |
+| `DISSEMINATION_EGRESS_ALLOWLIST` | **kept** |
+| `METAR_CONFIG_ENV=prod` | **kept** |
+| `DATABASE_URL` | **kept** (optional ops) |
+| `SUPABASE_URL` / `SUPABASE_SECRET_KEY` | still present (optional ops/archive; not Auth gate) |
+
+## Worker — unchanged
+
+F8 worker secrets (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, poller URL/interval) left intact.
+
+## Verification
 
 | Check | Result |
 |-------|--------|
 | `GET /health` | 200 |
-| `POST /auth/login` `{}` | **422** (route still mounted) |
-| `POST /api/v1/convert` (no JWT) | **401** Missing authorization credentials |
-
-**Frontend** `metar-to-iwxxm-frontend-v4-web` — image `…/frontend:main-latest`;
-`/config.json` still has `api.disableAuth` + `supabase.publishableKey` (Auth-era).
-
-## Why env deletes are deferred
-
-Production still runs **Auth-gated** `main-latest`. Removing `SUPABASE_*` now would
-break JWT verification on the current image (`503 Authentication not configured`).
-`DISABLE_AUTH=true` is **ignored in prod** (`METAR_CONFIG_ENV=prod`). F21 public
-convert + `/auth/*` 404 require merging EV-017 to `main`, rebuilding GHCR
-`main-latest`, and redeploying API + FE.
-
-## API service — remove if present (F21) — **after image cutover**
-
-| Key | Why |
-|-----|-----|
-| `SUPABASE_PUBLISHABLE_KEY` | Was browser/JWT Auth — not used by public API |
-| `DISABLE_AUTH` | Dual path retired |
-| `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` | Live login fixture retired |
-| `ADMIN_EMAIL` / `ADMIN_PASSWORD` | Already retired (S011) |
-| Any operator Auth JWT / anon key for `/auth/*` | Routes 404 |
-
-After delete: trigger API redeploy (`POST /services/{id}/deploys`) — image-based services
-do not auto-redeploy on env-only changes.
-
-## API service — keep / set
-
-| Key | Notes |
-|-----|-------|
-| `METAR_CONFIG_ENV=prod` | Selects `config/prod.json` |
-| `RATE_LIMIT_PUBLIC_PER_MIN` | Default 60 if unset |
-| `RATE_LIMIT_DISSEMINATION_PER_MIN` | Default 10 if unset |
-| `MAX_REQUEST_BODY_BYTES` | Default 2097152 if unset |
-| `DISSEMINATION_EGRESS_ALLOWLIST` | Required for F16–F19; empty ⇒ deny |
-| `DATABASE_URL` | Optional legacy/ops only |
-
-## Worker (`metar-to-iwxxm-worker`) — do not remove
-
-| Key |
-|-----|
-| `SUPABASE_URL` |
-| `SUPABASE_SERVICE_ROLE_KEY` |
-| `INGEST_POLLER_URL` |
-| `INGEST_POLL_INTERVAL_SEC` |
-
-## Cutover sequence (remaining)
-
-1. Push `evolve/EV-017-public-app-privacy` (refresh draft PR #786) — leave security WIP unstaged.
-2. User approves **merge #786 → main**.
-3. Wait for CI to publish `backend:main-latest` + `frontend:main-latest`.
-4. Redeploy API (`srv-d69v688gjchc73cn9kg0`) + FE (`srv-d6cvj2i4d50c73aelapg`).
-5. Verify: `/health` 200, `/auth/login` **404**, convert **without JWT** succeeds.
-6. Delete Auth-only API env keys; redeploy API again.
-7. Run **T7.2** `make test-live-connectivity` (H4–H5).
+| `POST/GET /auth/login` | 404 |
+| Public `POST /api/v1/convert` (no JWT) | 200 |
+| FE `/config.json` `disableAuth` | absent (after #787) |
+| T7.2 H4–H5 | **pass** (`make test-live-connectivity`) |


### PR DESCRIPTION
## Summary
- Record T7.4 Render Auth env cutover complete after #786/#787
- Record T7.2 H4–H5 live connectivity PASS
- Mark M7 complete in execution plan (handoff 08-verify-build)

## Test plan
- [x] Live `make test-live-connectivity` already green post-#787


Made with [Cursor](https://cursor.com)