### PR TITLE
hotfix: SIGMET/AIRMET multi-line split PARSE_ERROR (BUG-2026-07-30)

### DIFF
--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -374,21 +374,24 @@ async def parse_files(request: Request) -> List[UploadFile]:
         )
 
 
-# Multi-line template advisories (F26/F27) — keep the whole buffer as one TAC entry.
-_MULTILINE_TEMPLATE_PRODUCTS = frozenset({"VAA", "TCA"})
+# Multi-line TAC products — keep the whole buffer as one entry (do not line-split).
+# SIGMET/AIRMET: WMO examples are header- + body= across lines (BUG-2026-07-30 / F23 UI).
+# VAA/TCA: advisory templates with labeled fields (F26/F27).
+_MULTILINE_TEMPLATE_PRODUCTS = frozenset({"SIGMET", "AIRMET", "VAA", "TCA"})
 
 
 def _is_multiline_template_product(product: Optional[str]) -> bool:
-    """Return True for VAA/TCA advisory products that must not be line-split."""
+    """Return True for products whose TAC must not be split one-entry-per-line."""
     return (product or "").strip().upper() in _MULTILINE_TEMPLATE_PRODUCTS
 
 
 def split_manual_entries(manual_text: str, product: Optional[str] = None) -> List[str]:
     """Split manual text into TAC entries.
 
-    Default (METAR/SPECI/TAF/SIGMET/AIRMET): one entry per non-empty line.
-    VAA/TCA (F26/F27): entire buffer is one multi-line advisory document —
-    line-splitting would shred template fields (``VA ADVISORY`` / ``DTG:`` / …).
+    Default (METAR/SPECI/TAF): one entry per non-empty line.
+    SIGMET/AIRMET/VAA/TCA: entire buffer is one multi-line document —
+    line-splitting would shred the header/body (SIGMET/AIRMET) or template
+    fields (``VA ADVISORY`` / ``DTG:`` / …).
     """
     if not manual_text:
         return []
@@ -403,8 +406,8 @@ def manual_entries_with_offsets(manual_text: str, product: Optional[str] = None)
 
     Offsets point at the first non-whitespace character of each kept entry so
     soft-preview ``failed_spans`` can be remapped onto the full editor document.
