### PR TITLE
[EV-017] docs: S023 verify/deploy closeout + F22 E2E locator fix

### DIFF
--- a/apps/backend/tests/infrastructure/test_coverage_boost.py
+++ b/apps/backend/tests/infrastructure/test_coverage_boost.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from src.api import app, verify_supabase_token
+from src.api import app
 from src.utilities.conversion import ConversionError
+from src.utilities.security import verify_supabase_token
 
 
 @pytest.fixture

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1503,11 +1503,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/apps/e2e/public-app-f21-f22.e2e.spec.ts
+++ b/apps/e2e/public-app-f21-f22.e2e.spec.ts
@@ -69,7 +69,10 @@ test.describe('T7.1 — Public app + privacy (F21/F22)', () => {
   }) => {
     await openPublicConverter(page);
 
-    await page.getByRole('button', { name: /open privacy settings/i }).click();
+    // Footer control (exact) — notice also has "Open privacy settings from notice".
+    await page
+      .getByRole('button', { name: 'Open privacy settings', exact: true })
+      .click();
     await expect(page.getByTestId('privacy-settings-dialog')).toBeVisible();
     await expect(page.getByText(/Work history and converter sessions/i)).toBeVisible();
     await expect(page.getByLabel(/necessary storage always enabled/i)).toBeDisabled();
@@ -89,9 +92,16 @@ test.describe('T7.1 — Public app + privacy (F21/F22)', () => {
     });
 
     await page.goto('/');
+    await expect(
+      page.getByRole('heading', { name: /METAR.*IWXXM.*Converter/i }),
+    ).toBeVisible({ timeout: 10_000 });
     await dismissPrivacyNoticeIfPresent(page);
+    await expect(page.getByTestId('privacy-notice')).toHaveCount(0);
 
-    await page.getByRole('button', { name: /open privacy settings/i }).click();
+    await page
+      .getByRole('button', { name: 'Open privacy settings', exact: true })
+      .click();
+    await expect(page.getByTestId('privacy-settings-dialog')).toBeVisible();
     await expect(page.getByTestId('privacy-gpc-active')).toBeVisible();
   });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 All notable user-facing and deployable changes for METAR to IWXXM.
 
-## 2026-07-28 — S023 EV-017 (F21 public app + F22 privacy) — draft
-
-> Draft bullets for the EV-017 cutover release. Finalize on merge / deploy (T7.3).
+## 2026-07-28 — S023 EV-017 (F21 public app + F22 privacy)
 
 ### Added
 - **F21**: Public unauthenticated converter — no operator login/JWT; Auth routes 404.
@@ -20,9 +18,11 @@ All notable user-facing and deployable changes for METAR to IWXXM.
   [env-contract.md](env-contract.md)); ADR-031 Accepted (supersedes ADR-020 for operator history).
 
 ### Deploy
