### PR TITLE
[hotfix] Prefer /config.json API host over stale Render bake

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,8 +20,8 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   FRONTEND_VITE_SUPABASE_URL: ${{ secrets.FRONTEND_VITE_SUPABASE_URL }}
   FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-  FRONTEND_VITE_APP_URL: https://metar-to-iwxxm-frontend-v4-web.onrender.com
-  FRONTEND_VITE_API_BASE_URL: https://metar-to-iwxxm-api.onrender.com
+  FRONTEND_VITE_APP_URL: https://app.tac-to-iwxxm.com
+  FRONTEND_VITE_API_BASE_URL: https://api.tac-to-iwxxm.com
 
 jobs:
   # ============================================================================

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -55,6 +55,7 @@ WORKDIR /workspace/apps/frontend
 # prepare-config.sh; Docker build uses repo root context).
 RUN node -e "\
 const fs = require('fs'); \
+const publishable = process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || ''; \
 const cfg = { \
   environment: 'prod', \
   api: { \
@@ -64,6 +65,7 @@ const cfg = { \
   }, \
   supabase: { \
     url: process.env.VITE_SUPABASE_URL || '', \
+    ...(publishable ? { publishableKey: publishable } : {}), \
   }, \
 }; \
 fs.mkdirSync('public', { recursive: true }); \

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -19,7 +19,7 @@ function validateApiEnv() {
     return true;
   } catch {
     const errorMsg =
-      '❌ Missing VITE_API_BASE_URL environment variable. Please check .env.local file.';
+      '❌ Missing API base URL (/config.json or VITE_API_BASE_URL). Check runtime config.';
     console.error(errorMsg);
     toast.error(errorMsg);
     return false;

--- a/apps/frontend/src/test/bug-2026-08-04-frontend-baked-onrender-api-host.test.ts
+++ b/apps/frontend/src/test/bug-2026-08-04-frontend-baked-onrender-api-host.test.ts
@@ -1,0 +1,62 @@
+/**
+ * BUG-2026-08-04 — Production UI called suspended Render API despite /config.json
+ * pointing at https://api.tac-to-iwxxm.com (DOKS).
+ *
+ * Root cause: apiBase.ts read bake-time VITE_API_BASE_URL and ignored runtime-config.
+ * Regression: after initRuntimeConfig(), apiUrl/getApiBaseUrl must use config.json host
+ * even when VITE still points at the old onrender host.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('BUG-2026-08-04 frontend baked onrender API host', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    // Stale bake-time host (matches live App-BkEPMp_C.js after DOKS cutover).
+    vi.stubEnv('VITE_API_BASE_URL', 'https://metar-to-iwxxm-api.onrender.com');
+    vi.stubEnv('VITE_APP_URL', 'https://app.tac-to-iwxxm.com');
+    vi.stubEnv('MODE', 'production');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        environment: 'prod',
+        api: {
+          baseUrl: 'https://api.tac-to-iwxxm.com',
+          frontendUrl: 'https://app.tac-to-iwxxm.com',
+          corsOrigins: ['https://app.tac-to-iwxxm.com'],
+        },
+        supabase: {
+          url: 'https://ktvxijislbtgqapllmuk.supabase.co',
+          publishableKey: 'sb_publishable_test_key',
+        },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('uses /config.json API host for apiBase helpers after initRuntimeConfig', async () => {
+    const runtime = await import('../utils/runtime-config');
+    await runtime.initRuntimeConfig();
+
+    const apiBase = await import('../utils/apiBase');
+
+    expect(apiBase.getApiBaseUrl()).toBe('https://api.tac-to-iwxxm.com');
+    expect(apiBase.apiUrl('/lint-issue-catalog')).toBe(
+      'https://api.tac-to-iwxxm.com/api/v1/lint-issue-catalog',
+    );
+    expect(apiBase.requireApiBaseUrl()).toBe('https://api.tac-to-iwxxm.com');
+    // Must not keep calling the suspended Render hostname.
+    expect(apiBase.getApiBaseUrl()).not.toContain('onrender.com');
+  });
+
+  it('exposes supabase publishableKey from /config.json via runtime-config', async () => {
+    const runtime = await import('../utils/runtime-config');
+    await runtime.initRuntimeConfig();
+
+    expect(runtime.getSupabasePublishableKey()).toBe('sb_publishable_test_key');
+  });
+});

--- a/apps/frontend/src/test/vite-api-base-url.client.test.ts
+++ b/apps/frontend/src/test/vite-api-base-url.client.test.ts
@@ -4,13 +4,7 @@
  * RED until T6.3 implements ../utils/apiBase and migrates api.ts / authService.ts.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import {
-  getApiBaseUrl,
-  apiUrl,
-  authUrl,
-  adminUrl,
-  requireApiBaseUrl,
-} from '../utils/apiBase';
+import { getApiBaseUrl, apiUrl, authUrl, adminUrl } from '../utils/apiBase';
 
 const DEFAULT_DEV_API = 'http://localhost:18001';
 
@@ -113,15 +107,19 @@ describe('VITE_API_BASE_URL client', () => {
   });
 
   describe('requireApiBaseUrl', () => {
-    it('throws when VITE_API_BASE_URL is missing in production mode', () => {
+    it('throws when API host is unresolved in production mode', async () => {
+      vi.resetModules();
       vi.stubEnv('VITE_API_BASE_URL', '');
       vi.stubEnv('MODE', 'production');
-      expect(() => requireApiBaseUrl()).toThrow(/VITE_API_BASE_URL/);
+      const { requireApiBaseUrl: requireBase } = await import('../utils/apiBase');
+      expect(() => requireBase()).toThrow(/config\.json|VITE_API_BASE_URL/);
     });
 
-    it('returns trimmed URL when configured', () => {
+    it('returns trimmed URL when configured', async () => {
+      vi.resetModules();
       vi.stubEnv('VITE_API_BASE_URL', '  https://api.example.onrender.com  ');
-      expect(requireApiBaseUrl()).toBe('https://api.example.onrender.com');
+      const { requireApiBaseUrl: requireBase } = await import('../utils/apiBase');
+      expect(requireBase()).toBe('https://api.example.onrender.com');
     });
   });
 });

--- a/apps/frontend/src/utils/apiBase.ts
+++ b/apps/frontend/src/utils/apiBase.ts
@@ -1,7 +1,14 @@
 /**
- * Unified API base URL helpers (VITE_API_BASE_URL).
- * Single host for /api/v1/* and /auth/* per ADR-002 and deploy.md.
+ * Unified API base URL helpers.
+ * Prefers runtime `/config.json` (via runtime-config) over bake-time
+ * VITE_API_BASE_URL so DOKS/custom-domain deploys are not stuck on a stale
+ * Render hostname (BUG-2026-08-04).
  */
+
+import {
+  getApiBaseUrl as getRuntimeApiBaseUrl,
+  getRuntimeConfig,
+} from './runtime-config';
 
 const DEFAULT_DEV_API = 'http://localhost:18001';
 
@@ -9,20 +16,27 @@ function trimBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/, '');
 }
 