-    For VAA/TCA the single entry offset is the first non-whitespace character of
-    the buffer (document preserved with internal newlines).
+    For SIGMET/AIRMET/VAA/TCA the single entry offset is the first non-whitespace
+    character of the buffer (document preserved with internal newlines).
     """
     if not manual_text:
         return []

--- a/apps/backend/tests/unit/test_api_helper_functions_unit.py
+++ b/apps/backend/tests/unit/test_api_helper_functions_unit.py
@@ -77,6 +77,15 @@ def test_split_manual_entries_and_normalizers():
     tca = "TC ADVISORY\nDTG: 20040925/1900Z\n"
     assert api_module.split_manual_entries(tca, product="TCA") == [tca.strip()]
 
+    sigmet = (
+        "YUDD SIGMET 2 VALID 101200/101600 YUSO-\n"
+        "YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN=\n"
+    )
+    assert api_module.split_manual_entries(sigmet, product="SIGMET") == [sigmet.strip()]
+    sig_off = api_module.manual_entries_with_offsets(sigmet, product="SIGMET")
+    assert len(sig_off) == 1
+    assert "SHANLON" in sig_off[0][0]
+
     assert api_module.normalize_code(" kjfk ", 4) == "KJFK"
     assert api_module.normalize_code("", 4) is None
     assert api_module.normalize_validation_level("icao-opmet") == "icao_opmet"

--- a/apps/backend/tests/unit/test_api_helpers_middleware_unit.py
+++ b/apps/backend/tests/unit/test_api_helpers_middleware_unit.py
@@ -39,6 +39,19 @@ def test_split_manual_entries_vaa_tca_keep_multiline() -> None:
     assert api_module.split_manual_entries(tca, product="tca") == [tca.strip()]
 
 
+def test_split_manual_entries_sigmet_airmet_keep_multiline() -> None:
+    sigmet = (
+        "YUDD SIGMET 2 VALID 101200/101600 YUSO-\n"
+        "YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN=\n"
+    )
+    assert api_module.split_manual_entries(sigmet, product="SIGMET") == [sigmet.strip()]
+    airmet = (
+        "YUDD AIRMET 1 VALID 101200/101600 YUSO-\n"
+        "YUDD SHANLON FIR/UIR ISOL TS FCST N OF S50 TOP FL350 MOV E 20KT WKN=\n"
+    )
+    assert api_module.split_manual_entries(airmet, product="airmet") == [airmet.strip()]
+
+
 @pytest.mark.parametrize(
     "value,max_length,expected",
     [

--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -663,7 +663,7 @@ export function FileConverter({
       console.log('[FileConverter] Conversion response:', response);
 
       if (response.results && Array.isArray(response.results)) {
-        // Match backend split_manual_entries (product-aware: VAA/TCA stay one doc).
+        // Match backend split_manual_entries (SIGMET/AIRMET/VAA/TCA stay one doc).
         const manualLines = splitManualEntries(manualInput, resolvedProduct);
         const manualResultCount = manualLines.length;
 

--- a/apps/frontend/src/utils/tacProduct.test.ts
+++ b/apps/frontend/src/utils/tacProduct.test.ts
@@ -57,6 +57,20 @@ describe('splitManualEntries', () => {
     ]);
   });
 
+  it('keeps SIGMET multi-line report as a single document', () => {
+    const sigmet =
+      'YUDD SIGMET 2 VALID 101200/101600 YUSO-\n' +
+      'YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN=\n';
+    expect(splitManualEntries(sigmet, 'SIGMET')).toEqual([sigmet.trim()]);
+  });
+
+  it('keeps AIRMET multi-line report as a single document', () => {
+    const airmet =
+      'YUDD AIRMET 1 VALID 101200/101600 YUSO-\n' +
+      'YUDD SHANLON FIR/UIR ISOL TS FCST N OF S50 TOP FL350 MOV E 20KT WKN=\n';
+    expect(splitManualEntries(airmet, 'AIRMET')).toEqual([airmet.trim()]);
+  });
+
   it('keeps VAA multi-line advisory as a single document', () => {
     const vaa = 'VA ADVISORY\nDTG: 20240923/0130Z\nVAAC: TOKYO\n';
     expect(splitManualEntries(vaa, 'VAA')).toEqual([vaa.trim()]);

--- a/apps/frontend/src/utils/tacProduct.ts
+++ b/apps/frontend/src/utils/tacProduct.ts
@@ -68,15 +68,20 @@ export function resolveConvertProduct(
   return selection;
 }
 
-/** Products whose TAC is a multi-line template document (must not be line-split). */
-const MULTILINE_TEMPLATE_PRODUCTS = new Set<TacProduct>(['VAA', 'TCA']);
+/** Products whose TAC is a multi-line document (must not be line-split). */
+const MULTILINE_TEMPLATE_PRODUCTS = new Set<TacProduct>([
+  'SIGMET',
+  'AIRMET',
+  'VAA',
+  'TCA',
+]);
 
 /**
  * Split manual TAC input into conversion entries (mirrors backend
  * ``split_manual_entries``).
  *
- * METAR/SPECI/TAF/SIGMET/AIRMET: one entry per non-empty line.
- * VAA/TCA: entire buffer is one advisory document (F26/F27).
+ * METAR/SPECI/TAF: one entry per non-empty line.
+ * SIGMET/AIRMET/VAA/TCA: entire buffer is one document (header/body or advisory).
  *
  * @param manualText - Editor buffer
  * @param product - Resolved convert product

--- a/docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
+++ b/docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
@@ -9,7 +9,7 @@
 | **Remediation path** | local-first — deploy only after explicit approval |
 | **Session** | S028-sigmet-multiline-split |
 | **Branch** | fix/BUG-2026-07-30-sigmet-multiline-split |
-| **PR** | — |
+| **PR** | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/796 |
 
 ## Error description
 
@@ -112,6 +112,7 @@ TDD iteration log:
 | confirm_hotfix_plan | Proceed |
 | repro_test_matches_symptom | Yes |
 | investigation_root_cause | Agree — line-split of SIGMET/AIRMET; proceed to fix |
+| hotfix_commit_pr | Commit + push + open PR (#796) |
 
 ## Prevention & countermeasures
 

--- a/docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
+++ b/docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
@@ -1,0 +1,122 @@
+# BUG-2026-07-30 — SIGMET multi-line split → PARSE_ERROR
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixed (awaiting commit / PR / deploy approval) |
+| **Feature** | F7 soft-preview / convert + F23 SIGMET quality (UI path) |
+| **Severity** | high (WMO demo example fails in workbench) |
+| **Classification** | code bug (product-aware entry split) |
+| **Remediation path** | local-first — deploy only after explicit approval |
+| **Session** | S028-sigmet-multiline-split |
+| **Branch** | fix/BUG-2026-07-30-sigmet-multiline-split |
+| **PR** | — |
+
+## Error description
+
+Loading Examples catalog item **SIGMET WMO A6-1a-TS** (two-line TAC) shows:
+
+- **Failed-TAC** `PARSE_ERROR` — `unable to parse SIGMET header`
+- Soft-preview IWXXM with **nil geometry** and `intensityChange="NO_CHANGE"` (body not applied)
+- Decode residuals for tokens that belong on the second line (`SHANLON FIR/UIR`, `S OF N54…`, `FL390`, …)
+
+The same TAC converts cleanly via `tac2iwxxm.convert` when passed as **one** string. The failure is in the **HTTP convert / soft-preview** path that **line-splits** manual text.
+
+## Error logs
+
+User UI (production workbench, 2026-07-30):
+
+```
+Failed-TAC
+PARSE_ERROR
+unable to parse SIGMET header
+Soft-preview only — not a Schematron-passed publish.
+
+TAC:
+YUDD SIGMET 2 VALID 101200/101600 YUSO-
+YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN=
+```
+
+Live API probe (`POST /api/v1/convert`, product=SIGMET, profile=annex3):
+
+```
+successful=1 failed=1
+issues: manual_input_2 — PARSE_ERROR: unable to parse SIGMET header
+result0 tac_input: "YUDD SIGMET 2 VALID 101200/101600 YUSO-"   # line 1 only
+preview failed_spans: [{start: 40, end: 122, code: PARSE_ERROR, message: unable to parse SIGMET header}]
+preview XML: intensityChange="NO_CHANGE", geometry nilReason=missing (no posList)
+```
+
+Local library (same full buffer):
+
+```
+convert(..., product='SIGMET') → ok=True, issues=[], has posList
+```
+
+## Investigation
+
+### Timeline
+
+| When | Note |
+|------|------|
+| 2026-07-29 | F23 / S025 closed — library goldens + live smoke PASS (single-entry convert) |
+| 2026-07-30 | User reports UI failure on catalog example `sigmet-A6-1a-TS` |
+| 2026-07-30 | Live convert shows `manual_input_1` + `manual_input_2` split |
+
+### Hypotheses
+
+| # | Hypothesis | Result |
+|---|------------|--------|
+| H1 | SIGMET header regex broken for WMO A6-1a TAC | **Rejected** — full-buffer `convert()` succeeds |
+| H2 | Wrong product sent (METAR/AIRMET) | **Partial** — console shows cross-product lint noise; live SIGMET still fails via split |
+| H3 | `split_manual_entries` line-splits SIGMET; body line fails header parse | **Confirmed** — VAA/TCA already exempt; SIGMET/AIRMET still per-line |
+
+### Root cause (provisional)
+
+`apps/backend/src/api.py` `split_manual_entries` / `manual_entries_with_offsets` treat SIGMET/AIRMET like METAR (one entry per non-empty line). WMO SIGMET examples are **two lines** (`…YUSO-` then body `…=`). Line 1 soft-converts with empty body; line 2 raises `unable to parse SIGMET header`.
+
+Mirror: `apps/frontend/src/utils/tacProduct.ts` `MULTILINE_TEMPLATE_PRODUCTS` = VAA/TCA only.
+
+Related prior: BUG-2026-07-15 (span offsets for multi-line **METAR** batches) — different bug; same splitter.
+
+## Repro test
+
+| Path | Status |
+|------|--------|
+| `tests/bugs/test_bug_2026_07_30_sigmet_multiline_split.py` | **RED** 2026-07-30 → **GREEN** 2026-07-30 |
+
+TDD iteration log:
+
+1. Wrote split + soft-preview assertions for WMO A6-1a-TS — both fail as expected (line-split).
+2. Extended multiline product set with SIGMET+AIRMET (BE+FE) — both green.
+
+## Fix
+
+- `apps/backend/src/api.py` — `_MULTILINE_TEMPLATE_PRODUCTS` includes `SIGMET`/`AIRMET` (with VAA/TCA).
+- `apps/frontend/src/utils/tacProduct.ts` — mirror set + docs; `FileConverter` comment.
+- Unit tests: backend helpers + FE `tacProduct.test.ts`.
+
+## Interview record
+
+| Step | Answer |
+|------|--------|
+| hotfix_intent | Report a new issue |
+| symptom_type | Error / wrong soft-preview on WMO SIGMET example |
+| where_seen | Production Render |
+| when_started | Unknown / noticed after F23 (library OK; UI path broken) |
+| repro_frequency | Every time |
+| repro_environment | Production (live API confirmed); local library OK |
+| user_severity | High — catalog demo fails |
+| evidence_available | Yes — full UI paste + live API probe |
+| already_tried | Nothing noted |
+| remediation_path | Fix locally first — deploy only after I approve |
+| confirm_hotfix_plan | Proceed |
+| repro_test_matches_symptom | Yes |
+| investigation_root_cause | Agree — line-split of SIGMET/AIRMET; proceed to fix |
+
+## Prevention & countermeasures
+
+*(Phase 5)*
+
+## Cursor rule
+
+*(Phase 5.1)*

--- a/docs/sessions/S028-sigmet-multiline-split/routing-plan.md
+++ b/docs/sessions/S028-sigmet-multiline-split/routing-plan.md
@@ -1,0 +1,8 @@
+# Routing plan — S028-sigmet-multiline-split
+
+| Stage | Required | Mode | Status |
+|-------|----------|------|--------|
+| 00-context | yes | scoped | completed |
+| 14-hotfix | yes | full | in_progress |
+
+Skip: 15-service-health unless production verify is requested after merge.

--- a/docs/sessions/S028-sigmet-multiline-split/session-brief.md
+++ b/docs/sessions/S028-sigmet-multiline-split/session-brief.md
@@ -1,0 +1,16 @@
+# Session brief — S028-sigmet-multiline-split
+
+| Field | Value |
+|-------|-------|
+| **Type** | hotfix |
+| **Intent** | Hotfix BUG-2026-07-30 — SIGMET/AIRMET multi-line manual TAC incorrectly line-split → PARSE_ERROR unable to parse SIGMET header on WMO A6-1a-TS UI example |
+| **Branch** | `fix/BUG-2026-07-30-sigmet-multiline-split` |
+| **Orchestrator** | 14-hotfix |
+| **Bug report** | [docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md](../../docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md) |
+| **Started** | 2026-07-30 |
+| **Status** | in_progress |
+
+## Routing
+
+1. `00-context` — scoped (completed at open)
+2. `14-hotfix` — full (in_progress)

--- a/tests/bugs/test_bug_2026_07_30_sigmet_multiline_split.py
+++ b/tests/bugs/test_bug_2026_07_30_sigmet_multiline_split.py
@@ -1,0 +1,102 @@
+"""BUG-2026-07-30 — SIGMET/AIRMET multi-line manual TAC must not be line-split.
+
+WMO ``sigmet-A6-1a-TS`` is two lines (header ``…YUSO-`` + body ``…=``). Line-splitting
+yields ``manual_input_2`` → ``PARSE_ERROR: unable to parse SIGMET header`` and a
+soft-preview with nil geometry — matching production UI Failed-TAC on the catalog demo.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = ROOT / "apps" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from src import api as api_module  # noqa: E402
+from src.utilities.security import verify_supabase_token  # noqa: E402
+
+SIGMET_A6_1A_TS = (
+    "YUDD SIGMET 2 VALID 101200/101600 YUSO-\n"
+    "YUDD SHANLON FIR/UIR OBSC TS FCST S OF N54 AND E OF W012 TOP FL390 MOV E 20KT WKN=\n"
+)
+
+AIRMET_A6_1A_TS = (
+    "YUDD AIRMET 1 VALID 101200/101600 YUSO-\n"
+    "YUDD SHANLON FIR/UIR ISOL TS FCST N OF S50 TOP FL350 MOV E 20KT WKN=\n"
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    async def override_verify_token():
+        return {"sub": str(uuid4()), "aud": "test-project"}
+
+    api_module.app.dependency_overrides[verify_supabase_token] = override_verify_token
+    test_client = TestClient(api_module.app)
+    yield test_client
+    api_module.app.dependency_overrides.clear()
+
+
+def test_split_manual_entries_keeps_sigmet_airmet_multiline() -> None:
+    """Product-aware split must preserve SIGMET/AIRMET as one document (like VAA/TCA)."""
+    sigmet_entries = api_module.split_manual_entries(SIGMET_A6_1A_TS, product="SIGMET")
+    assert len(sigmet_entries) == 1, (
+        f"SIGMET must stay one entry; got {len(sigmet_entries)}: {sigmet_entries!r}"
+    )
+    assert "SHANLON" in sigmet_entries[0]
+    assert "YUSO-" in sigmet_entries[0]
+
+    airmet_entries = api_module.split_manual_entries(AIRMET_A6_1A_TS, product="AIRMET")
+    assert len(airmet_entries) == 1, (
+        f"AIRMET must stay one entry; got {len(airmet_entries)}: {airmet_entries!r}"
+    )
+
+    # METAR batching by line remains unchanged.
+    metars = api_module.split_manual_entries(
+        "METAR KJFK 161200Z 12012KT 10SM FEW250 22/14 A3015=\n"
+        "METAR EGLL 161220Z 09010KT 9999 SCT030 10/05 Q1018=\n",
+        product="METAR",
+    )
+    assert len(metars) == 2
+
+
+def test_sigmet_a6_1a_soft_preview_no_header_parse_error(client: TestClient) -> None:
+    """Soft-preview of WMO A6-1a-TS must not emit header PARSE_ERROR from line 2."""
+    response = client.post(
+        "/api/v1/convert",
+        data={
+            "manual_text": SIGMET_A6_1A_TS,
+            "product": "SIGMET",
+            "profile": "annex3",
+            "iwxxm_version": "2025-2",
+            "preview": "true",
+            "stop_on_error": "false",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    spans = payload.get("failed_spans") or []
+    header_errors = [
+        s
+        for s in spans
+        if s.get("code") == "PARSE_ERROR"
+        and "unable to parse SIGMET header" in (s.get("message") or "")
+    ]
+    assert header_errors == [], (
+        "two-line SIGMET was line-split; body line failed header parse: "
+        f"{header_errors!r}; all spans={spans!r}"
+    )
+    results = payload.get("results") or []
+    assert len(results) == 1, f"expected one IWXXM result, got {len(results)}"
+    xml = results[0].get("content") or ""
+    assert "posList" in xml or "AirspaceVolume" in xml, (
+        "expected geometry from body line; soft-preview looks header-only"
+    )
+    assert 'intensityChange="WEAKEN"' in xml or "WEAKEN" in xml

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,11 +1,36 @@
-overall_status: in_progress  # pipeline idle — active_session null after S027/EV-021 close 2026-07-30
+overall_status: in_progress  # S028 hotfix open — SIGMET multiline split (BUG-2026-07-30)
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 27
+session_counter: 28
 evolve_cycle_counter: 21
-active_session: null
+active_session:
+  id: S028-sigmet-multiline-split
+  type: hotfix
+  intent: "Hotfix BUG-2026-07-30 — SIGMET/AIRMET multi-line manual TAC incorrectly line-split → PARSE_ERROR unable to parse SIGMET header on WMO A6-1a-TS UI example"
+  status: in_progress
+  branch: fix/BUG-2026-07-30-sigmet-multiline-split
+  orchestrator: 14-hotfix
+  evolve_cycle_id: null
+  artifacts_dir: docs/sessions/S028-sigmet-multiline-split/
+  current_stage: 14-hotfix
+  started_at: "2026-07-30"
+  context_briefs: []
+  bug_report: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: scoped
+    status: completed
+    completed: "2026-07-30"
+    note: Session open via workflow-state-manager open_session (hotfix); routing 14-only pending user amend for 15
+  - stage: 14-hotfix
+    required: true
+    mode: full
+    status: in_progress
+    started: "2026-07-30"
+    note: "BUG-2026-07-30 open — pointer docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md"
 sessions:
 - id: S027-vaa-quality
   type: feature
@@ -5807,16 +5832,21 @@ stages:
     completed_at: '2026-07-27'
     note: 'H0c/H1/H4/H5 PASS; live UJ-032 PASS (Examples load + authed Convert → ZIP 1); PyPI Trusted Publisher still pending'
   14-hotfix:
-    status: completed
-    session_id: S012-empty-bearer-lint-tac
-    current_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
-    bug_status: resolved
+    status: in_progress
+    session_id: S028-sigmet-multiline-split
+    current_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
+    bug_status: open
     remediation_path: local-first
-    note: 'BUG-2026-07-15 resolved; PR #721 merged 6412b21; production verified; Cursor rule frontend-auth-token-hydrate.mdc'
-    completed_at: '2026-07-15'
-    pr_number: 721
-    merge_sha: 6412b21
+    started_at: '2026-07-30'
+    started: '2026-07-30'
+    note: 'S028 open — BUG-2026-07-30 SIGMET/AIRMET multi-line manual TAC line-split → PARSE_ERROR; prior S012 resolved (kept in notes)'
+    prior_session_id: S012-empty-bearer-lint-tac
+    prior_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    prior_bug_status: resolved
+    prior_pr_number: 721
+    prior_merge_sha: 6412b21
     notes:
+    - 2026-07-30 — S028-sigmet-multiline-split open (BUG-2026-07-30 SIGMET/AIRMET multi-line split); pointer docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md; cleared S012 as current.
     - 2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared stale S009 pointer.
     - 2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4).
     - 2026-07-12 — S006 closed (S006-R5); docs reorg unblocked — open via 00-context (process session), not 14-hotfix.
@@ -18882,8 +18912,9 @@ git_history:
   pending_commit:
   tip_sha: df56d1f
   tip_sha_full: df56d1fce29a22970d72b49c77733e0616369e43
-  note: 'S027/EV-021 CLOSED (D-S027-close) — PR #794 merged df56d1f; H1–H5 + live VAA/TCA smoke PASS; F26/F27 Done; active_session=null; pipeline idle; upcoming docs close commit pending; #736/#737'
+  note: 'S028 open — hotfix BUG-2026-07-30 sigmet-multiline-split; branch fix/BUG-2026-07-30-sigmet-multiline-split recorded active (base main); session_counter 28; tip remains df56d1f on main until checkout'
   notes:
+  - '2026-07-30 S028-sigmet-multiline-split open — branch fix/BUG-2026-07-30-sigmet-multiline-split recorded active (base main @ df56d1f); session_counter 28; stages.14-hotfix in_progress; bug docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md'
   - '2026-07-30 S027/EV-021 CLOSED (D-S027-close) — PR #794 merged df56d1f; workflow-state update + upcoming docs close commit pending; active_session=null; pipeline idle on main; #736/#737'
   - '2026-07-30 S027/EV-021 13-deploy-smoke COMPLETE (D-S027-E21-13-merge) — tip df56d1f; H1–H5 + live VAA/TCA PASS; deploys dep-d9lmsdflk1mc739232ug / dep-d9lmsefqj5pc739d3it0; #736/#737'
   - '2026-07-30 S027/EV-021 tip synced — a2ebef0 (a2ebef070b6ae31aaa71e0f2014ecb84799431bd); M5 complete T5.1–T5.3; stage 07-build; next M6 T6.1; not pushed; #736/#737'
@@ -19095,6 +19126,17 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: fix/BUG-2026-07-30-sigmet-multiline-split
+    purpose: "S028 hotfix BUG-2026-07-30 — SIGMET/AIRMET multi-line manual TAC incorrectly line-split"
+    base: main
+    status: active
+    created: '2026-07-30'
+    created_at: '2026-07-30'
+    session_id: S028-sigmet-multiline-split
+    note: 'Session opened; git create deferred to parent/14-hotfix; base main @ df56d1f'
+    tip_sha: df56d1f
+    tip_sha_full: df56d1fce29a22970d72b49c77733e0616369e43
+    pushed: false
   - name: evolve/EV-021-vaa-quality
     purpose: "S027/EV-021 VAA + TCA quality bars (#736/#737); F26/F27"
     base: main


### PR DESCRIPTION
## Summary
- Keep SIGMET/AIRMET manual TAC as one multi-line document in convert/soft-preview split (same as VAA/TCA), so WMO A6-1a-TS no longer fails with `PARSE_ERROR: unable to parse SIGMET header`.
- Mirror the product set in the frontend `splitManualEntries` helper.
- Add regression test `tests/bugs/test_bug_2026_07_30_sigmet_multiline_split.py` and bug report.

## Test plan
- [x] `uv run pytest tests/bugs/test_bug_2026_07_30_sigmet_multiline_split.py` (red → green)
- [x] Backend split unit tests + FE `tacProduct.test.ts`
- [ ] CI green on this branch
- [ ] After merge/deploy: load Examples → SIGMET WMO A6-1a-TS — no Failed-TAC header parse; soft-preview has geometry / WKN

Bug report: `docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md`  
Session: S028-sigmet-multiline-split


Made with [Cursor](https://cursor.com)