-- Interim draft PR [#786](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786); final cutover after
-  M7 / 08–13. Single deploy: FE + API together (E17-18). Remove unused Auth secrets from API
-  Render service (T7.4).
+- Cutover PRs [#786](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786) /
+  [#787](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/787) / [#788](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/788).
+- Live smoke COMPLETE (H0c–H5 + Playwright F21/F22 5/5). API Auth leftovers removed
+  (`SUPABASE_URL` / `SUPABASE_SECRET_KEY`); worker service-role retained. Redeploy
+  `dep-d9kii12jobas73fl4bi0`.
 
 ## 2026-07-27 — S021 EV-016 (F7.g workbench golden examples)
 

--- a/docs/deploy-state.md
+++ b/docs/deploy-state.md
@@ -1,17 +1,17 @@
 # Deploy State
 
 > Last updated: 2026-07-28  
-> Status: deployed (S023 / EV-017 F21 public app validated — smoke PASS pending user sign-off)
+> Status: deployed (S023 / EV-017 F21 public app — smoke COMPLETE)
 
 ## Deployment Log
 
 | # | Step | Status | Started | Completed | Notes |
 |---|------|--------|---------|-----------|-------|
-| 1 | Deploy | done | 2026-07-28 | 2026-07-28 | Existing live train (#786/#787); validate-existing (no redeploy) |
-| 2 | Smoke tests | done | 2026-07-28 | 2026-07-28 | H0c/H1/H3/H4/H5 + live Playwright F21/F22 5/5 |
-| 3 | Health check | done | 2026-07-28 | 2026-07-28 | `/health` healthy; `/auth/login` 404; public convert 200 |
-| 4 | Changelog | pending | — | — | S023 entry on cycle close |
-| 5 | Monitoring baseline | done | 2026-07-28 | 2026-07-28 | H3 convert ~635ms; health ~241ms |
+| 1 | Deploy | done | 2026-07-28 | 2026-07-28 | Validate-existing; then API env cleanup redeploy `dep-d9kii12jobas73fl4bi0` |
+| 2 | Smoke tests | done | 2026-07-28 | 2026-07-28 | H0c/H1/H3/H4/H5 + Playwright F21/F22 5/5; post-cleanup re-PASS |
+| 3 | Health check | done | 2026-07-28 | 2026-07-28 | `/health` 200; `/auth/login` 404; public convert 200 |
+| 4 | Changelog | done | 2026-07-28 | 2026-07-28 | `docs/CHANGELOG.md` S023 entry |
+| 5 | Monitoring baseline | done | 2026-07-28 | 2026-07-28 | Convert ~635ms; health ~241ms |
 
 ## Current Deployment
 
@@ -21,9 +21,10 @@
 | Deploy URL (API) | https://metar-to-iwxxm-api.onrender.com |
 | Deploy URL (FE) | https://metar-to-iwxxm-frontend-v4-web.onrender.com |
 | Deploy mode | GHCR `main-latest` + Render deploy hooks |
-| Commit | main-latest post-#786/#787 (evolve tip docs ahead) |
+| Commit | main-latest post-#786/#787 |
 | Branch | main (live) / evolve/EV-017-public-app-privacy (session) |
-| API deploy id | dep-d9khddad0e5s73dmm4r0 |
+| API deploy id | dep-d9kii12jobas73fl4bi0 |
 | FE deploy id | dep-d9khdedbedkc73aodib0 |
-| Images | `backend:main-latest` · `frontend:main-latest` (FE bake fix #787) |
+| Images | `backend:main-latest` · `frontend:main-latest` |
 | Session report | docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md |
+| API Auth leftovers | `SUPABASE_URL` / `SUPABASE_SECRET_KEY` **removed** (worker keys retained) |

--- a/docs/deploy-state.md
+++ b/docs/deploy-state.md
@@ -1,17 +1,17 @@
 # Deploy State
 
-> Last updated: 2026-07-27  
-> Status: deployed (FE tip still pre–F7.g; EV-016 live smoke waived → #781)
+> Last updated: 2026-07-28  
+> Status: deployed (S023 / EV-017 F21 public app validated — smoke PASS pending user sign-off)
 
 ## Deployment Log
 
 | # | Step | Status | Started | Completed | Notes |
 |---|------|--------|---------|-----------|-------|
-| 1 | Deploy | done | 2026-07-22T23:53Z | 2026-07-23T00:00Z | CI Deploy `29967487455`; hooks → API + FE live @ `eae8bdc` |
-| 2 | Smoke tests | done | 2026-07-23T00:02Z | 2026-07-23T00:03Z | H0c/H1/H3/H4/H5 + catalog taf/speci + lint/convert PASS |
-| 3 | Health check | done | 2026-07-23T00:02Z | 2026-07-23T00:02Z | `/health` healthy; `tac2iwxxm_available` |
-| 4 | Changelog | done | 2026-07-22 | 2026-07-22 | `docs/CHANGELOG.md` S020 entry |
-| 5 | Monitoring baseline | done | 2026-07-23T00:02Z | 2026-07-23T00:03Z | H3 response-times acceptable |
+| 1 | Deploy | done | 2026-07-28 | 2026-07-28 | Existing live train (#786/#787); validate-existing (no redeploy) |
+| 2 | Smoke tests | done | 2026-07-28 | 2026-07-28 | H0c/H1/H3/H4/H5 + live Playwright F21/F22 5/5 |
+| 3 | Health check | done | 2026-07-28 | 2026-07-28 | `/health` healthy; `/auth/login` 404; public convert 200 |
+| 4 | Changelog | pending | — | — | S023 entry on cycle close |
+| 5 | Monitoring baseline | done | 2026-07-28 | 2026-07-28 | H3 convert ~635ms; health ~241ms |
 
 ## Current Deployment
 
@@ -21,9 +21,9 @@
 | Deploy URL (API) | https://metar-to-iwxxm-api.onrender.com |
 | Deploy URL (FE) | https://metar-to-iwxxm-frontend-v4-web.onrender.com |
 | Deploy mode | GHCR `main-latest` + Render deploy hooks |
-| Commit | eae8bdc (merge #778) |
-| Branch | main |
-| API deploy id | dep-d9gljeupbkes73bspkl0 |
-| FE deploy id | dep-d9gljfrbc2fs738q90d0 |
-| Images | `backend:20260722235831-eae8bdc` · `frontend:20260722235831-eae8bdc` |
-| Session report | docs/sessions/S020-aerodrome-quality/reports/deploy-smoke.md |
+| Commit | main-latest post-#786/#787 (evolve tip docs ahead) |
+| Branch | main (live) / evolve/EV-017-public-app-privacy (session) |
+| API deploy id | dep-d9khddad0e5s73dmm4r0 |
+| FE deploy id | dep-d9khdedbedkc73aodib0 |
+| Images | `backend:main-latest` · `frontend:main-latest` (FE bake fix #787) |
+| Session report | docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -579,7 +579,7 @@
 
 ### F21: Public Unauthenticated Operator App — S023 / EV-017
 
-- **Status**: **Planned** (S023 / EV-017 / [#783](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/783))
+- **Status**: **Implemented** (S023 / EV-017 / [#783](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/783); 11-verify-impl approved 2026-07-28)
 - **What it does**: Makes the operator product **public** — no login/signup/logout/password-reset
   UX; no required Bearer JWT for convert, validate, lint, decode, preview, or dissemination-drawer
   flows. HTTP APIs are **stateless** with **baseline abuse controls** (per-IP + global rate limits,
@@ -601,7 +601,7 @@
 
 ### F22: Privacy Preference Center — S023 / EV-017
 
-- **Status**: **Planned** (S023 / EV-017 / #783)
+- **Status**: **Implemented** (S023 / EV-017 / #783; 11-verify-impl approved 2026-07-28)
 - **What it does**: **Solution A** (no non-essential tracking). Inventory cookies/`localStorage`/
   `sessionStorage`/IndexedDB/CDN. Footer **Privacy settings** + short first-visit notice.
   One global preference schema (versioned); `necessary` always on; preferences/analytics/marketing

--- a/docs/reports/implementation-verification.md
+++ b/docs/reports/implementation-verification.md
@@ -1,49 +1,55 @@
 # Implementation Verification
 
-> **Last completed**: 2026-07-12 — S008 / EV-006 (F6 + F2 package + F8 worker)  
-> **Branch**: `evolve/S008-general-tac-iwxxm-converter`  
-> **Session**: S008-general-tac-iwxxm-converter  
-> **Stage**: 11-verify-impl
+> **Last completed**: 2026-07-28 — S023 / EV-017 (F21 + F22 + F5/F7.h deepen)  
+> **Branch**: `evolve/EV-017-public-app-privacy`  
+> **Session**: S023-public-app-privacy  
+> **Stage**: 11-verify-impl  
+> **Detail**: [`docs/sessions/S023-public-app-privacy/reports/verify-impl.md`](../sessions/S023-public-app-privacy/reports/verify-impl.md)
 
 ## Outcome
 
-**APPROVED** — User signed off F6, F2, and F8 with live-connectivity waivers (12/13 skipped).
-Corpus: F6/F8 → **Implemented** ([ADR-019](../adr/ADR-019-s008-f6-f8-implemented-status.md)).
+**APPROVED** — User signed off F21, F22; acknowledged F5/F7.h IndexedDB deepen.
+UI preview declined (reports/tests only). T3 live UJ + QA-004 deferred to **13-deploy-smoke**.
+Corpus: F21/F22 → **Implemented**.
 
 ## Features verified
 
 | Feature | Status | User decision |
 |---------|--------|---------------|
-| F6 — General TAC→IWXXM | Implemented (live deferred) | Approve |
-| F2 — IWXXM validation package | Implemented (live deferred) | Approve |
-| F8 — Near-RT ingest worker | Implemented (live T7.4 deferred) | Approve |
+| F21 — Public unauthenticated operator app | Implemented | Approve (D-S023-11-f21) |
+| F22 — Privacy preference center | Implemented | Approve (D-S023-11-f22) |
+| F5 / F7.h — IndexedDB deepen | Deepened | Acknowledge (D-S023-11-f5-f7h) |
 
 ## Quality gates
 
 | Gate | Status |
 |------|--------|
 | 08-verify-build | PASS |
-| 09-qa | pass_with_advisories |
-| 10-e2e T0 | PASS 12/12 |
-| T3 / H4–H7 | Deferred |
+| 09-qa | pass_with_advisories (disposed) |
+| 10-e2e T0 | PASS (8 Playwright + Vitest + F21 unit) |
+| H4–H5 | PASS (T7.2); re-check at 13 |
+| T3 live browser UJ | Deferred → 13 |
 
 ## Journeys
 
-See session report for full table. Product journeys UJ-001–012 and UJ-014 approved with
-waivers; UJ-013 deferred (F7); UJ-004 skipped this cycle.
+| Journey | User |
+|---------|------|
+| UJ-001 | Approved (T3 → 13) |
+| UJ-004 | Approved (T3 → 13) |
+| UJ-018 | Approved (T3 → 13) |
+| UJ-033 | Approved (T3 → 13) |
 
 ## Scope
 
 - **Creep**: 0
-- **Gaps**: F7 Planned (intentional)
-- **Corpus**: F6/F8 status updated (ADR-019)
+- **Gaps**: 0
+- **Advisories**: QA-001/002 accept; QA-003 fixed; QA-004 → 13
 
-## Detail
+## Deploy gate (partial)
 
-Full session report:
-[docs/sessions/S008-general-tac-iwxxm-converter/reports/verify-impl.md](../sessions/S008-general-tac-iwxxm-converter/reports/verify-impl.md)
+- ✓ QA / E2E T0 / user implementation sign-off
+- ○ Next: **12-verify-deploy**
 
-## Next
+## Prior cycles
 
-S008 skips 12/13. Live deploy gates remain open if/when routing is amended; otherwise close
-session after routing-plan completion.
+- 2026-07-12 — S008 / EV-006 (F6 + F2 + F8) approved with live-connectivity waivers.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,7 +25,7 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S023-public-app-privacy](S023-public-app-privacy/session-brief.md) | feature | in_progress | Public app + local history + privacy (#783) | evolve/EV-017-public-app-privacy | 2026-07-27 | — |
+| [S023-public-app-privacy](S023-public-app-privacy/session-brief.md) | feature | completed | Public app + local history + privacy (#783); PR #790 open (do not auto-merge) | evolve/EV-017-public-app-privacy | 2026-07-27 | 2026-07-28 |
 | [S001-convert-send-buttons](S001-convert-send-buttons/session-brief.md) | feature | completed | Convert & Convert&Send UI (#656) | feat/S001-convert-send-buttons | 2026-06-22 | 2026-06-22 |
 | [S002-issue-594-feedback](S002-issue-594-feedback/session-brief.md) | hotfix | in_progress | COR handling + TAC traceability (#594) | fix/S002-issue-594-feedback | 2026-06-22 | — |
 | [S003-supabase-keys-config](S003-supabase-keys-config/session-brief.md) | hotfix | paused | Supabase keys / config split | fix/supabase-service-key-leak | 2026-06-23 | — |
@@ -51,11 +51,11 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 ## Active session
 
-**None** — S022 closed (`D-S022-close-option1`). Primary #781 cutover + live UJ-032 done; PyPI Trusted Publisher remains on [#781](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/781).
+**None** — S023 closed (`D-S023-close`). EV-017 completed; [PR #790](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790) open (CI green on tip `2e2f6c0`; mergeable; **do not auto-merge**).
 
 Parked/other: see rows above (S016 paused; S017 process).
 
-Last closed: **[S022-rename-cutover](S022-rename-cutover/session-brief.md)** — Empiric2 GHCR/Render cutover; H0c/H1/H4/H5 + UJ-032 PASS.
+Last closed: **[S023-public-app-privacy](S023-public-app-privacy/session-brief.md)** — Public app + IndexedDB history + privacy (F21/F22); PR #790 awaiting merge.
 
 ## Folder layout
 

--- a/docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
+++ b/docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
@@ -1,0 +1,25 @@
+# Phase C checkpoint — S023 / EV-017
+
+**Date**: 2026-07-28  
+**Gate**: C→D (all Fn tasks done; latest 08 PASS)
+
+## Digest
+
+| Item | Status |
+|------|--------|
+| Features | F21 (public/stateless converter), F22 (privacy/GPC); deepen F5/F7.h; `packages/auth` deleted |
+| Build | M1–M7 **28/28** completed |
+| Deploy train | #786 / #787 / #788 **merged**; live public convert + `/auth` 404; H4–H5 PASS (T7.2) |
+| 08-verify-build | **PASS** — `reports/verification-report.md` |
+| Security | `pyasn1` → 0.6.4; `ecdsa` ignored per existing policy |
+| Tip (pre-lock bump) | `73f8389`; uncommitted: lockfiles + session reports + workflow-state |
+| Security WIP | Stashed (`stash@{0}`) — not part of EV-017 product scope |
+
+## C→D criteria
+
+- [x] All Fn tasks done (execution plan 28/28)
+- [x] Latest 08 PASS
+
+## Recommended next
+
+Phase D: **09-qa** + **10-e2e** (parallel), then 11 → 12 → 13.

--- a/docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+++ b/docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
@@ -1,0 +1,140 @@
+# Deploy Checklist — S023 / EV-017 (F21 / F22 / #783)
+
+> Generated: 2026-07-28  
+> Branch: `evolve/EV-017-public-app-privacy` @ `489c9bf`  
+> Status: **READY** — strategy verified; handoff **13-deploy-smoke**  
+> Deployment plan: [`docs/deploy.md`](../../../deploy.md) §Integration / §Rollback  
+> Env contract: [`docs/env-contract.md`](../../../env-contract.md)
+
+## Scope (delta)
+
+Public app cutover (F21), privacy center (F22), IndexedDB deepen, Auth secret cleanup.
+Platform: **Render** (API + static FE + F8 worker). Not Modal.
+
+## Phase 1 — Pre-deploy checks
+
+### Agent 1 — Configuration
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `docs/deploy.md` F21 topology | PASS | Public API; no `/auth`; FE `/config.json` |
+| `docs/env-contract.md` | PASS | Rate limits + retired Auth keys documented |
+| `config/prod.json` CORS | PASS | FE origin in `corsOrigins` (live `/config.json` matches) |
+| Gaps / `Needs human input` | none | |
+
+### Agent 2 — Secrets (live Render inventory 2026-07-28)
+
+**API** `metar-to-iwxxm-api` (`srv-d69v688gjchc73cn9kg0`):
+
+| Key | Status | Action |
+|-----|--------|--------|
+| `DISABLE_AUTH` | **absent** | Done (T7.4) |
+| `SUPABASE_PUBLISHABLE_KEY` | **absent** | Done (T7.4) |
+| `DISSEMINATION_EGRESS_ALLOWLIST` | PRESENT | Keep |
+| `METAR_CONFIG_ENV` | PRESENT (`prod`) | Keep |
+| `DATABASE_URL` | PRESENT | Optional ops — keep |
+| `SUPABASE_URL` / `SUPABASE_SECRET_KEY` | PRESENT | **Optional cleanup at 13** — unused by public router; worker has own keys |
+| `RATE_LIMIT_*` | absent | OK — code defaults apply |
+
+**Worker** `metar-to-iwxxm-worker`: `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` + poller **PRESENT** (keep).
+
+### Agent 3 — Data / volumes
+
+N/A — operator history is browser IndexedDB; no new Modal/volume assets.
+
+### Agent 4 — Resources
+
+PASS — image-based Render services; GHCR `main-latest` train (#786/#787/#788).
+
+### Agent 5 — Template
+
+PASS — `static+api+worker`; no Modal deploy template required.
+
+### Agent 6 — Browser connectivity readiness
+
+| Check | Status |
+|-------|--------|
+| `tests/unit/test_cors_policy.py` (H0c) | **PASS** 6/6 |
+| `scripts/deploy/verify_connectivity.sh` | present |
+| `tests/smoke/test_staging_connectivity.py` | present |
+| Staging secrets / CORS matrix | PASS (`docs/ops/staging-secrets-matrix.md` + env-contract) |
+| Live H4–H5 (T7.2) | **PASS** (prior); re-run at **13** |
+| Live probes (this stage) | `/health` 200; `/auth/login` **404**; FE `/config.json` no `disableAuth`; form convert **200** w/o JWT |
+
+## Pre-Deploy checklist
+
+- [x] Configuration complete (no gaps)
+- [x] Secrets cutover mostly done (`DISABLE_AUTH` / publishable gone); optional API `SUPABASE_*` cleanup at 13
+- [x] Data assets N/A
+- [x] Resource allocation verified (Render images)
+- [x] Rollback plan reviewed (user approved)
+- [x] H0c CORS unit tests pass
+- [x] Frontend config ↔ API URL matrix (runtime `/config.json`)
+- [x] CORS origins documented (`config/prod.json` / live config)
+- [x] Post-deploy H4–H5 command documented (`make test-live-connectivity`)
+
+## Failure Mitigations
+
+| # | Risk | Mitigation | Status |
+|---|------|------------|--------|
+| 1 | Image / CI build failure | Wait for GHCR `main-latest` before redeploy | **approved** |
+| 2 | Stale FE `/config.json` (`disableAuth`) | #787 omit bake; H5 asserts absent | **approved** |
+| 3 | Auth secrets removed too early / leftover | Publishable/`DISABLE_AUTH` gone; optional API `SUPABASE_*` delete at 13 | **approved** (optional) |
+| 4 | CORS / browser connectivity | `corsOrigins` + H0c + H4–H5 at 13 | **approved** |
+| 5 | Rate-limit false positives | Defaults 60/10; env overrides available | **approved** |
+| 6 | Dissemination allowlist empty | Fail-closed intentional; keep populated allowlist | **approved** |
+
+**D-S023-12-mitigations:** User approved all (option 1); API `SUPABASE_*` optional at 13 (2026-07-28).
+
+## Rollback
+
+- Command: Redeploy previous Render deploy (API + FE) from dashboard, or revert merge commit on `main` and wait for GHCR rebuild
+- Procedure:
+  1. Identify last-known-good Render deploy IDs (API + FE)
+  2. Redeploy those images (image-based — env-only changes need explicit redeploy)
+  3. Re-run `make test-live-connectivity` (H4–H5)
+  4. Auth-era rollback only if reverting pre-F21 image (would need Auth env restored)
+- Last known good: F21 live train after #786/#787 (FE image `frontend:20260728202600-0a03c00`); tip docs `489c9bf`
+- Source: `docs/deploy.md` §Rollback
+- User review: **Approved** (D-S023-12-rollback, 2026-07-28)
+
+## Live evidence (12)
+
+```text
+GET  /health              → 200
+POST /auth/login          → 404
+GET  FE /config.json      → 200; api.baseUrl OK; disableAuth absent
+POST /api/v1/convert form → 200 (no JWT)
+H0c                       → 6 passed
+```
+
+## Sign-Off
+
+- [x] User approved implementation (11-verify-impl)
+- [x] Deploy strategy verified (this checklist)
+- [x] Ready for 13-deploy-smoke
+
+## Summary
+
+```
+Deploy Strategy Verification Complete.
+
+Pre-deploy checks:
+  Configuration: PASS
+  Secrets:       PASS (optional API SUPABASE_* cleanup → 13)
+  Data/Volumes:  N/A
+  Resources:     PASS
+  Connectivity:  PASS (H0c + live probes; H4–H5 re-run at 13)
+
+Failure mitigations: 6 risks approved
+Rollback plan: reviewed and approved
+
+Deploy gate:
+  ✓ QA checks passed (09-qa)
+  ✓ E2E behaviors passed (10-e2e)
+  ✓ Implementation verified (11-verify-impl)
+  ✓ Deploy strategy verified (12-verify-deploy)
+  → Ready for 13-deploy-smoke
+
+Next step: 13-deploy-smoke
+```

--- a/docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+++ b/docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
@@ -1,0 +1,66 @@
+# Deploy Smoke — S023 / EV-017 (F21 / F22 / #783)
+
+> Date: 2026-07-28  
+> Mode: **Validate existing** (no redeploy)  
+> Status: **SMOKE PASS** — pending user sign-off  
+> Branch tip: evolve docs `52c14e9`+; live GHCR `main-latest` (post #786/#787)
+
+## Pre-Deploy
+
+- Checklist: READY (`reports/deploy-checklist.md`)
+- Decision: D-S023-13-validate-existing (user option 1)
+
+## Deployment (existing)
+
+| Field | Value |
+|-------|-------|
+| API | https://metar-to-iwxxm-api.onrender.com |
+| FE | https://metar-to-iwxxm-frontend-v4-web.onrender.com |
+| API deploy | `dep-d9khddad0e5s73dmm4r0` (live) |
+| FE deploy | `dep-d9khdedbedkc73aodib0` (live) |
+| Images | `backend:main-latest` · `frontend:main-latest` |
+
+## Smoke Tests
+
+| Test | Status | Notes |
+|------|--------|-------|
+| H0c CORS unit | **PASS** | 6/6 |
+| H1 `/health` | **PASS** | 200 (~241ms) |
+| H3 convert (no JWT) | **PASS** | form convert 200; successful=1 |
+| H3 live_api suite | **PASS** | 13 passed, 8 skipped (Auth-era login fixtures — expected F21) |
+| H4 CORS preflight | **PASS** | 2/2 `test_staging_connectivity` |
+| H5 `/config.json` | **PASS** | baseUrl match; `disableAuth` absent |
+| Live Playwright F21/F22 | **PASS** | 5/5 after locator fix |
+| TC-F21 `/auth/login` | **PASS** | 404 |
+| Resources | **PASS** | No crash loop; services live |
+
+### Fix during 13
+
+- `apps/e2e/public-app-f21-f22.e2e.spec.ts` — use exact footer aria-label `Open privacy settings` (avoid strict-mode clash with notice button). Live TC-F22-003 green after fix.
+
+## Optional cleanup (pending user)
+
+| Item | Status |
+|------|--------|
+| API `SUPABASE_URL` / `SUPABASE_SECRET_KEY` | Still PRESENT — unused by public router; worker has own keys |
+
+## Health Check
+
+- `/health` healthy; `tac2iwxxm_available: true`
+- Auth routes gone
+- Error rate: acceptable (smokes green)
+
+## Rollback
+
+- Redeploy prior Render deploys or revert `main` (see deploy-checklist)
+- Last known good: current live train post-#786/#787
+
+## Changelog
+
+- Session entry pending close (see `docs/CHANGELOG.md` S023)
+
+## Sign-Off
+
+- [ ] User approved smoke results
+- [ ] Optional API `SUPABASE_*` cleanup: do / skip
+- [ ] Stage 13 complete → evolve close

--- a/docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+++ b/docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
@@ -1,23 +1,25 @@
 # Deploy Smoke — S023 / EV-017 (F21 / F22 / #783)
 
 > Date: 2026-07-28  
-> Mode: **Validate existing** (no redeploy)  
-> Status: **SMOKE PASS** — pending user sign-off  
-> Branch tip: evolve docs `52c14e9`+; live GHCR `main-latest` (post #786/#787)
+> Mode: **Validate existing** + optional API `SUPABASE_*` cleanup  
+> Status: **COMPLETE** — user approved (option 2)  
+> Branch tip: `7837cd1`+; live GHCR `main-latest` (post #786/#787)
 
 ## Pre-Deploy
 
 - Checklist: READY (`reports/deploy-checklist.md`)
 - Decision: D-S023-13-validate-existing (user option 1)
+- Sign-off: D-S023-13-approve-cleanup (user option 2 — delete API SUPABASE_* + redeploy)
 
-## Deployment (existing)
+## Deployment
 
 | Field | Value |
 |-------|-------|
 | API | https://metar-to-iwxxm-api.onrender.com |
 | FE | https://metar-to-iwxxm-frontend-v4-web.onrender.com |
-| API deploy | `dep-d9khddad0e5s73dmm4r0` (live) |
-| FE deploy | `dep-d9khdedbedkc73aodib0` (live) |
+| API deploy (pre-cleanup) | `dep-d9khddad0e5s73dmm4r0` |
+| API deploy (post-cleanup) | `dep-d9kii12jobas73fl4bi0` **live** |
+| FE deploy | `dep-d9khdedbedkc73aodib0` |
 | Images | `backend:main-latest` · `frontend:main-latest` |
 
 ## Smoke Tests
@@ -25,42 +27,42 @@
 | Test | Status | Notes |
 |------|--------|-------|
 | H0c CORS unit | **PASS** | 6/6 |
-| H1 `/health` | **PASS** | 200 (~241ms) |
-| H3 convert (no JWT) | **PASS** | form convert 200; successful=1 |
-| H3 live_api suite | **PASS** | 13 passed, 8 skipped (Auth-era login fixtures — expected F21) |
-| H4 CORS preflight | **PASS** | 2/2 `test_staging_connectivity` |
+| H1 `/health` | **PASS** | 200 (pre + post cleanup) |
+| H3 convert (no JWT) | **PASS** | 200; successful=1 (pre + post) |
+| H3 live_api suite | **PASS** | 13 passed, 8 skipped (Auth-era — expected) |
+| H4 CORS preflight | **PASS** | 2/2 (pre + post cleanup) |
 | H5 `/config.json` | **PASS** | baseUrl match; `disableAuth` absent |
 | Live Playwright F21/F22 | **PASS** | 5/5 after locator fix |
 | TC-F21 `/auth/login` | **PASS** | 404 |
-| Resources | **PASS** | No crash loop; services live |
+| Resources | **PASS** | API redeploy live; no crash |
 
 ### Fix during 13
 
-- `apps/e2e/public-app-f21-f22.e2e.spec.ts` — use exact footer aria-label `Open privacy settings` (avoid strict-mode clash with notice button). Live TC-F22-003 green after fix.
+- `apps/e2e/public-app-f21-f22.e2e.spec.ts` — exact footer aria-label for Privacy settings.
 
-## Optional cleanup (pending user)
+### API secret cleanup (D-S023-13-approve-cleanup)
 
-| Item | Status |
-|------|--------|
-| API `SUPABASE_URL` / `SUPABASE_SECRET_KEY` | Still PRESENT — unused by public router; worker has own keys |
+| Key | Result |
+|-----|--------|
+| `SUPABASE_URL` | **Deleted** from API |
+| `SUPABASE_SECRET_KEY` | **Deleted** from API |
+| Worker `SUPABASE_*` / poller | **Unchanged** (kept) |
+| `DISSEMINATION_EGRESS_ALLOWLIST` | **Kept** |
+| Redeploy | `dep-d9kii12jobas73fl4bi0` → live; health/convert/H4–H5 re-PASS |
 
 ## Health Check
 
 - `/health` healthy; `tac2iwxxm_available: true`
 - Auth routes gone
-- Error rate: acceptable (smokes green)
+- Public convert works without JWT after env cleanup
 
 ## Rollback
 
 - Redeploy prior Render deploys or revert `main` (see deploy-checklist)
-- Last known good: current live train post-#786/#787
-
-## Changelog
-
-- Session entry pending close (see `docs/CHANGELOG.md` S023)
+- Last known good: `dep-d9kii12jobas73fl4bi0` (post-cleanup) / FE `dep-d9khdedbedkc73aodib0`
 
 ## Sign-Off
 
-- [ ] User approved smoke results
-- [ ] Optional API `SUPABASE_*` cleanup: do / skip
-- [ ] Stage 13 complete → evolve close
+- [x] User approved smoke results
+- [x] API `SUPABASE_*` cleanup done + redeploy verified
+- [x] Stage 13 complete → evolve close

--- a/docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+++ b/docs/sessions/S023-public-app-privacy/reports/e2e-report.md
@@ -1,0 +1,62 @@
+# E2E Report — S023 / EV-017 (F21 / F22 / UJ-001/004/033)
+
+> Generated: 2026-07-28  
+> Scope: Public convert, Auth-gone, privacy/GPC, IndexedDB work history  
+> Branch: `evolve/EV-017-public-app-privacy` @ `836c1a4`  
+> Mode: evolve delta (10-e2e) · parallel with 09-qa  
+> Mechanism: Playwright (local webServer) + Vitest + backend unit
+
+## Journey matrix
+
+| Journey / TC | Mechanism | T0 | T2 connectivity | T3 browser |
+|--------------|-----------|----|-----------------|------------|
+| UJ-001 public convert | Playwright `public-app-f21-f22` | **PASS** | PASS (T7.2) | pending 13 / live smoke |
+| TC-F21-auth-gone FE/API | Playwright + pytest | **PASS** | PASS (live `/auth` 404) | pending 13 |
+| UJ-033 / TC-F22-001..003 | Playwright | **PASS** | — | pending 13 |
+| UJ-004 IndexedDB history | Playwright `metar-work-history` | **PASS** | — | pending 13 |
+| Preflight F21 | Playwright `00-preflight` | **PASS** | — | — |
+| Privacy + IDB Vitest | Vitest | **PASS** (22) | — | — |
+| Backend TC-F21 + abuse | pytest unit | **PASS** (10) | — | — |
+
+## Results
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| Playwright F21/F22 + preflight + UJ-004 | **8** passed | PASS |
+| Vitest privacy + localWorkSessionStore | **22** passed | PASS |
+| `test_tc_f21_auth_gone_unit` + abuse | **10** passed | PASS |
+
+### Playwright command (working)
+
+```bash
+cd apps/e2e && \
+  METAR_CONFIG_ENV=local \
+  PLAYWRIGHT_BASE_URL=http://localhost:18000 \
+  PLAYWRIGHT_API_BASE_URL=http://localhost:18001 \
+  pnpm exec playwright test \
+    public-app-f21-f22.e2e.spec.ts \
+    00-preflight.e2e.spec.ts \
+    metar-work-history.e2e.spec.ts
+# 8 passed (14.2s)
+```
+
+### Pitfall (QA-002)
+
+Repo `.env` sets `PLAYWRIGHT_BASE_URL=http://localhost:5173`. Playwright `webServer` serves
+the monorepo stack on **`:18000`**. Without overriding `PLAYWRIGHT_BASE_URL`, webServer
+health wait times out (first attempt this session). Always pass `:18000` for local T0.
+
+## Connectivity columns
+
+| Column | Status |
+|--------|--------|
+| T0 in-process / local browser | **PASS** |
+| T2 H4–H5 | **PASS** (M7 T7.2 live) |
+| T3 live browser UJ | pending — 13-deploy-smoke / optional 15 |
+
+**Overall T0: PASS**
+
+## Fix applied during 10
+
+- `apps/backend/tests/infrastructure/test_coverage_boost.py` — import `verify_supabase_token`
+  from `src.utilities.security` (F21 `src.api` export removed). Collect-only green.

--- a/docs/sessions/S023-public-app-privacy/reports/evolve-summary.md
+++ b/docs/sessions/S023-public-app-privacy/reports/evolve-summary.md
@@ -1,0 +1,41 @@
+# Evolve summary — EV-017 / S023 (public app privacy)
+
+> Completed: 2026-07-28  
+> Issue: [#783](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/783)  
+> Branch: `evolve/EV-017-public-app-privacy`  
+> Features: **F21**, **F22**; deepen F5/F7.h; Auth teardown (ADR-031)
+
+## Outcome
+
+Public unauthenticated operator app + privacy preference center shipped and live-smoke verified.
+Operator Auth / JWT path removed; work history is IndexedDB-only; GPC honored.
+
+## Stages
+
+| Stage | Result |
+|-------|--------|
+| 00 / 16 / 01 / 02 | Scope lock F21/F22; Phase A pass |
+| 04 | ADR-031 + execution plan |
+| 07–08 | M1–M7 build; verify-build PASS |
+| 09–10 | QA pass_with_advisories; T0 E2E PASS |
+| 11 | F21/F22 approved; UI preview declined; T3→13 |
+| 12 | Deploy checklist READY |
+| 13 | Validate-existing; H0c–H5 PASS; Playwright 5/5; API `SUPABASE_*` cleanup |
+
+## Live
+
+- API: https://metar-to-iwxxm-api.onrender.com  
+- FE: https://metar-to-iwxxm-frontend-v4-web.onrender.com  
+- Post-cleanup API deploy: `dep-d9kii12jobas73fl4bi0`
+
+## Artifacts
+
+- `reports/verify-impl.md`, `deploy-checklist.md`, `deploy-smoke.md`
+- `docs/reports/implementation-verification.md`
+- `docs/CHANGELOG.md` (S023 finalized)
+
+## Follow-ups (optional)
+
+- Push/merge remaining evolve-branch docs + E2E locator fix to `main`
+- 15-service-health / 17-retrospective if desired
+- Close #783 when PR train lands

--- a/docs/sessions/S023-public-app-privacy/reports/execution-plan.md
+++ b/docs/sessions/S023-public-app-privacy/reports/execution-plan.md
@@ -1,6 +1,6 @@
 # Execution plan — S023 / EV-017 (F21 public app + F22 privacy / #783)
 
-> **Status**: **approved** (D-S023-04-plan-approve-A) — 07-build in progress  
+> **Status**: **approved** (D-S023-04-plan-approve-A) — 08-verify-build in progress  
 > **Branch**: `evolve/EV-017-public-app-privacy`  
 > **Evolve cycle**: EV-017  
 > **Features**: **F21**, **F22**; deepen **F5** / **F7.h**; delete **packages/auth** (M4)  
@@ -12,10 +12,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Active phase** | Phase C — 07-build |
-| **Active milestone** | M7 — E2E / docs / connectivity gate |
-| **Active task** | T7.4 blocked on F21 image cutover (RENDER_API_KEY OK; inventory done) |
-| **Tasks** | 27 / ~28 completed |
+| **Active phase** | Phase C — 08-verify-build |
+| **Active milestone** | M7 — E2E / docs / connectivity gate (**complete**) |
+| **Active task** | 08-verify-build |
+| **Tasks** | 28 / 28 completed |
 | **Last updated** | 2026-07-28 |
 
 ## Tech Stack Summary (S023 delta)
@@ -116,9 +116,9 @@
 | Task | Type | Description | Spec Source | Depends On | Status |
 |------|------|-------------|-------------|------------|--------|
 | T7.1 | Test | Playwright: public UJ-001/004/013/018; Auth-gone negative; privacy smoke | test-plan; H6 | M2–M6 | completed |
-| T7.2 | Test | H4–H5 connectivity after FE/API deploy | connectivity-gates | T7.1 | pending |
+| T7.2 | Test | H4–H5 connectivity after FE/API deploy | connectivity-gates | T7.1 | completed — see reports/t7.2-h4-h5-connectivity.md |
 | T7.3 | Docs | Update deploy.md / CORPUS refs; session 04 report; CHANGELOG draft bullets | docs corpus | T5.4 | completed |
-| T7.4 | Config | Confirm Render env: remove Auth secrets from API if unused; keep F8 + allowlist | env-contract | T1.3 | blocked — live still Auth-era `main-latest`; delete env only after F21 image deploy; see reports/t7.4-render-env-checklist.md |
+| T7.4 | Config | Confirm Render env: remove Auth secrets from API if unused; keep F8 + allowlist | env-contract | T1.3 | completed — see reports/t7.4-render-env-checklist.md |
 
 ## Phase Gate Check (B→C)
 
@@ -141,11 +141,12 @@
 
 | PR | When | Status |
 |----|------|--------|
-| Draft #786 | Interim docs | open |
+| #786 / #787 / #788 | Interim + M7 cutover | merged |
 | Final EV-017 | After 08–11 (or earlier docs+code) | pending |
 
 ## References
 
 - ADR-031, evolve-decisions EV-017 (E17-12..25)
 - reports/02-verify-plan.md; impact-analysis.md
+- reports/t7.2-h4-h5-connectivity.md; reports/t7.4-render-env-checklist.md
 - Issue #783

--- a/docs/sessions/S023-public-app-privacy/reports/qa-report.md
+++ b/docs/sessions/S023-public-app-privacy/reports/qa-report.md
@@ -1,0 +1,66 @@
+# QA Report — S023 / EV-017 (F21 public app + F22 privacy / #783)
+
+> Generated: 2026-07-28  
+> Scope: F21 / F22 / F5–F7.h IndexedDB; Auth teardown (`packages/auth` deleted)  
+> Branch: `evolve/EV-017-public-app-privacy` @ `836c1a4` (+ uncommitted `test_coverage_boost` import fix)  
+> Mode: evolve delta (09-qa) · parallel with 10-e2e
+
+```text
+QA Results:
+  Lint:           PASS — 0 issues (ruff + eslint)
+  Format:         PASS — 0 files (ruff + prettier)
+  Typecheck:      PASS — 0 errors (basedpyright + tsc)
+  Tests (Python): PASS — H0c 6; TC-F21-auth-gone + abuse 10; full unit matrix green at 08
+  Tests (FE):     PASS — 698 passed / 80 files (@metar/frontend)
+  Security:       PASS — pip-audit 0 known / 1 ignored (ecdsa); gitleaks PASS
+  Cross-file:     PASS — WorkbenchConsole RegExp.exec only (not eval/exec misuse)
+  Dependencies:   PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A)
+  Template:       PASS — static+api+worker; packages/auth absent
+  Data / Modal:   N/A — no Modal assets; Compose H0i SKIPPED (Docker unavailable)
+```
+
+## Summary
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Format / Lint / Typecheck | PASS | `make validate-fast` |
+| FE Vitest | PASS | **698** / 80 files |
+| H0c CORS | PASS | 6/6 |
+| Security (lockfile) | PASS | `pyasn1` 0.6.4; ecdsa ignored |
+| Secrets | PASS | pre-commit gitleaks |
+| H0i integration | SKIPPED | Docker not on host — advisory |
+| Staging H4–H5 | ADVISORY | Already PASS at T7.2 live; re-confirm at 13 |
+
+**Overall: pass_with_advisories**
+
+## Blocking
+
+None.
+
+## Advisories (for 11-verify-impl)
+
+| ID | Severity | Finding | Suggested action |
+|----|----------|---------|------------------|
+| QA-001 | advisory | H0i Compose integration not run (no Docker) | Run on CI / machine with Docker; not blocking for F21 public HTTP |
+| QA-002 | advisory | `.env` `PLAYWRIGHT_BASE_URL=http://localhost:5173` mismatches local stack `:18000` | Override to `:18000` for local Playwright (see e2e-report); optional `.env.example` note |
+| QA-003 | advisory | `tests/infrastructure/test_coverage_boost.py` imported `verify_supabase_token` from `src.api` (removed F21) | Fixed in working tree — import from `src.utilities.security` |
+| QA-004 | advisory | Live H4–H5 already green (T7.2) but re-check after any further FE bake | 13-deploy-smoke |
+
+## Connectivity (stage 09)
+
+| Tier | Result |
+|------|--------|
+| H0c | PASS |
+| H0i | SKIPPED (no Docker) |
+| H4–H5 | PASS recorded at M7 (`t7.2-h4-h5-connectivity.md`); re-verify at 13 |
+
+## Commands run
+
+```bash
+make validate-fast
+uv run pytest tests/unit/test_cors_policy.py -q --no-cov
+pnpm --filter @metar/frontend test
+uv export … && uvx pip-audit -r /tmp/project-reqs.txt --disable-pip $(…ignore…)
+uv run pre-commit run gitleaks --all-files
+rg -n 'pickle\.loads|eval\(|exec\(' apps packages
+```

--- a/docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
+++ b/docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
@@ -1,0 +1,28 @@
+# T7.2 — H4–H5 connectivity (post F21 deploy)
+
+**Session**: S023 / EV-017  
+**Status**: **completed** 2026-07-28  
+**Depends**: T7.1, T7.4 (live cutover)
+
+## Command
+
+```bash
+export LIVE_API_URL="https://metar-to-iwxxm-api.onrender.com"
+export LIVE_FRONTEND_URL="https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+export VITE_API_BASE_URL="${LIVE_API_URL}"
+make test-live-connectivity
+```
+
+## Results
+
+| Tier | Result |
+|------|--------|
+| H0c CORS policy unit | 6 passed |
+| H4 Live CORS preflight | 2 passed |
+| H5 Frontend `/config.json` | OK — `api.baseUrl` matches; no `disableAuth` |
+
+## Deploy train
+
+- [#786](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786) F21 public app merge
+- [#787](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/787) FE Docker config bake fix (omit `disableAuth`)
+- Live FE image: `frontend:20260728202600-0a03c00`

--- a/docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
+++ b/docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
@@ -1,7 +1,7 @@
 # T7.4 — Render env Auth secret cutover (checklist)
 
 **Session**: S023 / EV-017  
-**Status**: **unblocked on `RENDER_API_KEY`** — live inventory done; **blocked on F21 image cutover**  
+**Status**: **COMPLETE** — Auth publishable/`DISABLE_AUTH` removed; API `SUPABASE_URL`/`SECRET` removed 2026-07-28 (D-S023-13-approve-cleanup); worker keys retained  
 **Spec**: env-contract F21; deploy.md secrets table (T7.3)
 
 ## Goal

--- a/docs/sessions/S023-public-app-privacy/reports/verification-report.md
+++ b/docs/sessions/S023-public-app-privacy/reports/verification-report.md
@@ -1,0 +1,79 @@
+# 08-verify-build — S023 / EV-017 (F21 public app + F22 privacy / #783)
+
+**Date**: 2026-07-28  
+**Scope**: Phase C closeout — M1–M7 complete (28/28); post-merge #786/#787/#788  
+**Branch**: `evolve/EV-017-public-app-privacy`  
+**Tip**: `73f8389`  
+**Note**: Security WIP stashed (`stash@{0}`) for this run
+
+## Result: **PASS**
+
+| Check | Status | Findings | Auto-Fixed | Tool |
+|-------|--------|----------|------------|------|
+| Format | PASS | 0 | — | `make format-check` (ruff + prettier) |
+| Lint | PASS | 0 | — | `make lint` (ruff + eslint) |
+| Typecheck | PASS | 0 | — | `make typecheck` (basedpyright + tsc) |
+| Secrets | PASS | 0 | — | gitleaks |
+| YAML / Actions | PASS | 0 | — | yamllint + actionlint |
+| ISSUE_CATALOG | PASS | 0 drift | — | catalog-check |
+| Issue registry guard | PASS | — | — | ISSUE_REGISTRY_GUARD_STRICT |
+| Tests (unit) | PASS | all green | — | `make test` |
+| CORS H0c | PASS | 6/6 | — | `tests/unit/test_cors_policy.py` |
+| Connectivity artifacts | present | smoke + verify script | — | paths below |
+| Integration (Compose) | SKIPPED | Docker unavailable on host | — | `make test-integration` |
+| Security (pip-audit) | PASS | 0 known; 1 ignored (`ecdsa`) | `pyasn1` → 0.6.4 | lockfile export |
+
+Overall: **PASS**
+
+## Unit test rollup (`make test`)
+
+| Suite | Result |
+|-------|--------|
+| workspace / shared py | 44 + 76 passed |
+| shared js | 4 passed |
+| backend | **1199** passed |
+| frontend Vitest | **698** passed (80 files) |
+| tac2iwxxm | 231 passed, 10 skipped |
+| iwxxm-validate | 76 passed, 1 skipped |
+| tac-validate | 471 passed |
+| dissemination | 127 passed, 15 deselected |
+| worker | 11 passed |
+| bugs (non-live) | 32 passed, 5 skipped, 1 deselected |
+
+## Connectivity (stage 08)
+
+- **Blocking H0c**: `tests/unit/test_cors_policy.py` — **PASS** (6)
+- Artifacts present:
+  - `tests/smoke/test_staging_connectivity.py`
+  - `scripts/deploy/verify_connectivity.sh`
+- Live H4–H5 already recorded under M7: `reports/t7.2-h4-h5-connectivity.md`
+
+## Template / F21 structural
+
+- `packages/auth`: **ABSENT** (expected after T5.4)
+- Template `static+api+worker` unchanged (ADR-018 / ADR-031)
+
+## Security detail
+
+Project-scoped:
+
+```bash
+uv export --format requirements-txt --no-emit-workspace --all-groups -o /tmp/project-reqs.txt
+uvx pip-audit -r /tmp/project-reqs.txt --disable-pip \
+  $(grep -v '^#' audit/pip-audit-ignore.txt | grep -v '^$' | sed 's/^/--ignore-vuln /')
+```
+
+| Package | Version | IDs | Disposition |
+|---------|---------|-----|-------------|
+| ecdsa | 0.19.2 | PYSEC-2026-1325 | Ignored — `audit/pip-audit-ignore.txt` (S013 QA-001) |
+| pyasn1 | **0.6.4** | — | **Upgraded** (D-S023-08-pyasn1-A) from 0.6.3; `uv.lock` + `apps/backend/uv.lock` |
+
+Re-audit after bump: **No known vulnerabilities found, 1 ignored**.
+
+## Auto-corrections
+
+- Lockfile bump: `pyasn1` 0.6.3 → 0.6.4 (root + `apps/backend/uv.lock`).
+
+## Next
+
+Phase C checkpoint → Phase D (`09-qa` + `10-e2e` in parallel) → `11-verify-impl` → `12` → `13`.

--- a/docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+++ b/docs/sessions/S023-public-app-privacy/reports/verify-impl.md
@@ -1,0 +1,147 @@
+# Implementation Verification — S023 / EV-017 (F21 / F22 / #783)
+
+> Generated: 2026-07-28  
+> Branch: `evolve/EV-017-public-app-privacy`  
+> Mode: evolve delta (11-verify-impl)  
+> Scope: **F21**, **F22**; deepen **F5** / **F7.h** (IndexedDB); Auth teardown  
+> Tip: `657d440`  
+> **Status: COMPLETE** — user approved; handoff **12-verify-deploy**
+
+## UI preview (non-deployed)
+
+| Item | Status |
+|------|--------|
+| Offered | Yes (before Phase 3 feature approval) |
+| User choice | **Declined** — approve from reports/tests only (option 2) |
+| Staging/prod | **Not** used for this preview |
+
+## Inputs collected
+
+| Source | Result |
+|--------|--------|
+| 08-verify-build | PASS (`verification-report.md`; pyasn1 0.6.4) |
+| 09-qa | `pass_with_advisories` — `qa-report.md` |
+| 10-e2e | T0 PASS — Playwright 8/8 + Vitest 22 + F21 unit 10 — `e2e-report.md` |
+| feature-list §F21 / §F22 | AC listed below |
+| UJ-001 / 004 / 018 / 033 | T0 evidence in e2e-report; H4–H5 PASS at T7.2 |
+
+## Feature completeness
+
+### F21 — Public unauthenticated operator app
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Implemented | PASS | Auth UX gone; public convert; `/auth/*` 404; abuse controls; `packages/auth` deleted |
+| Tested | PASS | TC-F21-auth-gone unit; Playwright Auth-gone + UJ-001 |
+| QA clean | PASS | No blocking; QA-001–004 advisory |
+| E2E T0 | PASS | public-app-f21-f22 + preflight |
+| E2E H4–H5 / T3 | H4–H5 PASS (T7.2); T3 live UJ → 13 optional |
+| Acceptance | **Approved** | User 2026-07-28 (D-S023-11-f21) |
+
+| # | Criterion | Evidence |
+|---|-----------|----------|
+| 1 | Unauth convert → validate → download/send | Playwright UJ-001 convert 200 w/o JWT |
+| 2 | No `/auth/login` required in prod | Live + local `/auth/login` → 404 |
+| 3 | work-sessions gone | Unit + API 404 |
+| 4 | Abuse-control tests green; dissemination SSRF intact | abuse unit PASS; allowlist kept (T7.4) |
+| 5 | Env/docs no operator Auth for public path | env-contract / deploy docs (T7.3) |
+| 6 | E2E UJ-001/004/018 public | Playwright + IndexedDB specs |
+
+### F22 — Privacy preference center
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Implemented | PASS | Notice + settings + GPC + IndexedDB disclosure |
+| Tested | PASS | TC-F22 Vitest + Playwright |
+| E2E T0 | PASS | TC-F22-001..003 Playwright |
+| Acceptance | **Approved** | User 2026-07-28 (D-S023-11-f22) |
+
+### F5 / F7.h deepen (IndexedDB)
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Implemented | PASS | `localWorkSessionStore` / idb; no workSession HTTP |
+| E2E T0 | PASS | UJ-004 Playwright; Vitest store |
+| User | **Acknowledged** | User 2026-07-28 (D-S023-11-f5-f7h) |
+
+## Journey signoff
+
+| Journey | T0 | T3 / H4–H5 | User |
+|---------|----|------------|------|
+| UJ-001 | PASS | H4–H5 PASS (T7.2); T3 → 13 | **Approved** (T3 waive → 13) |
+| UJ-004 | PASS | → 13 | **Approved** (T3 waive → 13) |
+| UJ-018 | PASS (Vitest/IDB path) | → 13 | **Approved** (T3 waive → 13) |
+| UJ-033 | PASS | → 13 | **Approved** (T3 waive → 13) |
+
+**T3 note:** Live browser UJ re-check deferred to **13-deploy-smoke** (H4–H5 already PASS at T7.2).
+
+**D-S023-11-uj-001-004:** Approved both; T3 waived to 13 (2026-07-28).  
+**D-S023-11-uj-018-033:** Approved both; T3 waived to 13 (2026-07-28).
+
+## QA advisories (disposed)
+
+| ID | Finding | Disposition |
+|----|---------|-------------|
+| QA-001 | H0i Compose skipped (no Docker) | **Accept** — CI covers |
+| QA-002 | `.env` PLAYWRIGHT_BASE_URL `:5173` vs stack `:18000` | **Accept** — override documented in e2e-report |
+| QA-003 | coverage_boost import | **Fixed** (`657d440`) |
+| QA-004 | Re-check H4–H5 after further FE bake | **Defer to 13** |
+
+**D-S023-11-advisories:** User approved disposition 2026-07-28.
+
+## Scope analysis
+
+```
+Scope Analysis:
+  Features in cycle: 2 (F21, F22) + F5/F7.h deepen
+  Features implemented: 2 + deepen
+  Features with passing E2E T0: 2 + deepen
+  Features with user-approved acceptance: 2 + deepen acknowledged
+
+  Undocumented features (scope creep): 0
+  Missing features (scope gap): 0
+```
+
+## Sign-off
+
+- [x] UI preview choice recorded (declined — reports/tests only)
+- [x] F21 approved
+- [x] F22 approved
+- [x] F5/F7.h deepen acknowledged
+- [x] Journeys UJ-001/004/018/033 approved (T3 → 13)
+- [x] Advisories disposed
+
+## Summary
+
+```
+Implementation Verification Complete.
+
+Features verified: 2 / 2 (+ F5/F7.h deepen)
+  Approved:    F21, F22
+  Acknowledged: F5/F7.h IndexedDB deepen
+  Fixed:       0 (QA-003 already fixed at 09/10)
+  Deferred:    T3 live UJ + QA-004 → 13
+  Accepted as-is: QA-001, QA-002
+
+QA status:     PASS (advisories disposed)
+E2E status:    PASS — T0 journeys green; T3 → 13
+Acceptance:    PASS — F21/F22 user-approved
+
+Scope:
+  Creep:  0
+  Gaps:   0
+
+Artifacts:
+  docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+  docs/reports/implementation-verification.md
+  docs/sessions/S023-public-app-privacy/reports/qa-report.md
+  docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+
+Deploy gate (partial):
+  ✓ QA checks pass_with_advisories (disposed)
+  ✓ E2E T0 behaviors
+  ✓ Implementation verified by user
+  ○ Deploy strategy pending (12-verify-deploy)
+```
+
+**Next step:** 12-verify-deploy

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -20,7 +20,7 @@
 | 10-e2e | yes | full | completed | T0 PASS (8 Playwright + Vitest + F21) — `reports/e2e-report.md` |
 | 11-verify-impl | yes | full | completed | F21/F22 approved; F5/F7.h ack; T3→13; `reports/verify-impl.md` |
 | 12-verify-deploy | yes | full | completed | READY — `reports/deploy-checklist.md`; mitigations+rollback approved |
-| 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings; optional API SUPABASE_* cleanup |
+| 13-deploy-smoke | yes | full | in_progress | Validate-existing: H0c–H5 PASS; Playwright 5/5; user sign-off next |
 
 ## Skip rationale
 

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -7,7 +7,7 @@
 | Stage | Required | Mode | Status | Skip rationale |
 |-------|----------|------|--------|----------------|
 | 00-context | yes | scoped | completed | Session open + `docs/context/public-app-privacy.md` |
-| 16-evolve | yes | orchestrator | in_progress | EV-017 — 12 COMPLETE; next 13-deploy-smoke |
+| 16-evolve | yes | orchestrator | in_progress | EV-017 — 13 COMPLETE; Phase D / close pending |
 | 01-requirements | yes | delta | completed | F21/F22 + F5/F7/M4 deltas — `reports/01-requirements.md` |
 | 02-verify-plan | yes | delta | completed | Gate A 2026-07-27; D-S023-02-C-EV017-A; Phase A passed |
 | 03-plan-tooling | **no** | — | skipped | No new Cursor rules/hooks expected at open; add if ADR needs guardrails |
@@ -20,7 +20,7 @@
 | 10-e2e | yes | full | completed | T0 PASS (8 Playwright + Vitest + F21) — `reports/e2e-report.md` |
 | 11-verify-impl | yes | full | completed | F21/F22 approved; F5/F7.h ack; T3→13; `reports/verify-impl.md` |
 | 12-verify-deploy | yes | full | completed | READY — `reports/deploy-checklist.md`; mitigations+rollback approved |
-| 13-deploy-smoke | yes | full | in_progress | Validate-existing: H0c–H5 PASS; Playwright 5/5; user sign-off next |
+| 13-deploy-smoke | yes | full | completed | Validate-existing + API SUPABASE_* cleanup; H0c–H5 PASS; Playwright 5/5 |
 
 ## Skip rationale
 
@@ -46,3 +46,4 @@
 | 11 UI preview | Declined — reports/tests only (D-S023-11-ui-preview-declined) | 2026-07-28 |
 | 11-verify-impl | **COMPLETE** — F21/F22 approved; F5/F7.h ack; advisories disposed; T3→13 | 2026-07-28 |
 | 12-verify-deploy | **COMPLETE** — mitigations+rollback approved; checklist READY → 13 | 2026-07-28 |
+| 13-deploy-smoke | **COMPLETE** — smoke approved; API SUPABASE_* deleted + redeploy live | 2026-07-28 |

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -7,17 +7,17 @@
 | Stage | Required | Mode | Status | Skip rationale |
 |-------|----------|------|--------|----------------|
 | 00-context | yes | scoped | completed | Session open + `docs/context/public-app-privacy.md` |
-| 16-evolve | yes | orchestrator | in_progress | EV-017 |
+| 16-evolve | yes | orchestrator | in_progress | EV-017 — Phase C checkpoint pending before 09+10 |
 | 01-requirements | yes | delta | completed | F21/F22 + F5/F7/M4 deltas — `reports/01-requirements.md` |
-| 02-verify-plan | yes | delta | in_progress | Gate A 2026-07-27; contradiction batch open |
+| 02-verify-plan | yes | delta | completed | Gate A 2026-07-27; D-S023-02-C-EV017-A; Phase A passed |
 | 03-plan-tooling | **no** | — | skipped | No new Cursor rules/hooks expected at open; add if ADR needs guardrails |
-| 04-tech-plan | yes | delta | pending | IndexedDB design, auth teardown tasks, abuse controls, privacy UI |
+| 04-tech-plan | yes | delta | completed | ADR-031 + execution plan (D-S023-04-plan-approve-A) |
 | 05-verify-tech | **no** | — | skipped | Standard skip unless 04 adds deps/ADR conflict |
 | 06-tech-tooling | **no** | — | skipped | No new tooling expected |
-| 07-build | yes | full | pending | FE history + auth strip + BE public routes + privacy |
-| 08-verify-build | yes | full | pending | — |
-| 09-qa | yes | full | pending | — |
-| 10-e2e | yes | full | pending | Replace JWT-gated UJ-003 / H3–H5 journeys |
+| 07-build | yes | full | completed | M1–M7 28/28; tip `73f8389` before 08 |
+| 08-verify-build | yes | full | completed | PASS 2026-07-28 — `reports/verification-report.md`; pyasn1 0.6.4 (D-S023-08-pyasn1-A) |
+| 09-qa | yes | full | pending | After Phase C checkpoint |
+| 10-e2e | yes | full | pending | After Phase C checkpoint (parallel with 09) |
 | 11-verify-impl | yes | full | pending | Per-Fn AC + UI preview |
 | 12-verify-deploy | yes | full | pending | Env matrix / secret cleanup checklist |
 | 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings |
@@ -38,3 +38,7 @@
 | Routing | **Standard** | 2026-07-27 (E17-3 = A) |
 | Scope lock | **Approved** — E17-4A…E17-11 | 2026-07-27 |
 | 01-requirements | Spec deltas written | 2026-07-27 |
+| 02-verify-plan / Phase A | D-S023-02-phase-a-A | 2026-07-27 |
+| 04-tech-plan / Phase B | D-S023-04-plan-approve-A | 2026-07-28 |
+| 08-verify-build | PASS (D-S023-08-pyasn1-A) | 2026-07-28 |
+| Phase C (C→D) | Pending AskQuestion | — |

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -7,7 +7,7 @@
 | Stage | Required | Mode | Status | Skip rationale |
 |-------|----------|------|--------|----------------|
 | 00-context | yes | scoped | completed | Session open + `docs/context/public-app-privacy.md` |
-| 16-evolve | yes | orchestrator | in_progress | EV-017 — next 11-verify-impl |
+| 16-evolve | yes | orchestrator | in_progress | EV-017 — 11 COMPLETE; next 12-verify-deploy |
 | 01-requirements | yes | delta | completed | F21/F22 + F5/F7/M4 deltas — `reports/01-requirements.md` |
 | 02-verify-plan | yes | delta | completed | Gate A 2026-07-27; D-S023-02-C-EV017-A; Phase A passed |
 | 03-plan-tooling | **no** | — | skipped | No new Cursor rules/hooks expected at open; add if ADR needs guardrails |
@@ -18,7 +18,7 @@
 | 08-verify-build | yes | full | completed | PASS 2026-07-28 — `reports/verification-report.md`; pyasn1 0.6.4 @ `836c1a4` |
 | 09-qa | yes | full | completed | pass_with_advisories — `reports/qa-report.md` |
 | 10-e2e | yes | full | completed | T0 PASS (8 Playwright + Vitest + F21) — `reports/e2e-report.md` |
-| 11-verify-impl | yes | full | pending | Next — per-Fn AC + UI preview (pending handoff) |
+| 11-verify-impl | yes | full | completed | F21/F22 approved; F5/F7.h ack; T3→13; `reports/verify-impl.md` |
 | 12-verify-deploy | yes | full | pending | Env matrix / secret cleanup checklist |
 | 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings |
 
@@ -43,3 +43,5 @@
 | 08-verify-build | PASS (D-S023-08-pyasn1-A) | 2026-07-28 |
 | Phase C (C→D) | **Passed** — D-S023-phase-c-A (user 2 then 1) | 2026-07-28 |
 | 09-qa / 10-e2e | COMPLETE — next 11 | 2026-07-28 |
+| 11 UI preview | Declined — reports/tests only (D-S023-11-ui-preview-declined) | 2026-07-28 |
+| 11-verify-impl | **COMPLETE** — F21/F22 approved; F5/F7.h ack; advisories disposed; T3→13 | 2026-07-28 |

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -7,18 +7,18 @@
 | Stage | Required | Mode | Status | Skip rationale |
 |-------|----------|------|--------|----------------|
 | 00-context | yes | scoped | completed | Session open + `docs/context/public-app-privacy.md` |
-| 16-evolve | yes | orchestrator | in_progress | EV-017 — Phase C checkpoint pending before 09+10 |
+| 16-evolve | yes | orchestrator | in_progress | EV-017 — next 11-verify-impl |
 | 01-requirements | yes | delta | completed | F21/F22 + F5/F7/M4 deltas — `reports/01-requirements.md` |
 | 02-verify-plan | yes | delta | completed | Gate A 2026-07-27; D-S023-02-C-EV017-A; Phase A passed |
 | 03-plan-tooling | **no** | — | skipped | No new Cursor rules/hooks expected at open; add if ADR needs guardrails |
 | 04-tech-plan | yes | delta | completed | ADR-031 + execution plan (D-S023-04-plan-approve-A) |
 | 05-verify-tech | **no** | — | skipped | Standard skip unless 04 adds deps/ADR conflict |
 | 06-tech-tooling | **no** | — | skipped | No new tooling expected |
-| 07-build | yes | full | completed | M1–M7 28/28; tip `73f8389` before 08 |
-| 08-verify-build | yes | full | completed | PASS 2026-07-28 — `reports/verification-report.md`; pyasn1 0.6.4 (D-S023-08-pyasn1-A) |
-| 09-qa | yes | full | pending | After Phase C checkpoint |
-| 10-e2e | yes | full | pending | After Phase C checkpoint (parallel with 09) |
-| 11-verify-impl | yes | full | pending | Per-Fn AC + UI preview |
+| 07-build | yes | full | completed | M1–M7 28/28 |
+| 08-verify-build | yes | full | completed | PASS 2026-07-28 — `reports/verification-report.md`; pyasn1 0.6.4 @ `836c1a4` |
+| 09-qa | yes | full | completed | pass_with_advisories — `reports/qa-report.md` |
+| 10-e2e | yes | full | completed | T0 PASS (8 Playwright + Vitest + F21) — `reports/e2e-report.md` |
+| 11-verify-impl | yes | full | pending | Next — per-Fn AC + UI preview (pending handoff) |
 | 12-verify-deploy | yes | full | pending | Env matrix / secret cleanup checklist |
 | 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings |
 
@@ -41,4 +41,5 @@
 | 02-verify-plan / Phase A | D-S023-02-phase-a-A | 2026-07-27 |
 | 04-tech-plan / Phase B | D-S023-04-plan-approve-A | 2026-07-28 |
 | 08-verify-build | PASS (D-S023-08-pyasn1-A) | 2026-07-28 |
-| Phase C (C→D) | Pending AskQuestion | — |
+| Phase C (C→D) | **Passed** — D-S023-phase-c-A (user 2 then 1) | 2026-07-28 |
+| 09-qa / 10-e2e | COMPLETE — next 11 | 2026-07-28 |

--- a/docs/sessions/S023-public-app-privacy/routing-plan.md
+++ b/docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -7,7 +7,7 @@
 | Stage | Required | Mode | Status | Skip rationale |
 |-------|----------|------|--------|----------------|
 | 00-context | yes | scoped | completed | Session open + `docs/context/public-app-privacy.md` |
-| 16-evolve | yes | orchestrator | in_progress | EV-017 — 11 COMPLETE; next 12-verify-deploy |
+| 16-evolve | yes | orchestrator | in_progress | EV-017 — 12 COMPLETE; next 13-deploy-smoke |
 | 01-requirements | yes | delta | completed | F21/F22 + F5/F7/M4 deltas — `reports/01-requirements.md` |
 | 02-verify-plan | yes | delta | completed | Gate A 2026-07-27; D-S023-02-C-EV017-A; Phase A passed |
 | 03-plan-tooling | **no** | — | skipped | No new Cursor rules/hooks expected at open; add if ADR needs guardrails |
@@ -19,8 +19,8 @@
 | 09-qa | yes | full | completed | pass_with_advisories — `reports/qa-report.md` |
 | 10-e2e | yes | full | completed | T0 PASS (8 Playwright + Vitest + F21) — `reports/e2e-report.md` |
 | 11-verify-impl | yes | full | completed | F21/F22 approved; F5/F7.h ack; T3→13; `reports/verify-impl.md` |
-| 12-verify-deploy | yes | full | pending | Env matrix / secret cleanup checklist |
-| 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings |
+| 12-verify-deploy | yes | full | completed | READY — `reports/deploy-checklist.md`; mitigations+rollback approved |
+| 13-deploy-smoke | yes | full | pending | Live public convert + privacy settings; optional API SUPABASE_* cleanup |
 
 ## Skip rationale
 
@@ -45,3 +45,4 @@
 | 09-qa / 10-e2e | COMPLETE — next 11 | 2026-07-28 |
 | 11 UI preview | Declined — reports/tests only (D-S023-11-ui-preview-declined) | 2026-07-28 |
 | 11-verify-impl | **COMPLETE** — F21/F22 approved; F5/F7.h ack; advisories disposed; T3→13 | 2026-07-28 |
+| 12-verify-deploy | **COMPLETE** — mitigations+rollback approved; checklist READY → 13 | 2026-07-28 |

--- a/docs/sessions/S023-public-app-privacy/session-brief.md
+++ b/docs/sessions/S023-public-app-privacy/session-brief.md
@@ -1,13 +1,18 @@
 ---
 session_id: S023-public-app-privacy
 type: feature
-status: in_progress
+status: completed
 branch: evolve/EV-017-public-app-privacy
 started_at: 2026-07-27
+completed_at: 2026-07-28
 intent: "Remove end-user auth; public/stateless converter; IndexedDB local F5/F7 history; privacy-minimizing preference center + GPC (#783)"
 orchestrator: 16-evolve
 evolve_cycle_id: EV-017
 github_issue: 783
+close_decision_id: D-S023-close
+pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790
+pr_status: open
+do_not_auto_merge: true
 context_briefs:
   - docs/context/public-app-privacy.md
 standing_docs_touched:

--- a/uv.lock
+++ b/uv.lock
@@ -1696,11 +1696,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-017
   github_issue: 783
   artifacts_dir: docs/sessions/S023-public-app-privacy/
-  current_stage: 07-build
+  current_stage: 08-verify-build
   feature_ids:
   - F21
   - F22
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 07-build in_progress — M1–M6 complete; M7 active; T7.3 completed @ f5aa024; T7.4 blocked (checklist committed @ d459164; awaiting RENDER_API_KEY for live env cutover); T7.2 pending (needs deploy after T7.4); progress 27/~28; tip d459164; interim draft PR #786; #783'
+  note: 'S023/EV-017 08-verify-build PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase A+B passed; current_stage 07-build; M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase A+B passed; 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -68,15 +68,19 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     skip_rationale:
     started: '2026-07-28'
-    note: 'S023/EV-017 07-build in_progress — M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 07-build COMPLETE 2026-07-28 — M1–M7 all done (T7.1–T7.4); tip 73f8389 before 08; PRs #786/#787/#788 merged; handoff 08-verify-build'
   - stage: 08-verify-build
     required: true
     mode: full
-    status: pending
+    status: completed
     skip_rationale:
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 08-verify-build COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; tip 73f8389 (locks uncommitted); Phase C checkpoint pending; #783'
   - stage: 09-qa
     required: true
     mode: full
@@ -3144,19 +3148,21 @@ stages:
       session_id: S023-public-app-privacy
       evolve_cycle_id: EV-017
       skill_id: 07-build
-      status: in_progress
+      status: completed
       started_at: '2026-07-28'
       started: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
       mode: full
-      note: 'T7.3 COMPLETE @ f5aa024; T7.4 blocked — checklist committed @ d459164; awaiting RENDER_API_KEY for live env deletes; artifact docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md; T7.2 pending (needs deploy after T7.4); progress 27/~28'
+      note: 'COMPLETE 2026-07-28 — M1–M7 all done (T7.1–T7.4); tip 73f8389 before 08; PRs #786/#787/#788 merged; artifacts t7.2-h4-h5-connectivity.md + t7.4-render-env-checklist.md; handoff 08-verify-build'
       active_milestone: M7
       active_task: T7.4
-      active_task_status: blocked
+      active_task_status: completed
       decision_id: D-S023-07-T7.4-blocked
       branch: evolve/EV-017-public-app-privacy
-      progress: 27/~28
-      tip_sha: d459164
-      tip_sha_full: d459164efe76caacb46ef38adaaa33d72beb731e
+      progress: 28/28
+      tip_sha: 73f8389
+      tip_sha_full: 73f8389ebd2ae764eb77ffd8b3e5e3acf12088c8
       report: docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
       feature_ids:
       - F21
@@ -3909,6 +3915,28 @@ stages:
       report:
         status: completed
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 08-verify-build
+      status: completed
+      started_at: '2026-07-28'
+      started: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      mode: full
+      overall: pass
+      note: 'COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; tip 73f8389 (locks uncommitted); security WIP stashed; Phase C checkpoint pending AskQuestion before 09+10; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/verification-report.md
+      decision_id: D-S023-08-pyasn1-A
+      active_milestone: M7
+      progress: 28/28
+      tip_sha: 73f8389
+      tip_sha_full: 73f8389ebd2ae764eb77ffd8b3e5e3acf12088c8
+      branch: evolve/EV-017-public-app-privacy
+      feature_ids:
+      - F21
+      - F22
     - id: S021-golden-examples-ui
       session_id: S021-golden-examples-ui
       evolve_cycle_id: EV-016
@@ -4366,9 +4394,12 @@ stages:
     evolve_cycle_id: EV-017
     started_at: '2026-07-27'
     completed_at:
-    current_stage: 07-build
-    note: 'S023/EV-017 16-evolve in_progress — Phase A+B PASSED; current_stage 07-build; M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786; 03/05/06 skipped; #783'
+    current_stage: 08-verify-build
+    note: 'S023/EV-017 16-evolve in_progress — 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; pyasn1 0.6.4 (D-S023-08-pyasn1-A); tip 73f8389 (locks uncommitted); security WIP stashed; #783'
     notes:
+    - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending; tip 73f8389 (locks uncommitted); #783'
+    - '2026-07-28 S023/EV-017 08-verify-build FAIL (security gate blocking C→D) — pending pyasn1 0.6.3→0.6.4 (PYSEC-2026-3455/3456/3457); ecdsa PYSEC-2026-1325 ignored; report verification-report.md; tip 73f8389; #783'
+    - '2026-07-28 S023/EV-017 08-verify-build STARTED — M7 COMPLETE (T7.1–T7.4); 07-build COMPLETE; tip 73f8389; PRs #786/#787/#788 merged; security WIP stashed; #783'
     - '2026-07-28 S023/EV-017 T7.4 checklist COMMITTED @ d459164 — still blocked (D-S023-07-T7.4-blocked) awaiting RENDER_API_KEY; T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786; #783'
     - '2026-07-28 S023/EV-017 T7.3 COMPLETE @ f5aa024 — T7.4 blocked (D-S023-07-T7.4-blocked); T7.2 pending after T7.4; progress 27/~28; tip f5aa024; interim draft PR #786; #783'
     - '2026-07-28 S023/EV-017 T7.1 COMPLETE @ ad28389 — Playwright public UJ + Auth-gone + privacy smoke; active_task T7.2 pending; progress 26/~28; tip ad28389; interim draft PR #786; #783'
@@ -8675,7 +8706,48 @@ decisions_log:
   related_issue: 783
   related_decision: D-S023-07-resume-T7.1
   artifact: docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
+- id: D-S023-08-pyasn1-A
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 08-verify-build
+  skill_id: 08-verify-build
+  skill: 08-verify-build
+  category: security
+  status: confirmed
+  resolved_at: '2026-07-28'
+  topic: Upgrade pyasn1 0.6.3→0.6.4 for 08 security gate
+  summary: Upgrade pyasn1 0.6.3→0.6.4 (PYSEC-2026-3455/3456/3457); ecdsa PYSEC-2026-1325 remains ignored per audit/pip-audit-ignore.txt
+  decision: Upgrade pyasn1 0.6.3→0.6.4 to clear 08-verify-build security gate (D-S023-08-pyasn1-A). ecdsa PYSEC-2026-1325 ignored per existing audit/pip-audit-ignore.txt policy. 08 PASS; C→D criteria met; Phase C checkpoint AskQuestion pending before 09+10.
+  related_issue: 783
+  artifact: docs/sessions/S023-public-app-privacy/reports/verification-report.md
 artifacts:
+- path: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
+  type: session-checkpoint
+  kind: phase-c
+  stage: 16-evolve
+  skill_id: 16-evolve
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: pending
+  decision_id: D-S023-08-pyasn1-A
+  note: 'S023/EV-017 Phase C checkpoint drafted — 08 PASS; C→D criteria met; awaiting AskQuestion approval before 09+10'
+- path: docs/sessions/S023-public-app-privacy/reports/verification-report.md
+  type: session-report
+  kind: verification-report
+  stage: 08-verify-build
+  skill_id: 08-verify-build
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  decision_id: D-S023-08-pyasn1-A
+  tip_sha: 73f8389
+  note: 'S023/EV-017 08-verify-build PASS — pyasn1 0.6.4; ecdsa ignored'
 - path: docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
   type: session-report
   kind: checklist
@@ -10665,10 +10737,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B passed; 04 COMPLETE; 07-build — M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786.'
-  current_stage: 07-build
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B passed; 04 COMPLETE; 07+08 COMPLETE; 08 PASS (pyasn1 0.6.4 / D-S023-08-pyasn1-A); C→D criteria met; Phase C checkpoint pending AskQuestion; tip 73f8389 (locks uncommitted).'
+  current_stage: 08-verify-build
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 Phase A+B PASSED — gates.a_to_b+b_to_c passed; current_stage 07-build — M1–M6 complete; M7 active; T7.3 completed @ f5aa024; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY for live env cutover); T7.2 pending after T7.4; progress 27/~28; tip d459164; 03/05/06 skipped; interim draft PR #786; #783.'
+  note: 'S023/EV-017 08 PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; #783.'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -10696,7 +10768,11 @@ evolve_cycles:
   - D-S023-04-plan-approve-A
   - D-S023-07-resume-T7.1
   - D-S023-07-T7.4-blocked
+  - D-S023-08-pyasn1-A
   notes:
+  - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending AskQuestion; tip 73f8389 (locks uncommitted); security WIP stashed; #783'
+  - '2026-07-28 S023/EV-017 08-verify-build FAIL (security gate blocking C→D) — pending pyasn1 0.6.3→0.6.4 (PYSEC-2026-3455/3456/3457); ecdsa PYSEC-2026-1325 ignored per audit/pip-audit-ignore.txt; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; tip 73f8389; security WIP still stashed; #783'
+  - '2026-07-28 S023/EV-017 08-verify-build STARTED — M7 COMPLETE (T7.1–T7.4); 07-build COMPLETE; tip 73f8389; PRs #786/#787/#788 merged; security WIP stashed; #783'
   - '2026-07-28 S023/EV-017 T7.4 checklist COMMITTED @ d459164 — still blocked (D-S023-07-T7.4-blocked) awaiting RENDER_API_KEY for live env cutover; T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786; #783'
   - '2026-07-28 S023/EV-017 T7.3 COMPLETE @ f5aa024 — F21 public deploy corpus + EV-017 CHANGELOG draft; T7.4 blocked (D-S023-07-T7.4-blocked, no RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip f5aa024; interim draft PR #786; #783'
   - '2026-07-28 S023/EV-017 T7.1 COMPLETE @ ad28389 — Playwright public UJ + Auth-gone + privacy smoke; active_task T7.2 pending; progress 26/~28; tip ad28389; interim draft PR #786; #783'
@@ -10732,7 +10808,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; Phase A+B PASSED; current_stage 07-build — M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164; 03/05/06 skipped
+      note: Orchestrator active; Phase A+B PASSED; 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -10772,21 +10848,30 @@ evolve_cycles:
       - docs/sessions/S023-public-app-privacy/reports/04-tech-plan.md
       completed: '2026-07-28'
     07-build:
-      status: in_progress
+      status: completed
       started: '2026-07-28'
+      completed: '2026-07-28'
       mode: full
-      note: 'T7.3 COMPLETE @ f5aa024; T7.4 blocked (checklist @ d459164; D-S023-07-T7.4-blocked awaiting RENDER_API_KEY for live env cutover); T7.2 pending after T7.4; progress 27/~28'
+      note: 'COMPLETE 2026-07-28 — M1–M7 all done (T7.1–T7.4); tip 73f8389 before 08; PRs #786/#787/#788 merged; artifacts t7.2-h4-h5-connectivity.md + t7.4-render-env-checklist.md'
       active_task: T7.4
       active_milestone: M7
-      active_task_status: blocked
-      progress: 27/~28
-      tip: d459164
-      tip_sha: d459164
-      tip_sha_full: d459164efe76caacb46ef38adaaa33d72beb731e
+      active_task_status: completed
+      progress: 28/28
+      tip: 73f8389
+      tip_sha: 73f8389
+      tip_sha_full: 73f8389ebd2ae764eb77ffd8b3e5e3acf12088c8
       decision_id: D-S023-07-T7.4-blocked
       report: docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
     08-verify-build:
-      status: pending
+      status: completed
+      started: '2026-07-28'
+      completed: '2026-07-28'
+      mode: full
+      overall: pass
+      note: 'COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; tip 73f8389 (locks uncommitted); security WIP stashed; Phase C checkpoint pending; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/verification-report.md
+      decision_id: D-S023-08-pyasn1-A
+      tip_sha: 73f8389
     09-qa:
       status: pending
     10-e2e:
@@ -10824,6 +10909,23 @@ evolve_cycles:
     status: completed
   - path: docs/sessions/S023-public-app-privacy/routing-plan.md
     status: completed
+  - path: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
+    status: pending
+    stage: 16-evolve
+    kind: phase-c
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    decision_id: D-S023-08-pyasn1-A
+    date: '2026-07-28'
+    note: '08 PASS; C→D criteria met; awaiting Phase C checkpoint AskQuestion before 09+10'
+  - path: docs/sessions/S023-public-app-privacy/reports/verification-report.md
+    status: completed
+    stage: 08-verify-build
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    decision_id: D-S023-08-pyasn1-A
+    date: '2026-07-28'
+    note: '08 PASS — pyasn1 0.6.4; ecdsa ignored'
   - path: docs/sessions/S023-public-app-privacy/reports/01-requirements.md
     status: completed
   - path: docs/sessions/S023-public-app-privacy/reports/impact-analysis.md

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-017
   github_issue: 783
   artifacts_dir: docs/sessions/S023-public-app-privacy/
-  current_stage: 08-verify-build
+  current_stage: 11-verify-impl
   feature_ids:
   - F21
   - F22
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 08-verify-build PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; #783'
+  note: 'S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories; 10 T0 PASS; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted: coverage_boost import fix + qa/e2e reports + workflow-state; security WIP stashed; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase A+B passed; 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -80,22 +80,29 @@ active_session:
     skip_rationale:
     started: '2026-07-28'
     completed: '2026-07-28'
-    note: 'S023/EV-017 08-verify-build COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; tip 73f8389 (locks uncommitted); Phase C checkpoint pending; #783'
+    note: 'S023/EV-017 08-verify-build COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); tip 836c1a4; #783'
   - stage: 09-qa
     required: true
     mode: full
-    status: pending
+    status: completed
     skip_rationale:
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 09-qa COMPLETE 2026-07-28 — overall pass_with_advisories; report docs/sessions/S023-public-app-privacy/reports/qa-report.md; tip 836c1a4; #783'
   - stage: 10-e2e
     required: true
     mode: full
-    status: pending
+    status: completed
     skip_rationale:
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 10-e2e COMPLETE 2026-07-28 — T0 PASS (8 Playwright + Vitest + F21 unit); report docs/sessions/S023-public-app-privacy/reports/e2e-report.md; tip 836c1a4; #783'
   - stage: 11-verify-impl
     required: true
     mode: full
     status: pending
     skip_rationale:
+    note: 'S023/EV-017 11-verify-impl pending handoff — Phase D 09+10 done; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
   - stage: 12-verify-deploy
     required: true
     mode: full
@@ -3425,12 +3432,32 @@ stages:
   09-qa:
     status: completed
     started_at: '2026-07-26'
-    completed_at: '2026-07-26'
-    report: docs/sessions/S021-golden-examples-ui/reports/qa-report.md
+    completed_at: '2026-07-28'
+    report: docs/sessions/S023-public-app-privacy/reports/qa-report.md
     overall: pass_with_advisories
-    session_id: S021-golden-examples-ui
-    evolve_cycle_id: EV-016
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 09-qa
+      status: completed
+      mode: full
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      branch: evolve/EV-017-public-app-privacy
+      tip_sha: 836c1a4
+      tip_sha_full: 836c1a4c856d25a3a341bdb2b3437a998d190926
+      decision_id: D-S023-phase-c-A
+      overall: pass_with_advisories
+      report: docs/sessions/S023-public-app-privacy/reports/qa-report.md
+      note: 'COMPLETE 2026-07-28 — pass_with_advisories; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+      feature_ids:
+      - F21
+      - F22
     - id: S021-golden-examples-ui
       session_id: S021-golden-examples-ui
       evolve_cycle_id: EV-016
@@ -3735,10 +3762,10 @@ stages:
   10-e2e:
     status: completed
     started_at: '2026-07-26'
-    completed_at: '2026-07-26'
-    report: docs/sessions/S021-golden-examples-ui/reports/e2e-report.md
+    completed_at: '2026-07-28'
+    report: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
     overall: pass
-    session_id: S021-golden-examples-ui
+    session_id: S023-public-app-privacy
     substeps:
       extract_journeys:
         status: completed
@@ -3755,6 +3782,26 @@ stages:
         status: completed
         notes: H3 13 pass 8 skip (legacy Supabase keys); T3 browser deferred
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 10-e2e
+      status: completed
+      mode: full
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      branch: evolve/EV-017-public-app-privacy
+      tip_sha: 836c1a4
+      tip_sha_full: 836c1a4c856d25a3a341bdb2b3437a998d190926
+      decision_id: D-S023-phase-c-A
+      overall: pass
+      report: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+      note: 'COMPLETE 2026-07-28 — T0 PASS (8 Playwright + Vitest + F21 unit); tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+      feature_ids:
+      - F21
+      - F22
     - id: S021-golden-examples-ui
       session_id: S021-golden-examples-ui
       evolve_cycle_id: EV-016
@@ -4394,9 +4441,11 @@ stages:
     evolve_cycle_id: EV-017
     started_at: '2026-07-27'
     completed_at:
-    current_stage: 08-verify-build
-    note: 'S023/EV-017 16-evolve in_progress — 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; pyasn1 0.6.4 (D-S023-08-pyasn1-A); tip 73f8389 (locks uncommitted); security WIP stashed; #783'
+    current_stage: 11-verify-impl
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 09+10 COMPLETE; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; security WIP stashed; #783'
     notes:
+    - '2026-07-28 S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories (qa-report.md); 10 T0 PASS 8 Playwright+Vitest+F21 (e2e-report.md); next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+    - '2026-07-28 S023/EV-017 Phase C PASSED (D-S023-phase-c-A / user 2 then 1) — commit 836c1a4 then proceed Phase D; 09-qa+10-e2e STARTED parallel; tip 836c1a4; #783'
     - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending; tip 73f8389 (locks uncommitted); #783'
     - '2026-07-28 S023/EV-017 08-verify-build FAIL (security gate blocking C→D) — pending pyasn1 0.6.3→0.6.4 (PYSEC-2026-3455/3456/3457); ecdsa PYSEC-2026-1325 ignored; report verification-report.md; tip 73f8389; #783'
     - '2026-07-28 S023/EV-017 08-verify-build STARTED — M7 COMPLETE (T7.1–T7.4); 07-build COMPLETE; tip 73f8389; PRs #786/#787/#788 merged; security WIP stashed; #783'
@@ -8722,6 +8771,26 @@ decisions_log:
   decision: Upgrade pyasn1 0.6.3→0.6.4 to clear 08-verify-build security gate (D-S023-08-pyasn1-A). ecdsa PYSEC-2026-1325 ignored per existing audit/pip-audit-ignore.txt policy. 08 PASS; C→D criteria met; Phase C checkpoint AskQuestion pending before 09+10.
   related_issue: 783
   artifact: docs/sessions/S023-public-app-privacy/reports/verification-report.md
+- id: D-S023-phase-c-A
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 16-evolve
+  skill_id: 16-evolve
+  skill: 16-evolve
+  category: checkpoint
+  status: confirmed
+  resolved_at: '2026-07-28'
+  topic: Phase C checkpoint — C→D (user 2 then 1)
+  summary: User choice "2 then 1" — commit pyasn1/verify-build lock, then proceed Phase D (09-qa + 10-e2e parallel)
+  decision: 'Phase C PASSED (D-S023-phase-c-A / 2026-07-28). User AskQuestion "2 then 1": commit [08] pyasn1 bump + verify-build close @ 836c1a4, then proceed Phase D. gates.c_to_d + checkpoints.phase_c passed; start 09-qa + 10-e2e in parallel. Related: D-S023-08-pyasn1-A, #783.'
+  related_issue: 783
+  related_decisions:
+  - D-S023-08-pyasn1-A
+  answers:
+  - '2 then 1'
+  artifact: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
 artifacts:
 - path: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
   type: session-checkpoint
@@ -8732,9 +8801,33 @@ artifacts:
   evolve_cycle_id: EV-017
   created_at: '2026-07-28'
   updated_at: '2026-07-28'
-  status: pending
-  decision_id: D-S023-08-pyasn1-A
-  note: 'S023/EV-017 Phase C checkpoint drafted — 08 PASS; C→D criteria met; awaiting AskQuestion approval before 09+10'
+  status: approved
+  decision_id: D-S023-phase-c-A
+  note: 'S023/EV-017 Phase C checkpoint APPROVED (D-S023-phase-c-A / user 2 then 1) — C→D passed; Phase D 09+10 completed; next 11'
+- path: docs/sessions/S023-public-app-privacy/reports/qa-report.md
+  type: session-report
+  kind: qa-report
+  stage: 09-qa
+  skill_id: 09-qa
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  tip_sha: 836c1a4
+  note: 'S023/EV-017 09-qa COMPLETE — pass_with_advisories'
+- path: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+  type: session-report
+  kind: e2e-report
+  stage: 10-e2e
+  skill_id: 10-e2e
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  tip_sha: 836c1a4
+  note: 'S023/EV-017 10-e2e COMPLETE — T0 PASS (8 Playwright + Vitest + F21 unit)'
 - path: docs/sessions/S023-public-app-privacy/reports/verification-report.md
   type: session-report
   kind: verification-report
@@ -8746,7 +8839,7 @@ artifacts:
   updated_at: '2026-07-28'
   status: completed
   decision_id: D-S023-08-pyasn1-A
-  tip_sha: 73f8389
+  tip_sha: 836c1a4
   note: 'S023/EV-017 08-verify-build PASS — pyasn1 0.6.4; ecdsa ignored'
 - path: docs/sessions/S023-public-app-privacy/reports/t7.4-render-env-checklist.md
   type: session-report
@@ -10737,10 +10830,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B passed; 04 COMPLETE; 07+08 COMPLETE; 08 PASS (pyasn1 0.6.4 / D-S023-08-pyasn1-A); C→D criteria met; Phase C checkpoint pending AskQuestion; tip 73f8389 (locks uncommitted).'
-  current_stage: 08-verify-build
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4.'
+  current_stage: 11-verify-impl
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 08 PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); security WIP stashed; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; #783.'
+  note: 'S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories; 10 T0 PASS; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted: coverage_boost import fix + qa/e2e reports + workflow-state; security WIP stashed; #783.'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -10769,7 +10862,10 @@ evolve_cycles:
   - D-S023-07-resume-T7.1
   - D-S023-07-T7.4-blocked
   - D-S023-08-pyasn1-A
+  - D-S023-phase-c-A
   notes:
+  - '2026-07-28 S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories (qa-report.md); 10 T0 PASS 8 Playwright+Vitest+F21 (e2e-report.md); next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+  - '2026-07-28 S023/EV-017 Phase C PASSED (D-S023-phase-c-A / user 2 then 1) — commit 836c1a4 then proceed Phase D; 09-qa+10-e2e STARTED parallel; tip 836c1a4; #783'
   - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending AskQuestion; tip 73f8389 (locks uncommitted); security WIP stashed; #783'
   - '2026-07-28 S023/EV-017 08-verify-build FAIL (security gate blocking C→D) — pending pyasn1 0.6.3→0.6.4 (PYSEC-2026-3455/3456/3457); ecdsa PYSEC-2026-1325 ignored per audit/pip-audit-ignore.txt; report docs/sessions/S023-public-app-privacy/reports/verification-report.md; tip 73f8389; security WIP still stashed; #783'
   - '2026-07-28 S023/EV-017 08-verify-build STARTED — M7 COMPLETE (T7.1–T7.4); 07-build COMPLETE; tip 73f8389; PRs #786/#787/#788 merged; security WIP stashed; #783'
@@ -10808,7 +10904,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; Phase A+B PASSED; 08 PASS; C→D criteria met; Phase C checkpoint pending AskQuestion before 09+10; tip 73f8389 (locks uncommitted); 03/05/06 skipped
+      note: Orchestrator active; Phase C PASSED; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -10868,16 +10964,33 @@ evolve_cycles:
       completed: '2026-07-28'
       mode: full
       overall: pass
-      note: 'COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; tip 73f8389 (locks uncommitted); security WIP stashed; Phase C checkpoint pending; #783'
+      note: 'COMPLETE 2026-07-28 — PASS; pyasn1 0.6.4 (D-S023-08-pyasn1-A); tip 836c1a4; #783'
       report: docs/sessions/S023-public-app-privacy/reports/verification-report.md
       decision_id: D-S023-08-pyasn1-A
-      tip_sha: 73f8389
+      tip_sha: 836c1a4
     09-qa:
-      status: pending
+      status: completed
+      started: '2026-07-28'
+      completed: '2026-07-28'
+      mode: full
+      overall: pass_with_advisories
+      note: 'COMPLETE 2026-07-28 — pass_with_advisories; tip 836c1a4; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/qa-report.md
+      tip_sha: 836c1a4
+      decision_id: D-S023-phase-c-A
     10-e2e:
-      status: pending
+      status: completed
+      started: '2026-07-28'
+      completed: '2026-07-28'
+      mode: full
+      overall: pass
+      note: 'COMPLETE 2026-07-28 — T0 PASS (8 Playwright + Vitest + F21 unit); tip 836c1a4; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+      tip_sha: 836c1a4
+      decision_id: D-S023-phase-c-A
     11-verify-impl:
       status: pending
+      note: 'Pending handoff — Phase D 09+10 done; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
     12-verify-deploy:
       status: pending
     13-deploy-smoke:
@@ -10894,12 +11007,12 @@ evolve_cycles:
   gates:
     a_to_b: passed
     b_to_c: passed
-    c_to_d: pending
+    c_to_d: passed
     deploy: pending
   checkpoints:
     phase_a: passed
     phase_b: passed
-    phase_c: pending
+    phase_c: passed
     phase_d: pending
     deploy: pending
   adrs:
@@ -10909,15 +11022,29 @@ evolve_cycles:
     status: completed
   - path: docs/sessions/S023-public-app-privacy/routing-plan.md
     status: completed
+  - path: docs/sessions/S023-public-app-privacy/reports/qa-report.md
+    status: completed
+    stage: 09-qa
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    date: '2026-07-28'
+    note: '09-qa pass_with_advisories'
+  - path: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
+    status: completed
+    stage: 10-e2e
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    date: '2026-07-28'
+    note: '10-e2e T0 PASS (8 Playwright + Vitest + F21 unit)'
   - path: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
-    status: pending
+    status: approved
     stage: 16-evolve
     kind: phase-c
     session_id: S023-public-app-privacy
     evolve_cycle_id: EV-017
-    decision_id: D-S023-08-pyasn1-A
+    decision_id: D-S023-phase-c-A
     date: '2026-07-28'
-    note: '08 PASS; C→D criteria met; awaiting Phase C checkpoint AskQuestion before 09+10'
+    note: 'Phase C PASSED (D-S023-phase-c-A / user 2 then 1); C→D open; Phase D 09+10 completed'
   - path: docs/sessions/S023-public-app-privacy/reports/verification-report.md
     status: completed
     stage: 08-verify-build
@@ -15406,6 +15533,16 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 836c1a4c856d25a3a341bdb2b3437a998d190926
+    short: 836c1a4
+    branch: evolve/EV-017-public-app-privacy
+    message: "[08] fix: bump pyasn1 0.6.3→0.6.4 and close verify-build"
+    stage: 08-verify-build
+    files_changed: 8
+    timestamp: '2026-07-28T20:58:30Z'
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+
   - sha: d459164efe76caacb46ef38adaaa33d72beb731e
     short: d459164
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 62af980; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 489c9bf; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 62af980; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -112,7 +112,7 @@ active_session:
     skip_rationale:
     started: '2026-07-28'
     completed: '2026-07-28'
-    note: 'S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+    note: 'S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
   - stage: 13-deploy-smoke
     required: true
     mode: full
@@ -4180,7 +4180,7 @@ stages:
     completed_at: '2026-07-28'
     session_id: S023-public-app-privacy
     evolve_cycle_id: EV-017
-    note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
+    note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 62af980; #783'
     report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
     overall: ready
     delta_substages:
@@ -4195,9 +4195,9 @@ stages:
       completed_at: '2026-07-28'
       mode: full
       branch: evolve/EV-017-public-app-privacy
-      tip_sha: 489c9bf
-      tip_sha_full: 489c9bfbe6e7adee898edcc49657ad446c91471b
-      note: 'COMPLETE 2026-07-28 — READY; mitigations+rollback approved (D-S023-12-mitigations, D-S023-12-rollback); artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+      tip_sha: 62af980
+      tip_sha_full: 62af9806b5c76711cebb8fa74b59923f8f9e9637
+      note: 'COMPLETE 2026-07-28 — READY; mitigations+rollback approved (D-S023-12-mitigations, D-S023-12-rollback); artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
       report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
       overall: ready
     - id: S019-dissemination-upload
@@ -4254,8 +4254,8 @@ stages:
       note: D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge approval
       report: docs/sessions/S011-f7-operator-ui/reports/deploy-checklist.md
     notes:
-    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
-    - 2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783
+    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
+    - 2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783
     - 2026-07-21 S019/EV-014 12-verify-deploy COMPLETE — T6.5 deploy-checklist.md PASS
     - '2026-07-20 S015/EV-011 12-verify-deploy completed — T5.9 checklist approved; PR #742 merged (D-S015-EV011-deploy-merge)'
     - '2026-07-19 S014/EV-010 T6.4 complete — D-S014-EV010-t64-merge-A; PR #726 MERGED (c73e0ad); CI green tip bd0aee5; 12 completed; T6.5 13-deploy-smoke started'
@@ -4495,10 +4495,10 @@ stages:
     started_at: '2026-07-27'
     completed_at:
     current_stage: 13-deploy-smoke
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 489c9bf; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 62af980; #783'
     notes:
-    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
-    - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
+    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
+    - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
     - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
     - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
     - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
@@ -8997,8 +8997,8 @@ artifacts:
   updated_at: '2026-07-28'
   status: completed
   overall: ready
-  tip_sha: 489c9bf
-  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; tip 489c9bf'
+  tip_sha: 62af980
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; tip 62af980'
 - path: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
   type: session-report
   kind: verify-impl
@@ -11062,10 +11062,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; next 13-deploy-smoke; tip 489c9bf.'
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; next 13-deploy-smoke; tip 62af980.'
   current_stage: 13-deploy-smoke
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 62af980; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11105,8 +11105,8 @@ evolve_cycles:
   - D-S023-12-mitigations
   - D-S023-12-rollback
   notes:
-  - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
-  - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
+  - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
+  - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
   - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
   - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
   - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports committed; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
@@ -11151,7 +11151,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; 12-verify-deploy STARTED; tip 489c9bf; 03/05/06 skipped
+      note: Orchestrator active; 12-verify-deploy STARTED; tip 62af980; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -11261,9 +11261,9 @@ evolve_cycles:
       started: '2026-07-28'
       started_at: '2026-07-28'
       mode: full
-      tip_sha: 489c9bf
-      tip_sha_full: 489c9bfbe6e7adee898edcc49657ad446c91471b
-      note: 'S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
+      tip_sha: 62af980
+      tip_sha_full: 62af9806b5c76711cebb8fa74b59923f8f9e9637
+      note: 'S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
     13-deploy-smoke:
       status: pending
     03-plan-tooling:
@@ -15818,6 +15818,19 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 62af9806b5c76711cebb8fa74b59923f8f9e9637
+    short: 62af980
+    branch: evolve/EV-017-public-app-privacy
+    message: '[12] docs: verify deploy strategy for F21/F22 public cutover'
+    stage: 12-verify-deploy
+    session_id: S023-public-app-privacy
+    files_changed:
+    - docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+    - docs/sessions/S023-public-app-privacy/routing-plan.md
+    - workflow-state.yaml
+    timestamp: '2026-07-28'
+    evolve_cycle_id: EV-017
+
   - sha: 17ad5630c6a11e721a4a0871718d43cd9d5d36d2
     short: 17ad563
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-017
   github_issue: 783
   artifacts_dir: docs/sessions/S023-public-app-privacy/
-  current_stage: 13-deploy-smoke
+  current_stage:
   feature_ids:
   - F21
   - F22
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
+  note: 'S023/EV-017 13 COMPLETE — smoke approved; API SUPABASE_* removed; redeploy live; evolve close AskQuestion pending; tip 7837cd1; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 13-deploy-smoke STARTED; tip 52c14e9; #783'
+    note: 'S023/EV-017 16-evolve — Phase D 13 COMPLETE; EV-017 completed; session close AskQuestion pending; tip 7837cd1; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -116,11 +116,15 @@ active_session:
   - stage: 13-deploy-smoke
     required: true
     mode: full
-    status: in_progress
+    status: completed
     skip_rationale:
     started: '2026-07-28'
     started_at: '2026-07-28'
-    note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
+    completed: '2026-07-28'
+    completed_at: '2026-07-28'
+    note: 'S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+    report: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+    decision_id: D-S023-13-approve-cleanup
   skipped:
   - 03-plan-tooling
   - 05-verify-tech
@@ -4274,33 +4278,47 @@ stages:
     - S003 — strategy verified; deploy blocked on key rotation (Docker COPY fixed in repo)
     - S004 / EV-004 — strategy verified 2026-06-24; H0c 6/6 PASS; H4 FAIL (CORS); H5 PASS (/config.json); operator T1.3 + S003 keys + redeploy required before 13
   13-deploy-smoke:
-    status: in_progress
+    status: completed
     started_at: '2026-07-28'
     started: '2026-07-28'
+    completed: '2026-07-28'
+    completed_at: '2026-07-28'
     session_id: S023-public-app-privacy
     evolve_cycle_id: EV-017
-    note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
-    tip_sha: 52c14e9
-    tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+    note: 'S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+    tip_sha: 7837cd1
+    tip_sha_full: 7837cd1bd50b75279e195293eab696073fa284ce
     prior_tip_12: 62af980
+    prior_tip_started: 52c14e9
+    overall: pass
+    decision_id: D-S023-13-approve-cleanup
+    report: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
     report_expected: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
     checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
     t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
+    deploy_id_api: dep-d9kii12jobas73fl4bi0
     delta_substages:
     - id: S023-public-app-privacy
       session_id: S023-public-app-privacy
       evolve_cycle_id: EV-017
       skill_id: 13-deploy-smoke
-      status: in_progress
+      status: completed
       mode: full
       branch: evolve/EV-017-public-app-privacy
       started: '2026-07-28'
       started_at: '2026-07-28'
-      tip_sha: 52c14e9
-      tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      tip_sha: 7837cd1
+      tip_sha_full: 7837cd1bd50b75279e195293eab696073fa284ce
       prior_tip_12: 62af980
+      prior_tip_started: 52c14e9
       github_issue: 783
-      note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
+      overall: pass
+      decision_id: D-S023-13-approve-cleanup
+      deploy_id_api: dep-d9kii12jobas73fl4bi0
+      report: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+      note: 'S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
       checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
       t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
     - id: S022-rename-cutover
@@ -4522,9 +4540,11 @@ stages:
     evolve_cycle_id: EV-017
     started_at: '2026-07-27'
     completed_at:
-    current_stage: 13-deploy-smoke
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 13-deploy-smoke STARTED; tip 52c14e9; #783'
+    current_stage: close
+    note: 'S023/EV-017 16-evolve — Phase D 13 COMPLETE; EV-017 completed; session close AskQuestion pending; tip 7837cd1; #783'
     notes:
+    - '2026-07-28 S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+    - '2026-07-28 S023/EV-017 13-deploy-smoke SMOKE PASS (pending user approve) — H0c–H5 PASS; Playwright 5/5; tip 7837cd1; optional SUPABASE_* cleanup; validate-existing 2026-07-28; report deploy-smoke.md; #783'
     - '2026-07-28 S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
     - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
     - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
@@ -4625,7 +4645,7 @@ deployment:
     t0_journeys_passed: 4
   staging:
     status: deployed
-    last_verified: '2026-07-27'
+    last_verified: '2026-07-28'
     commit_deployed: 6b9d2b9
     commit_head: 6b9d2b9
     drift: false
@@ -4633,13 +4653,13 @@ deployment:
       api: https://metar-to-iwxxm-api.onrender.com
       frontend: https://metar-to-iwxxm-frontend-v4-web.onrender.com
     deploy_ids:
-      api: dep-d9gljeupbkes73bspkl0
-      frontend: dep-d9gljfrbc2fs738q90d0
+      api: dep-d9kii12jobas73fl4bi0
+      frontend: dep-d9khdedbedkc73aodib0
     ci_deploy_run: '30227888075'
     images:
       api: ghcr.io/empiric2/tac-to-iwxxm/backend:main-latest
       frontend: ghcr.io/empiric2/tac-to-iwxxm/frontend:main-latest
-      note: S022 cutover — empiric2 imagePath + classic read:packages GHCR cred; live main-latest
+      note: 'S023/EV-017 13 COMPLETE — Auth leftovers removed; API redeploy dep-d9kii12jobas73fl4bi0; health tiers pass; empiric2 imagePath'
     health_tiers:
       H0ci: note_deploy_hook_may_still_need_verify
       H0c: pass
@@ -4651,14 +4671,18 @@ deployment:
       AHL_convert_bulletin: pass
       COLLECT_ingest_collect: expected_501
       Playwright_workbench: pass
+      Playwright_F21_F22: pass_5_of_5
       goldens_ui: pass
       h0c: pass
       h1: pass
+      h3: pass
       h4: pass
       h5: pass
       h0ci: note_deploy_hook_may_still_need_verify
       uj032: pass
     notes:
+    - '2026-07-28 S023/EV-017 13 COMPLETE — API SUPABASE_* Auth leftovers removed; redeploy dep-d9kii12jobas73fl4bi0; health/convert/H4–H5 re-PASS; tip 7837cd1'
+    - '2026-07-28 S023/EV-017 13-deploy-smoke validate-existing PASS — H0c–H5 PASS; Playwright F21/F22 5/5; tip 7837cd1; deploys dep-d9khddad0e5s73dmm4r0 / dep-d9khdedbedkc73aodib0; pending user approve + optional API SUPABASE_* cleanup'
     - 2026-07-27 S022 13-deploy-smoke PASS — UJ-032 live verified; PyPI Trusted Publisher still pending
     - 2026-07-27 S022/15 cutover PASS — Render imagePath → empiric2; classic PAT read:packages; API/FE/worker live @ 6b9d2b9 / main-latest; H0c/H1/H4/H5 PASS; goldens_ui_live; UJ-032 → 13; PyPI/secrets remaining; H0ci deploy-hook may still need verify
     - 'S021/EV-016 13-deploy-smoke BLOCKED 2026-07-27 — CI 30227888075 tests green; Deploy FAILED (Render deploy hook 400 for empiric2 GHCR imgURL); pushed ghcr.io/empiric2/tac-to-iwxxm/*:20260727004311-c49f22b+main-latest; live still ghcr.io/joseph-c-mcguire/metar-to-iwxxm/*; FE redeploy dep-d9jalpb7uimc73cobuog re-pulled old main-latest (no goldens UI); blocker #781 private EMPIRIC2 GHCR cutover (PATCH imagePath could not be fetched; local gh token lacks packages scopes; joseph GHCR push permission_denied). Pending user decision on #781 minimal cutover.'
@@ -9014,7 +9038,49 @@ decisions_log:
   summary: Rollback plan approved for S023 public-app privacy cutover
   decision: Rollback plan approved
   related_issue: 783
+- id: D-S023-13-approve-cleanup
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 13-deploy-smoke
+  skill_id: 13-deploy-smoke
+  skill: 13-deploy-smoke
+  category: deploy
+  status: confirmed
+  topic: Approve smoke + API SUPABASE_* cleanup
+  summary: User option 2 — approve smoke; delete API SUPABASE_URL/SECRET leftovers; redeploy; health tiers re-PASS
+  decision: 'User option 2 — smoke approved; deleted API SUPABASE_URL/SECRET; redeploy dep-d9kii12jobas73fl4bi0; health/convert/H4-H5 re-PASS; tip 7837cd1; #783'
+  related_issue: 783
+  deploy_id: dep-d9kii12jobas73fl4bi0
 artifacts:
+- path: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+  type: session-report
+  kind: deploy-smoke
+  stage: 13-deploy-smoke
+  skill_id: 13-deploy-smoke
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  overall: pass
+  tip_sha: 7837cd1
+  decision_id: D-S023-13-approve-cleanup
+  deploy_id_api: dep-d9kii12jobas73fl4bi0
+  note: 'S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+- path: docs/sessions/S023-public-app-privacy/reports/evolve-summary.md
+  type: report
+  kind: evolve-summary
+  stage: 16-evolve
+  skill_id: 16-evolve
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  note: 'S023/EV-017 evolve-summary — 13 COMPLETE; session close AskQuestion pending; tip 7837cd1; #783'
 - path: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
   type: session-report
   kind: deploy-checklist
@@ -11059,9 +11125,10 @@ evolve_cycles:
   feature_id:
   feature_note: Also deepen F5/F7 (IndexedDB); deprecate operator M4
   title: "Public app + local history + privacy (#783)"
-  status: in_progress
+  status: completed
   started: '2026-07-27'
-  completed:
+  completed: '2026-07-28'
+  completed_at: '2026-07-28'
   scope_summary: |
     Public/stateless operator app (F21); IndexedDB F5/F7 history; privacy Solution A
     preference center + GPC (F22); baseline API abuse controls; ~30-day legacy session
@@ -11091,10 +11158,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; 13-deploy-smoke STARTED; tip 52c14e9.'
-  current_stage: 13-deploy-smoke
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. All required stages COMPLETE; session close AskQuestion pending; tip 7837cd1.'
+  current_stage:
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
+  note: 'S023/EV-017 COMPLETE (pending session close AskQuestion) — 13 smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11133,7 +11200,10 @@ evolve_cycles:
   - D-S023-11-uj-018-033
   - D-S023-12-mitigations
   - D-S023-12-rollback
+  - D-S023-13-approve-cleanup
   notes:
+  - '2026-07-28 S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+  - '2026-07-28 S023/EV-017 13-deploy-smoke SMOKE PASS (pending user approve) — H0c–H5 PASS; Playwright 5/5; tip 7837cd1; optional SUPABASE_* cleanup; validate-existing 2026-07-28; report deploy-smoke.md; #783'
   - '2026-07-28 S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
   - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
   - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
@@ -11181,7 +11251,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; 13-deploy-smoke STARTED; tip 52c14e9; 03/05/06 skipped
+      note: Orchestrator active; 13-deploy-smoke SMOKE PASS pending user approve; tip 7837cd1; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -11299,14 +11369,21 @@ evolve_cycles:
       report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
       note: 'COMPLETE 2026-07-28 — READY; mitigations+rollback approved; tip 62af980; next 13; #783'
     13-deploy-smoke:
-      status: in_progress
+      status: completed
       started: '2026-07-28'
       started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
       mode: full
-      tip_sha: 52c14e9
-      tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+      tip_sha: 7837cd1
+      tip_sha_full: 7837cd1bd50b75279e195293eab696073fa284ce
       prior_tip_12: 62af980
-      note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
+      prior_tip_started: 52c14e9
+      overall: pass
+      decision_id: D-S023-13-approve-cleanup
+      deploy_id_api: dep-d9kii12jobas73fl4bi0
+      report: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+      note: 'S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
       checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
       t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
     03-plan-tooling:
@@ -11322,13 +11399,13 @@ evolve_cycles:
     a_to_b: passed
     b_to_c: passed
     c_to_d: passed
-    deploy: pending
+    deploy: passed
   checkpoints:
     phase_a: passed
     phase_b: passed
     phase_c: passed
-    phase_d: pending
-    deploy: pending
+    phase_d: passed
+    deploy: passed
   adrs:
   - docs/adr/ADR-031-public-app-indexeddb-history.md
   artifacts:
@@ -14964,13 +15041,14 @@ evolve_cycles:
   merge_sha: '4660602'
 git_history:
   current_branch: evolve/EV-017-public-app-privacy
-  ahead_of_origin: 3
+  ahead_of_origin: 7
   pushed: false
   pending_commit:
-  tip_sha: d459164
-  tip_sha_full: d459164efe76caacb46ef38adaaa33d72beb731e
-  note: 'S023/EV-017 tip d459164 — M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist committed; awaiting RENDER_API_KEY for live env cutover); T7.2 pending after T7.4; progress 27/~28; interim draft PR #786; #783'
+  tip_sha: 7837cd1
+  tip_sha_full: 7837cd1bd50b75279e195293eab696073fa284ce
+  note: 'S023/EV-017 tip 7837cd1 — 13-deploy-smoke SMOKE PASS (pending user approve); H0c–H5 PASS; Playwright 5/5; validate-existing 2026-07-28; optional SUPABASE_* cleanup; #783'
   notes:
+  - '2026-07-28 S023/EV-017 tip synced — 7837cd1 (7837cd1bd50b75279e195293eab696073fa284ce); "[13] fix: harden F22 privacy E2E locators + record live smoke"; stage 13-deploy-smoke; SMOKE PASS pending user approve; H0c–H5 PASS; Playwright 5/5'
   - '2026-07-28 S023/EV-017 tip synced — d459164 (d459164efe76caacb46ef38adaaa33d72beb731e); T7.4 checklist COMMITTED (still blocked awaiting RENDER_API_KEY for live env deletes); stage 07-build; active T7.4 blocked / T7.2 pending after T7.4; progress 27/~28; pending_commit cleared'
   - '2026-07-28 S023/EV-017 tip synced — f5aa024 (f5aa024483d2eef87611a4173ae0803efa1d372e); T7.3 COMPLETE (F21 public deploy corpus + EV-017 CHANGELOG draft); T7.4 blocked (D-S023-07-T7.4-blocked); stage 07-build; active T7.4 blocked / T7.2 pending after T7.4; progress 27/~28'
   - '2026-07-28 S023/EV-017 tip synced — ad28389 (ad28389d47325bcf74f994af24d1f878ebc617b7); T7.1 COMPLETE (Playwright public UJ + Auth-gone + privacy smoke); stage 07-build; active T7.2 pending; progress 26/~28; leave unrelated security-static-analysis / abuse_controls WIP unstaged'
@@ -15861,6 +15939,21 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 7837cd1bd50b75279e195293eab696073fa284ce
+    short: 7837cd1
+    branch: evolve/EV-017-public-app-privacy
+    message: '[13] fix: harden F22 privacy E2E locators + record live smoke'
+    stage: 13-deploy-smoke
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    files_changed:
+    - apps/e2e/public-app-f21-f22.e2e.spec.ts
+    - docs/deploy-state.md
+    - docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+    - docs/sessions/S023-public-app-privacy/routing-plan.md
+    - workflow-state.yaml
+    timestamp: '2026-07-28'
+
   - sha: 62af9806b5c76711cebb8fa74b59923f8f9e9637
     short: 62af980
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-017
   github_issue: 783
   artifacts_dir: docs/sessions/S023-public-app-privacy/
-  current_stage: 11-verify-impl
+  current_stage: 12-verify-deploy
   feature_ids:
   - F21
   - F22
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories; 10 T0 PASS; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted: coverage_boost import fix + qa/e2e reports + workflow-state; security WIP stashed; #783'
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -100,9 +100,11 @@ active_session:
   - stage: 11-verify-impl
     required: true
     mode: full
-    status: pending
+    status: completed
     skip_rationale:
-    note: 'S023/EV-017 11-verify-impl pending handoff — Phase D 09+10 done; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 11-verify-impl COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts docs/sessions/S023-public-app-privacy/reports/verify-impl.md + docs/reports/implementation-verification.md; tip 657d440; next 12-verify-deploy; #783'
   - stage: 12-verify-deploy
     required: true
     mode: full
@@ -3449,12 +3451,12 @@ stages:
       completed: '2026-07-28'
       completed_at: '2026-07-28'
       branch: evolve/EV-017-public-app-privacy
-      tip_sha: 836c1a4
-      tip_sha_full: 836c1a4c856d25a3a341bdb2b3437a998d190926
+      tip_sha: 657d440
+      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
       decision_id: D-S023-phase-c-A
       overall: pass_with_advisories
       report: docs/sessions/S023-public-app-privacy/reports/qa-report.md
-      note: 'COMPLETE 2026-07-28 — pass_with_advisories; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+      note: 'COMPLETE 2026-07-28 — pass_with_advisories; tip 657d440 ([10] coverage_boost + reports); #783'
       feature_ids:
       - F21
       - F22
@@ -3591,9 +3593,13 @@ stages:
   11-verify-impl:
     status: completed
     started_at: '2026-07-26'
-    session_id: S021-golden-examples-ui
-    evolve_cycle_id: EV-016
-    note: 'COMPLETE 2026-07-26 (E16-19=A) — Approve UJ-032 + F7.g (T0 + local preview; H4–H5 waived to 13; QA-001–004 accepted); overall approved; artifact docs/sessions/S021-golden-examples-ui/reports/verify-impl.md; gates.c_to_d + phase_c passed; phase_d/deploy remain pending; next: open minor PR then 13-deploy-smoke'
+    completed: '2026-07-28'
+    completed_at: '2026-07-28'
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
+    report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+    overall: approved
     substeps:
       collect_results:
         status: completed
@@ -3601,23 +3607,43 @@ stages:
         status: completed
       journey_signoff:
         status: completed
-        approved: 2
+        approved: 4
         flagged: 0
-        total: 2
-        notes: UJ-003 + UJ-OPS-001 approved; T3 auth waived to 12-verify-deploy
+        total: 4
+        notes: UJ-001/004/018/033 approved; T3 waived to 13-deploy-smoke (D-S023-11-uj-001-004, D-S023-11-uj-018-033)
       feature_approval:
         status: completed
         approved: 2
         flagged: 0
         total: 2
+        notes: F21/F22 approved; F5/F7.h deepen acknowledged
       fixes_applied:
         status: completed
-        notes: None required — user approved with T3 waiver
+        notes: QA-003 fixed @ 657d440; QA-001/002 accept; QA-004→13 (D-S023-11-advisories)
       scope_analysis:
         status: completed
       summary:
         status: completed
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 11-verify-impl
+      status: completed
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      mode: full
+      branch: evolve/EV-017-public-app-privacy
+      tip_sha: 657d440
+      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
+      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts verify-impl.md + implementation-verification.md; tip 657d440; next 12-verify-deploy; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+      overall: approved
+      feature_ids:
+      - F21
+      - F22
     - id: S021-golden-examples-ui
       session_id: S021-golden-examples-ui
       evolve_cycle_id: EV-016
@@ -3721,6 +3747,7 @@ stages:
       report: docs/sessions/S011-f7-operator-ui/reports/verify-impl.md
       note: D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout T6.5
     notes:
+    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
     - S021/EV-016 11-verify-impl STARTED 2026-07-26 — user approved non-deployed UI preview ("Looks good proceed"); committing 09/10 reports then running 11; tip 3d1c58b; gates.c_to_d / phase_c / phase_d remain pending (do NOT mark yet)
     - ? 2026-07-22 S020/EV-015 T5.6 tip recorded — tip/sha dc64b77 (dc64b77d07913c582668239c537832be381efad1); message "[T5.6] docs
       : 11-verify-impl PASS (D-S020-EV015-11-A; H4–H5→T5.7)"; stage 11-verify-impl; appended git_history.commits; T5.7 in_progress (13-deploy-smoke); progress 27/28; evolve PR to be opened; merge required before GHCR main-latest image redeploy; H1–H5 after merge; gates.c_to_d remains pending.
@@ -3793,12 +3820,12 @@ stages:
       completed: '2026-07-28'
       completed_at: '2026-07-28'
       branch: evolve/EV-017-public-app-privacy
-      tip_sha: 836c1a4
-      tip_sha_full: 836c1a4c856d25a3a341bdb2b3437a998d190926
+      tip_sha: 657d440
+      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
       decision_id: D-S023-phase-c-A
       overall: pass
       report: docs/sessions/S023-public-app-privacy/reports/e2e-report.md
-      note: 'COMPLETE 2026-07-28 — T0 PASS (8 Playwright + Vitest + F21 unit); tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
+      note: 'COMPLETE 2026-07-28 — T0 PASS (8 Playwright + Vitest + F21 unit); tip 657d440 ([10] coverage_boost + reports); #783'
       feature_ids:
       - F21
       - F22
@@ -4441,9 +4468,13 @@ stages:
     evolve_cycle_id: EV-017
     started_at: '2026-07-27'
     completed_at:
-    current_stage: 11-verify-impl
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 09+10 COMPLETE; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; security WIP stashed; #783'
+    current_stage: 12-verify-deploy
+    note: 'S023/EV-017 16-evolve in_progress — 11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; #783'
     notes:
+    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+    - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
+    - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
+    - '2026-07-28 S023/EV-017 11-verify-impl STARTED — UI preview AskQuestion pending before feature approval; scope F21/F22 + F5/F7.h deepen; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
     - '2026-07-28 S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories (qa-report.md); 10 T0 PASS 8 Playwright+Vitest+F21 (e2e-report.md); next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
     - '2026-07-28 S023/EV-017 Phase C PASSED (D-S023-phase-c-A / user 2 then 1) — commit 836c1a4 then proceed Phase D; 09-qa+10-e2e STARTED parallel; tip 836c1a4; #783'
     - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending; tip 73f8389 (locks uncommitted); #783'
@@ -8791,7 +8822,137 @@ decisions_log:
   answers:
   - '2 then 1'
   artifact: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
+- id: D-S023-11-ui-preview-declined
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: UI preview declined — approve from reports/tests only
+  summary: User declined live UI preview; continue 11-verify-impl from reports/tests only; journey + feature sign-off next
+  decision: UI preview declined; approve from reports/tests only
+  related_issue: 783
+- id: D-S023-11-f21
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: F21 feature approval
+  summary: F21 (public unauthenticated operator app) approved at 11-verify-impl
+  decision: F21 approved
+  related_issue: 783
+- id: D-S023-11-f22
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: F22 feature approval
+  summary: F22 (privacy preference center) approved at 11-verify-impl
+  decision: F22 approved
+  related_issue: 783
+- id: D-S023-11-f5-f7h
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: F5/F7.h IndexedDB deepen acknowledgement
+  summary: F5/F7.h IndexedDB deepen acknowledged at 11-verify-impl
+  decision: F5/F7.h deepen acknowledged
+  related_issue: 783
+- id: D-S023-11-advisories
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: QA advisories disposition
+  summary: QA-001/002 accept; QA-003 fixed; QA-004 deferred to 13-deploy-smoke
+  decision: QA-001/002 accept; QA-003 fixed; QA-004→13
+  related_issue: 783
+- id: D-S023-11-uj-001-004
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: Journey signoff UJ-001 / UJ-004
+  summary: UJ-001 and UJ-004 approved; T3 live browser re-check waived to 13-deploy-smoke
+  decision: UJ-001/004 approved; T3 waived to 13
+  related_issue: 783
+- id: D-S023-11-uj-018-033
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  skill: 11-verify-impl
+  category: verification
+  status: confirmed
+  topic: Journey signoff UJ-018 / UJ-033
+  summary: UJ-018 and UJ-033 approved; T3 live browser re-check waived to 13-deploy-smoke
+  decision: UJ-018/033 approved; T3 waived to 13
+  related_issue: 783
 artifacts:
+- path: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+  type: session-report
+  kind: verify-impl
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  overall: approved
+  tip_sha: 657d440
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed'
+- path: docs/reports/implementation-verification.md
+  type: standing-doc
+  kind: implementation-verification
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  overall: approved
+  note: 'S023/EV-017 standing implementation-verification updated — F21/F22 approved'
 - path: docs/sessions/S023-public-app-privacy/checkpoints/phase-c.md
   type: session-checkpoint
   kind: phase-c
@@ -10830,10 +10991,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4.'
-  current_stage: 11-verify-impl
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending); tip 657d440.'
+  current_stage: 12-verify-deploy
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories; 10 T0 PASS; next 11-verify-impl (pending handoff); tip 836c1a4; uncommitted: coverage_boost import fix + qa/e2e reports + workflow-state; security WIP stashed; #783.'
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -10863,7 +11024,18 @@ evolve_cycles:
   - D-S023-07-T7.4-blocked
   - D-S023-08-pyasn1-A
   - D-S023-phase-c-A
+  - D-S023-11-ui-preview-declined
+  - D-S023-11-f21
+  - D-S023-11-f22
+  - D-S023-11-f5-f7h
+  - D-S023-11-advisories
+  - D-S023-11-uj-001-004
+  - D-S023-11-uj-018-033
   notes:
+  - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+  - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
+  - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports committed; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
+  - '2026-07-28 S023/EV-017 11-verify-impl STARTED — UI preview AskQuestion pending before feature approval; scope F21/F22 + F5/F7.h deepen; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
   - '2026-07-28 S023/EV-017 Phase D 09+10 COMPLETE — 09 pass_with_advisories (qa-report.md); 10 T0 PASS 8 Playwright+Vitest+F21 (e2e-report.md); next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; #783'
   - '2026-07-28 S023/EV-017 Phase C PASSED (D-S023-phase-c-A / user 2 then 1) — commit 836c1a4 then proceed Phase D; 09-qa+10-e2e STARTED parallel; tip 836c1a4; #783'
   - '2026-07-28 S023/EV-017 08-verify-build COMPLETE PASS — pyasn1 0.6.4 (D-S023-08-pyasn1-A); ecdsa ignored; report verification-report.md; C→D criteria met; Phase C checkpoint pending AskQuestion; tip 73f8389 (locks uncommitted); security WIP stashed; #783'
@@ -10904,7 +11076,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; Phase C PASSED; Phase D 09+10 COMPLETE; next 11-verify-impl; tip 836c1a4; uncommitted coverage_boost + reports + workflow-state; 03/05/06 skipped
+      note: Orchestrator active; 11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -10989,8 +11161,26 @@ evolve_cycles:
       tip_sha: 836c1a4
       decision_id: D-S023-phase-c-A
     11-verify-impl:
-      status: pending
-      note: 'Pending handoff — Phase D 09+10 done; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
+      status: completed
+      started: '2026-07-28'
+      completed: '2026-07-28'
+      mode: full
+      overall: approved
+      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+      tip_sha: 657d440
+      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
+      report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+      feature_ids:
+      - F21
+      - F22
+      decision_refs:
+      - D-S023-11-f21
+      - D-S023-11-f22
+      - D-S023-11-f5-f7h
+      - D-S023-11-advisories
+      - D-S023-11-uj-001-004
+      - D-S023-11-uj-018-033
+      - D-S023-11-ui-preview-declined
     12-verify-deploy:
       status: pending
     13-deploy-smoke:
@@ -11018,6 +11208,20 @@ evolve_cycles:
   adrs:
   - docs/adr/ADR-031-public-app-indexeddb-history.md
   artifacts:
+  - path: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+    status: completed
+    stage: 11-verify-impl
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    date: '2026-07-28'
+    note: '11 COMPLETE — F21/F22 approved; F5/F7.h ack'
+  - path: docs/reports/implementation-verification.md
+    status: completed
+    stage: 11-verify-impl
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    date: '2026-07-28'
+    note: 'Standing implementation-verification updated for S023'
   - path: docs/sessions/S023-public-app-privacy/session-brief.md
     status: completed
   - path: docs/sessions/S023-public-app-privacy/routing-plan.md
@@ -15533,6 +15737,19 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
+    short: 657d440
+    branch: evolve/EV-017-public-app-privacy
+    message: "[10] fix: F21 coverage_boost import + record 09/10 reports"
+    stage: 10-e2e
+    stages:
+    - 10-e2e
+    - 09-qa
+    files_changed: 5
+    timestamp: '2026-07-28T21:11:43Z'
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+
   - sha: 836c1a4c856d25a3a341bdb2b3437a998d190926
     short: 836c1a4
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,7 +15,7 @@ active_session:
   evolve_cycle_id: EV-017
   github_issue: 783
   artifacts_dir: docs/sessions/S023-public-app-privacy/
-  current_stage: 12-verify-deploy
+  current_stage: 13-deploy-smoke
   feature_ids:
   - F21
   - F22
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563; next 12-verify-deploy; #783'
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 489c9bf; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -108,8 +108,11 @@ active_session:
   - stage: 12-verify-deploy
     required: true
     mode: full
-    status: pending
+    status: completed
     skip_rationale:
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
   - stage: 13-deploy-smoke
     required: true
     mode: full
@@ -4171,11 +4174,32 @@ stages:
     - '2026-07-12 PRM-012/013 complete; PRs #706–#709 merged into evolve (D-S008-EV006-merge-m4-m7)'
   12-verify-deploy:
     status: completed
-    started_at: '2026-06-24T18:20:00Z'
-    completed_at: '2026-06-24T18:30:00Z'
-    session_id: S004-issue-555-feedback
-    report: docs/sessions/S004-issue-555-feedback/reports/deploy-checklist.md
+    started_at: '2026-07-28'
+    started: '2026-07-28'
+    completed: '2026-07-28'
+    completed_at: '2026-07-28'
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
+    report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+    overall: ready
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 12-verify-deploy
+      status: completed
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      mode: full
+      branch: evolve/EV-017-public-app-privacy
+      tip_sha: 489c9bf
+      tip_sha_full: 489c9bfbe6e7adee898edcc49657ad446c91471b
+      note: 'COMPLETE 2026-07-28 — READY; mitigations+rollback approved (D-S023-12-mitigations, D-S023-12-rollback); artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+      report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+      overall: ready
     - id: S019-dissemination-upload
       session_id: S019-dissemination-upload
       evolve_cycle_id: EV-014
@@ -4230,6 +4254,8 @@ stages:
       note: D-S011-EV008-deploy-check-A — checklist approved; PR-EV-008=#716 open (no merge/deploy); 13 pending on merge approval
       report: docs/sessions/S011-f7-operator-ui/reports/deploy-checklist.md
     notes:
+    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+    - 2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783
     - 2026-07-21 S019/EV-014 12-verify-deploy COMPLETE — T6.5 deploy-checklist.md PASS
     - '2026-07-20 S015/EV-011 12-verify-deploy completed — T5.9 checklist approved; PR #742 merged (D-S015-EV011-deploy-merge)'
     - '2026-07-19 S014/EV-010 T6.4 complete — D-S014-EV010-t64-merge-A; PR #726 MERGED (c73e0ad); CI green tip bd0aee5; 12 completed; T6.5 13-deploy-smoke started'
@@ -4468,9 +4494,11 @@ stages:
     evolve_cycle_id: EV-017
     started_at: '2026-07-27'
     completed_at:
-    current_stage: 12-verify-deploy
-    note: 'S023/EV-017 16-evolve in_progress — 11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; #783'
+    current_stage: 13-deploy-smoke
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 489c9bf; #783'
     notes:
+    - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+    - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
     - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
     - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
     - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
@@ -8927,7 +8955,50 @@ decisions_log:
   summary: UJ-018 and UJ-033 approved; T3 live browser re-check waived to 13-deploy-smoke
   decision: UJ-018/033 approved; T3 waived to 13
   related_issue: 783
+- id: D-S023-12-mitigations
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 12-verify-deploy
+  skill_id: 12-verify-deploy
+  skill: 12-verify-deploy
+  category: deploy
+  status: confirmed
+  topic: Deploy mitigations approval
+  summary: All 6 mitigations approved; API SUPABASE_* cleanup optional at 13-deploy-smoke
+  decision: All 6 mitigations approved; API SUPABASE_* optional at 13
+  related_issue: 783
+- id: D-S023-12-rollback
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  session_id: S023-public-app-privacy
+  session: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  stage: 12-verify-deploy
+  skill_id: 12-verify-deploy
+  skill: 12-verify-deploy
+  category: deploy
+  status: confirmed
+  topic: Deploy rollback plan approval
+  summary: Rollback plan approved for S023 public-app privacy cutover
+  decision: Rollback plan approved
+  related_issue: 783
 artifacts:
+- path: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+  type: session-report
+  kind: deploy-checklist
+  stage: 12-verify-deploy
+  skill_id: 12-verify-deploy
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  created_at: '2026-07-28'
+  updated_at: '2026-07-28'
+  status: completed
+  overall: ready
+  tip_sha: 489c9bf
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; tip 489c9bf'
 - path: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
   type: session-report
   kind: verify-impl
@@ -10991,10 +11062,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending); tip 17ad563.'
-  current_stage: 12-verify-deploy
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; next 13-deploy-smoke; tip 489c9bf.'
+  current_stage: 13-deploy-smoke
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563; next 12-verify-deploy; #783'
+  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 489c9bf; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11031,7 +11102,11 @@ evolve_cycles:
   - D-S023-11-advisories
   - D-S023-11-uj-001-004
   - D-S023-11-uj-018-033
+  - D-S023-12-mitigations
+  - D-S023-12-rollback
   notes:
+  - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 489c9bf; next 13; #783'
+  - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
   - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
   - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
   - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports committed; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
@@ -11076,7 +11151,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; 11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; 03/05/06 skipped
+      note: Orchestrator active; 12-verify-deploy STARTED; tip 489c9bf; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -11182,7 +11257,13 @@ evolve_cycles:
       - D-S023-11-uj-018-033
       - D-S023-11-ui-preview-declined
     12-verify-deploy:
-      status: pending
+      status: in_progress
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      mode: full
+      tip_sha: 489c9bf
+      tip_sha_full: 489c9bfbe6e7adee898edcc49657ad446c91471b
+      note: 'S023/EV-017 12-verify-deploy STARTED — tip 489c9bf; #783'
     13-deploy-smoke:
       status: pending
     03-plan-tooling:

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -5,11 +5,12 @@ project:
   output_directory: docs/
 session_counter: 23
 evolve_cycle_counter: 17
-active_session:
-  id: S023-public-app-privacy
+active_session: null
+sessions:
+- id: S023-public-app-privacy
   type: feature
   intent: "Remove end-user auth; public/stateless converter; IndexedDB local F5/F7 history; privacy-minimizing preference center + GPC (#783)"
-  status: in_progress
+  status: completed
   branch: evolve/EV-017-public-app-privacy
   orchestrator: 16-evolve
   evolve_cycle_id: EV-017
@@ -24,7 +25,17 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 13 COMPLETE — smoke approved; API SUPABASE_* removed; redeploy live; evolve close AskQuestion pending; tip 7837cd1; #783'
+  note: 'Phase 4 close D-S023-close — EV-017/S023 complete; PR #790 open (https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790; tip 2e2f6c0; CI 30404410993 success; mergeable; do not auto-merge); #783'
+  completed_at: '2026-07-28'
+  close_note: 'D-S023-close — user option 2 push then close; PR #790 opened; CI run 30404410993 success; tip 2e2f6c0; do not auto-merge; EV-017 remains completed'
+  close_decision_id: D-S023-close
+  pr_number: 790
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790
+  pr_status: open
+  tip_sha: 2e2f6c0
+  tip_sha_full: 2e2f6c022324585423f30765541f7ddc435def68
+  ci_run: '30404410993'
+  do_not_auto_merge: true
   routing_plan:
   - stage: 00-context
     required: true
@@ -37,10 +48,11 @@ active_session:
   - stage: 16-evolve
     required: true
     mode: orchestrator
-    status: in_progress
+    status: completed
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve — Phase D 13 COMPLETE; EV-017 completed; session close AskQuestion pending; tip 7837cd1; #783'
+    completed: '2026-07-28'
+    note: 'S023/EV-017 16-evolve COMPLETE — Phase 4 close D-S023-close; EV-017 completed; PR #790 open (tip 2e2f6c0; CI 30404410993 green; mergeable; do not auto-merge); #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -129,7 +141,6 @@ active_session:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-sessions:
 - id: S022-rename-cutover
   type: ops
   intent: 'ops: finish EMPIRIC2/TAC-to-IWXXM rename cutover (Render, GHCR, secrets, PyPI) — #781; unlock live H4–H5 / UJ-032 goldens deferred from S021'
@@ -9054,6 +9065,30 @@ decisions_log:
   decision: 'User option 2 — smoke approved; deleted API SUPABASE_URL/SECRET; redeploy dep-d9kii12jobas73fl4bi0; health/convert/H4-H5 re-PASS; tip 7837cd1; #783'
   related_issue: 783
   deploy_id: dep-d9kii12jobas73fl4bi0
+- id: D-S023-close
+  date: '2026-07-28'
+  timestamp: '2026-07-28'
+  resolved_at: '2026-07-28'
+  session_id: S023-public-app-privacy
+  evolve_cycle_id: EV-017
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  status: confirmed
+  topic: Close S023 / EV-017 session after push + PR
+  summary: 'User option 2 — push then close; PR #790 opened; CI run 30404410993 success; tip 2e2f6c0; do not auto-merge'
+  decision: 'Close S023-public-app-privacy (Phase 4). User option 2: push then close. Archive session; active_session=null; mark routing_plan 16-evolve completed. Record PR #790 (https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790) open/mergeable; CI/CD Pipeline run 30404410993 success on tip 2e2f6c0. EV-017 remains completed. Do not auto-merge PR #790.'
+  related_prs:
+  - 790
+  related_issues:
+  - 783
+  related_pr: 790
+  tip_sha: 2e2f6c0
+  tip_sha_full: 2e2f6c022324585423f30765541f7ddc435def68
+  ci_run: '30404410993'
+  user_option: 2
+  do_not_auto_merge: true
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790
 artifacts:
 - path: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
   type: session-report
@@ -11158,10 +11193,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. All required stages COMPLETE; session close AskQuestion pending; tip 7837cd1.'
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. All required stages COMPLETE including 16-evolve; session closed D-S023-close; PR #790 open tip 2e2f6c0 (do not auto-merge).'
   current_stage:
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 COMPLETE (pending session close AskQuestion) — 13 smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
+  note: 'S023/EV-017 COMPLETE (session closed D-S023-close) — PR #790 open (tip 2e2f6c0; CI 30404410993 success; mergeable; do not auto-merge); 13 smoke approved; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11201,7 +11236,9 @@ evolve_cycles:
   - D-S023-12-mitigations
   - D-S023-12-rollback
   - D-S023-13-approve-cleanup
+  - D-S023-close
   notes:
+  - '2026-07-28 S023/EV-017 CLOSED (D-S023-close) — user option 2 push then close; PR #790 open https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790 tip 2e2f6c0; CI 30404410993 success; mergeable; do not auto-merge; active_session=null; EV-017 remains completed; #783'
   - '2026-07-28 S023/EV-017 13-deploy-smoke COMPLETE — smoke approved; API SUPABASE_* removed; redeploy dep-d9kii12jobas73fl4bi0; tip 7837cd1; #783'
   - '2026-07-28 S023/EV-017 13-deploy-smoke SMOKE PASS (pending user approve) — H0c–H5 PASS; Playwright 5/5; tip 7837cd1; optional SUPABASE_* cleanup; validate-existing 2026-07-28; report deploy-smoke.md; #783'
   - '2026-07-28 S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
@@ -11249,9 +11286,10 @@ evolve_cycles:
       completed: '2026-07-27'
       note: E17-4A..E17-11 locked (D-S023-E17-scope-lock); F21/F22 allocated
     16-evolve:
-      status: in_progress
+      status: completed
       started: '2026-07-27'
-      note: Orchestrator active; 13-deploy-smoke SMOKE PASS pending user approve; tip 7837cd1; 03/05/06 skipped
+      completed: '2026-07-28'
+      note: 'COMPLETE — Phase 4 close D-S023-close; PR #790 open (tip 2e2f6c0; CI 30404410993; do not auto-merge); 03/05/06 skipped'
     01-requirements:
       status: completed
       mode: delta
@@ -15041,13 +15079,15 @@ evolve_cycles:
   merge_sha: '4660602'
 git_history:
   current_branch: evolve/EV-017-public-app-privacy
-  ahead_of_origin: 7
-  pushed: false
+  ahead_of_origin: 0
+  pushed: true
   pending_commit:
-  tip_sha: 7837cd1
-  tip_sha_full: 7837cd1bd50b75279e195293eab696073fa284ce
-  note: 'S023/EV-017 tip 7837cd1 — 13-deploy-smoke SMOKE PASS (pending user approve); H0c–H5 PASS; Playwright 5/5; validate-existing 2026-07-28; optional SUPABASE_* cleanup; #783'
+  tip_sha: 2e2f6c0
+  tip_sha_full: 2e2f6c022324585423f30765541f7ddc435def68
+  note: 'S023 CLOSED (D-S023-close) — tip 2e2f6c0; PR #790 open (CI 30404410993 success; mergeable; do not auto-merge); active_session=null; EV-017 completed; #783'
   notes:
+  - '2026-07-28 S023/EV-017 CLOSED (D-S023-close) — user option 2 push then close; PR #790 opened https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790; tip 2e2f6c0 (merge resolve main); CI run 30404410993 success; mergeable; do not auto-merge; active_session=null'
+  - '2026-07-28 S023/EV-017 tip synced — 2e2f6c0 (2e2f6c022324585423f30765541f7ddc435def68); "merge: resolve main into evolve/EV-017 for PR #790"; stage 16-evolve close; PR #790 open'
   - '2026-07-28 S023/EV-017 tip synced — 7837cd1 (7837cd1bd50b75279e195293eab696073fa284ce); "[13] fix: harden F22 privacy E2E locators + record live smoke"; stage 13-deploy-smoke; SMOKE PASS pending user approve; H0c–H5 PASS; Playwright 5/5'
   - '2026-07-28 S023/EV-017 tip synced — d459164 (d459164efe76caacb46ef38adaaa33d72beb731e); T7.4 checklist COMMITTED (still blocked awaiting RENDER_API_KEY for live env deletes); stage 07-build; active T7.4 blocked / T7.2 pending after T7.4; progress 27/~28; pending_commit cleared'
   - '2026-07-28 S023/EV-017 tip synced — f5aa024 (f5aa024483d2eef87611a4173ae0803efa1d372e); T7.3 COMPLETE (F21 public deploy corpus + EV-017 CHANGELOG draft); T7.4 blocked (D-S023-07-T7.4-blocked); stage 07-build; active T7.4 blocked / T7.2 pending after T7.4; progress 27/~28'
@@ -15236,16 +15276,20 @@ git_history:
     created_at: '2026-07-27'
     session_id: S023-public-app-privacy
     evolve_cycle_id: EV-017
-    note: 'Open/in_progress (base main). 07-build — M1–M6 complete; M7 active; T7.3 completed; T7.4 blocked (checklist @ d459164; awaiting RENDER_API_KEY); T7.2 pending after T7.4; progress 27/~28; tip d459164; interim draft PR #786 open.'
-    tip_sha: d459164
-    tip_sha_full: d459164efe76caacb46ef38adaaa33d72beb731e
+    note: 'Session closed D-S023-close (base main). EV-017 completed; tip 2e2f6c0; PR #790 open (CI 30404410993 success; mergeable; do not auto-merge). Interim draft PR #786 superseded/merged earlier.'
+    tip_sha: 2e2f6c0
+    tip_sha_full: 2e2f6c022324585423f30765541f7ddc435def68
     pushed: true
     pr_id: PR-EV-017
-    pr_number: 786
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/786
+    pr_number: 790
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/790
+    pr_title: '[EV-017] docs: S023 verify/deploy closeout + F22 E2E locator fix'
     pr_base: main
     pr_head: evolve/EV-017-public-app-privacy
-    pr_status: draft
+    pr_status: open
+    ci_run: '30404410993'
+    mergeable: true
+    do_not_auto_merge: true
   - name: evolve/EV-016-golden-examples-ui
     purpose: S021/EV-016 UI pre-loaded golden examples (#780); deepen F7; FE-only
     base: main
@@ -15939,6 +15983,18 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 2e2f6c022324585423f30765541f7ddc435def68
+    short: 2e2f6c0
+    branch: evolve/EV-017-public-app-privacy
+    message: 'merge: resolve main into evolve/EV-017 for PR #790'
+    stage: 16-evolve
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    files_changed: merge
+    timestamp: '2026-07-28'
+    pr_number: 790
+    note: 'Merge commit for PR #790; CI 30404410993 success; do not auto-merge'
+
   - sha: 7837cd1bd50b75279e195293eab696073fa284ce
     short: 7837cd1
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563; next 12-verify-deploy; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase C PASSED; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -104,7 +104,7 @@ active_session:
     skip_rationale:
     started: '2026-07-28'
     completed: '2026-07-28'
-    note: 'S023/EV-017 11-verify-impl COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts docs/sessions/S023-public-app-privacy/reports/verify-impl.md + docs/reports/implementation-verification.md; tip 657d440; next 12-verify-deploy; #783'
+    note: 'S023/EV-017 11-verify-impl COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts docs/sessions/S023-public-app-privacy/reports/verify-impl.md + docs/reports/implementation-verification.md; tip 17ad563; next 12-verify-deploy; #783'
   - stage: 12-verify-deploy
     required: true
     mode: full
@@ -3597,7 +3597,7 @@ stages:
     completed_at: '2026-07-28'
     session_id: S023-public-app-privacy
     evolve_cycle_id: EV-017
-    note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
+    note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563; next 12-verify-deploy; #783'
     report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
     overall: approved
     substeps:
@@ -3636,9 +3636,9 @@ stages:
       completed_at: '2026-07-28'
       mode: full
       branch: evolve/EV-017-public-app-privacy
-      tip_sha: 657d440
-      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
-      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts verify-impl.md + implementation-verification.md; tip 657d440; next 12-verify-deploy; #783'
+      tip_sha: 17ad563
+      tip_sha_full: 17ad5630c6a11e721a4a0871718d43cd9d5d36d2
+      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; artifacts verify-impl.md + implementation-verification.md; tip 17ad563; next 12-verify-deploy; #783'
       report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
       overall: approved
       feature_ids:
@@ -3747,7 +3747,7 @@ stages:
       report: docs/sessions/S011-f7-operator-ui/reports/verify-impl.md
       note: D-S011-EV008-f7-approve — F7 criteria 1–6 T0; H4–H5 waived to T6.4/CI; AdminDashboard advisory; issue closeout T6.5
     notes:
-    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
     - S021/EV-016 11-verify-impl STARTED 2026-07-26 — user approved non-deployed UI preview ("Looks good proceed"); committing 09/10 reports then running 11; tip 3d1c58b; gates.c_to_d / phase_c / phase_d remain pending (do NOT mark yet)
     - ? 2026-07-22 S020/EV-015 T5.6 tip recorded — tip/sha dc64b77 (dc64b77d07913c582668239c537832be381efad1); message "[T5.6] docs
       : 11-verify-impl PASS (D-S020-EV015-11-A; H4–H5→T5.7)"; stage 11-verify-impl; appended git_history.commits; T5.7 in_progress (13-deploy-smoke); progress 27/28; evolve PR to be opened; merge required before GHCR main-latest image redeploy; H1–H5 after merge; gates.c_to_d remains pending.
@@ -4469,9 +4469,9 @@ stages:
     started_at: '2026-07-27'
     completed_at:
     current_stage: 12-verify-deploy
-    note: 'S023/EV-017 16-evolve in_progress — 11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; #783'
+    note: 'S023/EV-017 16-evolve in_progress — 11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; #783'
     notes:
-    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+    - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
     - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
     - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
     - '2026-07-28 S023/EV-017 11-verify-impl STARTED — UI preview AskQuestion pending before feature approval; scope F21/F22 + F5/F7.h deepen; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
@@ -8939,8 +8939,8 @@ artifacts:
   updated_at: '2026-07-28'
   status: completed
   overall: approved
-  tip_sha: 657d440
-  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed'
+  tip_sha: 17ad563
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563'
 - path: docs/reports/implementation-verification.md
   type: standing-doc
   kind: implementation-verification
@@ -10991,10 +10991,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending); tip 657d440.'
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11 COMPLETE; next 12-verify-deploy (pending); tip 17ad563.'
   current_stage: 12-verify-deploy
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 657d440; next 12-verify-deploy; #783'
+  note: 'S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; tip 17ad563; next 12-verify-deploy; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11032,7 +11032,7 @@ evolve_cycles:
   - D-S023-11-uj-001-004
   - D-S023-11-uj-018-033
   notes:
-  - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
+  - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
   - '2026-07-28 S023/EV-017 D-S023-11-ui-preview-declined — UI preview declined (option 2 reports/tests only); journey + feature sign-off next; tip 657d440; #783'
   - '2026-07-28 S023/EV-017 tip 657d440 — [10] fix coverage_boost + 09/10 reports committed; 11-verify-impl still in_progress; verify-impl.md draft untracked; #783'
   - '2026-07-28 S023/EV-017 11-verify-impl STARTED — UI preview AskQuestion pending before feature approval; scope F21/F22 + F5/F7.h deepen; tip 836c1a4; uncommitted coverage_boost + qa/e2e reports + workflow-state; #783'
@@ -11076,7 +11076,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; 11 COMPLETE; next 12-verify-deploy (pending start); tip 657d440; 03/05/06 skipped
+      note: Orchestrator active; 11 COMPLETE; next 12-verify-deploy (pending start); tip 17ad563; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -11166,9 +11166,9 @@ evolve_cycles:
       completed: '2026-07-28'
       mode: full
       overall: approved
-      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 657d440; next 12-verify-deploy; #783'
-      tip_sha: 657d440
-      tip_sha_full: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
+      note: 'COMPLETE 2026-07-28 — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
+      tip_sha: 17ad563
+      tip_sha_full: 17ad5630c6a11e721a4a0871718d43cd9d5d36d2
       report: docs/sessions/S023-public-app-privacy/reports/verify-impl.md
       feature_ids:
       - F21
@@ -15737,6 +15737,21 @@ git_history:
     session_id: S022-rename-cutover
     pr_url:
   commits:
+  - sha: 17ad5630c6a11e721a4a0871718d43cd9d5d36d2
+    short: 17ad563
+    branch: evolve/EV-017-public-app-privacy
+    message: "[11] docs: complete F21/F22 implementation verification"
+    stage: 11-verify-impl
+    session_id: S023-public-app-privacy
+    files_changed:
+    - docs/feature-list.md
+    - docs/reports/implementation-verification.md
+    - docs/sessions/S023-public-app-privacy/routing-plan.md
+    - docs/sessions/S023-public-app-privacy/reports/verify-impl.md
+    - workflow-state.yaml
+    timestamp: '2026-07-28'
+    evolve_cycle_id: EV-017
+
   - sha: 657d4408b5b92aacd2dd465a9d7382bfea7144ba
     short: 657d440
     branch: evolve/EV-017-public-app-privacy

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -24,7 +24,7 @@ active_session:
   preset: Standard
   routing_decision_id: D-S023-00-open
   context_briefs: []
-  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 62af980; #783'
+  note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
   routing_plan:
   - stage: 00-context
     required: true
@@ -40,7 +40,7 @@ active_session:
     status: in_progress
     skip_rationale:
     started: '2026-07-27'
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 62af980; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 13-deploy-smoke STARTED; tip 52c14e9; #783'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -116,8 +116,11 @@ active_session:
   - stage: 13-deploy-smoke
     required: true
     mode: full
-    status: pending
+    status: in_progress
     skip_rationale:
+    started: '2026-07-28'
+    started_at: '2026-07-28'
+    note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
   skipped:
   - 03-plan-tooling
   - 05-verify-tech
@@ -4271,10 +4274,35 @@ stages:
     - S003 — strategy verified; deploy blocked on key rotation (Docker COPY fixed in repo)
     - S004 / EV-004 — strategy verified 2026-06-24; H0c 6/6 PASS; H4 FAIL (CORS); H5 PASS (/config.json); operator T1.3 + S003 keys + redeploy required before 13
   13-deploy-smoke:
-    status: completed
-    started_at: '2026-07-27'
-    session_id: S022-rename-cutover
+    status: in_progress
+    started_at: '2026-07-28'
+    started: '2026-07-28'
+    session_id: S023-public-app-privacy
+    evolve_cycle_id: EV-017
+    note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
+    tip_sha: 52c14e9
+    tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+    prior_tip_12: 62af980
+    report_expected: docs/sessions/S023-public-app-privacy/reports/deploy-smoke.md
+    checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+    t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
     delta_substages:
+    - id: S023-public-app-privacy
+      session_id: S023-public-app-privacy
+      evolve_cycle_id: EV-017
+      skill_id: 13-deploy-smoke
+      status: in_progress
+      mode: full
+      branch: evolve/EV-017-public-app-privacy
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      tip_sha: 52c14e9
+      tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+      prior_tip_12: 62af980
+      github_issue: 783
+      note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
+      checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+      t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
     - id: S022-rename-cutover
       session_id: S022-rename-cutover
       evolve_cycle_id:
@@ -4495,8 +4523,9 @@ stages:
     started_at: '2026-07-27'
     completed_at:
     current_stage: 13-deploy-smoke
-    note: 'S023/EV-017 16-evolve in_progress — Phase D 12 COMPLETE; next 13-deploy-smoke; tip 62af980; #783'
+    note: 'S023/EV-017 16-evolve in_progress — Phase D 13-deploy-smoke STARTED; tip 52c14e9; #783'
     notes:
+    - '2026-07-28 S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
     - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
     - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
     - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
@@ -11062,10 +11091,10 @@ evolve_cycles:
     provisional: false
     preset: Standard
     decision_id: D-S023-00-open
-    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; next 13-deploy-smoke; tip 62af980.'
+    note: 'Approved Standard routing (D-S023-00-open). Skip 03/05/06. Phase A+B+C passed; Phase D 09+10+11+12 COMPLETE; 13-deploy-smoke STARTED; tip 52c14e9.'
   current_stage: 13-deploy-smoke
   branch: evolve/EV-017-public-app-privacy
-  note: 'S023/EV-017 12-verify-deploy COMPLETE — checklist READY; mitigations+rollback approved; optional API SUPABASE_* cleanup at 13; next 13-deploy-smoke; tip 62af980; #783'
+  note: 'S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
   decision_refs:
   - D-S023-00-open
   - D-S023-E17-scope-lock
@@ -11105,6 +11134,7 @@ evolve_cycles:
   - D-S023-12-mitigations
   - D-S023-12-rollback
   notes:
+  - '2026-07-28 S023/EV-017 13-deploy-smoke STARTED — tip 52c14e9 (12 tip 62af980); checklist READY; optional API SUPABASE_* cleanup; #783'
   - '2026-07-28 S023/EV-017 12-verify-deploy COMPLETE — READY; mitigations+rollback approved; artifact reports/deploy-checklist.md; tip 62af980; next 13; #783'
   - '2026-07-28 S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
   - '2026-07-28 S023/EV-017 11-verify-impl COMPLETE — F21/F22 approved; F5/F7.h ack; T3→13; advisories disposed; verify-impl.md; tip 17ad563; next 12-verify-deploy; #783'
@@ -11151,7 +11181,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-07-27'
-      note: Orchestrator active; 12-verify-deploy STARTED; tip 62af980; 03/05/06 skipped
+      note: Orchestrator active; 13-deploy-smoke STARTED; tip 52c14e9; 03/05/06 skipped
     01-requirements:
       status: completed
       mode: delta
@@ -11257,15 +11287,28 @@ evolve_cycles:
       - D-S023-11-uj-018-033
       - D-S023-11-ui-preview-declined
     12-verify-deploy:
+      status: completed
+      started: '2026-07-28'
+      started_at: '2026-07-28'
+      completed: '2026-07-28'
+      completed_at: '2026-07-28'
+      mode: full
+      tip_sha: 62af980
+      tip_sha_full: 62af9806b5c76711cebb8fa74b59923f8f9e9637
+      overall: ready
+      report: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+      note: 'COMPLETE 2026-07-28 — READY; mitigations+rollback approved; tip 62af980; next 13; #783'
+    13-deploy-smoke:
       status: in_progress
       started: '2026-07-28'
       started_at: '2026-07-28'
       mode: full
-      tip_sha: 62af980
-      tip_sha_full: 62af9806b5c76711cebb8fa74b59923f8f9e9637
-      note: 'S023/EV-017 12-verify-deploy STARTED — tip 62af980; #783'
-    13-deploy-smoke:
-      status: pending
+      tip_sha: 52c14e9
+      tip_sha_full: 52c14e90dc5c53adabb2c172ef7b2612994e217d
+      prior_tip_12: 62af980
+      note: 'S023/EV-017 13-deploy-smoke STARTED 2026-07-28 — tip 52c14e9; reports/deploy-checklist.md READY; optional API SUPABASE_* cleanup; #783'
+      checklist: docs/sessions/S023-public-app-privacy/reports/deploy-checklist.md
+      t7_2_report: docs/sessions/S023-public-app-privacy/reports/t7.2-h4-h5-connectivity.md
     03-plan-tooling:
       status: skipped
       note: Standard routing skip; 04 prerequisite waived


### PR DESCRIPTION
## Summary
- Complete S023/EV-017 stages 08–13 artifacts (QA, E2E, verify-impl, deploy checklist/smoke, evolve-summary).
- Harden Playwright privacy locators (exact footer `Open privacy settings`) so live TC-F22-003 is stable.
- Mark F21/F22 **Implemented**; finalize CHANGELOG S023; record live API `SUPABASE_*` cleanup.

Live smoke already validated (H0c–H5 + Playwright 5/5). Primary F21 cutover landed via #786/#787/#788.

## Test plan
- [x] Local `make validate-ci` / pre-push hooks
- [x] Live `make test-live-connectivity` (H0c–H5)
- [x] Live Playwright `public-app-f21-f22.e2e.spec.ts` 5/5
- [ ] CI green on this branch


Made with [Cursor](https://cursor.com)