### PR TITLE
hotfix: SPECI A3-2 F9 decode residuals (BUG-2026-07-30)

### DIFF
--- a/docs/bug-reports/BUG-2026-07-30-speci-decode-residuals.md
+++ b/docs/bug-reports/BUG-2026-07-30-speci-decode-residuals.md
@@ -1,0 +1,108 @@
+# BUG-2026-07-30 — SPECI A3-2 decode residuals (F9)
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixed locally — awaiting commit/PR/deploy approval |
+| **Feature** | F9 value-aware decode / plain-language (operator CODE panel) |
+| **Severity** | medium (catalog SPECI demo shows undecoded residuals; IWXXM convert OK) |
+| **Classification** | code bug (decode explainer gaps vs convert parser) |
+| **Remediation path** | local-first — deploy only after explicit approval |
+| **Session** | ad-hoc 14-hotfix (active_session was null) |
+| **Branch** | fix/BUG-2026-07-30-speci-decode-residuals |
+| **PR** | — |
+
+## Error description
+
+Loading / decoding Annex 3 **SPECI A3-2** (`SPECI YUDO … 1200NE +TSRA BKN005CB … TEMPO TL1200 … BECMG AT1200 8000 NSW NSC=`) shows CODE/PLAIN LANGUAGE residuals for groups that convert already maps into IWXXM:
+
+- `1200NE` (minimum visibility + sector)
+- `BKN005CB` (cloud + CB)
+- `TEMPO TL1200` / `BECMG AT1200` (trend change + time)
+- `NSW` (no significant weather in trend)
+
+Plain-language summary also mis-attributes trend visibility (`0600`, `8000`) as prevailing observation visibility because those tokens match the generic 4-digit vis explainer while trend keywords stay residual.
+
+Convert (`tac2iwxxm.convert`, profile `annex3`) succeeds with `minimumVisibility`, cloud CB, and both trend forecasts — **not** an IWXXM emit bug.
+
+## Error logs
+
+User UI (operator workbench decode panel, 2026-07-30):
+
+```
+[lint-tac] 1 issue(s): [MISSING_PRODUCT_KEYWORD] SPECI TAC must contain one of ['SPECI']
+[lint-tac] 2 issue(s): [INVALID_RVR] METAR invalid RVR token 'R12/1000U' — research R8; [NSW_PRESENT] METAR NSW present — research T3 / S1
+PLAIN LANGUAGE
+… Prevailing visibility 3000 m; Heavy thunderstorm with rain; … Prevailing visibility 600 m; Prevailing visibility 8000 m; No significant cloud. Not decoded: 1200NE BKN005CB TEMPO TL1200 BECMG AT1200 NSW.
+RESIDUALS
+1200NE
+BKN005CB
+TEMPO TL1200
+BECMG AT1200
+```
+
+Local library probe (`decode_tac(..., product="SPECI")`):
+
+```
+residuals: ['1200NE', 'BKN005CB', 'TEMPO TL1200', 'BECMG AT1200', 'NSW']
+convert(..., product='SPECI', profile='annex3') → ok=True, issues=[]
+  minimumVisibility / trendForecast present
+```
+
+Note: lint lines referencing `R12/1000U` / `MISSING_PRODUCT_KEYWORD` look like cross-product UI noise — **out of scope** for this hotfix (decode-only).
+
+## Investigation
+
+### Timeline
+
+| When | Note |
+|------|------|
+| 2026-07-30 | User reports SPECI residuals on “standard IWXXM” workbench decode |
+| 2026-07-30 | Confirmed fixture = `speci_a3_2.tac` / frontend `speci_a3_2.tac` |
+| 2026-07-30 | Convert OK; gaps isolated to `_explain_metar_speci` in `decode.py` |
+
+### Hypotheses
+
+| # | Hypothesis | Result |
+|---|------------|--------|
+| H1 | Convert/IWXXM missing min-vis / cloud / trends | **Rejected** — annex3 emit includes them |
+| H2 | F9 METAR/SPECI explainer lacks min-vis, CB/TCU, trend tokens, NSW | **Confirmed** |
+| H3 | Cloud regex rejects `BKN005CB` (no CB/TCU group) | **Confirmed** |
+
+### Root cause (provisional)
+
+`packages/tac2iwxxm/src/tac2iwxxm/decode.py` `_explain_metar_speci` / `_CLOUD` do not cover groups that `products/metar_speci.py` already parses for convert. TAF decode already explains `TEMPO`/`BECMG`; METAR/SPECI path does not.
+
+## Repro test
+
+| Path | Status |
+|------|--------|
+| `tests/bugs/test_bug_2026_07_30_speci_decode_residuals.py` | **RED** 2026-07-30 → **GREEN** 2026-07-30 |
+
+TDD iteration log:
+
+1. Asserted SPECI A3-2 explains `1200NE`, `BKN005CB`, `TEMPO`/`TL1200`, `BECMG`/`AT1200`, `NSW` and keeps them out of residuals — failed as expected.
+2. Extended `_explain_metar_speci` + cloud/min-vis/trend-time patterns — repro green; F9 decode suites (61) green.
+
+## Fix
+
+- `packages/tac2iwxxm/src/tac2iwxxm/decode.py`:
+  - `_VIS_MIN` — minimum visibility + compass sector
+  - `_CLOUD` — optional `CB`/`TCU`; `_fmt_cloud` names the type
+  - `_TREND_TIME` — `TL`/`AT`/`FM` + HHMM for METAR/SPECI trends
+  - Explain `TEMPO` / `BECMG` / `NOSIG` / `NSW`; mark `in_trend` so trend vis/wx/cloud wording is distinct from observation
+
+## Interview record
+
+| Step | Answer |
+|------|--------|
+| Intent | Investigate + fix (go-ahead) |
+| Scope | Decode / plain-language residuals only |
+| Sample | SPECI A3-2 (exact golden / catalog) |
+
+## Prevention & countermeasures
+
+— (Phase 5)
+
+## Cursor rule
+
+— (deferred until close)