+/** API base URL: runtime config after init, else Vite / local default. */
 export function getApiBaseUrl(): string {
-  const raw = import.meta.env.VITE_API_BASE_URL?.trim() ?? '';
-  if (!raw) {
-    return DEFAULT_DEV_API;
-  }
-  return trimBaseUrl(raw);
+  return getRuntimeApiBaseUrl();
 }
 
+/**
+ * Ensure a production build has a configured API host (config.json or VITE).
+ * Rejects the silent localhost fallback when MODE is production.
+ */
 export function requireApiBaseUrl(): string {
-  const raw = import.meta.env.VITE_API_BASE_URL?.trim() ?? '';
-  if (!raw && import.meta.env.MODE === 'production') {
-    throw new Error('VITE_API_BASE_URL must be set in production builds');
+  const base = getApiBaseUrl();
+  if (import.meta.env.MODE === 'production') {
+    const vite = import.meta.env.VITE_API_BASE_URL?.trim() ?? '';
+    const runtime = getRuntimeConfig().api.baseUrl?.trim() ?? '';
+    if (!vite && (!runtime || trimBaseUrl(runtime) === DEFAULT_DEV_API)) {
+      throw new Error(
+        'API base URL must be set via /config.json or VITE_API_BASE_URL in production builds',
+      );
+    }
   }
-  return trimBaseUrl(raw || DEFAULT_DEV_API);
+  return base;
 }
 
 export function apiUrl(path: string): string {

--- a/apps/frontend/src/utils/authService.ts
+++ b/apps/frontend/src/utils/authService.ts
@@ -2,14 +2,12 @@
  * Auth Service API Client
  *
  * Handles all authentication requests through the merged API host.
- * Auth routes are served at /auth/* on VITE_API_BASE_URL.
+ * Auth routes are served at /auth/* on the runtime API base (config.json / VITE).
  */
 
 import { authUrl, getApiBaseUrl } from './apiBase';
 
-const API_BASE_URL = getApiBaseUrl();
-
-console.log('[Auth Service] Initialized with URL:', API_BASE_URL);
+console.log('[Auth Service] Initialized with URL:', getApiBaseUrl());
 
 export interface AuthUser {
   id: string;

--- a/apps/frontend/src/utils/runtime-config.ts
+++ b/apps/frontend/src/utils/runtime-config.ts
@@ -21,12 +21,14 @@ function configFromViteEnv(): MetarRuntimeConfig {
   return {
     environment: import.meta.env.MODE || 'development',
     api: {
-      baseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:18001',
-      frontendUrl: import.meta.env.VITE_APP_URL || 'http://localhost:18000',
+      baseUrl: (import.meta.env.VITE_API_BASE_URL || 'http://localhost:18001').trim(),
+      frontendUrl: (import.meta.env.VITE_APP_URL || 'http://localhost:18000').trim(),
     },
     supabase: {
-      url: import.meta.env.VITE_SUPABASE_URL || '',
-      publishableKey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || '',
+      url: (import.meta.env.VITE_SUPABASE_URL || '').trim(),
+      publishableKey: (
+        import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || ''
+      ).trim(),
     },
   };
 }
@@ -53,17 +55,22 @@ export async function initRuntimeConfig(): Promise<MetarRuntimeConfig> {
   return cachedConfig;
 }
 
-/** Return loaded config; throws if ``initRuntimeConfig`` was not called. */
+/**
+ * Return loaded config.
+ * After ``initRuntimeConfig``, returns the cached ``/config.json`` (or Vite
+ * fallback from init). Before init, reads Vite env fresh (not cached) so
+ * bake-time stubs and tests stay consistent.
+ */
 export function getRuntimeConfig(): MetarRuntimeConfig {
-  if (!cachedConfig) {
-    cachedConfig = configFromViteEnv();
+  if (cachedConfig) {
+    return cachedConfig;
   }
-  return cachedConfig;
+  return configFromViteEnv();
 }
 
 /** API base URL for merged backend (/api/v1, /auth, /admin). */
 export function getApiBaseUrl(): string {
-  return getRuntimeConfig().api.baseUrl.replace(/\/$/, '');
+  return getRuntimeConfig().api.baseUrl.trim().replace(/\/+$/, '');
 }
 
 /** Supabase project URL. */

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,9 +1,13 @@
 {
   "environment": "prod",
   "api": {
-    "baseUrl": "https://metar-to-iwxxm-api.onrender.com",
-    "corsOrigins": ["https://metar-to-iwxxm-frontend-v4-web.onrender.com"],
-    "frontendUrl": "https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+    "baseUrl": "https://api.tac-to-iwxxm.com",
+    "corsOrigins": [
+      "https://app.tac-to-iwxxm.com",
+      "http://app.tac-to-iwxxm.com",
+      "http://168.144.12.70"
+    ],
+    "frontendUrl": "https://app.tac-to-iwxxm.com"
   },
   "supabase": {
     "url": "https://ktvxijislbtgqapllmuk.supabase.co"
@@ -18,7 +22,7 @@
     "enableStatistics": true
   },
   "liveE2e": {
-    "apiUrl": "https://metar-to-iwxxm-api.onrender.com",
-    "frontendUrl": "https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+    "apiUrl": "https://api.tac-to-iwxxm.com",
+    "frontendUrl": "https://app.tac-to-iwxxm.com"
   }
 }

--- a/docs/bug-reports/BUG-2026-08-04-frontend-baked-onrender-api-host.md
+++ b/docs/bug-reports/BUG-2026-08-04-frontend-baked-onrender-api-host.md
@@ -1,0 +1,119 @@
+# BUG-2026-08-04 — Frontend calls suspended Render API host (ignores `/config.json`)
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixing (local green; awaiting commit / PR / DOKS FE deploy approval) |
+| **Feature** | F15 / F21 connectivity (H5 API host) |
+| **Severity** | critical (production operator UI blocked) |
+| **Classification** | connectivity / config / deploy |
+| **Remediation path** | local-first — wire `apiBase` → `/config.json` + inject publishable key; deploy after approval |
+| **Branch** | `fix/frontend-runtime-api-host` |
+
+## Error description
+
+On `https://app.tac-to-iwxxm.com/`, operator flows fail: `lint-issue-catalog`, `lint-tac`,
+and `decode-tac` return **503 Service Unavailable**. DevTools also shows CORS
+`No 'Access-Control-Allow-Origin'` and a console warning that the Supabase publishable
+key is not set.
+
+## Error logs
+
+```
+Request URL: https://metar-to-iwxxm-api.onrender.com/api/v1/lint-issue-catalog?product=metar
+Status Code: 503 Service Unavailable
+x-render-routing: suspend-by-user
+content-type: text/html; charset=utf-8
+
+⚠️ Supabase publishable key not set. Supabase integration will not work.
+
+Access to fetch at 'https://metar-to-iwxxm-api.onrender.com/api/v1/lint-issue-catalog?product=metar'
+from origin 'https://app.tac-to-iwxxm.com' has been blocked by CORS policy:
+No 'Access-Control-Allow-Origin' header is present on the requested resource.
+```
+
+Render HTML body for the same host:
+
+```html
+<title>Service Suspended</title>
+This service has been suspended by its owner.
+```
+
+## Symptoms & reproduction
+
+| Field | User answer |
+|-------|-------------|
+| Symptom | Error / crash — API 503 + CORS in browser |
+| Where | Production (`app.tac-to-iwxxm.com`) |
+| When | After last frontend deploy / DOKS cutover (intake 2 = first option) |
+| Frequency | Every time (probe-confirmed) |
+| Repro env | Production |
+| Severity | Critical / blocked |
+| Evidence | DevTools network + console (pasted) |
+| Tried | Nothing prior; hotfix intake 2026-08-04 |
+
+### Intake (Phase 0)
+
+- Intent: new production issue
+- Remediation: **A+D** — code-fix `apiBase` → runtime config **and** fix missing Supabase publishable key
+- Plan: Proceed
+- Verification (defaults; AskQuestion tool unavailable): live app must call `https://api.tac-to-iwxxm.com`; frontend vitest + H5 live smoke; user re-checks UI after deploy
+
+## Investigation
+
+### Live probes (2026-08-04)
+
+| Target | Result |
+|--------|--------|
+| `GET https://metar-to-iwxxm-api.onrender.com/health` | **503** `x-render-routing: suspend-by-user` |
+| Render API `metar-to-iwxxm-api` (`srv-d69v688gjchc73cn9kg0`) | `suspended=suspended`, `suspenders=["user"]` |
+| `GET https://api.tac-to-iwxxm.com/health` | **200** healthy |
+| `GET https://api.tac-to-iwxxm.com/api/v1/lint-issue-catalog?product=metar` | **200** (issues payload) |
+| OPTIONS same + `Origin: https://app.tac-to-iwxxm.com` | CORS allow-origin present |
+| `GET https://app.tac-to-iwxxm.com/config.json` | `api.baseUrl` = `https://api.tac-to-iwxxm.com` (correct); **no** `supabase.publishableKey` |
+| Live bundles `App-BkEPMp_C.js` / `index-*.js` | Bake-time `VITE_API_BASE_URL` = `https://metar-to-iwxxm-api.onrender.com` |
+
+### Hypotheses
+
+1. **Primary (confirmed):** Frontend `apps/frontend/src/utils/apiBase.ts` reads bake-time
+   `import.meta.env.VITE_API_BASE_URL` and **does not** use `runtime-config` /
+   `/config.json`. Production static assets were built with the old Render URL; that
+   Render web service is suspended by the account owner → 503 HTML → browser reports
+   missing CORS headers (secondary symptom).
+2. **Secondary:** `/config.json` omits `supabase.publishableKey` → console warning
+   (auth/Supabase client path); separate from the 503s on lint/decode.
+3. **Not root cause:** CORS misconfiguration on the healthy custom-domain API (OPTIONS
+   succeeds for `app.tac-to-iwxxm.com`).
+
+### Root cause (confirmed)
+
+1. `apiBase.ts` read bake-time `VITE_API_BASE_URL` only; ignored `/config.json`
+   loaded by `main.tsx` → `initRuntimeConfig()`.
+2. CI `FRONTEND_VITE_*` defaults and `config/prod.json` still pointed at suspended
+   Render hosts after DOKS cutover.
+3. Frontend Dockerfile wrote `supabase.url` but never `publishableKey` into
+   `config.json` (secondary console warning).
+
+## Repro test
+
+| Path | Status |
+|------|--------|
+| `apps/frontend/src/test/bug-2026-08-04-frontend-baked-onrender-api-host.test.ts` | green (was red) |
+| `tests/bugs/test_bug_2026_08_04_frontend_baked_onrender_api_host.py` | green (was red) |
+
+## Fix
+
+- `apiBase.ts` → prefer `runtime-config` / `/config.json`
+- `runtime-config.ts` → do not cache Vite fallback; trim URLs
+- `Dockerfile` → inject `publishableKey` into `config.json`
+- `ci-cd.yml` + `config/prod.json` → DOKS hosts (`api` / `app.tac-to-iwxxm.com`)
+- CORS unit assertion updated for new prod origin
+
+## Verification plan
+
+- Success: live app calls `https://api.tac-to-iwxxm.com` (lint/decode 200)
+- Checks: frontend vitest + bug pytest + H5 live smoke after DOKS FE rollout
+- Follow-up: user re-checks UI in browser after deploy
+
+## Prevention
+
+*(pending Phase 5 after deploy)*

--- a/docs/bug-reports/BUG-2026-08-04-frontend-baked-onrender-api-host.md
+++ b/docs/bug-reports/BUG-2026-08-04-frontend-baked-onrender-api-host.md
@@ -2,12 +2,13 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | fixing (local green; awaiting commit / PR / DOKS FE deploy approval) |
+| **Status** | fixing (PR open; awaiting merge + DOKS FE deploy approval) |
 | **Feature** | F15 / F21 connectivity (H5 API host) |
 | **Severity** | critical (production operator UI blocked) |
 | **Classification** | connectivity / config / deploy |
 | **Remediation path** | local-first — wire `apiBase` → `/config.json` + inject publishable key; deploy after approval |
 | **Branch** | `fix/frontend-runtime-api-host` |
+| **PR** | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/862 |
 
 ## Error description
 

--- a/tests/bugs/test_bug_2026_08_04_frontend_baked_onrender_api_host.py
+++ b/tests/bugs/test_bug_2026_08_04_frontend_baked_onrender_api_host.py
@@ -1,0 +1,46 @@
+"""BUG-2026-08-04 — FE must prefer /config.json API host; Docker must inject publishable key.
+
+Production ``app.tac-to-iwxxm.com`` called suspended ``metar-to-iwxxm-api.onrender.com``
+because ``apiBase.ts`` ignored runtime config, and the frontend Dockerfile never wrote
+``supabase.publishableKey`` into ``config.json``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+API_BASE = ROOT / "apps" / "frontend" / "src" / "utils" / "apiBase.ts"
+DOCKERFILE = ROOT / "apps" / "frontend" / "Dockerfile"
+CI_CD = ROOT / ".github" / "workflows" / "ci-cd.yml"
+PROD_CONFIG = ROOT / "config" / "prod.json"
+
+
+def test_bug_2026_08_04_api_base_uses_runtime_config() -> None:
+    src = API_BASE.read_text(encoding="utf-8")
+    assert (
+        "runtime-config" in src or "getRuntimeConfig" in src or "getApiBaseUrl" in src
+    )
+    # Must not be Vite-only (the production failure mode).
+    assert "import.meta.env.VITE_API_BASE_URL" not in src or "runtime-config" in src
+    assert "from './runtime-config'" in src or 'from "./runtime-config"' in src
+
+
+def test_bug_2026_08_04_dockerfile_injects_publishable_key() -> None:
+    df = DOCKERFILE.read_text(encoding="utf-8")
+    assert "VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY" in df
+    assert "publishableKey" in df
+
+
+def test_bug_2026_08_04_ci_and_prod_config_use_doks_hosts() -> None:
+    ci = CI_CD.read_text(encoding="utf-8")
+    assert "FRONTEND_VITE_API_BASE_URL: https://api.tac-to-iwxxm.com" in ci
+    assert "FRONTEND_VITE_APP_URL: https://app.tac-to-iwxxm.com" in ci
+    # Stale Render bake-args must not remain as the CI defaults.
+    assert (
+        "FRONTEND_VITE_API_BASE_URL: https://metar-to-iwxxm-api.onrender.com" not in ci
+    )
+
+    prod = PROD_CONFIG.read_text(encoding="utf-8")
+    assert "https://api.tac-to-iwxxm.com" in prod
+    assert "https://app.tac-to-iwxxm.com" in prod

--- a/tests/unit/test_cors_policy.py
+++ b/tests/unit/test_cors_policy.py
@@ -71,4 +71,4 @@ class TestMetarCorsOriginsPolicy:
         from src.api import get_cors_origins
 
         origins = get_cors_origins()
-        assert "https://metar-to-iwxxm-frontend-v4-web.onrender.com" in origins
+        assert "https://app.tac-to-iwxxm.com" in origins


### PR DESCRIPTION
## Summary
- Fixes BUG-2026-08-04: production UI called suspended `metar-to-iwxxm-api.onrender.com` (503 / false CORS) despite DOKS `/config.json` pointing at `https://api.tac-to-iwxxm.com`.
- Wire `apiBase` to runtime `/config.json`; inject Supabase `publishableKey` in the frontend Docker image; update CI + `config/prod.json` hosts to `app` / `api.tac-to-iwxxm.com`.

## Test plan
- [x] `apps/frontend/src/test/bug-2026-08-04-frontend-baked-onrender-api-host.test.ts` (red → green)
- [x] `tests/bugs/test_bug_2026_08_04_frontend_baked_onrender_api_host.py`
- [x] Frontend vitest apiBase / runtime-config suite
- [x] `tests/unit/test_cors_policy.py` (prod origin)
- [ ] After merge: CI builds FE image; DOKS `kubectl set image deploy/metar-frontend …`
- [ ] Live: Network tab shows `api.tac-to-iwxxm.com` for lint/decode (200); no Render 503

## Deploy note
Render deploy hooks will still fail while services are suspended — use DOKS FE rollout after GHCR push (same pattern as S040).


Made with [Cursor](https://cursor.com)