### PR TITLE
[hotfix] Skip Render deploy when service is suspended

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -495,17 +495,21 @@ jobs:
             exit 1
           fi
 
+      # Live traffic is on DOKS (app/api.tac-to-iwxxm.com). Render services may be
+      # suspended; still push GHCR, but do not fail Deploy when Render is suspended.
       - name: Deploy backend image to Render
         if: steps.guard.outputs.skip != 'true' && env.RENDER_BACKEND_DEPLOY_HOOK != ''
         env:
           DEPLOY_HOOK: ${{ env.RENDER_BACKEND_DEPLOY_HOOK }}
           IMAGE_URL: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
+          RENDER_SKIP_IF_SUSPENDED: "1"
         run: |
           if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
             python3 scripts/deploy/trigger_render_image_deploy.py \
               --deploy-hook "${DEPLOY_HOOK}" \
               --image-url "${IMAGE_URL}" \
-              --service-name metar-to-iwxxm-api
+              --service-name metar-to-iwxxm-api \
+              --skip-if-suspended
           else
             curl -fsSL "${DEPLOY_HOOK}"
           fi
@@ -515,15 +519,24 @@ jobs:
         env:
           DEPLOY_HOOK: ${{ env.RENDER_FRONTEND_DEPLOY_HOOK }}
           IMAGE_URL: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
+          RENDER_SKIP_IF_SUSPENDED: "1"
         run: |
           if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
             python3 scripts/deploy/trigger_render_image_deploy.py \
               --deploy-hook "${DEPLOY_HOOK}" \
               --image-url "${IMAGE_URL}" \
-              --service-name metar-to-iwxxm-frontend-v4-web
+              --service-name metar-to-iwxxm-frontend-v4-web \
+              --skip-if-suspended
           else
             curl -fsSL "${DEPLOY_HOOK}"
           fi
+
+      - name: Note DOKS rollout
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          echo "::notice::GHCR tags pushed. Live deploy target is DOKS (metar-iwxxm)."
+          echo "Roll out with: kubectl -n metar-iwxxm set image deploy/metar-frontend frontend=ghcr.io/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}"
+          echo "               kubectl -n metar-iwxxm set image deploy/metar-api api=ghcr.io/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}"
 
       - name: CD skipped (credentials)
         if: steps.guard.outputs.skip == 'true'

--- a/scripts/deploy/trigger_render_image_deploy.py
+++ b/scripts/deploy/trigger_render_image_deploy.py
@@ -173,6 +173,20 @@ def trigger_via_rest(
     )
 
 
+def is_suspended_deploy_block(status_code: int, detail: str) -> bool:
+    """True when Render refuses deploy because the service is suspended.
+
+    After DOKS cutover, production traffic is on Kubernetes while Render services
+    may remain suspended. CI still pushes GHCR images; treating suspended as a
+    hard Deploy failure keeps ``main`` red without changing the live site.
+    """
+    text = (detail or "").lower()
+    if "suspended" not in text:
+        return False
+    # Hook conflict / REST reject shapes seen in production CI.
+    return status_code in (0, 400, 409, 500) or "cannot deploy" in text or "conflict" in text
+
+
 def trigger_via_hook(
     *,
     deploy_hook: str,
@@ -213,6 +227,7 @@ def trigger_image_deploy(
     http: HttpCaller | None = None,
     hook_retries: int = 3,
     allow_hook_without_imgurl: bool = True,
+    skip_if_suspended: bool = False,
 ) -> TriggerResult:
     """Try hook+imgURL, then REST imageUrl, then hook without imgURL."""
     caller = http or _default_http
@@ -252,6 +267,19 @@ def trigger_image_deploy(
                 f"rest={rest.status_code}:{rest.detail}"
             )[:800],
         )
+        if skip_if_suspended and is_suspended_deploy_block(
+            hook_result.status_code, hook_result.detail
+        ):
+            return TriggerResult(
+                ok=True,
+                method="skipped_suspended",
+                status_code=hook_result.status_code,
+                detail=(
+                    "Render service is suspended — GHCR image push succeeded; "
+                    "skipping Render deploy (DOKS is the live target). "
+                    f"{hook_result.detail}"
+                )[:800],
+            )
 
     if allow_hook_without_imgurl:
         fallback = trigger_via_hook(
@@ -271,6 +299,33 @@ def trigger_image_deploy(
                     f"{fallback.detail}"
                 )[:800],
             )
