### PR TITLE
hotfix: Render deploy-hook imgURL 500 → REST fallback

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -352,6 +352,8 @@ jobs:
       RENDER_BACKEND_DEPLOY_HOOK: ${{ secrets.RENDER_BACKEND_DEPLOY_HOOK }}
       RENDER_FRONTEND_DEPLOY_HOOK: ${{ secrets.RENDER_FRONTEND_DEPLOY_HOOK }}
       RENDER_WORKER_DEPLOY_HOOK: ${{ secrets.RENDER_WORKER_DEPLOY_HOOK }}
+      # Optional: REST fallback when deploy-hook+imgURL returns 5xx (BUG-2026-08-03).
+      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
 
     steps:
       - uses: actions/checkout@v5
@@ -500,8 +502,10 @@ jobs:
           IMAGE_URL: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
         run: |
           if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
-            ENCODED_URL=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['IMAGE_URL'], safe=''))")
-            curl -fsSL "${DEPLOY_HOOK}&imgURL=${ENCODED_URL}"
+            python3 scripts/deploy/trigger_render_image_deploy.py \
+              --deploy-hook "${DEPLOY_HOOK}" \
+              --image-url "${IMAGE_URL}" \
+              --service-name metar-to-iwxxm-api
           else
             curl -fsSL "${DEPLOY_HOOK}"
           fi
@@ -513,8 +517,10 @@ jobs:
           IMAGE_URL: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
         run: |
           if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
-            ENCODED_URL=$(python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['IMAGE_URL'], safe=''))")
-            curl -fsSL "${DEPLOY_HOOK}&imgURL=${ENCODED_URL}"
+            python3 scripts/deploy/trigger_render_image_deploy.py \
+              --deploy-hook "${DEPLOY_HOOK}" \
+              --image-url "${IMAGE_URL}" \
+              --service-name metar-to-iwxxm-frontend-v4-web
           else
             curl -fsSL "${DEPLOY_HOOK}"
           fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 # Fast gates (ruff/prettier/eslint/types/gitleaks/actionlint) via pre-commit framework.
+# Includes Render deploy-hook fallback regression (BUG-2026-08-03) when related files change.
 set -e
 uv run pre-commit run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,20 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: render-deploy-hook-guard
+        name: Render deploy hook fallback (BUG-2026-08-03)
+        entry: uv run pytest tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        files: ^(scripts/deploy/trigger_render_image_deploy\.py|\.github/workflows/ci-cd\.yml|tests/bugs/test_bug_2026_08_03_render_deploy_hook_500\.py)$
+      - id: render-deploy-no-bare-curl-imgurl
+        name: forbid brittle curl imgURL in ci-cd.yml
+        entry: bash scripts/deploy/check_no_bare_curl_imgurl.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        files: ^(\.github/workflows/ci-cd\.yml|scripts/deploy/check_no_bare_curl_imgurl\.sh)$
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7

