### PR TITLE
[EV-027] Official WMO decode residual matrix (#815)

### DIFF
--- a/apps/frontend/src/app/components/FileConverter.test.tsx
+++ b/apps/frontend/src/app/components/FileConverter.test.tsx
@@ -220,8 +220,17 @@ vi.mock('./ui/sonner', () => ({
 describe('FileConverter Component', () => {
   const defaultProps = {};
 
+  // Coverage + full-suite load routinely exceeds Vitest's default 5s on Branch Path cases.
+  vi.setConfig({ testTimeout: 20_000 });
+
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
+    // Reset queued Once/implementations so coverage runs do not leak mocks across cases.
+    mockConvertMetarToIwxxm.mockReset();
+    mockConvertBulletin.mockReset();
+    mockDecodeTac.mockReset();
+    mockLintTac.mockReset();
     localStorage.clear();
     mockSignOutWithScope.mockResolvedValue(true);
     mockPersistSession.mockResolvedValue(null);
@@ -229,6 +238,31 @@ describe('FileConverter Component', () => {
       success: true,
       data: '<iwxxm>test</iwxxm>',
     });
+    mockConvertBulletin.mockResolvedValue({
+      bulletin_meta: {
+        ahl: 'SAUS31 KZNY 121200',
+        report_count: 0,
+        tt: 'SA',
+        aa: 'US',
+        cccc: 'KZNY',
+        yygggg: '121200',
+      },
+      results: [],
+    });
+    mockDecodeTac.mockResolvedValue({
+      product: 'METAR',
+      segments: [{ start: 0, end: 5, code: 'METAR', explanation: 'type' }],
+      residuals: [],
+    });
+    mockLintTac.mockResolvedValue({
+      ok: true,
+      issues: [{ severity: 'error', code: 'x', message: 'm', start: 0, end: 5 }],
+      fixes: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   describe('Rendering', () => {

--- a/apps/frontend/src/fixtures/examples/FIXTURE_GAPS.md
+++ b/apps/frontend/src/fixtures/examples/FIXTURE_GAPS.md
@@ -10,9 +10,22 @@ samples (`wmoReference`) per ADR-032 amend.
 | SPECI   | 1 (`annex3_golden/speci_a3_2.tac`)                                | Second WMO SPECI — none in vendor pin                                                                                                                     |
 | TAF     | 2 (`taf_a5_1` + `taf_a5_2`)                                       | none                                                                                                                                                      |
 | SIGMET  | 4 (A6-1a-TS + A6-1b-CNL + VA-EGGX ref + multi-location-VA passer) | TC SIGMET A6-2 deferred (#738 / S02.M2); **#809** `sigmet-multi-location-VA` ADR-032 equality **green** (TC-EV025-008) → catalog `wmoPass` (TC-EV025-009) |
-| AIRMET  | 1 (`airmet_a6_1a_ts`)                                             | CNL peer — none in vendor pin                                                                                                                             |
-| **VAA** | **1** (`annex3_golden/vaa_a7_2.tac`)                              | Second WMO VAA — none in vendor pin                                                                                                                       |
-| **TCA** | **1** (`annex3_golden/tca_a2_2.tac`)                              | Second WMO TCA — none in vendor pin                                                                                                                       |
+
+### Stem-level deferrals (EV-027 / #815 inventory)
+
+Happy-path sample menu covers all in-scope single-report official peers under pin
+`2025-2`. Explicit non-menu stems (package inventory SoT
+`packages/tac2iwxxm/tests/fixtures/wmo_official_tac_inventory.py`):
+
+| Stem                                    | Reason                                                         |
+| --------------------------------------- | -------------------------------------------------------------- | ----------------------------------- |
+| `sigmet-A6-2-TC`                        | TC SIGMET deferred (#738)                                      |
+| `metar-NIL-collect` / `taf-NIL-collect` | COLLECT / validate shape — not sample-menu happy-path (EV-024) |
+| `*-translation-failed*`                 | quarantine                                                     |
+| `spacewx-*` / `vona-*`                  | deferred products                                              |
+| AIRMET                                  | 1 (`airmet_a6_1a_ts`)                                          | CNL peer — none in vendor pin       |
+| **VAA**                                 | **1** (`annex3_golden/vaa_a7_2.tac`)                           | Second WMO VAA — none in vendor pin |
+| **TCA**                                 | **1** (`annex3_golden/tca_a2_2.tac`)                           | Second WMO TCA — none in vendor pin |
 
 `vaa_basic` / `tca_basic` product_matrix demos are **hidden** once WMO passers unlock (E21-3 / S02.M2).
 

--- a/apps/frontend/src/fixtures/examples/examplesCatalog.test.ts
+++ b/apps/frontend/src/fixtures/examples/examplesCatalog.test.ts
@@ -157,6 +157,29 @@ describe('examplesCatalog WMO-passers (TC-F25-003)', () => {
     expect(getTacExamplesForProduct('SIGMET').length).toBeGreaterThanOrEqual(4);
   });
 
+  it('registers every EV-027 inventory happy-path official seed (TC-EV027-002)', () => {
+    // Mirrors packages/tac2iwxxm/tests/fixtures/wmo_official_tac_inventory.py registered peers.
+    const expected: ReadonlyArray<{ id: string; seed: string }> = [
+      { id: 'metar_a3_1', seed: 'metar-A3-1' },
+      { id: 'speci_a3_2', seed: 'speci-A3-2' },
+      { id: 'taf_a5_1', seed: 'taf-A5-1' },
+      { id: 'taf_a5_2', seed: 'taf-A5-2' },
+      { id: 'sigmet_a6_1a_ts', seed: 'sigmet-A6-1a-TS' },
+      { id: 'sigmet_a6_1b_cnl', seed: 'sigmet-A6-1b-CNL' },
+      { id: 'sigmet_va_eggx', seed: 'sigmet-VA-EGGX' },
+      { id: 'sigmet_multi_location_va', seed: 'sigmet-multi-location-VA' },
+      { id: 'airmet_a6_1a_ts', seed: 'airmet-A6-1a-TS' },
+      { id: 'vaa_a7_2', seed: 'va-advisory-A7-2' },
+      { id: 'tca_a2_2', seed: 'tc-advisory-A2-2' },
+    ];
+    for (const { id, seed } of expected) {
+      const ex = getExampleById(id);
+      expect(ex, `missing catalog id ${id}`).toBeDefined();
+      expect(ex?.wmoSeed).toBe(seed);
+      expect(ex?.wmoPass === true || ex?.wmoReference === true).toBe(true);
+    }
+  });
+
   it('documents vendor mirror provenance policy', () => {
     expect(WMO_PROVENANCE_NOTE).toMatch(/vendor\/schemas\/iwxxm/);
     expect(WMO_PROVENANCE_NOTE.toLowerCase()).toMatch(/mirror/);

--- a/docs/context/wmo-decode-residual-matrix.md
+++ b/docs/context/wmo-decode-residual-matrix.md
@@ -1,0 +1,56 @@
+# Context — Official WMO decode residual matrix (#815)
+
+**Session:** S034-wmo-decode-residual-matrix · **Cycle:** EV-027  
+**Mode:** scoped · **Date:** 2026-07-31
+
+## Problem
+
+Sample menu + catalog work (EV-024 / UJ-039 / #804) made official stems **loadable**, but CI
+does not yet assert **decode residual emptiness** across the full official TAC corpus.
+Unexpected `"Not decoded: …"` on textbook WMO examples erodes operator trust.
+
+## Issue SoT
+
+[#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815) — Quality: official WMO IWXXM TAC
+examples load cleanly with no unexpected decode residuals.
+
+## Feature / journey map
+
+| Item | Ref |
+|------|-----|
+| Features | **F25 deepen**, **F9 deepen**, **F7.g deepen** (no new Fn proposed) |
+| Journeys | UJ-039, UJ-036; deepen UJ-020 / decode residual clauses |
+| ADR | ADR-032 (catalog tiers); ADR-025 (decode-tac / summary) |
+| Prior | #780, #702, #804, S029 (parked), `FIXTURE_GAPS.md`, `test_tc_f9_sigmet_a6_decode_residuals.py`, BUG-2026-07-30 |
+
+## Products in scope
+
+METAR, SPECI, TAF, SIGMET, AIRMET, VAA, TCA (F6 seven). Deferred products stay out unless
+already catalogued.
+
+## Catalog snapshot (current `FIXTURE_GAPS`)
+
+| Product | Catalog TAC count | Noted gaps |
+|---------|-------------------|------------|
+| METAR | 1 | Second WMO METAR — none in pin |
+| SPECI | 1 | Second WMO SPECI — none in pin |
+| TAF | 2 | none |
+| SIGMET | 4 | TC A6-2 deferred (#738); multi-location-VA now passer |
+| AIRMET | 1 | CNL peer — none in pin |
+| VAA | 1 | Second — none in pin |
+| TCA | 1 | Second — none in pin |
+
+## Suggested first steps (from #815)
+
+1. Diff vendor pin TAC peers vs `examplesCatalog.ts` + package annex3 fixtures
+2. Run decode over the union; dump residual text per stem
+3. Triage: fix coverage vs expected-allowlist vs child issue
+4. Lock the matrix in CI before closing
+
+## Non-goals
+
+Encode equality promotion; IWXXM-US in WMO menu; inventing TAC; new products beyond F6 seven.
+
+## UI surfaces
+
+Workbench sample menu + F9 decode panel residual chrome — optional H4–H5 / local preview.

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -28,6 +28,12 @@
 | S02.M2 | decision | Gate C residual bar? | **2** — all seven target empty; allowlist only if standing docs say intentional (F9 G4 / ADR-025) + child issue (`D-S034-EV027-s02m2-2`) |
 | S02.L1 | decision | Inventory SoT? | **1** — pytest-discovered vendor/mirrored peers (`D-S034-EV027-s02l1-1`) |
 | E27-02 | decision | Gate A / 02 close? | **PASS** — Batch F 1,2,1; Lean → **04-tech-plan** (`D-S034-02-phase-a`) |
+| E27-T1 | decision | Build order? | **2** — catalog completeness first, then residual matrix (`D-S034-E27-T-batch`) |
+| E27-T2 | decision | Decode fix grain? | **1** — one commit per product family / theme |
+| E27-T3 | decision | New deps? | **2** — AskQuestion per new dep (prefer none) |
+| E27-T4 | decision | Gate C? | **1** — matrix + catalog∪gaps + #815/children required (no soft escape) |
+| E27-T5 | decision | Draft plan? | **1** — M0–M3 as written (catalog-first order) |
+| E27-04 | decision | Gate B? | **1** — approve → **07-build** @ T0.1 (`D-S034-04-plan-approve`) |
 
 **Scope (verbatim)**: Every in-scope official WMO IWXXM TAC peer from the vendor pin is
 loadable from the workbench sample menu (or explicitly deferred in `FIXTURE_GAPS`) and

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -24,6 +24,10 @@
 | E27-UJ | decision | Journey id? | **1** — new **UJ-042**; deepen UJ-039 / UJ-020 |
 | E27-TC | decision | TC ids? | **1** — new **TC-EV027-001..005** |
 | E27-E1 | decision | Close 01 → 02? | **1** — mark 01 completed; start **02-verify-plan** (`D-S034-E27-E1`) |
+| S02.M1 | decision | Allowlist SoT? | **1** — package test artifact; FIXTURE_GAPS = catalog/load only (`D-S034-EV027-s02m1-1`) |
+| S02.M2 | decision | Gate C residual bar? | **2** — all seven target empty; allowlist only if standing docs say intentional (F9 G4 / ADR-025) + child issue (`D-S034-EV027-s02m2-2`) |
+| S02.L1 | decision | Inventory SoT? | **1** — pytest-discovered vendor/mirrored peers (`D-S034-EV027-s02l1-1`) |
+| E27-02 | decision | Gate A / 02 close? | **PASS** — Batch F 1,2,1; Lean → **04-tech-plan** (`D-S034-02-phase-a`) |
 
 **Scope (verbatim)**: Every in-scope official WMO IWXXM TAC peer from the vendor pin is
 loadable from the workbench sample menu (or explicitly deferred in `FIXTURE_GAPS`) and

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -34,6 +34,8 @@
 | E27-T4 | decision | Gate C? | **1** — matrix + catalog∪gaps + #815/children required (no soft escape) |
 | E27-T5 | decision | Draft plan? | **1** — M0–M3 as written (catalog-first order) |
 | E27-04 | decision | Gate B? | **1** — approve → **07-build** @ T0.1 (`D-S034-04-plan-approve`) |
+| E27-GC | decision | Gate C / PR? | **1** — push + PR to main; close #815 on merge; link #820; waive TC-EV027-005 / 13 (`D-S034-gate-c`) |
+| E27-13 | decision | 13-deploy-smoke? | **waived** — no FE deploy this cycle |
 
 **Scope (verbatim)**: Every in-scope official WMO IWXXM TAC peer from the vendor pin is
 loadable from the workbench sample menu (or explicitly deferred in `FIXTURE_GAPS`) and

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,44 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-027 — Official WMO decode residual matrix (#815) (S034)
+
+**Session**: S034-wmo-decode-residual-matrix  
+**Features**: Deepen **F25** / **F9** / **F7.g** — no new Fn  
+**Issues**: [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815)  
+**Started**: 2026-07-31  
+**Branch**: `evolve/EV-027-wmo-decode-residual-matrix`  
+**Status**: in_progress  
+
+### Scope (Phase 0 — locked 2026-07-31)
+
+| ID | Category | Question | Decision |
+|----|----------|----------|----------|
+| E27-1 | decision | Session + scope? | **1** — S034 / EV-027; #815 inventory + residual matrix + CI (`D-S034-open=1`) |
+| E27-2 | decision | Routing? | **1** — Lean+build `00→16→01→02→04→07→08→10` (+13 when ships) |
+| E27-3 | decision | UI preview now? | **2** — no; proceed from docs/repo; re-offer after build |
+| E27-4 | decision | Residual triage? | **1** — fix decode in-cycle when cheap; else allowlist + child issue (no silent leftovers) |
+| E27-M | decision | Document Manifest? | **1** — lean: feature-list + UJ-042 + test-plan TC-EV027 + decisions; skip Spec/Config/API/Deploy (`D-S034-E27-M`) |
+| E27-UJ | decision | Journey id? | **1** — new **UJ-042**; deepen UJ-039 / UJ-020 |
+| E27-TC | decision | TC ids? | **1** — new **TC-EV027-001..005** |
+| E27-E1 | decision | Close 01 → 02? | **1** — mark 01 completed; start **02-verify-plan** (`D-S034-E27-E1`) |
+
+**Scope (verbatim)**: Every in-scope official WMO IWXXM TAC peer from the vendor pin is
+loadable from the workbench sample menu (or explicitly deferred in `FIXTURE_GAPS`) and
+decode leaves no residuals unless on a documented expected-residual allowlist; unexpected
+residuals fail CI.
+
+**In:** inventory SoT; load-path parity; decode residual matrix; parametrized CI; child
+issues for stems that cannot close in-cycle.
+
+**Out:** inventing TAC; `wmoReference`→`wmoPass` encode equality; IWXXM-US in WMO menu;
+new products beyond F6 seven; deferred SWX/VONA/WAFS/QVACI / TC-SIGMET A6-2 unless already
+catalogued.
+
+**Supersedes:** S029 / EV-022 (parked) narrow SIGMET A6-1a residual work — broadened by #815.
+
+---
+
 ## Cycle EV-026 — #809 VA multi-location ADR-032 equality / wmoPass (S033)
 
 **Session**: S033-va-multi-location-equality  

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -335,6 +335,10 @@
 | EV-027/E27-UJ | Journey | **New UJ-042**; deepen UJ-039 / UJ-020 | confirmed |
 | EV-027/E27-TC | TC ids | **New TC-EV027-001..005** | confirmed |
 | EV-027/E27-E1 | Close 01 | Mark 01 completed → start 02-verify-plan | confirmed |
+| EV-027/S02.M1 | Allowlist SoT | Package test artifact; FIXTURE_GAPS = catalog/load gaps only | confirmed |
+| EV-027/S02.M2 | Gate C bar | All seven target empty residuals; allowlist only with standing-doc intent (F9 G4 / ADR-025) + child issue | confirmed |
+| EV-027/S02.L1 | Inventory SoT | Pytest-discovered vendor/mirrored TAC peers | confirmed |
+| EV-027/E27-02 | Gate A | PASS Batch F 1,2,1 → 04-tech-plan | confirmed |
 
 ## EV-026 / #809 — VA multi-location ADR-032 equality / wmoPass (2026-07-31)
 

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -323,6 +323,19 @@
 | EV-024/S02.L1 | Vitest | Amend examplesCatalog tests for pass **or** reference in 07 | confirmed |
 | EV-024/E24-02 | Gate A | PASS Batch F 1,1,1 → 04-tech-plan | confirmed |
 
+## EV-027 / #815 — Official WMO decode residual matrix (2026-07-31)
+
+| ID | Topic | Decision | Status |
+|----|-------|----------|--------|
+| EV-027/E27-1 | Session | Open S034 / EV-027; #815 inventory + residual matrix + CI | confirmed |
+| EV-027/E27-2 | Routing | Lean+build; 13 when ships; skip 03/05/06/09/11/12 | confirmed |
+| EV-027/E27-3 | UI preview | Defer until after build (`D-S034-open` Q3=2) | confirmed |
+| EV-027/E27-4 | Triage | Fix decode when cheap; else allowlist + child issue (no silent leftovers) | confirmed |
+| EV-027/E27-M | Docs | **Lean** — feature-list + user-journeys (UJ-042) + test-plan (TC-EV027-001..005) + requirements/evolve decisions; skip Spec/Config/API/Deploy | confirmed |
+| EV-027/E27-UJ | Journey | **New UJ-042**; deepen UJ-039 / UJ-020 | confirmed |
+| EV-027/E27-TC | TC ids | **New TC-EV027-001..005** | confirmed |
+| EV-027/E27-E1 | Close 01 | Mark 01 completed → start 02-verify-plan | confirmed |
+
 ## EV-026 / #809 — VA multi-location ADR-032 equality / wmoPass (2026-07-31)
 
 | ID | Topic | Decision | Status |

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -339,6 +339,8 @@
 | EV-027/S02.M2 | Gate C bar | All seven target empty residuals; allowlist only with standing-doc intent (F9 G4 / ADR-025) + child issue | confirmed |
 | EV-027/S02.L1 | Inventory SoT | Pytest-discovered vendor/mirrored TAC peers | confirmed |
 | EV-027/E27-02 | Gate A | PASS Batch F 1,2,1 → 04-tech-plan | confirmed |
+| EV-027/E27-T1..T5 | Batch T | Order/grain/deps/Gate C/draft = **2,1,2,1,1** | confirmed |
+| EV-027/E27-04 | Gate B | Approve M0–M3 (catalog-first) → 07-build @ T0.1 | confirmed |
 
 ## EV-026 / #809 — VA multi-location ADR-032 equality / wmoPass (2026-07-31)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -953,8 +953,9 @@
 - **What it does**:
   1. Inventory official WMO TAC peers under the vendor pin; match catalog ∪ `FIXTURE_GAPS`
   2. Every in-scope peer loads from the sample menu **or** has an explicit gap + child issue
-  3. Decode residual matrix: happy-path official TAC → `residuals == []` except documented
-     expected-residual allowlist (`E27-4` triage: fix when cheap, else allowlist + child)
+  3. Decode residual matrix: happy-path official TAC → `residuals == []` for all seven
+     products (**S02.M2=2**); allowlist only when standing docs mark residuals intentional
+     (F9 **G4** / ADR-025) + linked child issue — fix when cheap otherwise (`E27-4`)
   4. Unexpected residuals fail parametrized CI (not only manual UI checks)
 - **Acceptance**:
   1. Inventory SoT checked in (docs or generated list) matches catalog ∪ `FIXTURE_GAPS`

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-07-31 (S033 / EV-026 — #809 VA multi-location ADR-032 equality / wmoPass)
+> **Last updated**: 2026-07-31 (S034 / EV-027 — #815 official WMO decode residual matrix)
 
 ## Summary
 
@@ -911,10 +911,10 @@
 
 ### F23 / F6 / F7.g deepen (S033 / EV-026 — #809 VA multi-location equality)
 
-- **Status**: **In progress** (S033 / EV-026) — no new Fn; equality + catalog promote
+- **Status**: **Done** (S033 / EV-026) — PR #817 / #818; #809 closed
 - **Issues**: [#809](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/809)
 - **Runtime SoT**: `vendor/manifest.json` → IWXXM **v2025-2**
-- **What it does**: Make `canonicalize_xml(convert(sigmet-multi-location-VA.tac))` equal
+- **What it did**: Make `canonicalize_xml(convert(sigmet-multi-location-VA.tac))` equal
   vendor XML under annex3 + default pin (ADR-032); flip soft golden → strict; promote
   catalog `wmoReference` → `wmoPass`; close #809
 - **Acceptance**:
@@ -927,23 +927,65 @@
 - **Out of scope**: US REMARKS reopen; #738; sample-menu removal
 - **Packages / apps**: `packages/tac2iwxxm` encode + annex3 golden; frontend catalog /
   FIXTURE_GAPS / Vitest (no new UI surface)
-- **Source**: E26-*; [evolve-decisions.md](decisions/evolve-decisions.md) §EV-026;
+- **Source**: E26-*; [evolve-report-EV-026.md](evolve-report-EV-026.md);
   [Context: va-multi-location-809](context/va-multi-location-809.md)
 
 ### F6 deepen (S033 / EV-026)
 
 - **Status note**: F6 remains **Implemented**; encoder deltas for multi-location VA shape /
-  metadata so ADR-032 equality holds.
+  metadata so ADR-032 equality holds. **Done** with EV-026.
 
 ### F7.g deepen (S033 / EV-026)
 
 - **Status note**: F7 remains **Planned**; catalog tier flip only (`wmoPass`) when equality
-  holds — no new UI surface.
+  holds — no new UI surface. **Done** with EV-026.
 
 ### F23 deepen (S033 / EV-026)
 
-- **Status note**: F23 remains **Done**; this cycle completes #809 multi-location VA
-  convert equality / catalog promote (**UJ-041**).
+- **Status note**: F23 remains **Done**; EV-026 completed #809 multi-location VA convert
+  equality / catalog promote (**UJ-041**).
+
+### F25 / F9 / F7.g deepen (S034 / EV-027 — #815 official WMO decode residual matrix)
+
+- **Status**: **In progress** (S034 / EV-027) — no new Fn; inventory + residual CI gate
+- **Issues**: [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815)
+- **Runtime SoT**: `vendor/manifest.json` → IWXXM **v2025-2**
+- **What it does**:
+  1. Inventory official WMO TAC peers under the vendor pin; match catalog ∪ `FIXTURE_GAPS`
+  2. Every in-scope peer loads from the sample menu **or** has an explicit gap + child issue
+  3. Decode residual matrix: happy-path official TAC → `residuals == []` except documented
+     expected-residual allowlist (`E27-4` triage: fix when cheap, else allowlist + child)
+  4. Unexpected residuals fail parametrized CI (not only manual UI checks)
+- **Acceptance**:
+  1. Inventory SoT checked in (docs or generated list) matches catalog ∪ `FIXTURE_GAPS`
+  2. Load path green for registered stems (ADR-032 `wmoPass` / `wmoReference`)
+  3. Residual matrix CI green for happy-path peers; allowlist documented; child issues for
+     stems deferred in-cycle
+  4. GitHub #815 closable when AC met
+- **Journeys / tests**: **UJ-042** (new); deepen **UJ-039** / **UJ-020**; **TC-EV027-001..005**
+  (`E27-UJ=1`, `E27-TC=1`)
+- **Out of scope**: inventing TAC; encode equality promotion; IWXXM-US in WMO menu; new
+  products beyond F6 seven; deferred SWX/VONA/WAFS/QVACI / TC-SIGMET A6-2 unless catalogued
+- **Packages / apps**: `packages/tac2iwxxm` decode + fixtures; FE catalog / FIXTURE_GAPS /
+  Vitest; optional H4–H5 when FE ships
+- **Source**: E27-*; [evolve-decisions.md](decisions/evolve-decisions.md) §EV-027;
+  [Context: wmo-decode-residual-matrix](context/wmo-decode-residual-matrix.md)
+- **Supersedes**: S029 / EV-022 (parked) narrow SIGMET A6-1a residual work
+
+### F25 deepen (S034 / EV-027)
+
+- **Status note**: F25 remains **Done**; this cycle deepens beyond catalog listing to
+  **decode residual emptiness** on official TAC peers (**UJ-042** / TC-EV027).
+
+### F9 deepen (S034 / EV-027)
+
+- **Status note**: F9 remains **Done**; matrix asserts `decode_tac` residuals empty or
+  allowlisted for official WMO peers (deepen **UJ-020**).
+
+### F7.g deepen (S034 / EV-027)
+
+- **Status note**: F7 remains **Planned**; inventory ↔ catalog ∪ `FIXTURE_GAPS` completeness
+  for official WMO TAC peers (deepen **UJ-039**).
 
 ## Platform Feature Details (Monorepo Migration)
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,7 +25,8 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S033-va-multi-location-equality](S033-va-multi-location-equality/session-brief.md) | feature | in_progress | #809 ADR-032 equality → wmoPass; EV-026 | evolve/EV-026-va-multi-location-equality | 2026-07-31 | — |
+| [S034-wmo-decode-residual-matrix](S034-wmo-decode-residual-matrix/session-brief.md) | feature | in_progress | #815 official WMO decode residual matrix; EV-027 | evolve/EV-027-wmo-decode-residual-matrix | 2026-07-31 | — |
+| [S033-va-multi-location-equality](S033-va-multi-location-equality/session-brief.md) | feature | completed | #809 ADR-032 equality → wmoPass; EV-026; PR #817/#818 | evolve/EV-026-va-multi-location-equality | 2026-07-31 | 2026-07-31 |
 | [S032-iwxxm-us-remarks-va](S032-iwxxm-us-remarks-va/session-brief.md) | feature | completed | iwxxm-us REMARKS + #809 soft; EV-025; PR #816 | evolve/EV-025-iwxxm-us-remarks-va | 2026-07-31 | 2026-07-31 |
 | [S029-sigmet-decode-residuals](S029-sigmet-decode-residuals/session-brief.md) | feature | in_progress | F9 deepen — SIGMET/AIRMET decode residual A6-1a tokens; EV-022 | feat/EV-022-sigmet-decode-residuals | 2026-07-30 | — |
 | [S028-sigmet-multiline-split](S028-sigmet-multiline-split/session-brief.md) | hotfix | completed | BUG-2026-07-30 SIGMET multiline split; PR #796 | fix/BUG-2026-07-30-sigmet-multiline-split | 2026-07-30 | 2026-07-30 |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
@@ -1,0 +1,40 @@
+# 01-requirements report — S034 / EV-027
+
+**Date**: 2026-07-31  
+**Mode**: delta  
+**Cycle**: EV-027 · **Issue**: [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815)
+
+## Phase 0 lock (E27-1..4)
+
+| ID | Decision |
+|----|----------|
+| E27-1 | S034 / EV-027; #815 inventory + residual matrix + CI |
+| E27-2 | Lean+build (+13 when ships) |
+| E27-3 | UI preview deferred until after build |
+| E27-4 | Fix when cheap; else allowlist + child issue |
+| E27-M | **1** — lean feature-list + UJ-042 + test-plan |
+| E27-UJ | **1** — new UJ-042; deepen UJ-039 / UJ-020 |
+| E27-TC | **1** — new TC-EV027-001..005 |
+
+## Documents updated
+
+| Doc | Delta |
+|-----|-------|
+| `docs/feature-list.md` | EV-026 → Done; new S034/EV-027 deepen F25/F9/F7.g |
+| `docs/user-journeys.md` | **UJ-042** + deepen UJ-039 / UJ-020 |
+| `docs/test-plan.md` | TC-EV027-001..005 + EV-027 gate; EV-026 gate checked |
+| `docs/decisions/evolve-decisions.md` | §EV-027 + E27-M/UJ/TC |
+| `docs/decisions/requirements-decisions.md` | EV-027 table |
+| Session brief / routing / context | Phase 0 artifacts |
+
+## Skipped (manifest)
+
+Spec · Config Spec · API Contract · Deploy plan — no contract/env surface expected.
+
+## Handoff
+
+**Next**: **02-verify-plan** (delta consistency on touched corpus) → Gate A → **04-tech-plan**.
+
+## Close decision
+
+`D-S034-E27-E1` — mark 01 completed; start 02-verify-plan.

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
@@ -42,14 +42,22 @@ Derived from D-S034-open / E27-* / corpus deltas already locked:
 11. S029/EV-022 parked work superseded/broadened by #815
 12. 13-deploy-smoke only when FE/decode chrome ships
 
-## Medium confidence (Batch F — pending)
+## Medium confidence (Batch F — locked)
 
-| ID | Statement | Options |
-|----|-----------|---------|
-| S02.M1 | Expected-residual **allowlist SoT** is a package test artifact (module/YAML next to fixtures); `FIXTURE_GAPS.md` stays catalog/load gaps only | 1 Approve · 2 Put allowlist in FIXTURE_GAPS · 3 Explain |
-| S02.M2 | **METAR/SPECI/TAF** happy-path official peers must reach `residuals == []` to close Gate C; **VAA/TCA (G4)** may remain on allowlist + child issue without blocking close | 1 Approve · 2 All seven must be empty · 3 Explain |
-| S02.L1 | Inventory SoT for TC-EV027-001 is **pytest-discovered** vendor/mirrored TAC peers (checked-in list or discovery helper), not a hand-only docs table | 1 Approve · 2 Docs-only inventory OK · 3 Explain |
+| ID | Statement | Decision |
+|----|-----------|----------|
+| S02.M1 | Expected-residual **allowlist SoT** is a package test artifact (module/YAML next to fixtures); `FIXTURE_GAPS.md` stays catalog/load gaps only | **1** Approve — `D-S034-EV027-s02m1-1` |
+| S02.M2 | All seven products target `residuals == []` for happy-path official peers to close Gate C; allowlist entries allowed **only** when standing docs mark residuals intentional (F9 **G4** / ADR-025 sparse best-effort) + linked child issue — check docs, no silent leftovers | **2** (+ doc check) — `D-S034-EV027-s02m2-2` |
+| S02.L1 | Inventory SoT for TC-EV027-001 is **pytest-discovered** vendor/mirrored TAC peers (checked-in list or discovery helper), not a hand-only docs table | **1** Approve — `D-S034-EV027-s02l1-1` |
+
+### S02.M2 doc evidence
+
+| Source | Intentional residual policy |
+|--------|------------------------------|
+| `feature-list.md` F9 **G4** | VAA/TCA decode spans: best-effort + **explicit residuals** in v1 |
+| F9 acceptance / ADR-025 | Sparse products best-effort; residuals named in “Not decoded: …” |
+| #815 / E27-4 | Unexpected residuals = defect; expected = allowlist (now gated on doc intent) |
 
 ## Gate A
 
-Pending Batch F answers (`D-S034-02-phase-a`).
+**PASS** (`D-S034-02-phase-a`) — Batch F **1, 2, 1**; Lean → **04-tech-plan**.

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
@@ -1,0 +1,55 @@
+# 02-verify-plan audit — S034 / EV-027
+
+**Date**: 2026-07-31  
+**Mode**: delta  
+**Issue**: [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815)
+
+## Scope audited
+
+`feature-list.md` (EV-026 Done + EV-027 deepen) · `user-journeys.md` (UJ-042 + UJ-039/020) ·
+`test-plan.md` (TC-EV027-001..005 + EV-027 gate) · `requirements-decisions.md` ·
+`evolve-decisions.md` §EV-027 · session brief / context
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Journey | **PASS** — F25/F9/F7.g deepen ↔ UJ-042 |
+| Journey ↔ Test | **PASS** — UJ-042 ↔ TC-EV027-001..005 |
+| EV-026 vs EV-027 status | **PASS** — EV-026 Done; EV-027 In progress |
+| TC ids | **PASS** — new TC-EV027-001..005 (`E27-TC=1`) |
+| UJ id | **PASS** — new UJ-042 (`E27-UJ=1`); deepens UJ-039/UJ-020 |
+| ADR-025 / ADR-032 | **PASS** — decode residuals + catalog tiers unchanged |
+| Out of scope | **PASS** — encode equality / US menu / new products excluded |
+| Spec/Config/API skipped | **PASS** — lean manifest; no contract surface |
+| Connectivity | **PASS** — H4–H5 via TC-EV027-005 when_ships; same origins as UJ-039/020 |
+| Supersedes S029 | **PASS** — noted in feature-list + evolve-decisions |
+
+## Auto-approved (high confidence) — 12
+
+Derived from D-S034-open / E27-* / corpus deltas already locked:
+
+1. #815 = inventory + load path + decode residual matrix + CI
+2. No new Fn — deepen F25 / F9 / F7.g
+3. New UJ-042 + TC-EV027-001..005
+4. Lean+build; skip 03/05/06/09/11/12
+5. UI preview deferred until after build
+6. Triage: fix when cheap; else allowlist + child issue (no silent leftovers)
+7. Encode equality promotion out of scope
+8. IWXXM-US not in WMO sample menu
+9. No inventing TAC; F6 seven only
+10. TC-SIGMET A6-2 / SWX/VONA/WAFS deferred unless already catalogued
+11. S029/EV-022 parked work superseded/broadened by #815
+12. 13-deploy-smoke only when FE/decode chrome ships
+
+## Medium confidence (Batch F — pending)
+
+| ID | Statement | Options |
+|----|-----------|---------|
+| S02.M1 | Expected-residual **allowlist SoT** is a package test artifact (module/YAML next to fixtures); `FIXTURE_GAPS.md` stays catalog/load gaps only | 1 Approve · 2 Put allowlist in FIXTURE_GAPS · 3 Explain |
+| S02.M2 | **METAR/SPECI/TAF** happy-path official peers must reach `residuals == []` to close Gate C; **VAA/TCA (G4)** may remain on allowlist + child issue without blocking close | 1 Approve · 2 All seven must be empty · 3 Explain |
+| S02.L1 | Inventory SoT for TC-EV027-001 is **pytest-discovered** vendor/mirrored TAC peers (checked-in list or discovery helper), not a hand-only docs table | 1 Approve · 2 Docs-only inventory OK · 3 Explain |
+
+## Gate A
+
+Pending Batch F answers (`D-S034-02-phase-a`).

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
@@ -3,7 +3,7 @@
 **Date**: 2026-07-31  
 **Mode**: delta  
 **Issue**: #815  
-**Status**: in_progress — Batch T / Gate B pending
+**Status**: **completed** — Gate B approved (`D-S034-04-plan-approve`)
 
 ## Inputs
 
@@ -28,11 +28,14 @@ ADR-025 / ADR-032 unchanged (apply residual naming + catalog tiers).
 No new CORS / origin map. Same decode-tac + static catalog as UJ-039/UJ-020.
 H4–H5 via TC-EV027-005 only when FE ships (13).
 
-## Draft plan
+## Approved plan
 
-See `execution-plan.md` — M0 dig → M1 matrix red/green → M2 catalog → M3 verify/close.
-14 tasks (T0.1–T3.4).
+See `execution-plan.md` — M0 dig → **M1 catalog first** → M2 residual matrix → M3 verify/close.
+14 tasks (T0.1–T3.4). **E27-T1=2** catalog-before-matrix.
 
 ## Batch T + Gate B
 
-Pending.
+| ID | Lock |
+|----|------|
+| E27-T1..T5 | **2,1,2,1,1** |
+| Gate B | **1** — approve plan → **07-build** @ T0.1 |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
@@ -1,0 +1,38 @@
+# 04-tech-plan — S034 / EV-027
+
+**Date**: 2026-07-31  
+**Mode**: delta  
+**Issue**: #815  
+**Status**: in_progress — Batch T / Gate B pending
+
+## Inputs
+
+- Gate A PASS (`D-S034-02-phase-a`) — Batch F **1, 2, 1**
+- Context: `docs/context/wmo-decode-residual-matrix.md`
+- Policies: S02.M1/M2/L1; E27-4 triage; F9 G4 / ADR-025 intentional residuals
+
+## Architecture (delta)
+
+No new packages, routes, or deps expected.
+
+| Area | Change |
+|------|--------|
+| `packages/tac2iwxxm` | Inventory discovery helper; residual matrix tests; allowlist artifact; decode coverage fixes |
+| FE catalog | Register missing stems or FIXTURE_GAPS + children; Vitest completeness |
+| Docs | Child issues for doc-intentional / deferred residuals |
+
+ADR-025 / ADR-032 unchanged (apply residual naming + catalog tiers).
+
+## Connectivity
+
+No new CORS / origin map. Same decode-tac + static catalog as UJ-039/UJ-020.
+H4–H5 via TC-EV027-005 only when FE ships (13).
+
+## Draft plan
+
+See `execution-plan.md` — M0 dig → M1 matrix red/green → M2 catalog → M3 verify/close.
+14 tasks (T0.1–T3.4).
+
+## Batch T + Gate B
+
+Pending.

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
@@ -1,0 +1,15 @@
+# 10-e2e smoke — S034 / EV-027
+
+**Date**: 2026-07-31  
+**Mode**: smoke (Lean+build)
+
+| Journey / TC | Evidence | Result |
+|--------------|----------|--------|
+| UJ-042 / TC-EV027-001..003 | pytest residual matrix + inventory | PASS |
+| UJ-039 / TC-EV027-002 | Vitest catalog seed completeness | PASS |
+| TC-EV027-004 load path | Existing catalog Vitest + registered stems | PASS (covered) |
+| TC-EV027-005 H4–H5 | when_ships | pending / waive at close if no FE deploy |
+
+## Verdict
+
+**PASS** smoke — no Playwright delta required (catalog/Vitest + package matrix).

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
@@ -23,26 +23,26 @@
 
 | Task | Status | Spec Source | Depends On | Description |
 |------|--------|-------------|------------|-------------|
-| T0.1 | pending | #815 §1; TC-EV027-001; S02.L1 | — | Discover official WMO TAC peers (vendor pin + mirrored annex3); dump stem list |
-| T0.2 | pending | TC-EV027-002; UJ-039 | T0.1 | Diff inventory vs `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md`; note silent omissions |
-| T0.3 | pending | TC-EV027-003; E27-4 | T0.1 | Run `decode_tac` over registered peers; dump residual text per stem (informational until M2) |
+| T0.1 | **completed** | #815 §1; TC-EV027-001; S02.L1 | — | Discover official WMO TAC peers (vendor pin + mirrored annex3); dump stem list |
+| T0.2 | **completed** | TC-EV027-002; UJ-039 | T0.1 | Diff inventory vs `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md`; note silent omissions |
+| T0.3 | **completed** | TC-EV027-003; E27-4 | T0.1 | Run `decode_tac` over registered peers; dump residual text per stem (informational until M2) |
 
 ### M1 — Catalog / load path (first)
 
 | Task | Status | Spec Source | Depends On | Description |
 |------|--------|-------------|------------|-------------|
-| T1.1 | pending | TC-EV027-001..002; TC-EV027-004 | T0.2 | Register missing in-scope stems **or** gap rows + child issues |
-| T1.2 | pending | TC-EV027-004 | T1.1 | Load-path Vitest/unit smoke for registered stems |
-| T1.3 | pending | UJ-039 deepen | T1.1 | Catalog Vitest: inventory ↔ catalog ∪ FIXTURE_GAPS; US/quarantine out |
+| T1.1 | **completed** | TC-EV027-001..002; TC-EV027-004 | T0.2 | No silent omissions — inventory locks registered ∪ deferred |
+| T1.2 | **completed** | TC-EV027-004 | T1.1 | Existing load-path / catalog Vitest covers registered stems |
+| T1.3 | **completed** | UJ-039 deepen | T1.1 | Catalog Vitest: inventory ↔ catalog ∪ FIXTURE_GAPS; US/quarantine out |
 
 ### M2 — CI residual matrix (after catalog)
 
 | Task | Status | Spec Source | Depends On | Description |
 |------|--------|-------------|------------|-------------|
-| T2.1 | pending | TC-EV027-003; S02.M1 | T0.3, T1.3 | Residual matrix pytest + empty allowlist scaffold (red on unexpected) |
-| T2.2 | pending | E27-4; S02.M2; E27-T2 | T2.1 | Fix cheap decode residuals — one commit per product family |
-| T2.3 | pending | S02.M2; F9 G4 | T2.2 | Allowlist only doc-intentional residuals + file child issues |
-| T2.4 | pending | TC-EV027-003 | T2.2, T2.3 | Matrix green (empty or allowlisted) |
+| T2.1 | **completed** | TC-EV027-003; S02.M1 | T0.3, T1.3 | Residual matrix pytest + allowlist scaffold |
+| T2.2 | **completed** | E27-4; S02.M2; E27-T2 | T2.1 | Decode fixes — RVR/CNL/VA SIGMET geometry |
+| T2.3 | **completed** | S02.M2; F9 G4 | T2.2 | Allowlist VAA/TCA G4 + child #820 |
+| T2.4 | **completed** | TC-EV027-003 | T2.2, T2.3 | Matrix green (empty or allowlisted) |
 
 ### M3 — Verify / close
 

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
@@ -48,10 +48,10 @@
 
 | Task | Status | Spec Source | Depends On | Description |
 |------|--------|-------------|------------|-------------|
-| T3.1 | pending | 08-verify-build | T2.4, T1.3 | Full suite + lint/typecheck green |
-| T3.2 | pending | 10-e2e | T3.1 | Catalog Vitest + residual matrix smoke report |
-| T3.3 | pending | #815 AC; E27-T4 | T3.2 | PR + close #815 (or link deferral children); Gate C |
-| T3.4 | pending | TC-EV027-005 | T3.3 | 13-deploy-smoke when FE ships (else waive) |
+| T3.1 | **completed** | 08-verify-build | T2.4, T1.3 | Full suite + lint/typecheck green |
+| T3.2 | **completed** | 10-e2e | T3.1 | Catalog Vitest + residual matrix smoke report |
+| T3.3 | in_progress | #815 AC; E27-T4 | T3.2 | PR + close #815; link #820; Gate C (`D-S034-gate-c`) |
+| T3.4 | **waived** | TC-EV027-005 | T3.3 | 13 waived — no FE deploy this cycle |
 
 ## Gate C (close)
 

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
@@ -2,7 +2,7 @@
 
 **Branch**: `evolve/EV-027-wmo-decode-residual-matrix`  
 **Preset**: Lean+build · **Features**: F25 / F9 / F7.g deepen  
-**Status**: draft (pending Gate B)
+**Status**: **approved** — Gate B (`D-S034-04-plan-approve`) · Batch T **2,1,2,1,1**
 
 ## Policies (locked)
 
@@ -12,43 +12,46 @@
 | S02.M2 | All seven target `residuals == []`; allowlist only with standing-doc intent (F9 G4 / ADR-025) + child issue |
 | S02.L1 | Inventory = pytest-discovered vendor/mirrored TAC peers |
 | E27-4 | Fix decode when cheap; else allowlist + child (no silent leftovers) |
+| E27-T1 | **2** — Catalog completeness **first**, then residual matrix |
+| E27-T2 | **1** — One commit per product family (or shared theme) when fixing residuals |
+| E27-T3 | **2** — AskQuestion per new dep (prefer none) |
+| E27-T4 | **1** — Gate C: matrix green + catalog∪gaps + #815 closed/deferred children (no soft escape) |
 
-## Milestones
+## Milestones (catalog-first)
 
 ### M0 — Inventory dig
 
-| Task | Spec Source | Depends On | Description |
-|------|-------------|------------|-------------|
-| T0.1 | #815 §1; TC-EV027-001; S02.L1 | — | Discover official WMO TAC peers (vendor pin + mirrored annex3); dump stem list |
-| T0.2 | TC-EV027-002; UJ-039 | T0.1 | Diff inventory vs `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md`; note silent omissions |
-| T0.3 | TC-EV027-003; E27-4 | T0.1 | Run `decode_tac` over registered peers; dump residual text per stem |
+| Task | Status | Spec Source | Depends On | Description |
+|------|--------|-------------|------------|-------------|
+| T0.1 | pending | #815 §1; TC-EV027-001; S02.L1 | — | Discover official WMO TAC peers (vendor pin + mirrored annex3); dump stem list |
+| T0.2 | pending | TC-EV027-002; UJ-039 | T0.1 | Diff inventory vs `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md`; note silent omissions |
+| T0.3 | pending | TC-EV027-003; E27-4 | T0.1 | Run `decode_tac` over registered peers; dump residual text per stem (informational until M2) |
 
-### M1 — CI matrix (red → green)
+### M1 — Catalog / load path (first)
 
-| Task | Spec Source | Depends On | Description |
-|------|-------------|------------|-------------|
-| T1.1 | TC-EV027-001..002 | T0.2 | Parametrized inventory/catalog∪gaps tests (red if omissions) |
-| T1.2 | TC-EV027-003; S02.M1 | T0.3 | Residual matrix pytest + empty allowlist scaffold (red on unexpected) |
-| T1.3 | E27-4; S02.M2 | T1.2 | Fix cheap decode residuals (METAR/SPECI/TAF first; SIGMET/AIRMET next) |
-| T1.4 | S02.M2; F9 G4 | T1.3 | Allowlist only doc-intentional residuals (G4/ADR-025) + file child issues |
-| T1.5 | TC-EV027-001..003 | T1.3, T1.4 | Matrix green (empty or allowlisted) |
+| Task | Status | Spec Source | Depends On | Description |
+|------|--------|-------------|------------|-------------|
+| T1.1 | pending | TC-EV027-001..002; TC-EV027-004 | T0.2 | Register missing in-scope stems **or** gap rows + child issues |
+| T1.2 | pending | TC-EV027-004 | T1.1 | Load-path Vitest/unit smoke for registered stems |
+| T1.3 | pending | UJ-039 deepen | T1.1 | Catalog Vitest: inventory ↔ catalog ∪ FIXTURE_GAPS; US/quarantine out |
 
-### M2 — Load path / catalog
+### M2 — CI residual matrix (after catalog)
 
-| Task | Spec Source | Depends On | Description |
-|------|-------------|------------|-------------|
-| T2.1 | TC-EV027-004; UJ-039 | T0.2 | Register missing in-scope stems **or** gap rows + child issues |
-| T2.2 | TC-EV027-004 | T2.1 | Load-path Vitest/unit smoke for registered stems |
-| T2.3 | UJ-039 deepen | T2.1 | Catalog Vitest: no silent omissions; US/quarantine out of WMO list |
+| Task | Status | Spec Source | Depends On | Description |
+|------|--------|-------------|------------|-------------|
+| T2.1 | pending | TC-EV027-003; S02.M1 | T0.3, T1.3 | Residual matrix pytest + empty allowlist scaffold (red on unexpected) |
+| T2.2 | pending | E27-4; S02.M2; E27-T2 | T2.1 | Fix cheap decode residuals — one commit per product family |
+| T2.3 | pending | S02.M2; F9 G4 | T2.2 | Allowlist only doc-intentional residuals + file child issues |
+| T2.4 | pending | TC-EV027-003 | T2.2, T2.3 | Matrix green (empty or allowlisted) |
 
 ### M3 — Verify / close
 
-| Task | Spec Source | Depends On | Description |
-|------|-------------|------------|-------------|
-| T3.1 | 08-verify-build | T1.5, T2.3 | Full suite + lint/typecheck green |
-| T3.2 | 10-e2e | T3.1 | Catalog Vitest + residual matrix smoke report |
-| T3.3 | #815 AC | T3.2 | PR + close #815 (or link deferral children); Gate C |
-| T3.4 | TC-EV027-005 | T3.3 | 13-deploy-smoke when FE ships (else waive) |
+| Task | Status | Spec Source | Depends On | Description |
+|------|--------|-------------|------------|-------------|
+| T3.1 | pending | 08-verify-build | T2.4, T1.3 | Full suite + lint/typecheck green |
+| T3.2 | pending | 10-e2e | T3.1 | Catalog Vitest + residual matrix smoke report |
+| T3.3 | pending | #815 AC; E27-T4 | T3.2 | PR + close #815 (or link deferral children); Gate C |
+| T3.4 | pending | TC-EV027-005 | T3.3 | 13-deploy-smoke when FE ships (else waive) |
 
 ## Gate C (close)
 

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
@@ -1,0 +1,62 @@
+# Execution plan — S034 / EV-027 (#815)
+
+**Branch**: `evolve/EV-027-wmo-decode-residual-matrix`  
+**Preset**: Lean+build · **Features**: F25 / F9 / F7.g deepen  
+**Status**: draft (pending Gate B)
+
+## Policies (locked)
+
+| ID | Policy |
+|----|--------|
+| S02.M1 | Residual allowlist = package test artifact; FIXTURE_GAPS = catalog/load only |
+| S02.M2 | All seven target `residuals == []`; allowlist only with standing-doc intent (F9 G4 / ADR-025) + child issue |
+| S02.L1 | Inventory = pytest-discovered vendor/mirrored TAC peers |
+| E27-4 | Fix decode when cheap; else allowlist + child (no silent leftovers) |
+
+## Milestones
+
+### M0 — Inventory dig
+
+| Task | Spec Source | Depends On | Description |
+|------|-------------|------------|-------------|
+| T0.1 | #815 §1; TC-EV027-001; S02.L1 | — | Discover official WMO TAC peers (vendor pin + mirrored annex3); dump stem list |
+| T0.2 | TC-EV027-002; UJ-039 | T0.1 | Diff inventory vs `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md`; note silent omissions |
+| T0.3 | TC-EV027-003; E27-4 | T0.1 | Run `decode_tac` over registered peers; dump residual text per stem |
+
+### M1 — CI matrix (red → green)
+
+| Task | Spec Source | Depends On | Description |
+|------|-------------|------------|-------------|
+| T1.1 | TC-EV027-001..002 | T0.2 | Parametrized inventory/catalog∪gaps tests (red if omissions) |
+| T1.2 | TC-EV027-003; S02.M1 | T0.3 | Residual matrix pytest + empty allowlist scaffold (red on unexpected) |
+| T1.3 | E27-4; S02.M2 | T1.2 | Fix cheap decode residuals (METAR/SPECI/TAF first; SIGMET/AIRMET next) |
+| T1.4 | S02.M2; F9 G4 | T1.3 | Allowlist only doc-intentional residuals (G4/ADR-025) + file child issues |
+| T1.5 | TC-EV027-001..003 | T1.3, T1.4 | Matrix green (empty or allowlisted) |
+
+### M2 — Load path / catalog
+
+| Task | Spec Source | Depends On | Description |
+|------|-------------|------------|-------------|
+| T2.1 | TC-EV027-004; UJ-039 | T0.2 | Register missing in-scope stems **or** gap rows + child issues |
+| T2.2 | TC-EV027-004 | T2.1 | Load-path Vitest/unit smoke for registered stems |
+| T2.3 | UJ-039 deepen | T2.1 | Catalog Vitest: no silent omissions; US/quarantine out of WMO list |
+
+### M3 — Verify / close
+
+| Task | Spec Source | Depends On | Description |
+|------|-------------|------------|-------------|
+| T3.1 | 08-verify-build | T1.5, T2.3 | Full suite + lint/typecheck green |
+| T3.2 | 10-e2e | T3.1 | Catalog Vitest + residual matrix smoke report |
+| T3.3 | #815 AC | T3.2 | PR + close #815 (or link deferral children); Gate C |
+| T3.4 | TC-EV027-005 | T3.3 | 13-deploy-smoke when FE ships (else waive) |
+
+## Gate C (close)
+
+1. TC-EV027-001..004 green  
+2. Residual matrix: empty or allowlisted with doc intent + child issues  
+3. No silent catalog omissions  
+4. #815 closed or deferrals filed  
+
+## Out of scope (do not schedule)
+
+Encode equality promotion · IWXXM-US in WMO menu · inventing TAC · new products beyond F6 seven

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/t0-1-inventory-dig.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/t0-1-inventory-dig.md
@@ -1,0 +1,59 @@
+# T0.1–T0.3 — Official WMO TAC inventory + residual dig
+
+**Date**: 2026-07-31 · **Cycle**: EV-027 · **Issue**: #815
+
+## Pin SoT
+
+`vendor/schemas/iwxxm/2025-2/IWXXM/examples/*.tac` (manifest pin v2025-2).
+
+## In-scope product TAC peers (F6 seven)
+
+| Vendor stem | Disposition | Catalog id / gap |
+|-------------|-------------|------------------|
+| metar-A3-1 | registered | `metar_a3_1` wmoPass |
+| speci-A3-2 | registered | `speci_a3_2` wmoPass |
+| taf-A5-1 | registered | `taf_a5_1` wmoPass |
+| taf-A5-2 | registered | `taf_a5_2` wmoPass |
+| sigmet-A6-1a-TS | registered | `sigmet_a6_1a_ts` wmoPass |
+| sigmet-A6-1b-CNL | registered | `sigmet_a6_1b_cnl` wmoPass |
+| sigmet-VA-EGGX | registered | `sigmet_va_eggx` wmoReference |
+| sigmet-multi-location-VA | registered | `sigmet_multi_location_va` wmoPass |
+| sigmet-A6-2-TC | **gap** | deferred #738 (FIXTURE_GAPS.md / inventory) |
+| airmet-A6-1a-TS | registered | `airmet_a6_1a_ts` wmoPass |
+| va-advisory-A7-2 | registered | `vaa_a7_2` wmoPass |
+| tc-advisory-A2-2 | registered | `tca_a2_2` wmoPass |
+
+## Explicitly out of happy-path WMO list
+
+| Stem class | Reason |
+|------------|--------|
+| `*-translation-failed*` | quarantine (UJ-039) |
+| `spacewx-*` | deferred product |
+| `vona-*` | deferred product |
+| `metar-NIL-collect` / `taf-NIL-collect` | COLLECT / validate shape — not sample-menu happy-path (EV-024) |
+
+## Product-level FIXTURE_GAPS (already)
+
+METAR / SPECI / AIRMET / VAA / TCA — second peer absent from pin (document only).
+
+## T0.3 — decode residuals (registered peers)
+
+| Stem | n_res | Sample residuals |
+|------|------:|------------------|
+| metar_a3_1 | 1 | `R12/1000U` |
+| speci_a3_2 | 0 | — |
+| taf_a5_1 | 0 | — |
+| taf_a5_2 | 1 | `CNL` |
+| sigmet_a6_1a_ts | 0 | — |
+| sigmet_a6_1b_cnl | 1 | `SIGMET 2` |
+| sigmet_va_eggx | 7 | geometry / eruption tokens |
+| sigmet_multi_location_va | 24 | multi-location geometry / FL |
+| airmet_a6_1a_ts | 0 | — |
+| vaa_a7_2 | 13 | advisory fields (F9 G4 candidate) |
+| tca_a2_2 | 14 | advisory fields (F9 G4 candidate) |
+
+## Catalog-first verdict (T0.2)
+
+No silent omissions among in-scope single-report peers: every stem is registered **or**
+documented deferred (A6-2-TC / NIL-collect / translation-failed / spacewx / vona).
+M1 locks this in CI; M2 addresses residual matrix.

--- a/docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
@@ -1,0 +1,27 @@
+# 08-verify-build — S034 / EV-027
+
+**Date**: 2026-07-31  
+**Tip**: `994c3b1`  
+**Issue**: #815
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| `make validate-fast` | PASS (pre-commit / format / typecheck / lint) |
+| TC-EV027-001..002 inventory | PASS (4 tests) |
+| TC-EV027-003 residual matrix | PASS (12 parametrized + allowlist guard) |
+| TC-F9 SIGMET A6 residuals | PASS (regression) |
+| examplesCatalog Vitest | PASS (20 tests) |
+
+## Matrix outcome
+
+| Peer class | Residuals |
+|------------|-----------|
+| METAR/SPECI/TAF/AIRMET + SIGMET TS/CNL | `[]` after decode fixes |
+| VA SIGMET (EGGX + multi-location) | `[]` after geometry/eruption tokens |
+| VAA / TCA | allowlisted (`allow_any`) — F9 G4 / ADR-025 · child [#820](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/820) |
+
+## Verdict
+
+**PASS** — ready for 10-e2e smoke + PR / Gate C.

--- a/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
@@ -12,10 +12,10 @@
 | 01-requirements | yes | delta | **completed** | E27-M/UJ/TC=1,1,1; D-S034-E27-E1 |
 | 02-verify-plan | yes | delta | **completed** | PASS Batch F 1,2,1; Gate A → 04 |
 | 04-tech-plan | yes | delta | **completed** | Batch T 2,1,2,1,1; Gate B → 07 @ T0.1 |
-| 07-build | yes | full | in_progress | Catalog-first then matrix; @ T0.1 |
-| 08-verify-build | yes | delta | pending | Full suite green |
+| 07-build | yes | full | **completed** | M0–M2 green; #820 filed |
+| 08-verify-build | yes | delta | **completed** | PASS — verification-report.md |
 | 09-qa | no | — | skipped | 08+10 cover |
-| 10-e2e | yes | smoke | pending | Catalog Vitest + residual matrix pytest |
+| 10-e2e | yes | smoke | **completed** | Catalog Vitest + residual matrix pytest |
 | 11-verify-impl | no | — | skipped | Lean+build |
 | 12-verify-deploy | no | — | skipped | — |
 | 13-deploy-smoke | when ships | full | pending | H4–H5 if FE menu/decode chrome ships |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
@@ -11,8 +11,8 @@
 | 16-evolve | yes | orchestrator | in_progress | Phase 0 done; 01 interview |
 | 01-requirements | yes | delta | **completed** | E27-M/UJ/TC=1,1,1; D-S034-E27-E1 |
 | 02-verify-plan | yes | delta | **completed** | PASS Batch F 1,2,1; Gate A → 04 |
-| 04-tech-plan | yes | delta | in_progress | Inventory + residual matrix + CI tasks |
-| 07-build | yes | full | pending | Matrix tests + decode fixes / allowlist |
+| 04-tech-plan | yes | delta | **completed** | Batch T 2,1,2,1,1; Gate B → 07 @ T0.1 |
+| 07-build | yes | full | in_progress | Catalog-first then matrix; @ T0.1 |
 | 08-verify-build | yes | delta | pending | Full suite green |
 | 09-qa | no | — | skipped | 08+10 cover |
 | 10-e2e | yes | smoke | pending | Catalog Vitest + residual matrix pytest |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
@@ -18,7 +18,7 @@
 | 10-e2e | yes | smoke | **completed** | Catalog Vitest + residual matrix pytest |
 | 11-verify-impl | no | — | skipped | Lean+build |
 | 12-verify-deploy | no | — | skipped | — |
-| 13-deploy-smoke | when ships | full | pending | H4–H5 if FE menu/decode chrome ships |
+| 13-deploy-smoke | when ships | full | **waived** | D-S034-gate-c — no FE deploy this cycle |
 
 ## Skip rationale
 

--- a/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
@@ -10,8 +10,8 @@
 | 00-context | yes | scoped | **completed** | Phase 0 locked D-S034-open=1,1,2,1 |
 | 16-evolve | yes | orchestrator | in_progress | Phase 0 done; 01 interview |
 | 01-requirements | yes | delta | **completed** | E27-M/UJ/TC=1,1,1; D-S034-E27-E1 |
-| 02-verify-plan | yes | delta | in_progress | Consistency + Gate A Lean |
-| 04-tech-plan | yes | delta | pending | Inventory + residual matrix + CI tasks |
+| 02-verify-plan | yes | delta | **completed** | PASS Batch F 1,2,1; Gate A → 04 |
+| 04-tech-plan | yes | delta | in_progress | Inventory + residual matrix + CI tasks |
 | 07-build | yes | full | pending | Matrix tests + decode fixes / allowlist |
 | 08-verify-build | yes | delta | pending | Full suite green |
 | 09-qa | no | — | skipped | 08+10 cover |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
@@ -1,0 +1,37 @@
+# Routing plan — S034-wmo-decode-residual-matrix
+
+**Preset:** Lean+build + **13 when behavior/UI ships** (**approved** D-S034-open=1,1,2,1)  
+**Orchestrator:** 16-evolve · **Cycle:** EV-027  
+**Path:** `00→16→01→02→04→07→08→10` (+ `13` if FE/decode UX ships)  
+**Skip:** `03, 05, 06, 09, 11, 12`
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | scoped | **completed** | Phase 0 locked D-S034-open=1,1,2,1 |
+| 16-evolve | yes | orchestrator | in_progress | Phase 0 done; 01 interview |
+| 01-requirements | yes | delta | **completed** | E27-M/UJ/TC=1,1,1; D-S034-E27-E1 |
+| 02-verify-plan | yes | delta | in_progress | Consistency + Gate A Lean |
+| 04-tech-plan | yes | delta | pending | Inventory + residual matrix + CI tasks |
+| 07-build | yes | full | pending | Matrix tests + decode fixes / allowlist |
+| 08-verify-build | yes | delta | pending | Full suite green |
+| 09-qa | no | — | skipped | 08+10 cover |
+| 10-e2e | yes | smoke | pending | Catalog Vitest + residual matrix pytest |
+| 11-verify-impl | no | — | skipped | Lean+build |
+| 12-verify-deploy | no | — | skipped | — |
+| 13-deploy-smoke | when ships | full | pending | H4–H5 if FE menu/decode chrome ships |
+
+## Skip rationale
+
+Quality / CI matrix deepen on existing F25 catalog + F9 decode — no new deployable, no new Fn.
+Lean+build matches S031/S033. 03/05/06 unnecessary (no new rules/deps/tooling). 09/11/12
+covered by 08+10 (+13 when operator-visible ships). Routine Lean checkpoints skipped unless
+gate failure.
+
+## Approved
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Cycle pick | #815 Lean+build (user `/16-evolve` option 1) | 2026-07-31 |
+| Session open / Phase 0 | `D-S034-open` = **1,1,2,1** — scope + Lean+build + UI defer + triage fix/allowlist | 2026-07-31 |
+| UI preview | **2** — defer until after build | 2026-07-31 |
+| Residual triage | **1** — fix when cheap; else allowlist + child issue | 2026-07-31 |

--- a/docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
+++ b/docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
@@ -1,0 +1,85 @@
+---
+session_id: S034-wmo-decode-residual-matrix
+type: feature
+status: in_progress
+branch: evolve/EV-027-wmo-decode-residual-matrix
+started_at: 2026-07-31
+intent: "#815 — official WMO IWXXM TAC peers load cleanly with no unexpected decode residuals; inventory ∪ FIXTURE_GAPS + CI residual matrix gate"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-027
+github_issues:
+  - 815
+context_briefs:
+  - docs/context/wmo-decode-residual-matrix.md
+standing_docs_touched:
+  - docs/feature-list.md
+  - docs/test-plan.md
+  - docs/user-journeys.md
+  - docs/decisions/evolve-decisions.md
+  - docs/decisions/requirements-decisions.md
+e27_manifest: "E27-M/UJ/TC = 1,1,1 — lean + UJ-042 + TC-EV027-001..005"
+feature_ids: [F25, F9, F7]
+feature_note: "Deepen F25 (WMO parity beyond catalog) + F9 (decode residuals) + F7.g (sample menu inventory) — no new Fn (D-S034-open)"
+ui_preview: deferred_after_build
+phase0_lock: "D-S034-open = 1,1,2,1"
+---
+
+# Session S034 — wmo-decode-residual-matrix
+
+## Intent
+
+Deliver [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815): every in-scope official
+WMO IWXXM TAC peer from the vendor pin is **loadable** from the workbench sample menu (or
+explicitly deferred in `FIXTURE_GAPS`) and **decode leaves no residuals unless expected**.
+
+This deepens **F25 / F9 / UJ-039** beyond “listed in catalog” — operators and CI should see
+full token coverage on official textbook TAC, with unexpected leftovers treated as defects.
+
+## Prior art
+
+| Item | Disposition |
+|------|-------------|
+| S031 / EV-024 | **Completed** — UJ-039 sample menu; official stems loadable (#813) |
+| S026 / EV-020 | **Completed** — F25 encode parity METAR/SPECI/TAF (#793) |
+| S029 / EV-022 | **Cancelled** (`D-S029-park`) — narrow SIGMET A6-1a residuals; **superseded/broadened** by #815 matrix |
+| BUG-2026-07-30 / #805 | Merged — SPECI A3-2 decode residuals (piecemeal) |
+| S033 / EV-026 | **Completed** — #809 VA encode equality (orthogonal; just closed) |
+
+## Scope (locked — D-S034-open = 1,1,2,1)
+
+| Q | Choice | Decision |
+|---|--------|----------|
+| 1 Session + scope | **1** | Lock #815 as drafted — inventory + residual matrix + CI; F25/F9/F7.g deepen |
+| 2 Routing | **1** | Lean+build; 13 when FE/decode chrome ships |
+| 3 UI preview | **2** | No now — docs/repo only; re-offer after build |
+| 4 Residual triage | **1** | Fix decode in-cycle when cheap; else allowlist + child issue (no silent leftovers) |
+
+### In
+
+1. **Inventory (SoT)** — official WMO stems with TAC peers under current `vendor/schemas` pin;
+   cross-check `examplesCatalog.ts` ∪ `FIXTURE_GAPS.md` ∪ package fixtures
+2. **Load path** — registered stems load correct TAC/product/provenance (ADR-032
+   `wmoPass` vs `wmoReference`); US/quarantine stay out of WMO happy-path list
+3. **Decode residual matrix** — happy-path official TAC → `residuals == []`; expected
+   residuals on documented allowlist; unexpected → defect or child issue
+4. **CI** — parametrized package/API tests + catalog Vitest; optional H4–H5 smoke when FE ships
+
+### Out (issue non-goals)
+
+- Inventing TAC not in vendor pin / mirrored fixtures
+- Promoting `wmoReference` → `wmoPass` encode equality (ADR-032 / encode children)
+- Expanding IWXXM-US REMARKS into WMO sample menu (#810–#812 closed)
+- New products beyond F6 seven; deferred SWX/VONA/WAFS/QVACI / TC-SIGMET A6-2 unless already catalogued
+
+## Success (from #815 AC)
+
+1. Inventory checked in (docs or generated list) matches catalog ∪ `FIXTURE_GAPS`
+2. Every in-scope peer loads from sample menu **or** has gap row + linked child issue
+3. Residual matrix: empty for happy-path peers except documented allowlist
+4. Unexpected residuals fail CI
+5. Child issues filed for stems that cannot close in-cycle
+
+## Routing (locked)
+
+**Lean+build**: `00→16→01→02→04→07→08→10` (+ `13` when UI/behavior ships)  
+**Skip:** `03, 05, 06, 09, 11, 12`

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-07-31 (S033 / EV-026 — TC-EV025-008..009 strict / wmoPass #809)
+> **Last updated**: 2026-07-31 (S034 / EV-027 — TC-EV027-001..005 #815 decode residual matrix)
 
 ## Scope
 
@@ -90,6 +90,7 @@ Unified manual live test harness against Render staging:
 | UJ-039 | F25/F7.g deepen | Load official WMO examples from sample menu | H4–H5 if FE | TC-EV024-004..006 |
 | UJ-040 | F6.b deepen | Structured iwxxm-us REMARKS encode pack | — (API T3 optional) | TC-EV025-001..007 |
 | UJ-041 | F23 deepen | sigmet-multi-location-VA ADR-032 equality / wmoPass (EV-026) | — | TC-EV025-008..009 |
+| UJ-042 | F25/F9/F7.g deepen | Official WMO TAC peers decode empty/allowlisted residuals | H4–H5 if FE | TC-EV027-001..005 |
 
 **Admin dashboard E2E**: **Retired** (S011 / #697). Replace prior admin panel locator guidance with
 **TC-F7-006** — assert `/admin` and legacy admin deep links return not-found; delete/skip old
@@ -1130,10 +1131,65 @@ Reuses **TC-EV025-008..009** with strict semantics (`E26-TC=1`). No new TC ids.
 
 ### EV-026 verify/deploy gate
 
-- [ ] TC-EV025-008 strict equality green (no soft_compare)
-- [ ] TC-EV025-009 catalog `wmoPass` + FIXTURE_GAPS cleared
-- [ ] #809 GitHub closed
-- [ ] 13-deploy-smoke if API convert/validate / catalog behavior ships
+- [x] TC-EV025-008 strict equality green (no soft_compare) (#817)
+- [x] TC-EV025-009 catalog `wmoPass` + FIXTURE_GAPS cleared (#817)
+- [x] #809 GitHub closed
+- [x] 13-deploy-smoke PASS (S033 / EV-026)
+
+## EV-027 / S034 — #815 official WMO decode residual matrix
+
+New **TC-EV027-001..005** (`E27-TC=1`). Ties **UJ-042**; deepens UJ-039 / UJ-020.
+
+### TC-EV027-001: Inventory of official WMO TAC peers (UJ-042)
+
+- **Given** current `vendor/schemas` pin (`IWXXM/examples/` + annex3 goldens mirrored)
+- **When** inventory is generated / checked in
+- **Then** every in-scope official WMO stem with a TAC peer appears in catalog **or**
+  `FIXTURE_GAPS` with rationale + child issue (no silent omissions)
+- **Tier**: T0
+- **Source**: #815; E27-1
+
+### TC-EV027-002: Catalog ∪ FIXTURE_GAPS completeness (UJ-042 / UJ-039 deepen)
+
+- **Given** inventory from TC-EV027-001
+- **When** catalog Vitest / `FIXTURE_GAPS.md` assert
+- **Then** set equality holds; US/quarantine/translation-failed stay out of WMO happy-path
+- **Tier**: T0 / T2
+- **Source**: #815; ADR-032; UJ-039
+
+### TC-EV027-003: Decode residual matrix — empty or allowlisted (UJ-042)
+
+- **Given** each registered official happy-path TAC peer (CI-mirrored fixture)
+- **When** `decode_tac` runs
+- **Then** `residuals == []` **or** residual text matches documented expected-residual
+  allowlist (G4 best-effort / deferred token / linked child issue); unexpected leftovers fail
+- **Tier**: T0 / T2
+- **Source**: #815; ADR-025; E27-4 triage
+
+### TC-EV027-004: Load path for registered official stems (UJ-042 / UJ-039)
+
+- **Given** a registered official stem in `examplesCatalog.ts`
+- **When** sample is selected (unit/smoke)
+- **Then** correct TAC body, product, and provenance banner (`wmoPass` vs `wmoReference`)
+- **Tier**: T0 / T2
+- **Source**: #815; ADR-032
+
+### TC-EV027-005: Optional H4–H5 residual chrome smoke (UJ-042)
+
+- **Given** deployed FE + API when catalog/decode chrome ships
+- **When** operator loads one passer per product and opens decode panel
+- **Then** no unexpected residual chrome for happy-path textbook peers
+- **Tier**: H4–H5 / T3 (when_ships)
+- **Source**: #815; connectivity gates
+
+### EV-027 verify/deploy gate
+
+- [ ] TC-EV027-001..002 inventory + catalog∪gaps green
+- [ ] TC-EV027-003 residual matrix green (allowlist documented)
+- [ ] TC-EV027-004 load path green
+- [ ] TC-EV027-005 when FE ships (else waive at close)
+- [ ] #815 GitHub closed (or child issues for in-cycle deferrals)
+- [ ] 13-deploy-smoke if FE/decode chrome ships
 
 ## F9 deepen (S026 / EV-020) — glossary registry
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1184,12 +1184,12 @@ New **TC-EV027-001..005** (`E27-TC=1`). Ties **UJ-042**; deepens UJ-039 / UJ-020
 
 ### EV-027 verify/deploy gate
 
-- [ ] TC-EV027-001..002 inventory + catalog∪gaps green
-- [ ] TC-EV027-003 residual matrix green (allowlist documented)
-- [ ] TC-EV027-004 load path green
-- [ ] TC-EV027-005 when FE ships (else waive at close)
-- [ ] #815 GitHub closed (or child issues for in-cycle deferrals)
-- [ ] 13-deploy-smoke if FE/decode chrome ships
+- [x] TC-EV027-001..002 inventory + catalog∪gaps green
+- [x] TC-EV027-003 residual matrix green (allowlist documented; VAA/TCA → #820)
+- [x] TC-EV027-004 load path green (catalog Vitest)
+- [x] TC-EV027-005 **waived** at close (`D-S034-gate-c` — no FE deploy)
+- [ ] #815 GitHub closed on PR merge (deferral child #820)
+- [x] 13-deploy-smoke **waived** (`D-S034-gate-c`)
 
 ## F9 deepen (S026 / EV-020) — glossary registry
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -6,7 +6,7 @@
 > S015 / EV-011 F15 METAR lint registry + #732 quality; S016 / EV-012 Manual TAC Input modes (#730);
 > S019 / EV-014 dissemination epic F16–F19; S020 / EV-015 F20 TAF+SPECI quality (#735/#734);
 > S023 / EV-017 public app + privacy (#783)
-> **Last updated**: 2026-07-31 (S033 / EV-026 — UJ-041 #809 ADR-032 equality / wmoPass)
+> **Last updated**: 2026-07-31 (S034 / EV-027 — UJ-042 #815 official WMO decode residual matrix)
 
 Product-facing journeys (UJ-*) describe end-user flows. Developer journeys (UJ-DEV-*)
 describe monorepo workflows introduced by migration features M1–M6 and F6.
@@ -56,6 +56,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-039 | Load official WMO IWXXM examples from sample menu | apps/frontend / CI | F25/F7.g deepen (EV-024) | T0 / T2 / **T3** / H4–H5 |
 | UJ-040 | Convert METAR/SPECI with structured iwxxm-us REMARKS | library / API / CI | F6.b deepen (EV-025) | T0 / T2 (+ T3 smoke if API ships) |
 | UJ-041 | Promote sigmet-multi-location-VA to WMO passer | library / CI / catalog | F23 deepen (EV-025 soft; EV-026 equality) | T0 / T2 |
+| UJ-042 | Official WMO TAC peers decode with empty/allowlisted residuals | library / CI / workbench | F25/F9/F7.g deepen (EV-027) | T0 / T2 / **T3** / H4–H5 |
 | — | **EV-023 #800** — no new UJ; deepen UJ-001/005/006/016 + TC-EV023-001..009 | library / API / CI | F6/F2/F12/F13 | T0 / T2 (+ T3 smoke if API ships) |
 | UJ-DEV-001 | Clone and run monorepo | `git clone` + `make dev` | M1, M5 | T0 |
 | UJ-DEV-002 | Sync vendor schemas | Scheduled Action / manual | M2, M6, F6 | CI |
@@ -535,6 +536,10 @@ renders live for all seven products; residuals named when present.
 products (e.g. `OBSC` → “Obscured”, `TS` → “Thunderstorm”); optional OpenAIP/F3 **names** when
 available. Tests: TC-F9-003/004; ADR-032.
 
+**S034 / EV-027 deepen**: Official WMO textbook TAC peers must leave **no unexpected
+residuals** after decode — see **UJ-042** / TC-EV027 residual matrix (allowlist + child issue
+when not fixable in-cycle).
+
 ---
 
 ### UJ-021: IWXXM Preview Pane + Terminator Quick Fix (F10)
@@ -1012,7 +1017,11 @@ accurate; ADR-032 amend honored.
 **Deepen (S032 / EV-025)**: New US REMARKS goldens / fixtures (**UJ-040**) remain **out** of
 the WMO sample menu — regression assert in TC-EV025-005.
 
-**Automated tests**: TC-EV024-*; TC-F25-003 deepen; examplesCatalog Vitest; TC-EV025-005.
+**Deepen (S034 / EV-027)**: Inventory completeness for official WMO TAC peers is gated with
+decode residual emptiness (**UJ-042** / TC-EV027-001..003) — listing alone is not enough.
+
+**Automated tests**: TC-EV024-*; TC-F25-003 deepen; examplesCatalog Vitest; TC-EV025-005;
+TC-EV027-001..003.
 
 ---
 
@@ -1073,6 +1082,46 @@ TC-F23-003 adjacency; #809 closable.
 **Automated tests**: TC-EV025-008..009 (reused ids — `E26-TC=1`); FIXTURE_GAPS / catalog row.
 
 **Source**: #809 · [Context: va-multi-location-809](context/va-multi-location-809.md) · ADR-032
+
+---
+
+### UJ-042: Official WMO TAC Peers Decode Cleanly (S034 / EV-027)
+
+**Actor**: Operator / CI maintainer
+
+**Goal**: Every in-scope official WMO IWXXM TAC peer (vendor pin) is either loadable from the
+workbench sample menu or explicitly deferred in `FIXTURE_GAPS`, and after `decode_tac` the
+report has **empty residuals** unless listed on a documented expected-residual allowlist.
+Unexpected leftovers are defects (fix decode or file a child issue — no silent leftovers).
+
+**Feature**: Deepen F25 / F9 / F7.g — S034 / EV-027 · Issue [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815)
+
+**Steps (CI — T0)**:
+
+1. Inventory official WMO stems with TAC peers under the current vendor pin; assert the set
+   equals catalog registrations ∪ `FIXTURE_GAPS` rows (no silent omissions).
+2. For each registered happy-path stem: load fixture TAC → `decode_tac` → `residuals == []`
+   **or** match expected-residual allowlist entry (product G4 best-effort / deferred token /
+   linked child issue).
+3. Parametrized tests fail CI on unexpected residuals.
+4. Catalog Vitest: every in-scope vendor TAC peer is registered or gap-documented.
+
+**Steps (operator — T2 / T3 / H4–H5 when FE ships)**:
+
+1. Open **Examples / sample menu** — select a registered official WMO stem (UJ-039 path).
+2. Confirm TAC loads with correct product + provenance banner (`wmoPass` vs `wmoReference`).
+3. Open decode panel (UJ-020) — no unexpected residual chrome / “Not decoded: …” for
+   happy-path textbook peers (allowlisted stems may show named residuals).
+
+**Acceptance**: TC-EV027-001..005 green; #815 closable; child issues for in-cycle deferrals.
+
+**Automated tests**: TC-EV027-001..005; deepen TC-EV024-004..006; examplesCatalog Vitest;
+`decode_tac` residual matrix pytest.
+
+**Browser wiring**: Same public decode-tac + static catalog as UJ-039 / UJ-020 — no new
+origins (H4–H5 when FE ships).
+
+**Source**: #815 · ADR-025 · ADR-032 · [Context: wmo-decode-residual-matrix](context/wmo-decode-residual-matrix.md)
 
 ---
 

--- a/packages/tac2iwxxm/src/tac2iwxxm/decode.py
+++ b/packages/tac2iwxxm/src/tac2iwxxm/decode.py
@@ -37,9 +37,13 @@ _TAF_PROB = re.compile(r"^PROB(?P<pct>\d{2})$")
 _TREND_TIME = re.compile(r"^(?P<kind>TL|AT|FM)(?P<hh>\d{2})(?P<mm>\d{2})$")
 _SIG_VALID = re.compile(r"^(?P<d1>\d{2})(?P<h1>\d{2})(?P<m1>\d{2})/(?P<d2>\d{2})(?P<h2>\d{2})(?P<m2>\d{2})$")
 _SIG_FL = re.compile(r"^FL(?P<fl>\d{2,3})$")
+# Vertical layer — ``SFC/FL550`` or ``FL250/370``.
+_SIG_FL_LAYER = re.compile(r"^(?:SFC/FL(?P<sfc>\d{2,3})|FL(?P<a>\d{2,3})/(?:FL)?(?P<b>\d{2,3}))$")
 _SIG_SPEED_KT = re.compile(r"^(?P<spd>\d{1,3})KT$")
 _SIG_LAT = re.compile(r"^(?P<hemi>[NS])(?P<deg>\d{1,2})(?P<min>\d{2})?$")
 _SIG_LON = re.compile(r"^(?P<hemi>[EW])(?P<deg>\d{1,3})(?P<min>\d{2})?$")
+# Observation/forecast clock ``1600Z`` (hhmmZ) — distinct from METAR ``ddhhmmZ``.
+_SIG_HHMMZ = re.compile(r"^(?P<hh>\d{2})(?P<mm>\d{2})Z$")
 _SIG_DIR = frozenset({"N", "NE", "E", "SE", "S", "SW", "W", "NW"})
 _SIG_DIR_NAME = {
     "N": "North",
@@ -62,6 +66,8 @@ _WX = re.compile(
     r"(?P<desc>MI|PR|BC|DR|BL|SH|TS|FZ)?"
     r"(?P<phen>(?:DZ|RA|SN|SG|IC|PL|GR|GS|UP|BR|FG|FU|VA|DU|SA|HZ|PY|PO|SQ|FC|SS|DS)+)$"
 )
+# Runway visual range — R{rw}/{vis}{U|D|N}? (e.g. R12/1000U).
+_RVR = re.compile(r"^R(?P<rw>\d{2}[LCR]?)/(?P<vis>[MP]?\d{4})(?P<trend>[UDN])?$")
 
 _WX_INTENSITY = {"+": "heavy", "-": "light", "VC": "in the vicinity"}
 _WX_DESCRIPTOR = {
@@ -265,6 +271,14 @@ def _explain_metar_speci(token: str, *, product: str, seen: dict[str, int]) -> s
         return f"QNH {int(m.group('val'))} hPa"
     if m := _WX.match(upper):
         return _fmt_wx(m, forecast=bool(seen.get("in_trend")))
+    if m := _RVR.match(upper):
+        trend = m.group("trend")
+        trend_txt = {
+            "U": ", upward trend",
+            "D": ", downward trend",
+            "N": ", no distinct trend",
+        }.get(trend or "", "")
+        return f"Runway visual range runway {m.group('rw')}: {m.group('vis')} m{trend_txt}"
     if upper.startswith("PK") or upper == "WND":
         return "Peak wind remarks token"
     _ = product
@@ -278,6 +292,8 @@ def _explain_taf(token: str, *, seen: dict[str, int]) -> str | None:
         return "Report type (terminal aerodrome forecast)"
     if upper in {"AMD", "COR"}:
         return "Amendment / correction indicator"
+    if upper == "CNL":
+        return "Cancelled forecast"
     if upper == "NIL":
         return "Nil forecast"
     if upper == "=":
@@ -330,13 +346,21 @@ def _explain_sigmet_airmet(token: str, *, product: str, seen: dict[str, int]) ->
     if upper == product and seen.get("rtype", 0) == 0:
         seen["rtype"] = 1
         return f"Report type ({product})"
+    if upper == product and seen.get("cnl"):
+        # Cancelled bulletin references the product again (``CNL SIGMET 2 …``).
+        return f"Cancelled {product} reference"
     if upper == "=":
         return "Report terminator"
+    if upper == "CNL":
+        seen["cnl"] = 1
+        return explain_glossary_token(upper, fallback="Cancellation")
     if upper == "VALID":
         return "Validity period marker"
     if upper.isdigit() and seen.get("rtype") and not seen.get("seq"):
         seen["seq"] = 1
         return f"Sequence number ({int(upper)})"
+    if upper.isdigit() and seen.get("cnl"):
+        return f"Cancelled sequence number ({int(upper)})"
     if m := _SIG_VALID.match(upper):
         seen["valid_period"] = 1
         return (
@@ -365,8 +389,27 @@ def _explain_sigmet_airmet(token: str, *, product: str, seen: dict[str, int]) ->
 
     if upper in {"FIR/UIR", "FIR", "UIR"}:
         return explain_glossary_token(upper, fallback="Flight information region")
+    if upper == "OCEANIC":
+        return "Oceanic FIR qualifier"
+    if upper == "ERUPTION":
+        seen["eruption"] = 1
+        return "Volcanic eruption"
+    if upper == "MT":
+        return "Mount"
+    if upper == "AT":
+        return "At (observation / forecast time)"
+    if upper == "WI":
+        return "Within (area polygon)"
+    if upper == "-":
+        return "Polygon vertex separator"
+    if m := _SIG_FL_LAYER.match(upper):
+        if m.group("sfc"):
+            return f"Surface to flight level {int(m.group('sfc'))}"
+        return f"Flight levels {int(m.group('a'))} to {int(m.group('b'))}"
     if m := _SIG_FL.match(upper):
         return f"Flight level {int(m.group('fl'))}"
+    if m := _SIG_HHMMZ.match(upper):
+        return f"Time {m.group('hh')}:{m.group('mm')} UTC"
     if upper == "MOV":
         seen["mov"] = 1
         return explain_glossary_token(upper, fallback="Moving")
@@ -391,6 +434,16 @@ def _explain_sigmet_airmet(token: str, *, product: str, seen: dict[str, int]) ->
         return f"Longitude {int(m.group('deg'))}° {hemi}"
     if upper in {"OF", "AND"}:
         return explain_glossary_token(upper, fallback=upper.capitalize())
+
+    # Volcano name after ``ERUPTION MT …`` (e.g. HEKLA, ASHVAL).
+    if (
+        seen.get("eruption")
+        and icao.isalpha()
+        and len(icao) >= 3
+        and not meaning_for(icao)
+        and icao not in {"FIR", "UIR", "VA", "CLD"}
+    ):
+        return f"Volcano name ({icao})"
 
     # FIR proper name (e.g. SHANLON) when not a known glossary hazard token.
     if icao.isalpha() and len(icao) >= 4 and seen.get("station") and not seen.get("fir_name") and not meaning_for(icao):

--- a/packages/tac2iwxxm/tests/fixtures/wmo_decode_residual_allowlist.py
+++ b/packages/tac2iwxxm/tests/fixtures/wmo_decode_residual_allowlist.py
@@ -11,17 +11,35 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class ExpectedResidual:
-    """One allowlisted residual span for a catalog-registered official peer."""
+    """Allowlisted residual policy for a catalog-registered official peer."""
 
     catalog_id: str
-    residual_text: str
     doc_intent: str  # e.g. "F9 G4" / "ADR-025"
     issue: str
+    residual_text: str | None = None  # exact match when set
+    allow_any: bool = False  # G4 best-effort — any residual text permitted
 
 
-# Start empty — populate only with doc-intentional residuals + child issues (S02.M2=2).
-EXPECTED_RESIDUALS: tuple[ExpectedResidual, ...] = ()
+# Doc-intentional G4 peers (#820) — fuller VAA/TCA decode tracked separately.
+EXPECTED_RESIDUALS: tuple[ExpectedResidual, ...] = (
+    ExpectedResidual(
+        catalog_id="vaa_a7_2",
+        doc_intent="F9 G4 / ADR-025 sparse best-effort",
+        issue="#820",
+        allow_any=True,
+    ),
+    ExpectedResidual(
+        catalog_id="tca_a2_2",
+        doc_intent="F9 G4 / ADR-025 sparse best-effort",
+        issue="#820",
+        allow_any=True,
+    ),
+)
 
 
 def allowlisted_texts(catalog_id: str) -> set[str]:
-    return {e.residual_text for e in EXPECTED_RESIDUALS if e.catalog_id == catalog_id}
+    return {e.residual_text for e in EXPECTED_RESIDUALS if e.catalog_id == catalog_id and e.residual_text is not None}
+
+
+def allows_any_residual(catalog_id: str) -> bool:
+    return any(e.allow_any and e.catalog_id == catalog_id for e in EXPECTED_RESIDUALS)

--- a/packages/tac2iwxxm/tests/fixtures/wmo_decode_residual_allowlist.py
+++ b/packages/tac2iwxxm/tests/fixtures/wmo_decode_residual_allowlist.py
@@ -1,0 +1,27 @@
+"""Expected-residual allowlist for EV-027 / TC-EV027-003 (S02.M1 package SoT).
+
+Entries require standing-doc intent (F9 G4 / ADR-025) and a linked child issue.
+Unexpected residuals must not be papered over here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedResidual:
+    """One allowlisted residual span for a catalog-registered official peer."""
+
+    catalog_id: str
+    residual_text: str
+    doc_intent: str  # e.g. "F9 G4" / "ADR-025"
+    issue: str
+
+
+# Start empty — populate only with doc-intentional residuals + child issues (S02.M2=2).
+EXPECTED_RESIDUALS: tuple[ExpectedResidual, ...] = ()
+
+
+def allowlisted_texts(catalog_id: str) -> set[str]:
+    return {e.residual_text for e in EXPECTED_RESIDUALS if e.catalog_id == catalog_id}

--- a/packages/tac2iwxxm/tests/fixtures/wmo_official_tac_inventory.py
+++ b/packages/tac2iwxxm/tests/fixtures/wmo_official_tac_inventory.py
@@ -1,0 +1,175 @@
+"""Official WMO IWXXM TAC peer inventory for EV-027 / #815 (TC-EV027-001).
+
+SoT: ``vendor/schemas/iwxxm/2025-2/IWXXM/examples/*.tac`` under the current pin.
+Every in-scope stem is either registered in the FE sample catalog or explicitly deferred.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PIN_EXAMPLES = _REPO_ROOT / "vendor" / "schemas" / "iwxxm" / "2025-2" / "IWXXM" / "examples"
+_ANNEX3 = Path(__file__).resolve().parent / "annex3_golden"
+
+# F6 seven — product prefixes / stems that belong on the WMO happy-path inventory.
+_IN_SCOPE_PREFIXES = (
+    "metar-",
+    "speci-",
+    "taf-",
+    "sigmet-",
+    "airmet-",
+    "va-advisory-",
+    "tc-advisory-",
+)
+
+_OUT_OF_HAPPY_PATH_SUBSTRINGS = (
+    "translation-failed",
+    "spacewx-",
+    "vona-",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OfficialTacPeer:
+    """One official WMO TAC peer stem from the vendor pin."""
+
+    stem: str  # e.g. metar-A3-1
+    disposition: str  # registered | deferred
+    catalog_id: str | None = None
+    annex3_tac: str | None = None  # filename under annex3_golden
+    product: str | None = None
+    deferral_reason: str | None = None
+    issue: str | None = None
+
+
+# Explicit inventory (checked, not inventing stems beyond the pin).
+OFFICIAL_TAC_PEERS: tuple[OfficialTacPeer, ...] = (
+    OfficialTacPeer(
+        "metar-A3-1",
+        "registered",
+        catalog_id="metar_a3_1",
+        annex3_tac="metar_a3_1.tac",
+        product="METAR",
+    ),
+    OfficialTacPeer(
+        "speci-A3-2",
+        "registered",
+        catalog_id="speci_a3_2",
+        annex3_tac="speci_a3_2.tac",
+        product="SPECI",
+    ),
+    OfficialTacPeer(
+        "taf-A5-1",
+        "registered",
+        catalog_id="taf_a5_1",
+        annex3_tac="taf_a5_1.tac",
+        product="TAF",
+    ),
+    OfficialTacPeer(
+        "taf-A5-2",
+        "registered",
+        catalog_id="taf_a5_2",
+        annex3_tac="taf_a5_2.tac",
+        product="TAF",
+    ),
+    OfficialTacPeer(
+        "sigmet-A6-1a-TS",
+        "registered",
+        catalog_id="sigmet_a6_1a_ts",
+        annex3_tac="sigmet_a6_1a_ts.tac",
+        product="SIGMET",
+    ),
+    OfficialTacPeer(
+        "sigmet-A6-1b-CNL",
+        "registered",
+        catalog_id="sigmet_a6_1b_cnl",
+        annex3_tac="sigmet_a6_1b_cnl.tac",
+        product="SIGMET",
+    ),
+    OfficialTacPeer(
+        "sigmet-VA-EGGX",
+        "registered",
+        catalog_id="sigmet_va_eggx",
+        annex3_tac="sigmet_va_eggx.tac",
+        product="SIGMET",
+    ),
+    OfficialTacPeer(
+        "sigmet-multi-location-VA",
+        "registered",
+        catalog_id="sigmet_multi_location_va",
+        annex3_tac="sigmet_multi_location_va.tac",
+        product="SIGMET",
+    ),
+    OfficialTacPeer(
+        "sigmet-A6-2-TC",
+        "deferred",
+        deferral_reason="TC SIGMET A6-2 out of F6 sample-menu happy-path",
+        issue="#738",
+    ),
+    OfficialTacPeer(
+        "airmet-A6-1a-TS",
+        "registered",
+        catalog_id="airmet_a6_1a_ts",
+        annex3_tac="airmet_a6_1a_ts.tac",
+        product="AIRMET",
+    ),
+    OfficialTacPeer(
+        "va-advisory-A7-2",
+        "registered",
+        catalog_id="vaa_a7_2",
+        annex3_tac="vaa_a7_2.tac",
+        product="VAA",
+    ),
+    OfficialTacPeer(
+        "tc-advisory-A2-2",
+        "registered",
+        catalog_id="tca_a2_2",
+        annex3_tac="tca_a2_2.tac",
+        product="TCA",
+    ),
+    OfficialTacPeer(
+        "metar-NIL-collect",
+        "deferred",
+        deferral_reason="COLLECT / validate shape — not sample-menu happy-path (EV-024)",
+        issue="EV-024",
+    ),
+    OfficialTacPeer(
+        "taf-NIL-collect",
+        "deferred",
+        deferral_reason="COLLECT / validate shape — not sample-menu happy-path (EV-024)",
+        issue="EV-024",
+    ),
+)
+
+
+def discover_pin_tac_stems() -> set[str]:
+    """Return ``*.tac`` stems under the 2025-2 examples directory."""
+    if not _PIN_EXAMPLES.is_dir():
+        return set()
+    return {p.stem for p in _PIN_EXAMPLES.glob("*.tac")}
+
+
+def in_scope_pin_stems(pin_stems: set[str] | None = None) -> set[str]:
+    """Filter pin stems to F6-seven happy-path candidates (excludes quarantine/deferred products)."""
+    stems = pin_stems if pin_stems is not None else discover_pin_tac_stems()
+    out: set[str] = set()
+    for stem in stems:
+        low = stem.lower()
+        if any(s in low for s in _OUT_OF_HAPPY_PATH_SUBSTRINGS):
+            continue
+        if not any(low.startswith(p) for p in _IN_SCOPE_PREFIXES):
+            continue
+        out.add(stem)
+    return out
+
+
+def registered_peers() -> tuple[OfficialTacPeer, ...]:
+    return tuple(p for p in OFFICIAL_TAC_PEERS if p.disposition == "registered")
+
+
+def annex3_path(peer: OfficialTacPeer) -> Path:
+    if not peer.annex3_tac:
+        raise ValueError(f"{peer.stem} has no annex3_tac")
+    return _ANNEX3 / peer.annex3_tac

--- a/packages/tac2iwxxm/tests/test_tc_ev027_001_002_inventory_catalog.py
+++ b/packages/tac2iwxxm/tests/test_tc_ev027_001_002_inventory_catalog.py
@@ -1,0 +1,57 @@
+"""TC-EV027-001 / TC-EV027-002 — official WMO TAC inventory ↔ catalog ∪ gaps (#815)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from wmo_official_tac_inventory import (  # noqa: E402
+    OFFICIAL_TAC_PEERS,
+    annex3_path,
+    discover_pin_tac_stems,
+    in_scope_pin_stems,
+    registered_peers,
+)
+
+
+def test_tc_ev027_001_inventory_covers_in_scope_pin_stems() -> None:
+    """Every in-scope pin TAC peer is listed as registered or deferred."""
+    pin = in_scope_pin_stems(discover_pin_tac_stems())
+    inventoried = {p.stem for p in OFFICIAL_TAC_PEERS}
+    missing = pin - inventoried
+    extra = inventoried - pin
+    assert not missing, f"pin stems missing from inventory: {sorted(missing)}"
+    assert not extra, f"inventory stems not on in-scope pin filter: {sorted(extra)}"
+
+
+def test_tc_ev027_001_deferred_have_rationale() -> None:
+    for peer in OFFICIAL_TAC_PEERS:
+        if peer.disposition != "deferred":
+            continue
+        assert peer.deferral_reason and peer.deferral_reason.strip()
+        assert peer.issue and peer.issue.strip()
+
+
+def test_tc_ev027_002_registered_peers_have_annex3_mirrors() -> None:
+    for peer in registered_peers():
+        path = annex3_path(peer)
+        assert path.is_file(), f"missing annex3 mirror for {peer.stem}: {path}"
+        assert peer.catalog_id
+        assert peer.product in {
+            "METAR",
+            "SPECI",
+            "TAF",
+            "SIGMET",
+            "AIRMET",
+            "VAA",
+            "TCA",
+        }
+
+
+def test_tc_ev027_002_catalog_ids_unique() -> None:
+    ids = [p.catalog_id for p in registered_peers()]
+    assert len(ids) == len(set(ids))

--- a/packages/tac2iwxxm/tests/test_tc_ev027_003_decode_residual_matrix.py
+++ b/packages/tac2iwxxm/tests/test_tc_ev027_003_decode_residual_matrix.py
@@ -13,8 +13,19 @@ _FIXTURES = Path(__file__).resolve().parent / "fixtures"
 if str(_FIXTURES) not in sys.path:
     sys.path.insert(0, str(_FIXTURES))
 
-from wmo_decode_residual_allowlist import allowlisted_texts  # noqa: E402
+from wmo_decode_residual_allowlist import (  # noqa: E402
+    EXPECTED_RESIDUALS,
+    allowlisted_texts,
+    allows_any_residual,
+)
 from wmo_official_tac_inventory import annex3_path, registered_peers  # noqa: E402
+
+
+def test_tc_ev027_003_allowlist_entries_have_doc_intent_and_issue() -> None:
+    for entry in EXPECTED_RESIDUALS:
+        assert entry.doc_intent.strip()
+        assert entry.issue.strip()
+        assert entry.allow_any or (entry.residual_text and entry.residual_text.strip())
 
 
 @pytest.mark.parametrize(
@@ -26,6 +37,9 @@ def test_tc_ev027_003_decode_residuals_empty_or_allowlisted(peer) -> None:
     assert peer.product and peer.catalog_id
     tac = annex3_path(peer).read_text(encoding="utf-8")
     result = decode_tac(tac, product=peer.product)
+    if allows_any_residual(peer.catalog_id):
+        # F9 G4 / ADR-025 — residuals permitted when allowlist entry cites intent + issue.
+        return
     got = {r.text for r in result.residuals}
     allowed = allowlisted_texts(peer.catalog_id)
     unexpected = sorted(got - allowed)

--- a/packages/tac2iwxxm/tests/test_tc_ev027_003_decode_residual_matrix.py
+++ b/packages/tac2iwxxm/tests/test_tc_ev027_003_decode_residual_matrix.py
@@ -1,0 +1,32 @@
+"""TC-EV027-003 — decode residual matrix for official WMO TAC peers (#815)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tac2iwxxm.decode import decode_tac
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from wmo_decode_residual_allowlist import allowlisted_texts  # noqa: E402
+from wmo_official_tac_inventory import annex3_path, registered_peers  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "peer",
+    registered_peers(),
+    ids=[p.catalog_id or p.stem for p in registered_peers()],
+)
+def test_tc_ev027_003_decode_residuals_empty_or_allowlisted(peer) -> None:
+    assert peer.product and peer.catalog_id
+    tac = annex3_path(peer).read_text(encoding="utf-8")
+    result = decode_tac(tac, product=peer.product)
+    got = {r.text for r in result.residuals}
+    allowed = allowlisted_texts(peer.catalog_id)
+    unexpected = sorted(got - allowed)
+    assert not unexpected, f"{peer.catalog_id}: unexpected residuals {unexpected!r} (allowlisted={sorted(allowed)!r})"

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,10 +3,162 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 33
-evolve_cycle_counter: 26
-active_session: null
+session_counter: 34
+evolve_cycle_counter: 27
+active_session:
+  id: S034-wmo-decode-residual-matrix
+  type: feature
+  intent: "#815 — official WMO decode residual matrix; inventory ∪ FIXTURE_GAPS + CI gate; Lean+build"
+  status: in_progress
+  branch: evolve/EV-027-wmo-decode-residual-matrix
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-027
+  github_issues:
+  - '815'
+  feature_ids:
+  - F25
+  - F9
+  - F7
+  artifacts_dir: docs/sessions/S034-wmo-decode-residual-matrix/
+  routing_plan_summary: "Lean+build 00→16→01→02→04→07→08→10 (+13 when ships)"
+  preset: Lean+build
+  preset_status: approved
+  note_skipped: "Lean+build — skip 03/05/06/09/11/12; 13 when_ships"
+  skipped:
+  - 03-plan-tooling
+  - 05-verify-tech
+  - 06-tech-tooling
+  - 09-qa
+  - 11-verify-impl
+  - 12-verify-deploy
+  current_stage: 02-verify-plan
+  started_at: '2026-07-31'
+  context_briefs:
+  - docs/context/wmo-decode-residual-matrix.md
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: scoped
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: "Phase 0 locked D-S034-open=1,1,2,1"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-07-31'
+    note: "Phase 0 done; 01 interview"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: pending
+  - stage: 07-build
+    required: true
+    mode: full
+    status: pending
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+  - stage: 10-e2e
+    required: true
+    mode: smoke
+    status: pending
+  - stage: 13-deploy-smoke
+    required: when_ships
+    mode: full
+    status: pending
 sessions:
+- id: S034-wmo-decode-residual-matrix
+  type: feature
+  intent: "#815 — official WMO decode residual matrix; inventory ∪ FIXTURE_GAPS + CI gate; Lean+build"
+  status: in_progress
+  branch: evolve/EV-027-wmo-decode-residual-matrix
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-027
+  github_issues:
+  - '815'
+  feature_ids:
+  - F25
+  - F9
+  - F7
+  artifacts_dir: docs/sessions/S034-wmo-decode-residual-matrix/
+  routing_plan_summary: "Lean+build 00→16→01→02→04→07→08→10 (+13 when ships)"
+  preset: Lean+build
+  preset_status: approved
+  note_skipped: "Lean+build — skip 03/05/06/09/11/12; 13 when_ships"
+  skipped:
+  - 03-plan-tooling
+  - 05-verify-tech
+  - 06-tech-tooling
+  - 09-qa
+  - 11-verify-impl
+  - 12-verify-deploy
+  current_stage: 02-verify-plan
+  started_at: '2026-07-31'
+  context_briefs:
+  - docs/context/wmo-decode-residual-matrix.md
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: scoped
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: "Phase 0 locked D-S034-open=1,1,2,1"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-07-31'
+    note: "Phase 0 done; 01 interview"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: pending
+  - stage: 07-build
+    required: true
+    mode: full
+    status: pending
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+  - stage: 10-e2e
+    required: true
+    mode: smoke
+    status: pending
+  - stage: 13-deploy-smoke
+    required: when_ships
+    mode: full
+    status: pending
 - id: S033-va-multi-location-equality
   type: feature
   intent: "#809 residual — ADR-032 canonicalize_xml equality for sigmet-multi-location-VA; promote wmoPass; close issue"
@@ -2784,27 +2936,26 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: iwxxm-us-remarks-va
-    session_id: S032-iwxxm-us-remarks-va
-    evolve_cycle_id: EV-025
+    scoped_slug: wmo-decode-residual-matrix
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
     started_at: '2026-07-31'
     completed_at: '2026-07-31'
-    completed: '2026-07-31'
     substeps:
       phase0: completed
       phase1a: pending
       phase1b: skipped
       phase1c: skipped
-      phase2: completed
-      phase3: completed
-      phase4: completed
-    note: 'S032/EV-025 00-context COMPLETE — Phase 0 locked E25-*; artifacts written; handoff 01-requirements; #810/#811/#812/#809'
-    prior_note: 'S031/EV-024 00-context COMPLETE — Phase 0 locked E24-1..4; F6/F2/F4/F12/F13/F25 deepen; Lean+build approved; tip deb43cf; #804/#807/#773'
+      phase2: pending
+      phase3: pending
+      phase4: pending
+    note: 'S034/EV-027 00-context COMPLETE — Phase 0 locked D-S034-open=1,1,2,1; artifacts written; handoff 01-requirements; #815'
+    prior_note: 'S034/EV-027 00-context STARTED — Phase 0 lock pending AskQuestion D-S034-open; #815 official WMO decode residual matrix; Lean+build; F25/F9/F7'
     artifacts:
-    - docs/sessions/S032-iwxxm-us-remarks-va/
-    - docs/sessions/S032-iwxxm-us-remarks-va/session-brief.md
-    - docs/sessions/S032-iwxxm-us-remarks-va/routing-plan.md
-    - docs/context/iwxxm-us-remarks-va.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/
+    - docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+    - docs/context/wmo-decode-residual-matrix.md
     - docs/decisions/evolve-decisions.md
   01-requirements:
     status: completed
@@ -2813,48 +2964,71 @@ stages:
     started: '2026-07-31'
     completed_at: '2026-07-31'
     completed: '2026-07-31'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    prior_note: 'S033/EV-026 01-requirements STARTED (delta) — #809 ADR-032 equality; F23/F6/F7; D-S033-open; interview pending'
-    note: 'COMPLETE (delta) — E26-E1=1; D-S033-E26-E1; reports/01-requirements.md; #809'
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    prior_note: 'S034/EV-027 01-requirements STARTED (delta) — deepen F25/F9/F7.g; D-S034-open=1,1,2,1; starting delta interview; #815'
+    note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
     substeps:
       interviews:
         status: completed
         completed: 1
-        total: 1
         current_template: complete
         current_section: complete
-        planned_docs:
-          status:
-            feature-list: completed
-            spec: skipped
-            user-journeys: completed
-            test-plan: completed
-            api-contract: skipped
-            coverage-matrix: skipped
-            ADR: skipped
-            requirements-decisions: completed
     active_session:
-      session_id: S033-va-multi-location-equality
-      evolve_cycle_id: EV-026
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
       status: completed
       mode: delta
       started_at: '2026-07-31'
       started: '2026-07-31'
       completed_at: '2026-07-31'
       completed: '2026-07-31'
-      note: 'COMPLETE (delta) — E26-E1=1; D-S033-E26-E1; reports/01-requirements.md; #809'
+      note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; handoff 02-verify-plan; #815'
       feature_ids:
-      - F23
-      - F6
+      - F25
+      - F9
       - F7
       decision_refs:
-      - D-S033-open
-      - E26-E1
-      - E26-M
-      - E26-TC
-      - D-S033-E26-E1
+      - D-S034-open
+      - E27-1
+      - E27-2
+      - E27-3
+      - E27-4
+      - E27-E1
+      - E27-M
+      - E27-UJ
+      - E27-TC
+      - D-S034-E27-E1
     delta_substages:
+    - status: completed
+      mode: delta
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      started_at: '2026-07-31'
+      started: '2026-07-31'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
+      deepen:
+      - F25
+      - F9
+      - F7
+      feature_ids:
+      - F25
+      - F9
+      - F7
+      artifacts:
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
+      - docs/feature-list.md
+      - docs/user-journeys.md
+      - docs/test-plan.md
+      - docs/decisions/evolve-decisions.md
+      decision_refs:
+      - E27-E1
+      - E27-M
+      - E27-UJ
+      - E27-TC
+      - D-S034-E27-E1
     - status: completed
       mode: delta
       session_id: S033-va-multi-location-equality
@@ -3379,6 +3553,8 @@ stages:
               domain-research-catalog: completed
               ADR: completed
     notes:
+    - 'S034/EV-027 01-requirements COMPLETE 2026-07-31 (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; report docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md; handoff 02-verify-plan; #815'
+    - '2026-07-31 S034/EV-027 01-requirements STARTED (delta) — deepen F25/F9/F7.g; D-S034-open=1,1,2,1; starting delta interview; #815'
     - 'S033/EV-026 01-requirements COMPLETE 2026-07-31 (delta) — E26-E1=1; deepen F23/F6/F7.g; D-S033-E26-E1; report docs/sessions/S033-va-multi-location-equality/reports/01-requirements.md; handoff 02-verify-plan; #809'
     - '2026-07-31 S033/EV-026 01-requirements STARTED (delta) — #809 ADR-032 equality; F23/F6/F7; D-S033-open; interview pending'
     - 'S032/EV-025 01-requirements COMPLETE 2026-07-31 (delta) — E25-E1=1; deepen F6/F12/F2/F13/F23; D-S032-E25-E1; report docs/sessions/S032-iwxxm-us-remarks-va/reports/01-requirements.md; handoff 02-verify-plan; #810/#811/#812/#809'
@@ -3423,57 +3599,46 @@ stages:
     - 2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. interviews.completed 7/7; planned_docs api-contract+adr completed
     - 2026-07-12 S008-realtime-ingest amend COMPLETE — delta status completed; overall 01-requirements completed; advancing to 04-tech-plan (pending)
   02-verify-plan:
-    status: completed
+    status: in_progress
     mode: delta
     started_at: '2026-07-31'
     started: '2026-07-31'
-    completed_at: '2026-07-31'
-    completed: '2026-07-31'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    prior_note: 'S033/EV-026 02-verify-plan STARTED (delta) — D-S033-E26-E1; #809'
-    note: 'PASS — Batch F 1,1,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S033-02-phase-a; #809'
-    auto_approved: 12
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    prior_note: 'PASS — Batch F 1,1,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S033-02-phase-a; #809'
+    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
     contradictions_resolved:
     contradictions_deferred:
     decision_refs:
-    - D-S033-E26-E1
-    - S02.M1
-    - S02.M2
-    - S02.L1
-    - D-S033-02-phase-a
+    - D-S034-E27-E1
+    - E27-E1
     substeps:
       inventory:
-        status: completed
+        status: pending
       consistency_check:
-        status: completed
+        status: pending
       statement_review:
-        auto_approved: 12
+        auto_approved: 0
         pending:
         reviewed:
     current_document:
     current_statement:
     active_session:
-      session_id: S033-va-multi-location-equality
-      evolve_cycle_id: EV-026
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
       skill_id: 02-verify-plan
-      status: completed
+      status: in_progress
       mode: delta
       started_at: '2026-07-31'
       started: '2026-07-31'
-      completed_at: '2026-07-31'
-      completed: '2026-07-31'
-      note: 'PASS — Batch F 1,1,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S033-02-phase-a; #809'
+      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
       feature_ids:
-      - F23
-      - F6
+      - F25
+      - F9
       - F7
       decision_refs:
-      - D-S033-E26-E1
-      - S02.M1
-      - S02.M2
-      - S02.L1
-      - D-S033-02-phase-a
+      - D-S034-E27-E1
+      - E27-E1
     artifacts:
     - docs/sessions/S033-va-multi-location-equality/reports/02-verify-plan-audit.md
     - docs/sessions/S032-iwxxm-us-remarks-va/reports/02-verify-plan-audit.md
@@ -3489,6 +3654,25 @@ stages:
     - docs/sessions/S020-aerodrome-quality/reports/02-verify-plan-audit.md
     - docs/sessions/S019-dissemination-upload/reports/02-verify-plan-audit.md
     delta_substages:
+    - session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      skill_id: 02-verify-plan
+      status: in_progress
+      started_at: '2026-07-31'
+      started: '2026-07-31'
+      mode: delta
+      deepen:
+      - F25
+      - F9
+      - F7
+      feature_ids:
+      - F25
+      - F9
+      - F7
+      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+      decision_refs:
+      - D-S034-E27-E1
+      - E27-E1
     - session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
       skill_id: 02-verify-plan
@@ -3815,6 +3999,7 @@ stages:
       - docs/feature-list.md
       - docs/CORPUS.md
     notes:
+    - '2026-07-31 S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
     - '2026-07-31 S033/EV-026 02-verify-plan COMPLETE (D-S033-02-phase-a) — PASS; Batch F 1,1,1; Gate A Lean → 04-tech-plan; report docs/sessions/S033-va-multi-location-equality/reports/02-verify-plan-audit.md; #809'
     - '2026-07-31 S033/EV-026 02-verify-plan STARTED (delta) — D-S033-E26-E1; #809'
     - '2026-07-31 S032/EV-025 02-verify-plan COMPLETE (D-S032-02-phase-a) — PASS; 12 auto + S02.M1/M2/L1=1; Gate A Lean → 04; report docs/sessions/S032-iwxxm-us-remarks-va/reports/02-verify-plan-audit.md; #810/#811/#812/#809'
@@ -23200,8 +23385,126 @@ evolve_cycles:
   close_decision_id: D-S033-EV026-phase4-close
   close_note: 'Phase 4 close 2026-07-31 (D-S033-EV026-phase4-close option 1) — approve 13 results; PR #817 merged 101f555; #818 MERGED @ 8c76421; #809 closed; EV-026/S033 complete'
   note: 'D-S033-EV026-phase4-close — Phase 4 close 2026-07-31; EV-026/S033 complete; PR #817 101f555; 13 PASS; #818 MERGED @ 8c76421 (D-S033-818-merge); #809 closed'
+- id: EV-027
+  session_id: S034-wmo-decode-residual-matrix
+  cycle_type: feature
+  feature_ids:
+  - F25
+  - F9
+  - F7
+  title: "Official WMO decode residual matrix (#815)"
+  status: in_progress
+  started: '2026-07-31'
+  started_at: '2026-07-31'
+  completed: null
+  scope_summary: |
+    #815 — every in-scope official WMO TAC peer loadable (or FIXTURE_GAPS) + decode residual
+    matrix empty or allowlisted; CI gate. Deepen F25/F9/F7.g. Lean+build.
+    Phase 0 locked D-S034-open=1,1,2,1 (E27-1..4).
+  github_issues:
+  - '815'
+  branch: evolve/EV-027-wmo-decode-residual-matrix
+  preset: Lean+build
+  preset_status: approved
+  current_stage: 02-verify-plan
+  routing_plan:
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 04-tech-plan
+    - 07-build
+    - 08-verify-build
+    - 10-e2e
+    skipped_stages:
+    - 03-plan-tooling
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 09-qa
+    - 11-verify-impl
+    - 12-verify-deploy
+    when_ships:
+    - 13-deploy-smoke
+    note: "Lean+build — skip 03/05/06/09/11/12; 13 when_ships"
+  stages:
+    00-context:
+      status: completed
+      started: '2026-07-31'
+      completed: '2026-07-31'
+      note: Phase 0 locked D-S034-open=1,1,2,1
+    16-evolve:
+      status: in_progress
+      started: '2026-07-31'
+      note: Phase 0 done; 01-requirements delta interview
+    01-requirements:
+      status: completed
+      mode: delta
+      started: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
+    02-verify-plan:
+      status: in_progress
+      mode: delta
+      started: '2026-07-31'
+      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+    04-tech-plan:
+      status: pending
+      mode: delta
+    07-build:
+      status: pending
+      mode: full
+    08-verify-build:
+      status: pending
+      mode: delta
+    10-e2e:
+      status: pending
+      mode: smoke
+    13-deploy-smoke:
+      status: pending
+      mode: when_ships
+  gates:
+    a_to_b: pending
+    b_to_c: pending
+    c_to_d: pending
+    deploy: pending
+  checkpoints:
+    phase_a: pending
+    phase_b: pending
+    phase_c: pending
+    phase_d: pending
+    deploy: pending
+  decision_refs:
+  - D-S034-open
+  - E27-1
+  - E27-2
+  - E27-3
+  - E27-4
+  - D-S034-E27-E1
+  - E27-E1
+  answers:
+    E27-1: '1'
+    E27-2: '1'
+    E27-3: '2'
+    E27-4: '1'
+    E27-E1: '1'
+  artifacts:
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
+    status: approved
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+    status: approved
+  - path: docs/context/wmo-decode-residual-matrix.md
+    status: draft
+  - path: docs/decisions/evolve-decisions.md
+    status: approved
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
+    status: completed
+  notes:
+  - '2026-07-31 S034/EV-027 01-requirements COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; handoff 02-verify-plan; #815'
+  - '2026-07-31 S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+  - '2026-07-31 S034/EV-027 Phase 0 locked D-S034-open=1,1,2,1 — E27-1..4; handoff 01-requirements; branch evolve/EV-027-wmo-decode-residual-matrix; #815'
 git_history:
-  current_branch: main
+  current_branch: evolve/EV-027-wmo-decode-residual-matrix
   ahead_of_origin: 0
   pushed: true
   pending_commit:
@@ -23217,9 +23520,9 @@ git_history:
   closeout_pr_status: merged
   closeout_merge_sha: 8c76421
   closeout_merge_sha_full: 8c7642110dbef1b9897154a20fcc76981a641062
-  note: 'S033/EV-026 close complete — #817 @ 101f555; #818 MERGED @ 8c76421 (D-S033-818-merge); active_session=null'
+  note: 'S034/EV-027 Phase 0 locked D-S034-open=1,1,2,1; 01-requirements STARTED; branch evolve/EV-027-wmo-decode-residual-matrix'
   notes:
-  - '2026-07-31 S033/EV-026 PR #818 MERGED @ 8c76421 (D-S033-818-merge) — closeout docs; branch docs/S033-ev026-deploy-smoke; tip 8c76421; active_session=null'
+  - '2026-07-31 S034/EV-027 OPEN — Phase 0 locked D-S034-open=1,1,2,1; 01-requirements STARTED; branch evolve/EV-027-wmo-decode-residual-matrix; #815'
   - '2026-07-31 S033/EV-026 CLOSED — Phase 4 close D-S033-EV026-phase4-close; PR #817 merged 101f555; 13 PASS approved; docs branch docs/S033-ev026-deploy-smoke / PR #818; active_session=null'
   - '2026-07-31 S033/EV-026 PR #817 MERGED @ 101f555 (D-S033-817-merge) — merge_commit 101f55586efacaee67bcd4260a04aa6758502123; optional 13/T3.4 when_ships pending user'
   - '2026-07-31 S033/EV-026 tip synced — 7e08051; Gate C PASS (D-S033-gate-c); 07/08/10 complete; T3.4/13 when_ships; #809 closed; awaiting PR'
@@ -23482,6 +23785,11 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-027-wmo-decode-residual-matrix
+    base: main
+    status: active
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
   - name: docs/S033-ev026-deploy-smoke
     purpose: S033/EV-026 13-deploy-smoke + closeout docs
     base: main

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -31,7 +31,7 @@ active_session:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 04-tech-plan
+  current_stage: 07-build
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -66,13 +66,16 @@ active_session:
   - stage: 04-tech-plan
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+    completed: '2026-07-31'
+    note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B Lean → 07 @ T0.1 (D-S034-04-plan-approve); #815'
   - stage: 07-build
     required: true
     mode: full
-    status: pending
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
   - stage: 08-verify-build
     required: true
     mode: delta
@@ -111,7 +114,7 @@ sessions:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 04-tech-plan
+  current_stage: 07-build
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -146,13 +149,16 @@ sessions:
   - stage: 04-tech-plan
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+    completed: '2026-07-31'
+    note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B Lean → 07 @ T0.1 (D-S034-04-plan-approve); #815'
   - stage: 07-build
     required: true
     mode: full
-    status: pending
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
   - stage: 08-verify-build
     required: true
     mode: delta
@@ -4151,10 +4157,12 @@ stages:
       - .cursor/hooks.json
       - .cursor/hooks/feature_drift.py
   04-tech-plan:
-    status: in_progress
+    status: completed
     mode: delta
     started_at: '2026-07-31'
     started: '2026-07-31'
+    completed_at: '2026-07-31'
+    completed: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
     previous_session_id: S033-va-multi-location-equality
@@ -4162,37 +4170,47 @@ stages:
     previous_note: 'S033/EV-026 04-tech-plan COMPLETE — Batch T E26-T1..T5=1,1,2,1,1; execution-plan approved M0–M3 (12 tasks); Gate B Lean → 07 @ T0.1 (D-S033-04-plan-approve)'
     session_id: S034-wmo-decode-residual-matrix
     evolve_cycle_id: EV-027
-    prior_note: 'S034/EV-027 02-verify-plan COMPLETE (D-S034-02-phase-a) — PASS Batch F 1,2,1; Gate A Lean → 04; report reports/02-verify-plan-audit.md; #815'
-    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+    prior_note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+    note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B Lean → 07 @ T0.1 (D-S034-04-plan-approve); #815'
     decision_refs:
+    - D-S034-04-plan-approve
+    - D-S034-E27-T-batch
     - D-S034-02-phase-a
     - D-S034-E27-E1
     - S02.M1
     - S02.M2
     - S02.L1
     - E27-02
+    - E27-T1
+    - E27-T2
+    - E27-T3
+    - E27-T4
+    - E27-T5
+    - E27-04
     substeps:
       phase_1_toolchain:
-        status: pending
+        status: completed
       phase_2_interview:
-        status: pending
+        status: completed
       phase_3_execution_plan:
-        status: pending
+        status: completed
       phase_4_user_review:
-        status: pending
+        status: completed
       phase_5_back_add:
-        status: pending
+        status: completed
       phase_6_documents:
-        status: pending
+        status: completed
     active_session:
       session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 04-tech-plan
-      status: in_progress
+      status: completed
       mode: delta
       started_at: '2026-07-31'
       started: '2026-07-31'
-      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved; Gate B → 07 @ T0.1 (D-S034-04-plan-approve); #815'
       feature_ids:
       - F25
       - F9
@@ -4232,9 +4250,11 @@ stages:
     - session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 04-tech-plan
-      status: in_progress
+      status: completed
       started_at: '2026-07-31'
       started: '2026-07-31'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
       mode: delta
       deepen:
       - F25
@@ -4244,14 +4264,22 @@ stages:
       - F25
       - F9
       - F7
-      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+      note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B → 07 @ T0.1 (D-S034-04-plan-approve); #815'
       decision_refs:
+      - D-S034-04-plan-approve
+      - D-S034-E27-T-batch
       - D-S034-02-phase-a
       - D-S034-E27-E1
       - S02.M1
       - S02.M2
       - S02.L1
       - E27-02
+      - E27-T1
+      - E27-T2
+      - E27-T3
+      - E27-T4
+      - E27-T5
+      - E27-04
       artifacts:
       - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
       - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
@@ -4862,6 +4890,7 @@ stages:
       - docs/sessions/S015-metar-lint-quality/reports/execution-plan.md
       - docs/sessions/S015-metar-lint-quality/reports/04-tech-plan.md
     notes:
+    - '2026-07-31 S034/EV-027 04 COMPLETE Gate B=1 (D-S034-04-plan-approve) — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); handoff 07 @ T0.1; gates.b_to_c pending (plan approved); #815'
     - '2026-07-31 S033/EV-026 04 COMPLETE Gate B=1 (D-S033-04-plan-approve) — Batch T E26-T1..T5=1,1,2,1,1; execution-plan approved M0–M3 (12 tasks); B→C; handoff 07 @ T0.1; #809'
     - '2026-07-31 S033/EV-026 04 Batch T locked E26-T1..T5=1,1,2,1,1 (D-S033-E26-T-batch) — draft execution-plan 12 tasks M0–M3 + 04-tech-plan.md; Gate B approved; #809'
     - '2026-07-31 S033/EV-026 04-tech-plan STARTED (D-S033-02-phase-a) — Gate A Lean (Batch F 1,1,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #809'
@@ -5111,80 +5140,95 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: completed
+    status: in_progress
     started_at: '2026-07-31'
     started: '2026-07-31'
-    completed: '2026-07-31'
-    completed_at: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
-    previous_session_id: S032-iwxxm-us-remarks-va
-    previous_evolve_cycle_id: EV-025
-    previous_tip_sha: 50d3d0a
-    previous_note: 'S032/EV-025 07-build COMPLETE (T0.1–T7.2); T7.3 deferred D-S032-EV025-closeout=1 (when ships after merge); tip 1e46b38; progress 27/28; #810/#811/#812/#809'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    note: 'S033/EV-026 07-build COMPLETE — M0–M3 done except T3.4 when_ships; tip 7e08051; #809 closed; Gate C PASS (D-S033-gate-c); progress 11/12'
-    tip_sha: .inf
-    tip_sha_full: 7e08051d0b2bfc8801d4fbeefb5fdcff155d14a3
-    current_stage: M3
-    current_milestone: M3
-    current_task: T3.4
-    active_milestone: M3
-    active_task: T3.4
-    active_task_status: deferred
-    progress: 11/12
+    previous_session_id: S033-va-multi-location-equality
+    previous_evolve_cycle_id: EV-026
+    previous_tip_sha: 7e08051
+    previous_tip_sha_full: 7e08051d0b2bfc8801d4fbeefb5fdcff155d14a3
+    previous_note: 'S033/EV-026 07-build COMPLETE — M0–M3 done except T3.4 when_ships; tip 7e08051; #809 closed; Gate C PASS (D-S033-gate-c); progress 11/12'
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
+    current_stage: M0
+    current_milestone: M0
+    current_task: T0.1
+    active_milestone: M0
+    active_task: T0.1
+    active_task_status: in_progress
+    progress: 0/14
     decision_refs:
-    - D-S033-gate-c
-    - D-S033-04-plan-approve
-    - D-S033-E26-T-batch
+    - D-S034-04-plan-approve
+    - D-S034-E27-T-batch
+    - E27-T1
+    - E27-T2
+    - E27-T3
+    - E27-T4
+    - E27-T5
     artifacts:
-    - docs/sessions/S033-va-multi-location-equality/reports/t3-1-gate-c-dig.md
-    - docs/sessions/S033-va-multi-location-equality/reports/verification-report.md
-    - docs/sessions/S033-va-multi-location-equality/reports/t0-1-canonicalize-diff-themes.md
-    - docs/sessions/S033-va-multi-location-equality/reports/execution-plan.md
-    - docs/sessions/S033-va-multi-location-equality/reports/04-tech-plan.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     active_session:
-      session_id: S033-va-multi-location-equality
-      evolve_cycle_id: EV-026
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
       skill_id: 07-build
-      status: completed
+      status: in_progress
       mode: full
       started_at: '2026-07-31'
       started: '2026-07-31'
-      completed: '2026-07-31'
-      completed_at: '2026-07-31'
-      note: 'COMPLETE — M0–M3 except T3.4 when_ships; Gate C PASS; tip 7e08051; #809 closed'
-      active_milestone: M3
-      current_milestone: M3
-      active_task: T3.4
-      current_task: T3.4
-      active_task_status: deferred
+      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
+      active_milestone: M0
+      current_milestone: M0
+      active_task: T0.1
+      current_task: T0.1
+      active_task_status: in_progress
+      progress: 0/14
       deepen:
-      - F23
-      - F6
+      - F25
+      - F9
       - F7
       decision_refs:
-      - D-S033-gate-c
-      - D-S033-04-plan-approve
-      - D-S033-E26-T-batch
+      - D-S034-04-plan-approve
+      - D-S034-E27-T-batch
       artifacts:
-      - docs/sessions/S033-va-multi-location-equality/reports/t3-1-gate-c-dig.md
-      - docs/sessions/S033-va-multi-location-equality/reports/verification-report.md
-      - docs/sessions/S033-va-multi-location-equality/reports/t0-1-canonicalize-diff-themes.md
-      - docs/sessions/S033-va-multi-location-equality/reports/execution-plan.md
-      progress: 11/12
-      tip_sha: .inf
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
     substeps:
       task_loop:
-        status: completed
-        current_task: T3.4
-        active_task_status: deferred
-        active_milestone: M3
+        status: in_progress
+        current_task: T0.1
+        active_task_status: in_progress
+        active_milestone: M0
         phase: C
-        milestone: M3
-        notes: 'S033/EV-026 07 COMPLETE Gate C PASS; T3.4 deferred when_ships; tip 7e08051; #809'
+        milestone: M0
+        notes: 'S034/EV-027 07-build @ T0.1 inventory dig; D-S034-04-plan-approve; #815'
     delta_substages:
+    - id: S034-wmo-decode-residual-matrix
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      skill_id: 07-build
+      status: in_progress
+      started_at: '2026-07-31'
+      started: '2026-07-31'
+      mode: full
+      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
+      active_milestone: M0
+      current_milestone: M0
+      active_task: T0.1
+      current_task: T0.1
+      active_task_status: in_progress
+      progress: 0/14
+      decision_id: D-S034-04-plan-approve
+      branch: evolve/EV-027-wmo-decode-residual-matrix
+      deepen:
+      - F25
+      - F9
+      - F7
+      artifacts:
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     - id: S033-va-multi-location-equality
       session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
@@ -5545,6 +5589,7 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - '2026-07-31 S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
     - '2026-07-31 S032/EV-025 PR #816 open; tip 50d3d0a; T7.3 deferred'
     - 2026-07-31 S032/EV-025 closeout=1; T7.3 deferred; PR opening
     - '2026-07-31 S032/EV-025 T7.2 COMPLETE @ 1e46b38; 08-verify-build + 10-e2e smoke PASS; next T7.3 when ships / PR closeout; progress 27/28; #810/#811/#812/#809'
@@ -23461,7 +23506,7 @@ evolve_cycles:
   branch: evolve/EV-027-wmo-decode-residual-matrix
   preset: Lean+build
   preset_status: approved
-  current_stage: 04-tech-plan
+  current_stage: 07-build
   routing_plan:
     required_stages:
     - 00-context
@@ -23505,13 +23550,19 @@ evolve_cycles:
       completed: '2026-07-31'
       note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
     04-tech-plan:
-      status: in_progress
+      status: completed
       mode: delta
       started: '2026-07-31'
-      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+      completed: '2026-07-31'
+      note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B Lean → 07 @ T0.1 (D-S034-04-plan-approve); #815'
     07-build:
-      status: pending
+      status: in_progress
       mode: full
+      started: '2026-07-31'
+      current_task: T0.1
+      active_milestone: M0
+      progress: 0/14
+      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
     08-verify-build:
       status: pending
       mode: delta
@@ -23524,11 +23575,13 @@ evolve_cycles:
   gates:
     a_to_b: passed
     b_to_c: pending
+    b_to_c_note: plan approved (D-S034-04-plan-approve); Batch T 2,1,2,1,1; Lean skip 05/06; 07-build @ T0.1; formal B→C pending
     c_to_d: pending
     deploy: pending
   checkpoints:
     phase_a: passed
     phase_b: pending
+    phase_b_note: plan approved (D-S034-04-plan-approve); formal Phase B checkpoint pending Lean skip 05/06
     phase_c: pending
     phase_d: pending
     deploy: pending
@@ -23545,6 +23598,14 @@ evolve_cycles:
   - S02.M2
   - S02.L1
   - E27-02
+  - D-S034-04-plan-approve
+  - D-S034-E27-T-batch
+  - E27-T1
+  - E27-T2
+  - E27-T3
+  - E27-T4
+  - E27-T5
+  - E27-04
   answers:
     E27-1: '1'
     E27-2: '1'
@@ -23555,6 +23616,12 @@ evolve_cycles:
     S02.M2: '2'
     S02.L1: '1'
     E27-02: PASS
+    E27-T1: '2'
+    E27-T2: '1'
+    E27-T3: '2'
+    E27-T4: '1'
+    E27-T5: '1'
+    E27-04: '1'
   artifacts:
   - path: docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
     status: approved
@@ -23569,10 +23636,12 @@ evolve_cycles:
   - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
     status: completed
   - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
-    status: draft
+    status: approved
   - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
-    status: draft
+    status: completed
   notes:
+  - '2026-07-31 S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
+  - '2026-07-31 S034/EV-027 04 COMPLETE Gate B=1 (D-S034-04-plan-approve) — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); handoff 07 @ T0.1; #815'
   - '2026-07-31 S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
   - '2026-07-31 S034/EV-027 02-verify-plan COMPLETE (D-S034-02-phase-a) — PASS Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04-tech-plan; report docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md; #815'
   - '2026-07-31 S034/EV-027 01-requirements COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; handoff 02-verify-plan; #815'

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -15,6 +15,7 @@ active_session:
   evolve_cycle_id: EV-027
   github_issues:
   - '815'
+  - '820'
   feature_ids:
   - F25
   - F9
@@ -31,7 +32,8 @@ active_session:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 07-build
+  current_stage: 10-e2e
+  note: 'S034/EV-027 07/08/10 COMPLETE — M0–M2 build; tip 245d518; gates.c_to_d pending (awaiting PR); #815/#820'
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -73,17 +75,24 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
+    completed: '2026-07-31'
+    note: 'COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; #815/#820'
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'PASS — verification-report.md; tip 245d518; #815'
   - stage: 10-e2e
     required: true
     mode: smoke
-    status: pending
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'PASS — e2e-report.md; tip 245d518; awaiting Gate C / PR; #815'
   - stage: 13-deploy-smoke
     required: when_ships
     mode: full
@@ -98,6 +107,7 @@ sessions:
   evolve_cycle_id: EV-027
   github_issues:
   - '815'
+  - '820'
   feature_ids:
   - F25
   - F9
@@ -114,7 +124,8 @@ sessions:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 07-build
+  current_stage: 10-e2e
+  note: 'S034/EV-027 07/08/10 COMPLETE — M0–M2 build; tip 245d518; gates.c_to_d pending (awaiting PR); #815/#820'
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -156,17 +167,24 @@ sessions:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
+    completed: '2026-07-31'
+    note: 'COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; #815/#820'
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'PASS — verification-report.md; tip 245d518; #815'
   - stage: 10-e2e
     required: true
     mode: smoke
-    status: pending
+    status: completed
+    started: '2026-07-31'
+    completed: '2026-07-31'
+    note: 'PASS — e2e-report.md; tip 245d518; awaiting Gate C / PR; #815'
   - stage: 13-deploy-smoke
     required: when_ships
     mode: full
@@ -5140,9 +5158,11 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: in_progress
+    status: completed
     started_at: '2026-07-31'
     started: '2026-07-31'
+    completed_at: '2026-07-31'
+    completed: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
     previous_session_id: S033-va-multi-location-equality
@@ -5152,14 +5172,16 @@ stages:
     previous_note: 'S033/EV-026 07-build COMPLETE — M0–M3 done except T3.4 when_ships; tip 7e08051; #809 closed; Gate C PASS (D-S033-gate-c); progress 11/12'
     session_id: S034-wmo-decode-residual-matrix
     evolve_cycle_id: EV-027
-    note: 'S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
-    current_stage: M0
-    current_milestone: M0
-    current_task: T0.1
-    active_milestone: M0
-    active_task: T0.1
-    active_task_status: in_progress
-    progress: 0/14
+    tip_sha: 245d518
+    tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
+    note: 'S034/EV-027 07-build COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; #815/#820'
+    current_stage: M2
+    current_milestone: M2
+    current_task: T2.4
+    active_milestone: M2
+    active_task: T2.4
+    active_task_status: completed
+    progress: 10/14
     decision_refs:
     - D-S034-04-plan-approve
     - D-S034-E27-T-batch
@@ -5175,17 +5197,19 @@ stages:
       session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 07-build
-      status: in_progress
+      status: completed
       mode: full
       started_at: '2026-07-31'
       started: '2026-07-31'
-      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
-      active_milestone: M0
-      current_milestone: M0
-      active_task: T0.1
-      current_task: T0.1
-      active_task_status: in_progress
-      progress: 0/14
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; handoff 08-verify-build; #815/#820'
+      active_milestone: M2
+      current_milestone: M2
+      active_task: T2.4
+      current_task: T2.4
+      active_task_status: completed
+      progress: 10/14
       deepen:
       - F25
       - F9
@@ -5197,30 +5221,34 @@ stages:
       - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
     substeps:
       task_loop:
-        status: in_progress
-        current_task: T0.1
-        active_task_status: in_progress
-        active_milestone: M0
+        status: completed
+        current_task: T2.4
+        active_task_status: completed
+        active_milestone: M2
         phase: C
-        milestone: M0
-        notes: 'S034/EV-027 07-build @ T0.1 inventory dig; D-S034-04-plan-approve; #815'
+        milestone: M2
+        notes: 'S034/EV-027 07-build COMPLETE M0–M2; tip 245d518; #815/#820'
     delta_substages:
     - id: S034-wmo-decode-residual-matrix
       session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 07-build
-      status: in_progress
+      status: completed
       started_at: '2026-07-31'
       started: '2026-07-31'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
       mode: full
-      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
-      active_milestone: M0
-      current_milestone: M0
-      active_task: T0.1
-      current_task: T0.1
-      active_task_status: in_progress
-      progress: 0/14
+      note: 'COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; #815/#820'
+      active_milestone: M2
+      current_milestone: M2
+      active_task: T2.4
+      current_task: T2.4
+      active_task_status: completed
+      progress: 10/14
       decision_id: D-S034-04-plan-approve
+      tip_sha: 245d518
+      tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
       branch: evolve/EV-027-wmo-decode-residual-matrix
       deepen:
       - F25
@@ -5589,6 +5617,7 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - '2026-07-31 S034/EV-027 07-build COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; 08/10 PASS; gates.c_to_d pending (awaiting PR); #815/#820'
     - '2026-07-31 S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; plan docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md; gates.b_to_c pending (plan approved); #815'
     - '2026-07-31 S032/EV-025 PR #816 open; tip 50d3d0a; T7.3 deferred'
     - 2026-07-31 S032/EV-025 closeout=1; T7.3 deferred; PR opening
@@ -6154,17 +6183,17 @@ stages:
     completed_at: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
-    previous_session_id: S032-iwxxm-us-remarks-va
-    previous_evolve_cycle_id: EV-025
-    previous_tip_sha: 1e46b38
-    previous_note: 'S032/EV-025 10-e2e smoke COMPLETE PASS — T7.2; report docs/sessions/S032-iwxxm-us-remarks-va/reports/e2e-report.md; tip 1e46b38; progress 27/28; #810/#811/#812/#809'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    tip_sha: .inf
-    tip_sha_full: 7e08051d0b2bfc8801d4fbeefb5fdcff155d14a3
+    previous_session_id: S033-va-multi-location-equality
+    previous_evolve_cycle_id: EV-026
+    previous_tip_sha: 7e08051
+    previous_note: 'S033/EV-026 10-e2e smoke COMPLETE PASS — TC-EV025-008/009 + Vitest (T3.2); tip 7e08051; Gate C PASS; #809'
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    tip_sha: 245d518
+    tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
     overall: pass
-    report: docs/sessions/S033-va-multi-location-equality/reports/verification-report.md
-    note: 'S033/EV-026 10-e2e smoke COMPLETE PASS — TC-EV025-008/009 + Vitest (T3.2); tip 7e08051; Gate C PASS; #809'
+    report: docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
+    note: 'S034/EV-027 10-e2e smoke COMPLETE PASS — e2e-report.md; tip 245d518; awaiting Gate C / PR; #815'
     substeps:
       extract_journeys:
         status: completed
@@ -6175,11 +6204,23 @@ stages:
         note: browser N/A — smoke via package/Vitest only
       t2_connectivity:
         status: skipped
-        note: deferred to 13 when_ships (T3.4)
+        note: deferred to 13 when_ships
       t3_live:
         status: skipped
-        note: deferred to 13 when_ships (T3.4)
+        note: deferred to 13 when_ships
     delta_substages:
+    - session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      skill_id: 10-e2e
+      status: completed
+      started_at: '2026-07-31'
+      completed_at: '2026-07-31'
+      mode: smoke
+      overall: pass
+      report: docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
+      tip_sha: 245d518
+      tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
+      note: smoke PASS — docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
     - session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
       skill_id: 10-e2e
@@ -6456,6 +6497,7 @@ stages:
       report: docs/sessions/S011-f7-operator-ui/reports/e2e-report.md
       note: T6.2 pass_with_advisories; Playwright/compose SKIPPED host ports/disk
     notes:
+    - '2026-07-31 S034/EV-027 10-e2e smoke COMPLETE PASS — e2e-report.md; tip 245d518; awaiting Gate C / PR; #815'
     - 2026-07-31 S032/EV-025 10-e2e smoke COMPLETE PASS — T7.2 @ 1e46b38; docs/sessions/S032-iwxxm-us-remarks-va/reports/e2e-report.md
     - '2026-07-30 S030/EV-023 10-e2e COMPLETE (smoke) — PASS; e2e-report.md; browser N/A; T7.3 done; next T7.4 13; progress 23/24; tip 9c040ee; #800'
     - '2026-07-29 S026/EV-020 10-e2e COMPLETE PASS — T6.3 UJ-035/036 T0; e2e-report.md; tip c963a0a (no [T6.3] commit yet); handoff 11-verify-impl T6.4; progress 25/~28; #731'
@@ -6488,17 +6530,17 @@ stages:
     completed: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
-    previous_session_id: S032-iwxxm-us-remarks-va
-    previous_evolve_cycle_id: EV-025
-    previous_tip_sha: 1e46b38
-    previous_note: 'S032/EV-025 08-verify-build COMPLETE PASS — T7.2; report docs/sessions/S032-iwxxm-us-remarks-va/reports/verification-report.md; tip 1e46b38; progress 27/28; #810/#811/#812/#809'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    tip_sha: .inf
-    tip_sha_full: 7e08051d0b2bfc8801d4fbeefb5fdcff155d14a3
+    previous_session_id: S033-va-multi-location-equality
+    previous_evolve_cycle_id: EV-026
+    previous_tip_sha: 7e08051
+    previous_note: 'S033/EV-026 08-verify-build COMPLETE PASS — T3.2; report docs/sessions/S033-va-multi-location-equality/reports/verification-report.md; tip 7e08051; Gate C PASS; #809'
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    tip_sha: 245d518
+    tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
     overall: pass
-    note: 'S033/EV-026 08-verify-build COMPLETE PASS — T3.2; report docs/sessions/S033-va-multi-location-equality/reports/verification-report.md; tip 7e08051; Gate C PASS; #809'
-    report: docs/sessions/S033-va-multi-location-equality/reports/verification-report.md
+    note: 'S034/EV-027 08-verify-build COMPLETE PASS — verification-report.md; tip 245d518; #815'
+    report: docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
     substeps:
       lint:
         status: completed
@@ -6513,6 +6555,18 @@ stages:
       report:
         status: completed
     delta_substages:
+    - session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      skill_id: 08-verify-build
+      status: completed
+      started_at: '2026-07-31'
+      completed_at: '2026-07-31'
+      mode: delta
+      overall: pass
+      report: docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
+      tip_sha: 245d518
+      tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
+      note: PASS — docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
     - session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
       skill_id: 08-verify-build
@@ -6792,6 +6846,7 @@ stages:
       report: docs/sessions/S011-f7-operator-ui/reports/verification-report.md
       note: T6.1 PASS; integration SKIPPED host ports/disk; C→D passed D-S011-EV008-c-to-d-pass
     notes:
+    - '2026-07-31 S034/EV-027 08-verify-build COMPLETE PASS — verification-report.md; tip 245d518; #815'
     - 2026-07-31 S032/EV-025 08-verify-build COMPLETE PASS — T7.2 @ 1e46b38; docs/sessions/S032-iwxxm-us-remarks-va/reports/verification-report.md
     - '2026-07-30 S030/EV-023 08-verify-build COMPLETE PASS — T7.2; report docs/sessions/S030-apac-encode-validate/reports/verification-report.md; handoff T7.3 10-e2e smoke; progress 22/24; #800'
     - '2026-07-29 S026/EV-020 08-verify-build COMPLETE PASS — T6.2 @ e839a6e; report docs/sessions/S026-airmet-quality-wmo-examples/reports/verification-report.md; FileConverter WMO A3-1 label fix; handoff 10-e2e T6.3; #731'
@@ -23503,10 +23558,12 @@ evolve_cycles:
     Phase 0 locked D-S034-open=1,1,2,1 (E27-1..4).
   github_issues:
   - '815'
+  - '820'
   branch: evolve/EV-027-wmo-decode-residual-matrix
   preset: Lean+build
   preset_status: approved
-  current_stage: 07-build
+  current_stage: 10-e2e
+  note: 'S034/EV-027 07/08/10 COMPLETE — M0–M2 build; tip 245d518; gates.c_to_d pending (awaiting PR); #815/#820'
   routing_plan:
     required_stages:
     - 00-context
@@ -23556,35 +23613,57 @@ evolve_cycles:
       completed: '2026-07-31'
       note: 'COMPLETE — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); Gate B Lean → 07 @ T0.1 (D-S034-04-plan-approve); #815'
     07-build:
-      status: in_progress
+      status: completed
       mode: full
       started: '2026-07-31'
-      current_task: T0.1
-      active_milestone: M0
-      progress: 0/14
-      note: 'STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
+      completed: '2026-07-31'
+      current_task: T2.4
+      active_milestone: M2
+      progress: 10/14
+      tip_sha: 245d518
+      note: 'COMPLETE — M0–M2 (T0.1–T2.4); tip 245d518; gates.b_to_c passed; #815/#820'
     08-verify-build:
-      status: pending
+      status: completed
       mode: delta
+      started: '2026-07-31'
+      completed: '2026-07-31'
+      overall: pass
+      report: docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
+      tip_sha: 245d518
+      note: 'PASS — verification-report.md; tip 245d518; #815'
     10-e2e:
-      status: pending
+      status: completed
       mode: smoke
+      started: '2026-07-31'
+      completed: '2026-07-31'
+      overall: pass
+      report: docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
+      tip_sha: 245d518
+      note: 'PASS — e2e-report.md; tip 245d518; awaiting Gate C / PR; #815'
     13-deploy-smoke:
       status: pending
       mode: when_ships
   gates:
     a_to_b: passed
-    b_to_c: pending
-    b_to_c_note: plan approved (D-S034-04-plan-approve); Batch T 2,1,2,1,1; Lean skip 05/06; 07-build @ T0.1; formal B→C pending
+    b_to_c: passed
+    b_to_c_note: M0–M2 build complete @ 245d518; 08/10 PASS
     c_to_d: pending
+    c_to_d_note: plan done; 07/08/10 complete; awaiting PR (Gate C)
     deploy: pending
   checkpoints:
     phase_a: passed
-    phase_b: pending
-    phase_b_note: plan approved (D-S034-04-plan-approve); formal Phase B checkpoint pending Lean skip 05/06
-    phase_c: pending
+    phase_b: passed
+    phase_b_note: plan approved (D-S034-04-plan-approve); Lean skip 05/06
+    phase_c: passed
+    phase_c_note: build+verify complete (07/08/10 PASS @ 245d518); formal C→D pending PR
     phase_d: pending
     deploy: pending
+  issues:
+  - id: 820
+    title: 'Child: VAA/TCA G4 residual allowlist (from #815)'
+    parent: 815
+    status: open
+    note: 'Opened during T2.3 allowlist work; tracked in EV-027'
   decision_refs:
   - D-S034-open
   - E27-1
@@ -23639,7 +23718,14 @@ evolve_cycles:
     status: approved
   - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     status: completed
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/verification-report.md
+    status: completed
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/e2e-report.md
+    status: completed
+  tip_sha: 245d518
+  tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
   notes:
+  - '2026-07-31 S034/EV-027 07/08/10 COMPLETE — M0–M2 build; 08 PASS verification-report.md; 10 PASS e2e-report.md; tip 245d518; gates.c_to_d pending (awaiting PR); child #820; #815'
   - '2026-07-31 S034/EV-027 07-build STARTED (D-S034-04-plan-approve) — @ T0.1 inventory dig; gates.b_to_c pending (plan approved); #815'
   - '2026-07-31 S034/EV-027 04 COMPLETE Gate B=1 (D-S034-04-plan-approve) — Batch T E27-T1..T5=2,1,2,1,1; execution-plan approved M0–M3 (14 tasks); handoff 07 @ T0.1; #815'
   - '2026-07-31 S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
@@ -23652,20 +23738,16 @@ git_history:
   ahead_of_origin: 0
   pushed: true
   pending_commit:
-  tip_sha: 8c76421
-  tip_sha_full: 8c7642110dbef1b9897154a20fcc76981a641062
-  pr_number: 817
-  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/817
-  pr_status: merged
-  merge_sha: 101f555
-  merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
+  tip_sha: 245d518
+  tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
   closeout_pr_number: 818
   closeout_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/818
   closeout_pr_status: merged
   closeout_merge_sha: 8c76421
   closeout_merge_sha_full: 8c7642110dbef1b9897154a20fcc76981a641062
-  note: 'S034/EV-027 Phase 0 locked D-S034-open=1,1,2,1; 01-requirements STARTED; branch evolve/EV-027-wmo-decode-residual-matrix'
+  note: 'S034/EV-027 07/08/10 COMPLETE — M0–M2 build; tip 245d518; gates.c_to_d pending (awaiting PR); #815/#820'
   notes:
+  - '2026-07-31 S034/EV-027 tip synced — 245d518 (245d518aec33a41a0dd9cd59ae1b39262af50dfc); 07-build M0–M2 + 08/10 PASS; gates.c_to_d pending (awaiting PR); child #820; #815'
   - '2026-07-31 S034/EV-027 OPEN — Phase 0 locked D-S034-open=1,1,2,1; 01-requirements STARTED; branch evolve/EV-027-wmo-decode-residual-matrix; #815'
   - '2026-07-31 S033/EV-026 CLOSED — Phase 4 close D-S033-EV026-phase4-close; PR #817 merged 101f555; 13 PASS approved; docs branch docs/S033-ev026-deploy-smoke / PR #818; active_session=null'
   - '2026-07-31 S033/EV-026 PR #817 MERGED @ 101f555 (D-S033-817-merge) — merge_commit 101f55586efacaee67bcd4260a04aa6758502123; optional 13/T3.4 when_ships pending user'
@@ -23934,6 +24016,9 @@ git_history:
     status: active
     session_id: S034-wmo-decode-residual-matrix
     evolve_cycle_id: EV-027
+    tip_sha: 245d518
+    tip_sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
+    note: 'S034/EV-027 07/08/10 COMPLETE; tip 245d518; awaiting Gate C / PR; #815/#820'
   - name: docs/S033-ev026-deploy-smoke
     purpose: S033/EV-026 13-deploy-smoke + closeout docs
     base: main
@@ -24835,6 +24920,46 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 245d518
+    sha_full: 245d518aec33a41a0dd9cd59ae1b39262af50dfc
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[S034] docs: 08/10 verify PASS for EV-027 residual matrix"
+    stage: 08-verify-build
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    timestamp: '2026-07-31'
+  - sha: 994c3b1
+    sha_full: 994c3b185cdf5e3db753922962c373fd1e485320
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[S034] docs: mark M0–M2 tasks completed for EV-027"
+    stage: 07-build
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    timestamp: '2026-07-31'
+  - sha: 37b552b
+    sha_full: 37b552b66f65d0531c212d8a23c4fd90d953137b
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[T2.3] test: allowlist VAA/TCA G4 residuals with #820 (#815)"
+    stage: 07-build
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    timestamp: '2026-07-31'
+  - sha: f6561fe
+    sha_full: f6561fe6d0f2af842c79ba0e79e9414c26b78a8a
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[T2.2] fix: decode RVR, TAF/SIGMET CNL, and VA SIGMET geometry (#815)"
+    stage: 07-build
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    timestamp: '2026-07-31'
+  - sha: a043a12
+    sha_full: a043a126d3b3ff6222e18e2c1eb90d6eafbcb123
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[T0.1] test: official WMO TAC inventory + catalog∪gaps CI (#815)"
+    stage: 07-build
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    timestamp: '2026-07-31'
   - sha: 3c432b3
     sha_full: 3c432b31a9faaf8c5b7e3689d807331d8433bc1b
     branch: evolve/EV-027-wmo-decode-residual-matrix

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -31,7 +31,7 @@ active_session:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 02-verify-plan
+  current_stage: 04-tech-plan
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -59,13 +59,16 @@ active_session:
   - stage: 02-verify-plan
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+    completed: '2026-07-31'
+    note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
   - stage: 04-tech-plan
     required: true
     mode: delta
-    status: pending
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
   - stage: 07-build
     required: true
     mode: full
@@ -108,7 +111,7 @@ sessions:
   - 09-qa
   - 11-verify-impl
   - 12-verify-deploy
-  current_stage: 02-verify-plan
+  current_stage: 04-tech-plan
   started_at: '2026-07-31'
   context_briefs:
   - docs/context/wmo-decode-residual-matrix.md
@@ -136,13 +139,16 @@ sessions:
   - stage: 02-verify-plan
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-07-31'
-    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+    completed: '2026-07-31'
+    note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
   - stage: 04-tech-plan
     required: true
     mode: delta
-    status: pending
+    status: in_progress
+    started: '2026-07-31'
+    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
   - stage: 07-build
     required: true
     mode: full
@@ -3599,39 +3605,52 @@ stages:
     - 2026-07-12 D-S008-01-api-q51q54 — Q51=A; Q52=B lint-tac; Q53=B convert-bulletin; Q54=A; ADR-015 written. interviews.completed 7/7; planned_docs api-contract+adr completed
     - 2026-07-12 S008-realtime-ingest amend COMPLETE — delta status completed; overall 01-requirements completed; advancing to 04-tech-plan (pending)
   02-verify-plan:
-    status: in_progress
+    status: completed
     mode: delta
     started_at: '2026-07-31'
     started: '2026-07-31'
+    completed_at: '2026-07-31'
+    completed: '2026-07-31'
     session_id: S034-wmo-decode-residual-matrix
     evolve_cycle_id: EV-027
-    prior_note: 'PASS — Batch F 1,1,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S033-02-phase-a; #809'
-    note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+    prior_note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+    note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
     contradictions_resolved:
     contradictions_deferred:
     decision_refs:
     - D-S034-E27-E1
     - E27-E1
+    - D-S034-02-phase-a
+    - S02.M1
+    - S02.M2
+    - S02.L1
+    - E27-02
     substeps:
       inventory:
-        status: pending
+        status: completed
       consistency_check:
-        status: pending
+        status: completed
       statement_review:
-        auto_approved: 0
-        pending:
-        reviewed:
+        auto_approved: 12
+        pending: 0
+        reviewed: 3
+        reviewed_ids:
+        - S02.M1
+        - S02.M2
+        - S02.L1
     current_document:
     current_statement:
     active_session:
       session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 02-verify-plan
-      status: in_progress
+      status: completed
       mode: delta
       started_at: '2026-07-31'
       started: '2026-07-31'
-      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; handoff 04-tech-plan; #815'
       feature_ids:
       - F25
       - F9
@@ -3639,7 +3658,15 @@ stages:
       decision_refs:
       - D-S034-E27-E1
       - E27-E1
+      - D-S034-02-phase-a
+      - S02.M1
+      - S02.M2
+      - S02.L1
+      - E27-02
+      artifacts:
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
     artifacts:
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
     - docs/sessions/S033-va-multi-location-equality/reports/02-verify-plan-audit.md
     - docs/sessions/S032-iwxxm-us-remarks-va/reports/02-verify-plan-audit.md
     - docs/decisions/product-audit.md
@@ -3657,9 +3684,11 @@ stages:
     - session_id: S034-wmo-decode-residual-matrix
       evolve_cycle_id: EV-027
       skill_id: 02-verify-plan
-      status: in_progress
+      status: completed
       started_at: '2026-07-31'
       started: '2026-07-31'
+      completed_at: '2026-07-31'
+      completed: '2026-07-31'
       mode: delta
       deepen:
       - F25
@@ -3669,10 +3698,18 @@ stages:
       - F25
       - F9
       - F7
-      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
+      auto_approved: 12
+      note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
       decision_refs:
       - D-S034-E27-E1
       - E27-E1
+      - D-S034-02-phase-a
+      - S02.M1
+      - S02.M2
+      - S02.L1
+      - E27-02
+      artifacts:
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
     - session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
       skill_id: 02-verify-plan
@@ -4114,73 +4151,65 @@ stages:
       - .cursor/hooks.json
       - .cursor/hooks/feature_drift.py
   04-tech-plan:
-    status: completed
+    status: in_progress
     mode: delta
     started_at: '2026-07-31'
     started: '2026-07-31'
-    completed_at: '2026-07-31'
-    completed: '2026-07-31'
     previous_started_at: '2026-07-31'
     previous_completed_at: '2026-07-31'
-    previous_session_id: S032-iwxxm-us-remarks-va
-    previous_evolve_cycle_id: EV-025
-    previous_note: 'S032/EV-025 04-tech-plan COMPLETE 2026-07-31 (delta) — Gate B=1; execution-plan approved (D-S032-04-plan-approve); E25-T1..T6=1,1,2,1,3,1; handoff 07 @ T0.1; #810/#811/#812/#809'
-    session_id: S033-va-multi-location-equality
-    evolve_cycle_id: EV-026
-    prior_note: 'S033/EV-026 04-tech-plan STARTED (D-S033-02-phase-a) — Gate A Lean (Batch F 1,1,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #809'
-    note: 'COMPLETE — Batch T E26-T1..T5=1,1,2,1,1; execution-plan approved M0–M3 (12 tasks); Gate B Lean → 07 @ T0.1 (D-S033-04-plan-approve)'
+    previous_session_id: S033-va-multi-location-equality
+    previous_evolve_cycle_id: EV-026
+    previous_note: 'S033/EV-026 04-tech-plan COMPLETE — Batch T E26-T1..T5=1,1,2,1,1; execution-plan approved M0–M3 (12 tasks); Gate B Lean → 07 @ T0.1 (D-S033-04-plan-approve)'
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    prior_note: 'S034/EV-027 02-verify-plan COMPLETE (D-S034-02-phase-a) — PASS Batch F 1,2,1; Gate A Lean → 04; report reports/02-verify-plan-audit.md; #815'
+    note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
     decision_refs:
-    - D-S033-04-plan-approve
-    - D-S033-E26-T-batch
-    - E26-T1
-    - E26-T2
-    - E26-T3
-    - E26-T4
-    - E26-T5
-    - D-S033-02-phase-a
-    - D-S033-E26-E1
+    - D-S034-02-phase-a
+    - D-S034-E27-E1
+    - S02.M1
+    - S02.M2
+    - S02.L1
+    - E27-02
     substeps:
       phase_1_toolchain:
-        status: completed
+        status: pending
       phase_2_interview:
-        status: completed
+        status: pending
       phase_3_execution_plan:
-        status: completed
+        status: pending
       phase_4_user_review:
-        status: completed
+        status: pending
       phase_5_back_add:
-        status: completed
+        status: pending
       phase_6_documents:
-        status: completed
+        status: pending
     active_session:
-      session_id: S033-va-multi-location-equality
-      evolve_cycle_id: EV-026
+      session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
       skill_id: 04-tech-plan
-      status: completed
+      status: in_progress
       mode: delta
       started_at: '2026-07-31'
       started: '2026-07-31'
-      completed_at: '2026-07-31'
-      completed: '2026-07-31'
-      note: 'COMPLETE — Batch T E26-T1..T5=1,1,2,1,1; execution-plan approved M0–M3 (12 tasks); Gate B Lean → 07 @ T0.1 (D-S033-04-plan-approve)'
+      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
       feature_ids:
-      - F23
-      - F6
+      - F25
+      - F9
       - F7
       decision_refs:
-      - D-S033-04-plan-approve
-      - D-S033-E26-T-batch
-      - E26-T1
-      - E26-T2
-      - E26-T3
-      - E26-T4
-      - E26-T5
-      - D-S033-02-phase-a
-      - D-S033-E26-E1
+      - D-S034-02-phase-a
+      - D-S034-E27-E1
+      - S02.M1
+      - S02.M2
+      - S02.L1
+      - E27-02
       artifacts:
-      - docs/sessions/S033-va-multi-location-equality/reports/execution-plan.md
-      - docs/sessions/S033-va-multi-location-equality/reports/04-tech-plan.md
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     artifacts:
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     - docs/sessions/S033-va-multi-location-equality/reports/execution-plan.md
     - docs/sessions/S033-va-multi-location-equality/reports/04-tech-plan.md
     - docs/sessions/S032-iwxxm-us-remarks-va/reports/execution-plan.md
@@ -4200,6 +4229,32 @@ stages:
     - docs/sessions/S026-airmet-quality-wmo-examples/reports/04-tech-plan.md
     - docs/sessions/S026-airmet-quality-wmo-examples/reports/execution-plan.md
     delta_substages:
+    - session_id: S034-wmo-decode-residual-matrix
+      evolve_cycle_id: EV-027
+      skill_id: 04-tech-plan
+      status: in_progress
+      started_at: '2026-07-31'
+      started: '2026-07-31'
+      mode: delta
+      deepen:
+      - F25
+      - F9
+      - F7
+      feature_ids:
+      - F25
+      - F9
+      - F7
+      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+      decision_refs:
+      - D-S034-02-phase-a
+      - D-S034-E27-E1
+      - S02.M1
+      - S02.M2
+      - S02.L1
+      - E27-02
+      artifacts:
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+      - docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
     - session_id: S033-va-multi-location-equality
       evolve_cycle_id: EV-026
       skill_id: 04-tech-plan
@@ -23406,7 +23461,7 @@ evolve_cycles:
   branch: evolve/EV-027-wmo-decode-residual-matrix
   preset: Lean+build
   preset_status: approved
-  current_stage: 02-verify-plan
+  current_stage: 04-tech-plan
   routing_plan:
     required_stages:
     - 00-context
@@ -23444,13 +23499,16 @@ evolve_cycles:
       completed: '2026-07-31'
       note: 'COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; reports/01-requirements.md; #815'
     02-verify-plan:
+      status: completed
+      mode: delta
+      started: '2026-07-31'
+      completed: '2026-07-31'
+      note: 'PASS — Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04; report reports/02-verify-plan-audit.md; D-S034-02-phase-a; #815'
+    04-tech-plan:
       status: in_progress
       mode: delta
       started: '2026-07-31'
-      note: 'S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
-    04-tech-plan:
-      status: pending
-      mode: delta
+      note: 'S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
     07-build:
       status: pending
       mode: full
@@ -23464,12 +23522,12 @@ evolve_cycles:
       status: pending
       mode: when_ships
   gates:
-    a_to_b: pending
+    a_to_b: passed
     b_to_c: pending
     c_to_d: pending
     deploy: pending
   checkpoints:
-    phase_a: pending
+    phase_a: passed
     phase_b: pending
     phase_c: pending
     phase_d: pending
@@ -23482,12 +23540,21 @@ evolve_cycles:
   - E27-4
   - D-S034-E27-E1
   - E27-E1
+  - D-S034-02-phase-a
+  - S02.M1
+  - S02.M2
+  - S02.L1
+  - E27-02
   answers:
     E27-1: '1'
     E27-2: '1'
     E27-3: '2'
     E27-4: '1'
     E27-E1: '1'
+    S02.M1: '1'
+    S02.M2: '2'
+    S02.L1: '1'
+    E27-02: PASS
   artifacts:
   - path: docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
     status: approved
@@ -23499,7 +23566,15 @@ evolve_cycles:
     status: approved
   - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
     status: completed
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
+    status: completed
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/execution-plan.md
+    status: draft
+  - path: docs/sessions/S034-wmo-decode-residual-matrix/reports/04-tech-plan.md
+    status: draft
   notes:
+  - '2026-07-31 S034/EV-027 04-tech-plan STARTED (D-S034-02-phase-a) — Gate A Lean (Batch F 1,2,1 + consistency PASS); gates.a_to_b passed; mode delta; interview pending; #815'
+  - '2026-07-31 S034/EV-027 02-verify-plan COMPLETE (D-S034-02-phase-a) — PASS Batch F 1,2,1 (S02.M1/M2/L1); Gate A Lean → 04-tech-plan; report docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md; #815'
   - '2026-07-31 S034/EV-027 01-requirements COMPLETE (delta) — E27-E1=1; E27-M/UJ/TC=1,1,1; D-S034-E27-E1; handoff 02-verify-plan; #815'
   - '2026-07-31 S034/EV-027 02-verify-plan STARTED (delta) — D-S034-E27-E1; #815'
   - '2026-07-31 S034/EV-027 Phase 0 locked D-S034-open=1,1,2,1 — E27-1..4; handoff 01-requirements; branch evolve/EV-027-wmo-decode-residual-matrix; #815'
@@ -24691,6 +24766,27 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 3c432b3
+    sha_full: 3c432b31a9faaf8c5b7e3689d807331d8433bc1b
+    branch: evolve/EV-027-wmo-decode-residual-matrix
+    message: "[S034] docs: open EV-027 #815 residual matrix + 01 delta specs"
+    stage: "01-requirements"
+    session_id: S034-wmo-decode-residual-matrix
+    evolve_cycle_id: EV-027
+    files_changed:
+    - docs/context/wmo-decode-residual-matrix.md
+    - docs/decisions/evolve-decisions.md
+    - docs/decisions/requirements-decisions.md
+    - docs/feature-list.md
+    - docs/sessions/README.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/01-requirements.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/reports/02-verify-plan-audit.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/routing-plan.md
+    - docs/sessions/S034-wmo-decode-residual-matrix/session-brief.md
+    - docs/test-plan.md
+    - docs/user-journeys.md
+    - workflow-state.yaml
+    timestamp: '2026-07-31'
   - sha: .inf
     sha_full: 7e08051d0b2bfc8801d4fbeefb5fdcff155d14a3
     branch: evolve/EV-026-va-multi-location-equality


### PR DESCRIPTION
## Summary

- Deepen **F25 / F9 / F7.g** for [#815](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/815): official WMO TAC peers inventory ↔ catalog ∪ gaps, plus CI decode residual matrix.
- **Catalog-first** (E27-T1=2): pin inventory SoT + Vitest seed completeness; no silent omissions (A6-2 / NIL-collect deferred).
- Decode coverage: METAR RVR, TAF/SIGMET CNL, VA SIGMET geometry/eruption/FL layers → empty residuals on happy-path peers.
- VAA/TCA remain residual-heavy per F9 **G4** / ADR-025 — allowlisted with child [#820](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/820).
- **Waive** TC-EV027-005 / 13-deploy-smoke (`D-S034-gate-c` — no FE deploy this cycle).
- Stabilize flaky `FileConverter` coverage mocks/timeouts blocking pre-push.

## Test plan

- [x] `TC-EV027-001..003` pytest (inventory + residual matrix)
- [x] `examplesCatalog` Vitest (20)
- [x] Frontend `test:coverage` green locally after mock reset
- [ ] CI green on PR branch
- [ ] Merge closes #815; #820 remains open for fuller VAA/TCA decode

Closes #815

Made with [Cursor](https://cursor.com)