+        if skip_if_suspended and is_suspended_deploy_block(
+            fallback.status_code, fallback.detail
+        ):
+            return TriggerResult(
+                ok=True,
+                method="skipped_suspended",
+                status_code=fallback.status_code,
+                detail=(
+                    "Render service is suspended — GHCR image push succeeded; "
+                    "skipping Render deploy (DOKS is the live target). "
+                    f"{fallback.detail}"
+                )[:800],
+            )
+
+    if skip_if_suspended and is_suspended_deploy_block(
+        hook_result.status_code, hook_result.detail
+    ):
+        return TriggerResult(
+            ok=True,
+            method="skipped_suspended",
+            status_code=hook_result.status_code,
+            detail=(
+                "Render service is suspended — GHCR image push succeeded; "
+                "skipping Render deploy (DOKS is the live target). "
+                f"{hook_result.detail}"
+            )[:800],
+        )
 
     return hook_result
 
@@ -296,8 +351,21 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Do not fall back to hook without imgURL",
     )
+    parser.add_argument(
+        "--skip-if-suspended",
+        action="store_true",
+        help=(
+            "Exit 0 when Render reports the service is suspended "
+            "(DOKS cutover; GHCR push is enough)"
+        ),
+    )
     args = parser.parse_args(argv)
 
+    skip_env = os.environ.get("RENDER_SKIP_IF_SUSPENDED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     result = trigger_image_deploy(
         deploy_hook=args.deploy_hook,
         image_url=args.image_url,
@@ -305,6 +373,7 @@ def main(argv: list[str] | None = None) -> int:
         service_id=args.service_id or os.environ.get("RENDER_SERVICE_ID"),
         service_name=args.service_name,
         allow_hook_without_imgurl=not args.no_hook_without_imgurl,
+        skip_if_suspended=args.skip_if_suspended or skip_env,
     )
     print(
         json.dumps(

--- a/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
+++ b/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
@@ -115,12 +115,46 @@ def test_bug_2026_08_03_hook_500_falls_back_to_default_hook() -> None:
     assert result.method == "hook_default_after_imgURL_fail"
 
 
+def test_bug_2026_08_04_suspended_render_skipped_when_enabled() -> None:
+    """DOKS cutover: suspended Render must not fail Deploy after GHCR push."""
+    mod = _load_mod()
+    calls: list[tuple[str, str]] = []
+
+    def fake_http(
+        url: str,
+        method: str,
+        headers: dict[str, str] | None,
+        body: bytes | None,
+    ) -> tuple[int, str]:
+        calls.append((method, url))
+        if "imgURL=" in url:
+            return 409, '{"conflict":"service is suspended"}'
+        if method == "POST" and "/deploys" in url:
+            return 400, '{"message":"cannot deploy suspended service"}'
+        return 404, "unexpected"
+
+    result = mod.trigger_image_deploy(
+        deploy_hook="https://api.render.com/deploy/srv-abc?key=k",
+        image_url="ghcr.io/empiric2/tac-to-iwxxm/backend:tag",
+        api_key="rnd_test",
+        http=fake_http,
+        hook_retries=1,
+        allow_hook_without_imgurl=False,
+        skip_if_suspended=True,
+    )
+    assert result.ok is True
+    assert result.method == "skipped_suspended"
+    assert "suspended" in result.detail.lower()
+
+
 def test_bug_2026_08_03_ci_uses_resilient_script_not_bare_curl() -> None:
     raw = CI_CD.read_text(encoding="utf-8")
     assert "trigger_render_image_deploy.py" in raw
     # Guard against regressing to the brittle one-liner that failed on 8bd111c.
     assert 'curl -fsSL "${DEPLOY_HOOK}&imgURL=' not in raw
     assert "&imgURL=${ENCODED_URL}" not in raw
+    assert "--skip-if-suspended" in raw
+    assert "RENDER_SKIP_IF_SUSPENDED" in raw
 
     doc = yaml.safe_load(raw)
     assert isinstance(doc, dict)


### PR DESCRIPTION
## Summary
- Main CI Deploy was failing after GHCR push with \`cannot deploy suspended service\` (Render services suspended post-DOKS cutover).
- Treat suspended Render as skip-success (\`--skip-if-suspended\` / \`RENDER_SKIP_IF_SUSPENDED=1\`) so Deploy stays green; add DOKS rollout notice.
- Ops (already applied): scaled \`metar-worker\` to 0 — secret had \`INGEST_POLLER_URL=REPLACE_ME_INGEST_POLLER_URL\` causing 30s error loops.

## Test plan
- [x] \`tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py\` (suspended skip + CI guards)
- [ ] After merge: main CI Deploy job success (skipped_suspended)
- [x] Live app/api healthy; worker 0/0


Made with [Cursor](https://cursor.com)