--- a/docs/bug-reports/BUG-2026-07-30-speci-decode-residuals.md
+++ b/docs/bug-reports/BUG-2026-07-30-speci-decode-residuals.md
@@ -9,7 +9,7 @@
 | **Remediation path** | local-first — deploy only after explicit approval |
 | **Session** | ad-hoc 14-hotfix (active_session was null) |
 | **Branch** | fix/BUG-2026-07-30-speci-decode-residuals |
-| **PR** | — |
+| **PR** | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/805 |
 
 ## Error description
 

--- a/packages/tac2iwxxm/src/tac2iwxxm/decode.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/decode.py
@@ -22,7 +22,9 @@ _SUPPORTED = frozenset({"AIRMET", "METAR", "SIGMET", "SPECI", "TAF", "VAA", "TCA
 _WIND = re.compile(r"^(?P<dir>\d{3}|VRB)(?P<spd>\d{2,3})(?:G(?P<gust>\d{2,3}))?(?P<unit>KT|MPS)$")
 _VIS_SM = re.compile(r"^(?P<mod>[PM])?(?P<val>\d{1,2})SM$")
 _VIS_M = re.compile(r"^\d{4}$")
-_CLOUD = re.compile(r"^(?P<amt>FEW|SCT|BKN|OVC|SKC|CLR|NSC|NCD)(?P<hgt>\d{3})?$")
+# Minimum visibility with compass sector (e.g. 1200NE) — after prevailing metres.
+_VIS_MIN = re.compile(r"^(?P<vis>\d{4})(?P<dir>N|NE|E|SE|S|SW|W|NW)$")
+_CLOUD = re.compile(r"^(?P<amt>FEW|SCT|BKN|OVC|SKC|CLR|NSC|NCD)(?P<hgt>\d{3})?(?P<ctype>CB|TCU)?$")
 _TEMP = re.compile(r"^(?P<t>M?\d{2})/(?P<td>M?\d{2})$")
 _ALT = re.compile(r"^A(?P<val>\d{4})$")
 _QNH = re.compile(r"^Q(?P<val>\d{3,4})$")
@@ -31,6 +33,8 @@ _STATION = re.compile(r"^[A-Z][A-Z0-9]{3}$")
 _TAF_VALID = re.compile(r"^(?P<d1>\d{2})(?P<h1>\d{2})/(?P<d2>\d{2})(?P<h2>\d{2})$")
 _TAF_FM = re.compile(r"^FM(?P<dd>\d{2})(?P<hh>\d{2})(?P<mm>\d{2})$")
 _TAF_PROB = re.compile(r"^PROB(?P<pct>\d{2})$")
+# METAR/SPECI trend time indicators (TL/AT/FM + HHMM) — distinct from TAF FMDDHHMM.
+_TREND_TIME = re.compile(r"^(?P<kind>TL|AT|FM)(?P<hh>\d{2})(?P<mm>\d{2})$")
 _SIG_VALID = re.compile(r"^(?P<d1>\d{2})(?P<h1>\d{2})(?P<m1>\d{2})/(?P<d2>\d{2})(?P<h2>\d{2})(?P<m2>\d{2})$")
 _SIG_FL = re.compile(r"^FL(?P<fl>\d{2,3})$")
 _SIG_SPEED_KT = re.compile(r"^(?P<spd>\d{1,3})KT$")
@@ -46,6 +50,12 @@ _SIG_DIR_NAME = {
     "SW": "Southwest",
     "W": "West",
     "NW": "Northwest",
+}
+_CLOUD_TYPE = {"CB": "cumulonimbus", "TCU": "towering cumulus"}
+_TREND_TIME_LABEL = {
+    "TL": "until",
+    "AT": "at",
+    "FM": "from",
 }
 _WX = re.compile(
     r"^(?P<int>\+|-|VC)?"
@@ -133,9 +143,11 @@ def _fmt_cloud(m: re.Match[str], *, forecast: bool) -> str:
     if forecast:
         amount = f"Forecast {amount[0].lower()}{amount[1:]}"
     height = m.group("hgt")
+    ctype = m.group("ctype")
+    type_note = f" ({_CLOUD_TYPE[ctype]})" if ctype else ""
     if height:
-        return f"{amount} at {int(height) * 100:,} ft"
-    return amount
+        return f"{amount} at {int(height) * 100:,} ft{type_note}"
+    return f"{amount}{type_note}"
 
 
 def _fmt_wx(m: re.Match[str], *, forecast: bool) -> str:
@@ -200,6 +212,17 @@ def _explain_metar_speci(token: str, *, product: str, seen: dict[str, int]) -> s
         return "Nil report (no observation)"
     if upper == "CAVOK":
         return "Ceiling and visibility OK"
+    if upper == "NOSIG":
+        seen["in_trend"] = 1
+        return "No significant change expected"
+    if upper == "TEMPO":
+        seen["in_trend"] = 1
+        return "Temporary fluctuations expected during the following period"
+    if upper == "BECMG":
+        seen["in_trend"] = 1
+        return "Becoming — gradual change during the following period"
+    if upper == "NSW":
+        return "No significant weather"
     if upper == "RMK":
         return "Remarks section"
     if upper == "AO1":
@@ -221,11 +244,19 @@ def _explain_metar_speci(token: str, *, product: str, seen: dict[str, int]) -> s
     if m := _WIND.match(upper):
         return _fmt_wind(m, label="Surface wind")
     if m := _VIS_SM.match(upper):
-        return _fmt_vis_sm(m, label="Prevailing visibility")
+        label = "Trend visibility" if seen.get("in_trend") else "Prevailing visibility"
+        return _fmt_vis_sm(m, label=label)
+    if m := _VIS_MIN.match(upper):
+        compass = _SIG_DIR_NAME[m.group("dir")]
+        return f"Minimum visibility {int(m.group('vis'))} m toward {compass} ({m.group('dir')})"
     if _VIS_M.match(upper):
-        return f"Prevailing visibility {int(upper)} m"
+        label = "Trend visibility" if seen.get("in_trend") else "Prevailing visibility"
+        return f"{label} {int(upper)} m"
+    if m := _TREND_TIME.match(upper):
+        kind = m.group("kind")
+        return f"Trend time — {_TREND_TIME_LABEL[kind]} {m.group('hh')}:{m.group('mm')} UTC"
     if m := _CLOUD.match(upper):
-        return _fmt_cloud(m, forecast=False)
+        return _fmt_cloud(m, forecast=bool(seen.get("in_trend")))
     if m := _TEMP.match(upper):
         return f"Temperature {_signed_temp(m.group('t'))} °C, dewpoint {_signed_temp(m.group('td'))} °C"
     if m := _ALT.match(upper):
@@ -233,7 +264,7 @@ def _explain_metar_speci(token: str, *, product: str, seen: dict[str, int]) -> s
     if m := _QNH.match(upper):
         return f"QNH {int(m.group('val'))} hPa"
     if m := _WX.match(upper):
-        return _fmt_wx(m, forecast=False)
+        return _fmt_wx(m, forecast=bool(seen.get("in_trend")))
     if upper.startswith("PK") or upper == "WND":
         return "Peak wind remarks token"
     _ = product

--- a/tests/bugs/test_bug_2026_07_30_speci_decode_residuals.py
+++ b/tests/bugs/test_bug_2026_07_30_speci_decode_residuals.py
@@ -1,0 +1,71 @@
+"""BUG-2026-07-30 — SPECI A3-2 F9 decode must not residual min-vis/cloud/trends/NSW.
+
+Annex 3 SPECI A3-2 converts cleanly to IWXXM, but ``decode_tac`` left
+``1200NE``, ``BKN005CB``, ``TEMPO``/``TL1200``, ``BECMG``/``AT1200``, and ``NSW``
+as residuals in the operator CODE / PLAIN LANGUAGE panel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tac2iwxxm.decode import decode_tac
+
+ROOT = Path(__file__).resolve().parents[2]
+SPECI_A3_2 = (
+    (
+        ROOT
+        / "packages"
+        / "tac2iwxxm"
+        / "tests"
+        / "fixtures"
+        / "annex3_golden"
+        / "speci_a3_2.tac"
+    )
+    .read_text(encoding="utf-8")
+    .strip()
+)
+
+# Tokens that must be explained individually (not coalesced into residuals).
+_MUST_EXPLAIN = (
+    "1200NE",
+    "BKN005CB",
+    "TEMPO",
+    "TL1200",
+    "BECMG",
+    "AT1200",
+    "NSW",
+)
+
+
+def test_speci_a3_2_decode_explains_min_vis_cloud_trends_nsw() -> None:
+    """WMO SPECI A3-2 decode must cover groups convert already emits to IWXXM."""
+    result = decode_tac(SPECI_A3_2, product="SPECI")
+    by_code = {seg.code: seg.explanation for seg in result.segments}
+    residual_text = " ".join(r.text for r in result.residuals)
+
+    for token in _MUST_EXPLAIN:
+        assert token in by_code, (
+            f"expected segment for {token!r}; residuals={residual_text!r}; "
+            f"codes={sorted(by_code)}"
+        )
+        assert by_code[token].strip(), f"empty explanation for {token!r}"
+
+    assert "1200" in by_code["1200NE"]
+    assert "NE" in by_code["1200NE"] or "northeast" in by_code["1200NE"].lower()
+    assert "500" in by_code["BKN005CB"] or "5,00" in by_code["BKN005CB"]
+    assert "cumulonimbus" in by_code["BKN005CB"].lower() or "CB" in by_code["BKN005CB"]
+    assert "temporary" in by_code["TEMPO"].lower() or "TEMPO" in by_code["TEMPO"]
+    assert "12:00" in by_code["TL1200"] or "1200" in by_code["TL1200"]
+    assert "becoming" in by_code["BECMG"].lower() or "BECMG" in by_code["BECMG"]
+    assert "12:00" in by_code["AT1200"] or "1200" in by_code["AT1200"]
+    assert "weather" in by_code["NSW"].lower() or "NSW" in by_code["NSW"]
+
+    for token in _MUST_EXPLAIN:
+        assert token not in residual_text, (
+            f"{token!r} still in residuals: {residual_text!r}"
+        )
+
+    assert "Not decoded:" not in result.summary or not any(
+        t in result.summary for t in ("1200NE", "BKN005CB", "TEMPO", "BECMG", "NSW")
+    )


### PR DESCRIPTION
## Summary
- Fix F9 METAR/SPECI decode so Annex 3 SPECI A3-2 no longer leaves `1200NE`, `BKN005CB`, `TEMPO`/`TL…`, `BECMG`/`AT…`, or `NSW` as CODE/PLAIN LANGUAGE residuals (convert→IWXXM was already correct).
- Add bug report + `tests/bugs` regression for SPECI A3-2.
- Trend visibility/weather/cloud wording is labeled distinctly once a trend keyword is seen.

## Test plan
- [x] `uv run pytest tests/bugs/test_bug_2026_07_30_speci_decode_residuals.py`
- [x] F9 decode suites (value-aware / summary / decode_tac / glossary) — 61 passed
- [ ] CI green on PR branch
- [ ] (optional) Operator UI: load SPECI A3-2 example — residuals empty; min-vis/CB/trends explained

Refs: `docs/bug-reports/BUG-2026-07-30-speci-decode-residuals.md`


Made with [Cursor](https://cursor.com)