--- a/docs/bug-reports/BUG-2026-08-03-render-deploy-hook-500.md
+++ b/docs/bug-reports/BUG-2026-08-03-render-deploy-hook-500.md
@@ -1,0 +1,46 @@
+# BUG-2026-08-03 — Render deploy hook `imgURL` returns HTTP 500 (main CI Deploy)
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixed (pending merge) |
+| **Feature** | M5 / deploy (CI CD) |
+| **Severity** | high (main `CI/CD Pipeline` Deploy red after green tests) |
+| **Classification** | integration / platform |
+| **Remediation path** | Resilient trigger script + REST fallback; pre-commit guards |
+| **Branch** | `fix/render-deploy-hook-500-fallback` |
+| **CI run** | https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/30826197508 |
+
+## Error description
+
+On merge of PR #832 (`8bd111c`), Validate + all Test jobs passed, but **Deploy**
+failed at "Deploy backend image to Render" when the deploy hook was called with
+`imgURL`. GHCR images were pushed successfully; live services were recovered via
+manual Render REST `POST /services/{id}/deploys` with `imageUrl`.
+
+## Error logs
+
+```
+curl -fsSL "${DEPLOY_HOOK}&imgURL=${ENCODED_URL}"
+curl: (22) The requested URL returned error: 500
+##[error]Process completed with exit code 22.
+```
+
+IMAGE_URL: `ghcr.io/empiric2/tac-to-iwxxm/backend:20260803151459-8bd111c`
+
+## Investigation
+
+1. Failure is isolated to Render deploy-hook + `imgURL` (HTTP 500), not build/test.
+2. Docs-only follow-up commit `86c9722` Deploy later succeeded — intermittent/platform.
+3. Manual REST with `imageUrl` for the same tag succeeded (deploy-smoke workaround).
+4. Root cause for CI redness: brittle one-liner with no retry/REST fallback.
+
+## Repro test
+
+- `tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py`
+- Simulates hook 500 → expects REST fallback success; guards `ci-cd.yml` against bare curl.
+
+## Fix
+
+- `scripts/deploy/trigger_render_image_deploy.py` — hook retries → REST `imageUrl` → optional hook without `imgURL`
+- `ci-cd.yml` Deploy steps call the script; wire optional `RENDER_API_KEY` secret
+- Pre-commit hook runs the bug unit tests so regressions fail locally via husky

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -10,7 +10,7 @@
 **Issues**: [#831](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/831), [#829](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/829), [#820](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/820)  
 **Started**: 2026-08-02  
 **Branch**: `evolve/EV-030-quality-residuals-831`  
-**Status**: **complete pending close** — M4 T4.5 done; #831/#829/#820 closed; #835 residual; live H1–H5 PASS (`8bd111c`)
+**Status**: **completed** — closed 2026-08-03 (`D-S037-13=1`); M4 done; #831/#829/#820 closed; #835 residual; live H1–H5 PASS (`8bd111c`)
 
 ### Scope (Phase 0 — locked 2026-08-02 via 00-context)
 
@@ -41,6 +41,7 @@
 | E30-semver-tac2iwxxm | decision | Bump `tac2iwxxm` after #820 decode deepen? | **2** — **patch** `0.2.3 → 0.2.4` (pyproject + Cargo + `__version__` + locks); no tags/PyPI (`D-S037-semver-tac2iwxxm`) |
 | E30-ui-preview | decision | Non-deployed UI preview (FE unlock)? | **2** — decline; H4–H5 at 13 (`D-S037-ui-preview`) |
 | E30-11 | decision | 11+12 signoff? | **1** — approve UJ-044 + F29 + deepen + start 13 (`D-S037-11` / `D-S037-12`) |
+| E30-13 | decision | Close EV-030 / S037? | **1** — mark cycle + session complete (`D-S037-13`); leave #835 open |
 | E30-T2.3 | decision | #829 STNR / exceptional geometry? | **OOS cite** for geometry beyond `WI … OF TC CENTRE`; **STNR in-cycle** via pack (`D-S037-T2.3-oos`; S02.M2) |
 | E30-ui-preview | decision | Non-deployed UI preview after FE catalog unlock? | **2** — **decline** (written interview; AskQuestion unavailable); **H4–H5 still required at M4/13** (`D-S037-ui-preview`) |
 

--- a/docs/evolve-report-EV-030.md
+++ b/docs/evolve-report-EV-030.md
@@ -1,0 +1,61 @@
+# Evolve report — EV-030
+
+| Field | Value |
+|-------|-------|
+| Cycle | EV-030 |
+| Session | S037-quality-residuals-831 |
+| Status | **completed** |
+| Started | 2026-08-02 |
+| Completed | 2026-08-03 |
+| Features | **F29** (new) + deepen F23 / F12 / F2 / F13 / F9 / F26 / F27 |
+| Issues | [#831](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/831) **closed**; [#829](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/829) **closed**; [#820](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/820) **closed** |
+| PRs | [#832](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/832) → `8bd111c` |
+| Deploy smoke (13) | **PASS** — API + FE `20260803151459-8bd111c`; H0c/H1/H3/H4/H5; CI deploy hook 500 → Render REST |
+| Close decision | `D-S037-13` = **1** (mark cycle + session complete) |
+
+## Scope
+
+EV-029 residuals in order #831 → #829 → #820: parameterized quality-matrix harness
+(F29); TC SIGMET lint pack + A6-2-TC catalog unlock; VAA/TCA structured decode residual
+shrink. Exclude SIGWX / VONA / QVACI; no non-deployed UI preview (H4–H5 at 13).
+
+## Routing
+
+Standard: `00→16→01→02→04→07→08→09→10→11→12→13` (skip 03/05/06).
+
+## Results
+
+| Gate | Result |
+|------|--------|
+| A→B | passed (`D-S037-02-phase-a`) |
+| B→C | passed (`D-S037-04-plan`) |
+| C→D | passed (M0–M4; 27/27; 08 PASS) |
+| Deploy (13) | passed (`D-S037-13` = 1) |
+
+## Package / runtime
+
+| Item | Version / note |
+|------|----------------|
+| `tac2iwxxm` | **0.2.4** (in-tree; no PyPI tag this cycle) |
+| `tac-validate` | 0.1.1 (no bump) |
+| FE catalog | A6-2-TC unlocked (`App-Bhd6UU87.js`) |
+
+## Verification
+
+- 08-verify-build: pass (M1–M3 reports)
+- 09-qa + 10-e2e: pass (H4–H5 at 13)
+- 11-verify-impl: approved (`D-S037-11`)
+- 12-verify-deploy: READY (`D-S037-12`)
+- 13-deploy-smoke: pass — see session `deploy-smoke.md`
+
+## Follow-ups
+
+- [#835](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/835) — A6-2-TC ADR-032 equality → `wmoPass`
+- Render deploy-hook 500 when passing `imgURL` — ops follow-up
+- Optional: PyPI tag `tac2iwxxm-v0.2.4` in a later ops cycle
+
+## Session artifacts
+
+- [evolve-summary.md](sessions/S037-quality-residuals-831/reports/evolve-summary.md)
+- [deploy-smoke.md](sessions/S037-quality-residuals-831/reports/deploy-smoke.md)
+- [evolve-decisions.md](decisions/evolve-decisions.md) §Cycle EV-030

--- a/docs/ops/DEVELOPMENT.md
+++ b/docs/ops/DEVELOPMENT.md
@@ -207,7 +207,10 @@ Primary workflow: `.github/workflows/ci-cd.yml`.
 Remote CI runs **validate** then the **test** matrix, **tac2iwxxm-native**, and
 **e2e-smoke**. Husky **pre-push** mirrors validate + unit/matrix locally.
 **Deploy** on `main` requires `test` + `tac2iwxxm-native`, and skips cleanly when
-GHCR login or Render deploy-hook secrets are missing.
+GHCR login or Render deploy-hook secrets are missing. Image deploys use
+`scripts/deploy/trigger_render_image_deploy.py` (hook + `imgURL`, with REST
+`imageUrl` fallback when `RENDER_API_KEY` is set — BUG-2026-08-03). Husky
+pre-commit runs regression guards for that path.
 
 | Job | Checks |
 |-----|--------|

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,7 +25,7 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S037-quality-residuals-831](S037-quality-residuals-831/session-brief.md) | feature | open | #831/#829/#820 residuals; EV-030 | evolve/EV-030-quality-residuals-831 | 2026-08-02 | — |
+| [S037-quality-residuals-831](S037-quality-residuals-831/session-brief.md) | feature | completed | #831/#829/#820 closed; F29 Done; residual #835; EV-030 | evolve/EV-030-quality-residuals-831 | 2026-08-02 | 2026-08-03 |
 | [S036-eight-family-ahl-rules-823](S036-eight-family-ahl-rules-823/session-brief.md) | feature | completed | #823 eight-family AHL/lint/convert/validate; EV-029; F28 Done; PR #828 | main (#828) | 2026-08-01 | 2026-08-02 |
 | [S034-wmo-decode-residual-matrix](S034-wmo-decode-residual-matrix/session-brief.md) | feature | in_progress | #815 official WMO decode residual matrix; EV-027 | evolve/EV-027-wmo-decode-residual-matrix | 2026-07-31 | — |
 | [S033-va-multi-location-equality](S033-va-multi-location-equality/session-brief.md) | feature | completed | #809 ADR-032 equality → wmoPass; EV-026; PR #817/#818 | evolve/EV-026-va-multi-location-equality | 2026-07-31 | 2026-07-31 |

--- a/docs/sessions/S037-quality-residuals-831/reports/evolve-summary.md
+++ b/docs/sessions/S037-quality-residuals-831/reports/evolve-summary.md
@@ -1,6 +1,7 @@
 # Evolve summary — EV-030 / S037 (quality residuals #831 / #829 / #820)
 
 > Date: 2026-08-03  
+> Status: **completed** (`D-S037-13=1`)  
 > Branch: `evolve/EV-030-quality-residuals-831` → **merged** [#832](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/832) (`8bd111c`)  
 > Features: **F29** (new) + deepen F23 / F12 / F2 / F13 / F9 / F26 / F27
 

--- a/docs/sessions/S037-quality-residuals-831/session-brief.md
+++ b/docs/sessions/S037-quality-residuals-831/session-brief.md
@@ -1,9 +1,11 @@
 ---
 session_id: S037-quality-residuals-831
 type: feature
-status: in_progress
+status: completed
 branch: evolve/EV-030-quality-residuals-831
 started_at: 2026-08-02
+completed_at: 2026-08-03
+close_decision_id: D-S037-13
 intent: "EV-029 residuals — #831 parameterized rule matrices (happy/sad/edge), #829 TC SIGMET deepen (lint pack / STNR / A6-2-TC menu), #820 VAA/TCA decode residual deepen beyond F9 G4."
 orchestrator: 16-evolve
 evolve_cycle_id: EV-030

--- a/scripts/deploy/check_no_bare_curl_imgurl.sh
+++ b/scripts/deploy/check_no_bare_curl_imgurl.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fail if ci-cd.yml regresses to brittle deploy-hook+imgURL curl (BUG-2026-08-03).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WF="${ROOT}/.github/workflows/ci-cd.yml"
+
+if grep -nE '\$\{DEPLOY_HOOK\}&imgURL=|imgURL=\$\{ENCODED_URL\}' "${WF}"; then
+  echo "ERROR: brittle Render deploy-hook imgURL curl found in ${WF}" >&2
+  echo "Use scripts/deploy/trigger_render_image_deploy.py instead." >&2
+  exit 1
+fi
+
+if ! grep -q 'trigger_render_image_deploy.py' "${WF}"; then
+  echo "ERROR: ${WF} must call trigger_render_image_deploy.py for image deploys." >&2
+  exit 1
+fi
+
+echo "OK: ci-cd.yml uses resilient Render image deploy trigger"

--- a/scripts/deploy/trigger_render_image_deploy.py
+++ b/scripts/deploy/trigger_render_image_deploy.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Trigger Render image deploys with deploy-hook → REST fallback.
+
+BUG-2026-08-03: ``curl …&imgURL=`` against a Render deploy hook can return HTTP 500
+even after GHCR push succeeds. Prefer the hook (with retries); on 5xx fall back to
+``POST /v1/services/{id}/deploys`` with ``imageUrl`` when ``RENDER_API_KEY`` is set;
+as a last resort, fire the hook without ``imgURL`` (service default / ``main-latest``).
+
+CLI::
+
+    python scripts/deploy/trigger_render_image_deploy.py \\
+      --deploy-hook "$RENDER_BACKEND_DEPLOY_HOOK" \\
+      --image-url "ghcr.io/empiric2/tac-to-iwxxm/backend:TAG" \\
+      --service-name metar-to-iwxxm-api
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+RENDER_API_BASE = "https://api.render.com/v1"
+HttpMethod = Literal["GET", "POST"]
+HttpCaller = Callable[
+    [str, HttpMethod, dict[str, str] | None, bytes | None], tuple[int, str]
+]
+
+
+@dataclass(frozen=True)
+class TriggerResult:
+    """Outcome of a deploy trigger attempt."""
+
+    ok: bool
+    method: str
+    status_code: int
+    detail: str
+
+
+def build_deploy_hook_url(deploy_hook: str, image_url: str | None = None) -> str:
+    """Append a URL-encoded ``imgURL`` query param to a Render deploy hook.
+
+    Parameters
+    ----------
+    deploy_hook
+        Hook URL that already includes ``?key=…``.
+    image_url
+        Full registry reference (``host/repo/name:tag``). When ``None``, return
+        the hook unchanged.
+
+    Returns
+    -------
+    str
+        Hook URL ready for GET/POST.
+    """
+    hook = deploy_hook.strip()
+    if not hook:
+        raise ValueError("deploy_hook must be non-empty")
+    if image_url is None:
+        return hook
+
+    parsed = urlparse(hook)
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    query["imgURL"] = [image_url]
+    new_query = urlencode(query, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def service_id_from_deploy_hook(deploy_hook: str) -> str | None:
+    """Extract ``srv-…`` from ``https://api.render.com/deploy/srv-…?key=…``."""
+    path = urlparse(deploy_hook.strip()).path.rstrip("/")
+    if "/deploy/" not in path:
+        return None
+    candidate = path.rsplit("/", 1)[-1]
+    if candidate.startswith("srv-"):
+        return candidate
+    return None
+
+
+def _default_http(
+    url: str,
+    method: HttpMethod,
+    headers: dict[str, str] | None,
+    body: bytes | None,
+) -> tuple[int, str]:
+    req = urllib.request.Request(url, data=body, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return int(resp.status), resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        body_txt = exc.read().decode("utf-8", errors="replace")
+        return int(exc.code), body_txt
+    except urllib.error.URLError as exc:
+        return 0, str(exc.reason if hasattr(exc, "reason") else exc)
+
+
+def resolve_service_id(
+    *,
+    deploy_hook: str,
+    service_id: str | None,
+    service_name: str | None,
+    api_key: str | None,
+    http: HttpCaller,
+) -> str | None:
+    """Resolve a Render service id from explicit id, hook path, or name lookup."""
+    if service_id:
+        return service_id
+    from_hook = service_id_from_deploy_hook(deploy_hook)
+    if from_hook:
+        return from_hook
+    if not (api_key and service_name):
+        return None
+    status, text = http(
+        f"{RENDER_API_BASE}/services?limit=100&name={urllib.parse.quote(service_name)}",
+        "GET",
+        {"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        None,
+    )
+    if status != 200:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        raw_svc = item.get("service")
+        svc: dict[str, object]
+        if isinstance(raw_svc, dict):
+            svc = raw_svc
+        else:
+            svc = item
+        if svc.get("name") == service_name:
+            sid = svc.get("id")
+            return sid if isinstance(sid, str) else None
+    return None
+
+
+def trigger_via_rest(
+    *,
+    service_id: str,
+    image_url: str,
+    api_key: str,
+    http: HttpCaller,
+) -> TriggerResult:
+    """POST ``/services/{id}/deploys`` with ``imageUrl``."""
+    body = json.dumps({"imageUrl": image_url}).encode("utf-8")
+    status, text = http(
+        f"{RENDER_API_BASE}/services/{service_id}/deploys",
+        "POST",
+        {
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        body,
+    )
+    ok = status in (200, 201, 202)
+    return TriggerResult(
+        ok=ok, method="rest_imageUrl", status_code=status, detail=text[:500]
+    )
+
+
+def trigger_via_hook(
+    *,
+    deploy_hook: str,
+    image_url: str | None,
+    http: HttpCaller,
+    retries: int = 3,
+    backoff_seconds: float = 2.0,
+) -> TriggerResult:
+    """GET deploy hook, optionally with ``imgURL``, with retries on 5xx/0."""
+    url = build_deploy_hook_url(deploy_hook, image_url)
+    method_label = "hook_imgURL" if image_url else "hook_default"
+    last = TriggerResult(ok=False, method=method_label, status_code=0, detail="")
+    for attempt in range(1, max(1, retries) + 1):
+        status, text = http(url, "GET", None, None)
+        last = TriggerResult(
+            ok=200 <= status < 300,
+            method=method_label,
+            status_code=status,
+            detail=text[:500],
+        )
+        if last.ok:
+            return last
+        # Retry transient failures only.
+        if status and status < 500 and status != 0:
+            return last
+        if attempt < retries:
+            time.sleep(backoff_seconds * attempt)
+    return last
+
+
+def trigger_image_deploy(
+    *,
+    deploy_hook: str,
+    image_url: str,
+    api_key: str | None = None,
+    service_id: str | None = None,
+    service_name: str | None = None,
+    http: HttpCaller | None = None,
+    hook_retries: int = 3,
+    allow_hook_without_imgurl: bool = True,
+) -> TriggerResult:
+    """Try hook+imgURL, then REST imageUrl, then hook without imgURL."""
+    caller = http or _default_http
+
+    hook_result = trigger_via_hook(
+        deploy_hook=deploy_hook,
+        image_url=image_url,
+        http=caller,
+        retries=hook_retries,
+    )
+    if hook_result.ok:
+        return hook_result
+
+    key = (api_key or "").strip() or None
+    sid = resolve_service_id(
+        deploy_hook=deploy_hook,
+        service_id=service_id,
+        service_name=service_name,
+        api_key=key,
+        http=caller,
+    )
+    if key and sid:
+        rest = trigger_via_rest(
+            service_id=sid,
+            image_url=image_url,
+            api_key=key,
+            http=caller,
+        )
+        if rest.ok:
+            return rest
+        hook_result = TriggerResult(
+            ok=False,
+            method=f"{hook_result.method}+{rest.method}",
+            status_code=rest.status_code or hook_result.status_code,
+            detail=(
+                f"hook={hook_result.status_code}:{hook_result.detail} | "
+                f"rest={rest.status_code}:{rest.detail}"
+            )[:800],
+        )
+
+    if allow_hook_without_imgurl:
+        fallback = trigger_via_hook(
+            deploy_hook=deploy_hook,
+            image_url=None,
+            http=caller,
+            retries=2,
+        )
+        if fallback.ok:
+            return TriggerResult(
+                ok=True,
+                method="hook_default_after_imgURL_fail",
+                status_code=fallback.status_code,
+                detail=(
+                    f"imgURL path failed ({hook_result.status_code}); "
+                    f"default hook succeeded (ensure service image tracks main-latest). "
+                    f"{fallback.detail}"
+                )[:800],
+            )
+
+    return hook_result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry for CI Deploy steps."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--deploy-hook", required=True, help="Render deploy hook URL")
+    parser.add_argument("--image-url", required=True, help="Full GHCR image reference")
+    parser.add_argument(
+        "--service-name",
+        default=None,
+        help="Render service name (lookup when hook lacks srv- id)",
+    )
+    parser.add_argument("--service-id", default=None, help="Explicit Render service id")
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="RENDER_API_KEY (default: env RENDER_API_KEY)",
+    )
+    parser.add_argument(
+        "--no-hook-without-imgurl",
+        action="store_true",
+        help="Do not fall back to hook without imgURL",
+    )
+    args = parser.parse_args(argv)
+
+    result = trigger_image_deploy(
+        deploy_hook=args.deploy_hook,
+        image_url=args.image_url,
+        api_key=args.api_key or os.environ.get("RENDER_API_KEY"),
+        service_id=args.service_id or os.environ.get("RENDER_SERVICE_ID"),
+        service_name=args.service_name,
+        allow_hook_without_imgurl=not args.no_hook_without_imgurl,
+    )
+    print(
+        json.dumps(
+            {
+                "ok": result.ok,
+                "method": result.method,
+                "status_code": result.status_code,
+                "detail": result.detail,
+            },
+            indent=2,
+        )
+    )
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
+++ b/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
@@ -1,0 +1,131 @@
+"""BUG-2026-08-03 — Render deploy hook imgURL 500 must fall back to REST.
+
+Main CI Deploy failed on merge ``8bd111c`` when ``curl …&imgURL=`` returned HTTP 500
+after GHCR push. Guard: resilient trigger script + CI must not use bare curl imgURL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "deploy" / "trigger_render_image_deploy.py"
+CI_CD = ROOT / ".github" / "workflows" / "ci-cd.yml"
+
+
+def _load_mod():
+    import sys
+
+    name = "trigger_render_image_deploy"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_bug_2026_08_03_build_deploy_hook_url_encodes_imgurl() -> None:
+    mod = _load_mod()
+    hook = "https://api.render.com/deploy/srv-abc123?key=secret"
+    image = "ghcr.io/empiric2/tac-to-iwxxm/backend:20260803151459-8bd111c"
+    url = mod.build_deploy_hook_url(hook, image)
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    assert qs["key"] == ["secret"]
+    assert qs["imgURL"] == [image]
+    # Must not naively append "&imgURL=" without encoding colons/slashes.
+    assert "imgURL=" in url
+    assert "ghcr.io%2Fempiric2" in url or "ghcr.io/empiric2" in qs["imgURL"][0]
+
+
+def test_bug_2026_08_03_service_id_from_deploy_hook() -> None:
+    mod = _load_mod()
+    assert (
+        mod.service_id_from_deploy_hook(
+            "https://api.render.com/deploy/srv-d69v688gjchc73cn9kg0?key=x"
+        )
+        == "srv-d69v688gjchc73cn9kg0"
+    )
+    assert mod.service_id_from_deploy_hook("https://example.com/nope") is None
+
+
+def test_bug_2026_08_03_hook_500_falls_back_to_rest() -> None:
+    """Repro of main CI failure: hook imgURL → 500; REST imageUrl → success."""
+    mod = _load_mod()
+    calls: list[tuple[str, str]] = []
+
+    def fake_http(
+        url: str,
+        method: str,
+        headers: dict[str, str] | None,
+        body: bytes | None,
+    ) -> tuple[int, str]:
+        calls.append((method, url))
+        if "imgURL=" in url:
+            return 500, "Internal Server Error"
+        if method == "POST" and "/deploys" in url:
+            assert body is not None
+            assert b"imageUrl" in body
+            assert headers is not None and "Bearer" in headers.get("Authorization", "")
+            return 201, '{"id":"dep-test"}'
+        return 404, "unexpected"
+
+    result = mod.trigger_image_deploy(
+        deploy_hook="https://api.render.com/deploy/srv-abc?key=k",
+        image_url="ghcr.io/empiric2/tac-to-iwxxm/backend:tag",
+        api_key="rnd_test",
+        http=fake_http,
+        hook_retries=1,
+        allow_hook_without_imgurl=False,
+    )
+    assert result.ok is True
+    assert result.method == "rest_imageUrl"
+    assert result.status_code == 201
+    assert any("imgURL=" in u for _, u in calls)
+    assert any(m == "POST" and "/deploys" in u for m, u in calls)
+
+
+def test_bug_2026_08_03_hook_500_falls_back_to_default_hook() -> None:
+    mod = _load_mod()
+
+    def fake_http(
+        url: str,
+        method: str,
+        headers: dict[str, str] | None,
+        body: bytes | None,
+    ) -> tuple[int, str]:
+        if "imgURL=" in url:
+            return 500, "boom"
+        return 200, "ok"
+
+    result = mod.trigger_image_deploy(
+        deploy_hook="https://api.render.com/deploy/srv-abc?key=k",
+        image_url="ghcr.io/empiric2/tac-to-iwxxm/backend:tag",
+        api_key=None,
+        http=fake_http,
+        hook_retries=1,
+        allow_hook_without_imgurl=True,
+    )
+    assert result.ok is True
+    assert result.method == "hook_default_after_imgURL_fail"
+
+
+def test_bug_2026_08_03_ci_uses_resilient_script_not_bare_curl() -> None:
+    raw = CI_CD.read_text(encoding="utf-8")
+    assert "trigger_render_image_deploy.py" in raw
+    # Guard against regressing to the brittle one-liner that failed on 8bd111c.
+    assert 'curl -fsSL "${DEPLOY_HOOK}&imgURL=' not in raw
+    assert "&imgURL=${ENCODED_URL}" not in raw
+
+    doc = yaml.safe_load(raw)
+    assert isinstance(doc, dict)
+    deploy = (doc.get("jobs") or {}).get("deploy") or {}
+    assert isinstance(deploy, dict)
+    # Optional REST fallback secret must be wired when present.
+    assert "RENDER_API_KEY" in raw
+    assert "secrets.RENDER_API_KEY" in raw

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,17 +1,18 @@
-overall_status: in_progress
+overall_status: completed
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
 session_counter: 37
 evolve_cycle_counter: 30
-active_session:
-  id: S037-quality-residuals-831
+active_session: null
+sessions:
+- id: S037-quality-residuals-831
   type: feature
   intent: |
     EV-029 residuals — #831 parameterized rule matrices, #829 TC SIGMET deepen,
     #820 VAA/TCA decode residual deepen. Work order #831 → #829 → #820.
-  status: in_progress
+  status: completed
   branch: evolve/EV-030-quality-residuals-831
   orchestrator: 16-evolve
   evolve_cycle_id: EV-030
@@ -39,9 +40,11 @@ active_session:
     skip_rationale: null
   - stage: 16-evolve
     required: true
-    status: in_progress
+    status: completed
     skip_rationale: null
-    note: 'IN PROGRESS — EV-030 complete pending D-S037-13 close AskQuestion; T4.5 done; progress 27/27'
+    started: '2026-08-02'
+    completed: '2026-08-03'
+    note: 'COMPLETE — D-S037-13=1 close; EV-030 Phase 4 complete; progress 27/27'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -114,8 +117,8 @@ active_session:
     started: '2026-08-03'
     completed: '2026-08-03'
     skip_rationale: null
-    note: 'COMPLETE — T4.4 PASS @ 8bd111c; D-S037-13 pending user close; report deploy-smoke.md; H1/H0c/H3/H4/H5 PASS'
-  current_stage: 13-deploy-smoke
+    note: 'COMPLETE — T4.4 PASS @ 8bd111c; D-S037-13=1 close approved; report deploy-smoke.md; H1/H0c/H3/H4/H5 PASS'
+  current_stage: null
   started_at: '2026-08-02'
   context_briefs:
   - docs/context/quality-residuals-831.md
@@ -195,14 +198,24 @@ active_session:
     status: completed
   - path: docs/sessions/S037-quality-residuals-831/reports/evolve-summary.md
     status: completed
+  - path: docs/evolve-report-EV-030.md
+    status: completed
   - path: tests/quality_matrices/
     status: staged
   - path: docs/api-contract.md
     status: touched
   preset: Standard
   preset_status: approved
-  note: 'S037/EV-030 — T4.4 COMPLETE (13-deploy-smoke PASS @ 8bd111c); T4.5 COMPLETE (#831 closed; F29 Done; evolve-summary.md); D-S037-11/12=1; PR #832 MERGED @ 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500 — Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 FE App-Bhd6UU87.js A6-2-TC; progress 27/27; awaiting D-S037-13 user close; #835 open residual; workflow-state dirty pending parent chore commit'
-sessions:
+  note: 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround; Phase 4 closeout docs — evolve-report-EV-030.md written; D-S037-13=1'
+  close_decision_id: D-S037-13
+  close_note: 'D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
+  completed_at: '2026-08-03'
+  pr_number: 832
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/832
+  pr_status: merged
+  pr_merge_commit_short: 8bd111c
+  tip_sha: 8bd111c
+  progress: 27/27
 - id: S036-eight-family-ahl-rules-823
   type: feature
   intent: |
@@ -8395,7 +8408,7 @@ stages:
     previous_evolve_cycle_id: EV-029
     session_id: S037-quality-residuals-831
     evolve_cycle_id: EV-030
-    note: 'COMPLETE — T4.4 PASS @ 8bd111c; PR #832 merged; Render REST deploy workaround; H1/H0c/H3/H4/H5 PASS; report deploy-smoke.md; pending D-S037-13; progress 27/27; #835'
+    note: 'COMPLETE — T4.4 PASS @ 8bd111c; PR #832 merged; Render REST deploy workaround; H1/H0c/H3/H4/H5 PASS; report deploy-smoke.md; D-S037-13=1 close; progress 27/27; #835'
     tip_sha: 8bd111c
     tip_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
     active_milestone: M4
@@ -8419,7 +8432,7 @@ stages:
       branch: main
       tip_sha: 8bd111c
       tip_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
-      note: 'COMPLETE — T4.4 PASS; PR #832 merged 8bd111c; Render REST deploy workaround; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 A6-2-TC; pending user approve D-S037-13'
+      note: 'COMPLETE — T4.4 PASS; PR #832 merged 8bd111c; Render REST deploy workaround; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 A6-2-TC; D-S037-13=1 close'
       active_milestone: M4
       active_task: T4.4
       active_task_status: completed
@@ -8437,7 +8450,9 @@ stages:
       ci_tests: pass
       ci_deploy: fail
       ci_deploy_note: 'Deploy hook 500; Render REST deploy workaround applied'
-      pending_decision: D-S037-13
+      pending_decision: null
+      decision_ids:
+      - D-S037-13
       fe_app_chunk: App-Bhd6UU87.js
       tc_ev030_005: pass
     - id: S036-eight-family-ahl-rules-823
@@ -8949,20 +8964,20 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: in_progress
+    status: completed
     mode: orchestrator
     session_id: S037-quality-residuals-831
     evolve_cycle_id: EV-030
     started_at: '2026-08-02'
     started: '2026-08-02'
-    completed_at:
-    completed:
-    current_stage: 13-deploy-smoke
-    prior_session_id: S035-empiric2-ops-leftovers-781
-    prior_evolve_cycle_id: EV-028
-    prior_completed: '2026-08-01'
-    prior_note: 'S035/EV-028 16-evolve CLOSED — Phase 4 close D-S035-EV028-phase4-close; PR #824 @ 70312dd; #825 closeout @ 8086664; #781 closed; active_session=null'
-    note: 'S037/EV-030 16-evolve — EV-030 complete pending D-S037-13 close AskQuestion; T4.5 done @ 8bd111c; progress 27/27; #835 open; dirty pending parent chore commit'
+    completed_at: '2026-08-03'
+    completed: '2026-08-03'
+    current_stage: null
+    prior_session_id: S037-quality-residuals-831
+    prior_evolve_cycle_id: EV-030
+    prior_completed: '2026-08-03'
+    prior_note: 'S037/EV-030 16-evolve CLOSED — D-S037-13=1; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; active_session=null'
+    note: 'S037/EV-030 16-evolve COMPLETE — D-S037-13=1 close; PR #832 @ 8bd111c; progress 27/27; #835 open residual'
     tip_sha: 8bd111c
     tip_sha_full: 1f47eb56fbd0dea7e4f2a59212d30a35b4e6d076
     notes:
@@ -9079,7 +9094,7 @@ deployment:
     images:
       api: ghcr.io/empiric2/tac-to-iwxxm/backend:20260803151459-8bd111c
       frontend: ghcr.io/empiric2/tac-to-iwxxm/frontend:20260803151459-8bd111c
-      note: 'S037/EV-030 13 PASS after #832 @ 8bd111c — Render REST deploy workaround (CI deploy hook 500); API dep-d9ob293l550s73a65rfg FE dep-d9ob2brm8hqs73fu8k2g; FE App chunk App-Bhd6UU87.js; pending user approve D-S037-13'
+      note: 'S037/EV-030 13 PASS after #832 @ 8bd111c — Render REST deploy workaround (CI deploy hook 500); API dep-d9ob293l550s73a65rfg FE dep-d9ob2brm8hqs73fu8k2g; FE App chunk App-Bhd6UU87.js; D-S037-13=1 close'
     health_tiers:
       H0ci: pass
       H0c: pass
@@ -9107,7 +9122,7 @@ deployment:
       SWXA_catalog_convert: pass
       FE_app_chunk_swxa: swxa_a7_3
     notes:
-    - '2026-08-03 S037/EV-030 13-deploy-smoke PASS — PR #832 merged 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500; Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g LIVE; H1/H0c/H3/H4/H5 PASS; FE App-Bhd6UU87.js A6-2-TC; report deploy-smoke.md; pending D-S037-13; #835'
+    - '2026-08-03 S037/EV-030 13-deploy-smoke PASS — PR #832 merged 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500; Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g LIVE; H1/H0c/H3/H4/H5 PASS; FE App-Bhd6UU87.js A6-2-TC; report deploy-smoke.md; D-S037-13=1 close; #835'
     - '2026-08-02 S036/EV-029 13-deploy-smoke PASS (technical) — PR #828 merged 4e6577a; docs tip 7e276a7; API dep-d9ntlclbedkc73fvcuvg + FE dep-d9ntlde1egvs738ph9h0 LIVE; H0c/H1/H3/H4/H5 + SWXA catalog/convert PASS; FE App chunk swxa_a7_3; report deploy-smoke.md; awaiting user approve D-S036-13; progress 46/48; #828; #823'
     - '2026-07-31 S033/EV-026 13-deploy-smoke PASS (D-S033-13-smoke-pass) — PR #817 @ 101f555; API dep-d9miestbedkc73dr3j9g + FE dep-d9mietnqj5pc73d3c8a0; H0ci/H0c/H1–H5 pass (H2 pass-or-skipped via live_api); EV-026 catalog/convert PASS; report deploy-smoke.md; pending user approve + cycle close'
     - '2026-07-30 S031/EV-024 13-deploy-smoke COMPLETE — PR #813 merged 864783e; CI 30595410610 SUCCESS (incl. Deploy); API dep-d9lvcr2jnfac73bbn340 + FE dep-d9lvcrrl550s73cuhvf0 LIVE; H0c/H1/H3/H4/H5 + EV-024 catalog + live convert PASS; D-S031-merge-close; #804/#807/#773'
@@ -9297,17 +9312,18 @@ decisions_log:
 - id: D-S037-13
   date: '2026-08-03'
   timestamp: '2026-08-03'
-  resolved_at:
+  resolved_at: '2026-08-03'
   session_id: S037-quality-residuals-831
   evolve_cycle_id: EV-030
   skill: 13-deploy-smoke
   skill_id: 13-deploy-smoke
   stage: 13-deploy-smoke
   category: deploy
-  status: pending
+  status: confirmed
   topic: 'T4.4 deploy smoke approval + EV-030 Phase 4 close'
-  summary: '13-deploy-smoke PASS (technical) @ 8bd111c; pending user approve D-S037-13 for cycle close'
-  decision: 'Await user D-S037-13=1 to close EV-030/S037 Phase 4'
+  summary: 'User D-S037-13=1 Yes — mark cycle + session complete; 13 PASS @ 8bd111c; EV-030/S037 closed'
+  decision: 'Yes — mark cycle + session complete (D-S037-13=1). Close EV-030/S037 Phase 4.'
+  user_option: '1'
   tip_sha: 8bd111c
   tip_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
   branch: main
@@ -18670,6 +18686,16 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/evolve-report-EV-030.md
+  kind: evolve-report
+  session_id: S037-quality-residuals-831
+  evolve_cycle_id: EV-030
+  stage: 16-evolve
+  skill_id: 16-evolve
+  created_at: '2026-08-03'
+  updated_at: '2026-08-03'
+  status: completed
+  note: 'Phase 4 closeout docs — evolve-report-EV-030.md written; D-S037-13=1'
 - path: docs/sessions/S037-quality-residuals-831/session-brief.md
   kind: session-brief
   session_id: S037-quality-residuals-831
@@ -27914,7 +27940,7 @@ evolve_cycles:
   - F26
   - F27
   title: 'Quality residuals #831 / #829 / #820'
-  status: complete_pending_close
+  status: completed
   started: '2026-08-02'
   completed: '2026-08-03'
   scope_summary: |
@@ -27937,14 +27963,16 @@ evolve_cycles:
     - 05-verify-tech
     - 06-tech-tooling
     note: 'Standard — D-S037-route; skip 03/05/06'
-  current_stage: 13-deploy-smoke
+  current_stage: null
   active_task: T4.5
   active_milestone: M4
   active_task_status: completed
   progress: 27/27
   tip_sha: 8bd111c
   tip_sha_full: 1f47eb56fbd0dea7e4f2a59212d30a35b4e6d076
-  note: 'S037/EV-030 — T4.4 COMPLETE (13-deploy-smoke PASS @ 8bd111c); T4.5 COMPLETE (#831 closed; F29 Done; evolve-summary.md); D-S037-11/12=1; PR #832 MERGED @ 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500 — Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 FE App-Bhd6UU87.js A6-2-TC; progress 27/27; awaiting D-S037-13 user close; #835 open residual; workflow-state dirty pending parent chore commit'
+  note: 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround; Phase 4 closeout docs — evolve-report-EV-030.md written; D-S037-13=1'
+  close_decision_id: D-S037-13
+  close_note: 'D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
   pr_m1_number: 832
   pr_m1_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/832
   pr_m1_status: merged
@@ -27962,10 +27990,11 @@ evolve_cycles:
       completed: '2026-08-02'
       note: 'D-S037-route (1) Standard approved'
     16-evolve:
-      status: in_progress
+      status: completed
       mode: orchestrator
       started: '2026-08-02'
-      note: 'Orchestrating T4.2 COMPLETE; T4.3 in_progress @ M4 (11+12 pending signoff); progress 24/27; D-S037-semver-tac2iwxxm=2 resolved; dirty pending chore sync'
+      completed: '2026-08-03'
+      note: 'COMPLETE — D-S037-13=1 close; EV-030 Phase 4; progress 27/27'
     01-requirements:
       status: completed
       started: '2026-08-02'
@@ -28034,13 +28063,16 @@ evolve_cycles:
       status: completed
       started: '2026-08-03'
       completed: '2026-08-03'
-      note: 'COMPLETE — T4.4 PASS @ 8bd111c; pending D-S037-13 user close'
+      note: 'COMPLETE — T4.4 PASS @ 8bd111c; D-S037-13=1 close'
       report: docs/sessions/S037-quality-residuals-831/reports/deploy-smoke.md
       overall: pass
-      pending_decision: D-S037-13
+      pending_decision: null
+      decision_ids:
+      - D-S037-13
     16-evolve:
-      status: in_progress
-      note: 'EV-030 complete pending D-S037-13 close AskQuestion'
+      status: completed
+      completed: '2026-08-03'
+      note: 'COMPLETE — D-S037-13=1 close; EV-030/S037 archived'
   gates:
     a_to_b: passed
     b_to_c: passed
@@ -28055,7 +28087,7 @@ evolve_cycles:
   adrs: []
   artifacts:
   - path: docs/decisions/evolve-decisions.md
-    status: in_progress
+    status: completed
   - path: docs/context/quality-residuals-831.md
     status: written
   - path: docs/sessions/S037-quality-residuals-831/session-brief.md
@@ -28091,6 +28123,8 @@ evolve_cycles:
     status: staged
   - path: docs/api-contract.md
     status: touched
+  - path: docs/evolve-report-EV-030.md
+    status: completed
   issues:
   - '835'
   github_issues:
@@ -28122,7 +28156,9 @@ evolve_cycles:
   - D-S037-12
   - D-S037-13
   notes:
-  - 'S037/EV-030 — T4.4 COMPLETE (13-deploy-smoke PASS @ 8bd111c); T4.5 COMPLETE (#831 closed; F29 Done; evolve-summary.md); D-S037-11/12=1; PR #832 MERGED @ 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500 — Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 FE App-Bhd6UU87.js A6-2-TC; progress 27/27; awaiting D-S037-13 user close; #835 open residual; workflow-state dirty pending parent chore commit'
+  - '2026-08-03 Phase 4 closeout docs — evolve-report-EV-030.md written; D-S037-13=1'
+  - 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround'
+  - '2026-08-03 D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
   - '2026-08-03 S037/EV-030 — T4.2 COMPLETE (09-qa + 10-e2e); T4.3 in_progress (verify-impl.md + deploy-checklist.md; PENDING user signoff 11 then 12); D-S037-semver-tac2iwxxm=2 patch tac2iwxxm 0.2.4 @ 3889e4c; progress 24/27; workflow-state dirty pending chore sync; PR #832 open; #831→#835'
   - '2026-08-03 S037/EV-030 — T4.1 COMPLETE (08-verify-build M3 PASS @ 1f47eb5); T3.3 fix [1f47eb5] pushed; CI 30823368642 SUCCESS (https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/30823368642); report verification-report-m3.md; D-S037-ui-preview=2 confirmed; active_task → T4.2 pending @ M4; progress 23/27; semver AskQuestion pending D-S037-semver-tac2iwxxm; workflow-state dirty pending chore sync; PR #832 open; #831→#835'
   - '2026-08-03 S037/EV-030 — T4.1 COMPLETE (08-verify-build M3 PASS @ 1f47eb5); T3.3 fix pushed; CI 30823368642 SUCCESS; D-S037-ui-preview=2 confirmed; H4–H5 still required at M4/13; progress 23/27; active_task → T4.2 pending @ M4; semver AskQuestion pending D-S037-semver-tac2iwxxm (tac2iwxxm 0.2.3 decode deepen); workflow-state dirty pending chore sync; PR #832 open; #831→#835'
@@ -28159,9 +28195,10 @@ git_history:
   main_merge_sha: 8bd111c
   main_merge_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
   recommended_branch: evolve/EV-030-quality-residuals-831
-  note: 'S037/EV-030 — T4.4 COMPLETE (13-deploy-smoke PASS @ 8bd111c); T4.5 COMPLETE (#831 closed; F29 Done; evolve-summary.md); D-S037-11/12=1; PR #832 MERGED @ 8bd111c; CI 30826197508 tests PASS deploy hook FAIL 500 — Render REST deploy workaround; API dep-d9ob293l550s73a65rfg + FE dep-d9ob2brm8hqs73fu8k2g; H1/H0c/H3/H4/H5 PASS; TC-EV030-005 FE App-Bhd6UU87.js A6-2-TC; progress 27/27; awaiting D-S037-13 user close; #835 open residual; workflow-state dirty pending parent chore commit'
+  note: 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround'
 
   notes:
+  - '2026-08-03 D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
   - '2026-08-03 S037/EV-030 — PR #832 MERGED @ 8bd111c (main); CI 30826197508 tests PASS deploy hook FAIL 500; Render REST deploy workaround LIVE; T4.4/T4.5 COMPLETE; progress 27/27; tip evolve branch dirty closeout files; #835'
   - '2026-08-03 S037/EV-030 — T4.2 COMPLETE (09-qa + 10-e2e); T4.3 in_progress (verify-impl.md + deploy-checklist.md; PENDING user signoff 11 then 12); D-S037-semver-tac2iwxxm=2 patch tac2iwxxm 0.2.4 @ 3889e4c; progress 24/27; workflow-state dirty pending chore sync; PR #832 open; #831→#835'
   - '2026-08-03 S037/EV-030 — T4.1 COMPLETE (08-verify-build M3 PASS @ 1f47eb5); T3.3 fix pushed; CI 30823368642 SUCCESS; D-S037-ui-preview=2 confirmed; H4–H5 still required at M4/13; progress 23/27; active_task → T4.2 pending @ M4; semver AskQuestion pending D-S037-semver-tac2iwxxm (tac2iwxxm 0.2.3 decode deepen); workflow-state dirty pending chore sync; PR #832 open; #831→#835'

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -28156,6 +28156,7 @@ evolve_cycles:
   - D-S037-12
   - D-S037-13
   notes:
+  - '2026-08-03 closeout commit 7c4522a [EV-030] docs: close S037 — D-S037-13 cycle complete; files: workflow-state + evolve-report + evolve-decisions + sessions README/brief/summary'
   - '2026-08-03 Phase 4 closeout docs — evolve-report-EV-030.md written; D-S037-13=1'
   - 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround'
   - '2026-08-03 D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
@@ -28185,19 +28186,22 @@ evolve_cycles:
   - '2026-08-02 S037/EV-030 D-S037-fn (1,1,1) — F29 + deepen F23/F12/F2/F13/F9/F26/F27; 01-requirements in_progress (delta); commit open; #831→#829→#820'
   - '2026-08-02 S037/EV-030 OPEN — D-S037-route (1); 00 COMPLETE; 16-evolve Phase 1 Fn allocation; feature_ids pending D-S037-fn; work order #831→#829→#820'
 git_history:
-  current_branch: evolve/EV-030-quality-residuals-831
+  current_branch: main
   ahead_of_origin: 1
   pushed: false
-  pending_commit: '[EV-030] chore: sync workflow-state + closeout reports after T4.4/T4.5 (13-deploy-smoke)'
-  dirty: true
-  tip_sha: 3889e4c
-  tip_sha_full: 3889e4c2bdeb17fcbb75f0964f4f7cec1d0e1b25
+  pending_commit: null
+  dirty: false
+  tip_sha: 7c4522a
+  tip_sha_full: 7c4522aecdc8a6bd195c3e7517894be876f5c63b
   main_merge_sha: 8bd111c
   main_merge_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
-  recommended_branch: evolve/EV-030-quality-residuals-831
-  note: 'S037/EV-030 COMPLETE — D-S037-13=1 close; PR #832 MERGED @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; progress 27/27; H1/H0c/H3/H4/H5 PASS; Render REST deploy workaround'
+  main_tip_sha: 7c4522a
+  main_tip_sha_full: 7c4522aecdc8a6bd195c3e7517894be876f5c63b
+  recommended_branch: main
+  note: 'S037/EV-030 COMPLETE — closeout @ 7c4522a on main; D-S037-13=1; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual'
 
   notes:
+  - '2026-08-03 closeout commit 7c4522a [EV-030] docs: close S037 — D-S037-13 cycle complete; main ahead 1; active_session=null'
   - '2026-08-03 D-S037-13=1 Yes — mark cycle + session complete (2026-08-03); EV-030/S037 closed; PR #832 @ 8bd111c; F29 Done; #831/#829/#820 closed; #835 open residual; 13-deploy-smoke PASS'
   - '2026-08-03 S037/EV-030 — PR #832 MERGED @ 8bd111c (main); CI 30826197508 tests PASS deploy hook FAIL 500; Render REST deploy workaround LIVE; T4.4/T4.5 COMPLETE; progress 27/27; tip evolve branch dirty closeout files; #835'
   - '2026-08-03 S037/EV-030 — T4.2 COMPLETE (09-qa + 10-e2e); T4.3 in_progress (verify-impl.md + deploy-checklist.md; PENDING user signoff 11 then 12); D-S037-semver-tac2iwxxm=2 patch tac2iwxxm 0.2.4 @ 3889e4c; progress 24/27; workflow-state dirty pending chore sync; PR #832 open; #831→#835'
@@ -29547,6 +29551,23 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 7c4522aecdc8a6bd195c3e7517894be876f5c63b
+    short: 7c4522a
+    branch: main
+    message: "[EV-030] docs: close S037 — D-S037-13 cycle complete"
+    stage: 16-evolve
+    session_id: S037-quality-residuals-831
+    evolve_cycle_id: EV-030
+    timestamp: "2026-08-03"
+    files_changed:
+    - workflow-state.yaml
+    - docs/evolve-report-EV-030.md
+    - docs/decisions/evolve-decisions.md
+    - docs/sessions/README.md
+    - docs/sessions/S037-quality-residuals-831/reports/evolve-summary.md
+    - docs/sessions/S037-quality-residuals-831/session-brief.md
+    pushed: false
+    note: 'Phase 4 closeout docs on main; EV-030/S037 closed; D-S037-13=1'
   - sha: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
     short: 8bd111c
     branch: main


### PR DESCRIPTION
## Summary
- Main CI Deploy failed on merge `8bd111c` when Render deploy hook + `imgURL` returned HTTP 500 after GHCR push ([run 30826197508](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/30826197508)).
- Route image deploys through `scripts/deploy/trigger_render_image_deploy.py`: hook retries → REST `imageUrl` (uses new `RENDER_API_KEY` secret) → optional hook without `imgURL`.
- Husky/pre-commit guards: unit tests for fallback + forbid brittle `curl …&imgURL=` in `ci-cd.yml`.

## Test plan
- [x] `pytest tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py`
- [x] pre-commit hooks `render-deploy-hook-guard` + `render-deploy-no-bare-curl-imgurl`
- [ ] Merge → confirm Deploy job on `main` uses script and stays green (or REST fallback if hook 500s again)


Made with [Cursor](https://cursor.com)