### PR TITLE
[EV-033] Harden F8 INGEST_POLLER_URL fail-closed cutover

### DIFF
--- a/.cursor/rules/optional/worker-ingest-poller-url.mdc
+++ b/.cursor/rules/optional/worker-ingest-poller-url.mdc
@@ -1,0 +1,22 @@
+---
+description: F8 INGEST_POLLER_URL must be real https before metar-worker replicas > 0
+globs:
+  - apps/worker/**/*
+  - deploy/doks/**/*
+  - scripts/deploy/*poller*
+  - scripts/deploy/check_worker_crashloop.sh
+alwaysApply: false
+---
+
+# F8 worker INGEST_POLLER_URL (EV-033)
+
+Evidence: DOKS cutover left `REPLACE_ME_INGEST_POLLER_URL` → worker unusable / noisy failures.
+
+1. **Never** scale `metar-worker` above 0 with `REPLACE_ME_*` or non-`https://` poller URL.
+2. Validate before scale-up: `bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up`.
+3. Non-prod fixture pin:
+   `https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json`
+4. Do **not** copy Render worker env poller URLs without `--probe` (suspended services / stale forks 404).
+5. CrashLoop: `bash scripts/deploy/check_worker_crashloop.sh`; optional PrometheusRule under
+   `deploy/doks/observability/`.
+6. Code: `metar_worker.poller.validate_ingest_poller_url` — keep tests green in `config-guard`.

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,12 @@ DATABASE_URL=
 E2E_USER_EMAIL=
 E2E_USER_PASSWORD=
 
-# F8 worker (apps/worker) — optional locally; required on Render worker service
+# F8 worker (apps/worker) — optional locally; required on DOKS/Render worker
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
-INGEST_POLLER_URL=
+# Must be https:// (not REPLACE_ME_*). Non-prod fixture (EV-033):
+# https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
+INGEST_POLLER_URL=https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
 INGEST_POLL_INTERVAL_SEC=30
 
 # F16–F19 dissemination egress (ADR-029). Comma-separated hostnames and/or CIDRs.

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ packages/iwxxm-validate/src/iwxxm_validate/schemas/LAST_SYNC.json
 # ADR-027 — xsdata pydantic trees are committed (T3.7); ignore only bytecode
 packages/shared/src/metar_shared/iwxxm_xsd/**/__pycache__/
 
+
+# Local DOKS kube/access secrets (never commit)
+deploy/doks/.env.access

--- a/Makefile
+++ b/Makefile
@@ -559,9 +559,19 @@ validate-fast: format-check typecheck lint secrets-check validate-yaml catalog-c
 
 config-guard:
 	$(UV) run pytest tests/test_config_placeholders.py tests/smoke/test_h5_runtime_config.py -v
+	$(UV) run python scripts/deploy/validate_ingest_poller_url.py --print-fixture >/dev/null
+	$(UV) run pytest apps/worker/tests/test_validate_ingest_poller_url.py \
+		tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py -q --no-cov
 
 env-check:
 	bash scripts/env/verify-sync.sh
+
+# EV-033 / F8 — DOKS worker poller preflight (requires kubectl + cluster context)
+doks-worker-poller-preflight:
+	bash scripts/deploy/doks_worker_poller_preflight.sh --probe
+
+doks-worker-crashloop-check:
+	bash scripts/deploy/check_worker_crashloop.sh
 
 # --- Supabase local stack (repo root supabase/) ---
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -21,5 +21,18 @@ Tests: `make test-unit-worker`
 ## Deploy
 
 Blueprint service `metar-to-iwxxm-worker` in `render.yaml` (Docker context repo root).
+DOKS: `metar-worker` — see [deploy/doks/README-worker-hardening.md](../../deploy/doks/README-worker-hardening.md).
 Apply migration `supabase/migrations/20260712000009_iwxxm_ingest_store_quarantine.sql`
 before enabling the worker.
+
+**INGEST_POLLER_URL (EV-033):** must be `https://` (not `REPLACE_ME_*`). Non-prod fixture:
+
+```
+https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
+```
+
+```bash
+python3 scripts/deploy/validate_ingest_poller_url.py --probe "$INGEST_POLLER_URL"
+bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up
+bash scripts/deploy/check_worker_crashloop.sh
+```

--- a/apps/worker/src/metar_worker/__main__.py
+++ b/apps/worker/src/metar_worker/__main__.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 import signal
+import sys
 import time
 
 from metar_worker.pipeline import process_job
 from metar_worker.poller import fetch_jobs, safe_url_for_log
+from metar_worker.poller_url import validate_ingest_poller_url
 from metar_worker.settings import WorkerSettings
 from metar_worker.store import SupabaseRestStore, write_result
 
@@ -32,8 +34,7 @@ def run_once(settings: WorkerSettings, store: SupabaseRestStore | None = None) -
     int
         Number of jobs processed (skips already-seen ``job_id`` values in-process).
     """
-    if not settings.ingest_poller_url:
-        raise RuntimeError("INGEST_POLLER_URL is required")
+    poller_url = validate_ingest_poller_url(settings.ingest_poller_url)
 
     writer = store
     if writer is None:
@@ -46,11 +47,11 @@ def run_once(settings: WorkerSettings, store: SupabaseRestStore | None = None) -
             service_role_key=settings.supabase_service_role_key,
         )
 
-    jobs = fetch_jobs(settings.ingest_poller_url)
+    jobs = fetch_jobs(poller_url)
     logger.info(
         "fetched %s job(s) from %s",
         len(jobs),
-        safe_url_for_log(settings.ingest_poller_url),
+        safe_url_for_log(poller_url),
     )
     processed = 0
     for job in jobs:
@@ -84,6 +85,14 @@ def main() -> None:
     signal.signal(signal.SIGINT, _handle_sigterm)
 
     settings = WorkerSettings()
+    try:
+        validate_ingest_poller_url(settings.ingest_poller_url)
+    except ValueError as exc:
+        # Fail closed with a clear exit so CrashLoopBackOff is diagnosable;
+        # ops must keep replicas at 0 until the secret is a real https URL.
+        logger.critical("INGEST_POLLER_URL invalid — refusing to start: %s", exc)
+        sys.exit(2)
+
     if settings.once:
         run_once(settings)
         return

--- a/apps/worker/src/metar_worker/poller.py
+++ b/apps/worker/src/metar_worker/poller.py
@@ -8,6 +8,11 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
+from metar_worker.poller_url import (
+    DEFAULT_FIXTURE_INGEST_POLLER_URL,
+    validate_ingest_poller_url,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class IngestJob:
@@ -98,8 +103,7 @@ def fetch_jobs(
     list[IngestJob]
         Zero or more jobs from the feed.
     """
-    if not url.lower().startswith("https://"):
-        raise ValueError("INGEST_POLLER_URL must be an https:// URL (ADR-018 Q16=A)")
+    url = validate_ingest_poller_url(url)
 
     own_client = client is None
     http = client or httpx.Client(timeout=timeout)
@@ -113,4 +117,10 @@ def fetch_jobs(
             http.close()
 
 
-__all__ = ["IngestJob", "fetch_jobs", "safe_url_for_log"]
+__all__ = [
+    "DEFAULT_FIXTURE_INGEST_POLLER_URL",
+    "IngestJob",
+    "fetch_jobs",
+    "safe_url_for_log",
+    "validate_ingest_poller_url",
+]

--- a/apps/worker/src/metar_worker/poller_url.py
+++ b/apps/worker/src/metar_worker/poller_url.py
@@ -1,0 +1,70 @@
+"""INGEST_POLLER_URL validation (no network deps — safe for ops CLI)."""
+
+from __future__ import annotations
+
+# Non-prod fixture used after DOKS cutover when no operational feed is configured.
+# Keep in sync with docs/deploy.md / docs/env-contract.md / .env.example.
+DEFAULT_FIXTURE_INGEST_POLLER_URL = (
+    "https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/"
+    "apps/worker/tests/fixtures/ingest_feed.json"
+)
+
+_PLACEHOLDER_MARKERS = (
+    "REPLACE_ME",
+    "CHANGEME",
+    "TODO_SET",
+    "YOUR_POLLER",
+)
+
+
+def validate_ingest_poller_url(url: str) -> str:
+    """
+    Return a stripped HTTPS poller URL, or raise ``ValueError``.
+
+    Rejects empty values, non-HTTPS schemes, and cutover placeholders such as
+    ``REPLACE_ME_INGEST_POLLER_URL`` so the worker fails closed with a clear
+    message instead of looping on a bogus feed (EV-033 / F8 harden).
+
+    Parameters
+    ----------
+    url :
+        Raw ``INGEST_POLLER_URL`` value.
+
+    Returns
+    -------
+    str
+        Stripped URL suitable for ``fetch_jobs``.
+
+    Raises
+    ------
+    ValueError
+        If the URL is missing, a placeholder, or not ``https://``.
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(
+            "INGEST_POLLER_URL is required (HTTPS JSON feed). "
+            f"Non-prod fixture: {DEFAULT_FIXTURE_INGEST_POLLER_URL}"
+        )
+    upper = cleaned.upper()
+    for marker in _PLACEHOLDER_MARKERS:
+        if marker.upper() in upper:
+            raise ValueError(
+                "INGEST_POLLER_URL looks like a cutover placeholder "
+                f"({marker!r} in {cleaned!r}). Set a real https:// feed or the "
+                f"fixture URL: {DEFAULT_FIXTURE_INGEST_POLLER_URL}. "
+                "Scale metar-worker to 0 until the secret is fixed "
+                "(scripts/deploy/doks_worker_poller_preflight.sh)."
+            )
+    if not cleaned.lower().startswith("https://"):
+        raise ValueError(
+            "INGEST_POLLER_URL must be an https:// URL (ADR-018 Q16=A); "
+            f"got {cleaned!r}. Non-prod fixture: {DEFAULT_FIXTURE_INGEST_POLLER_URL}"
+        )
+    return cleaned
+
+
+__all__ = [
+    "DEFAULT_FIXTURE_INGEST_POLLER_URL",
+    "validate_ingest_poller_url",
+]

--- a/apps/worker/tests/test_validate_ingest_poller_url.py
+++ b/apps/worker/tests/test_validate_ingest_poller_url.py
@@ -1,0 +1,42 @@
+"""EV-033 — reject placeholder / non-https INGEST_POLLER_URL (F8 harden)."""
+
+from __future__ import annotations
+
+import pytest
+from metar_worker.poller_url import (
+    DEFAULT_FIXTURE_INGEST_POLLER_URL,
+    validate_ingest_poller_url,
+)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "   ",
+        "REPLACE_ME_INGEST_POLLER_URL",
+        "https://REPLACE_ME.example/feed.json",
+        "http://ingest.example.test/feed.json",
+        "ftp://ingest.example.test/feed.json",
+    ],
+)
+def test_validate_ingest_poller_url_rejects_bad(bad: str) -> None:
+    with pytest.raises(ValueError, match="INGEST_POLLER_URL"):
+        validate_ingest_poller_url(bad)
+
+
+def test_validate_ingest_poller_url_accepts_https() -> None:
+    url = "https://ingest.example.test/feed.json"
+    assert validate_ingest_poller_url(url) == url
+    assert validate_ingest_poller_url(f"  {url}  ") == url
+
+
+def test_default_fixture_url_is_https_raw_github() -> None:
+    assert DEFAULT_FIXTURE_INGEST_POLLER_URL.startswith("https://")
+    assert "EMPIRIC2/TAC-to-IWXXM" in DEFAULT_FIXTURE_INGEST_POLLER_URL
+    assert DEFAULT_FIXTURE_INGEST_POLLER_URL.endswith(
+        "apps/worker/tests/fixtures/ingest_feed.json"
+    )
+    assert validate_ingest_poller_url(DEFAULT_FIXTURE_INGEST_POLLER_URL) == (
+        DEFAULT_FIXTURE_INGEST_POLLER_URL
+    )

--- a/deploy/doks/README-worker-hardening.md
+++ b/deploy/doks/README-worker-hardening.md
@@ -1,0 +1,41 @@
+# DOKS `metar-worker` poller hardening (EV-033 / F8)
+
+## Why
+
+Cutover left `INGEST_POLLER_URL=REPLACE_ME_INGEST_POLLER_URL`, which is not a valid
+HTTPS feed. Keep **replicas at 0** until the secret is a probed `https://` URL.
+
+## Non-prod fixture (default when no operational feed)
+
+```
+https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
+```
+
+## Do not copy stale Render URLs
+
+After DOKS cutover, Render worker/API services may be **suspended** and old
+`INGEST_POLLER_URL` values (fork/branch raw.githubusercontent.com links) often
+**404**. Always:
+
+1. `python3 scripts/deploy/validate_ingest_poller_url.py --probe "$URL"`
+2. Patch the DOKS secret
+3. `bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up`
+
+## Fail-closed ops
+
+| Step | Command |
+|------|---------|
+| Validate + scale 0 if bad | `bash scripts/deploy/doks_worker_poller_preflight.sh --fail-closed` |
+| Probe + scale to 1 | `bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up` |
+| CrashLoop check | `bash scripts/deploy/check_worker_crashloop.sh` |
+
+## Alerts
+
+- **Now (no Prometheus operator):** run `check_worker_crashloop.sh` in smoke/cron.
+- **When kube-prometheus-stack exists:**  
+  `kubectl apply -f deploy/doks/observability/prometheusrule-metar-worker.yaml`
+
+## Manifest defaults
+
+- `deploy/doks/base/deployment-worker.yaml` — `replicas: 0`
+- `deploy/doks/base/secret-worker.yaml` — stub only; never apply blindly over live secrets

--- a/deploy/doks/base/deployment-worker.yaml
+++ b/deploy/doks/base/deployment-worker.yaml
@@ -1,0 +1,39 @@
+# EV-033 — default replicas: 0 (fail-closed) until INGEST_POLLER_URL preflight passes.
+# Scale up only via:
+#   bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metar-worker
+  labels:
+    app.kubernetes.io/name: metar-worker
+    app.kubernetes.io/component: worker
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metar-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: metar-worker
+        app.kubernetes.io/component: worker
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: worker
+          image: ghcr.io/empiric2/tac-to-iwxxm/worker:main-latest
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: metar-worker-config
+            - secretRef:
+                name: metar-worker-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/deploy/doks/base/secret-worker.yaml
+++ b/deploy/doks/base/secret-worker.yaml
@@ -1,0 +1,25 @@
+# Stub Secret — replace values out-of-band before apply (never commit real secrets).
+# Do NOT `kubectl apply -k` this into a live cluster without editing first — it will
+# overwrite live secret values. Prefer patching:
+#   kubectl -n metar-iwxxm patch secret metar-worker-secrets --type=merge \
+#     -p '{"stringData":{"INGEST_POLLER_URL":"<https-url>"}}'
+#
+# EV-033 — INGEST_POLLER_URL must be a real https:// feed before replicas > 0.
+# Non-prod fixture (ADR-018 / UJ-014):
+#   https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
+# Do not copy stale Render worker env URLs without probing (GET 200 + JSON items).
+# Preflight: bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metar-worker-secrets
+  labels:
+    app.kubernetes.io/name: metar-worker
+    app.kubernetes.io/component: worker
+type: Opaque
+stringData:
+  DATABASE_URL: "REPLACE_ME_DO_POSTGRES_URL"
+  # Leave REPLACE_ME until set; keep deploy/metar-worker replicas at 0 until preflight OK.
+  INGEST_POLLER_URL: "REPLACE_ME_INGEST_POLLER_URL"
+  SUPABASE_URL: "REPLACE_ME_SUPABASE_URL"
+  SUPABASE_SERVICE_ROLE_KEY: "REPLACE_ME_SUPABASE_SERVICE_ROLE_KEY"

--- a/deploy/doks/observability/prometheusrule-metar-worker.yaml
+++ b/deploy/doks/observability/prometheusrule-metar-worker.yaml
@@ -1,0 +1,38 @@
+# Optional — apply only when the cluster has prometheus-operator CRDs
+# (PrometheusRule). Current DOKS cutover cluster may not; until then use:
+#   bash scripts/deploy/check_worker_crashloop.sh
+#
+# EV-033 / F8 — alert when metar-worker CrashLoopBackOff (often bad INGEST_POLLER_URL).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: metar-worker-crashloop
+  namespace: metar-iwxxm
+  labels:
+    app.kubernetes.io/name: metar-worker
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: metar-iwxxm
+spec:
+  groups:
+    - name: metar-worker
+      rules:
+        - alert: MetarWorkerCrashLooping
+          expr: |
+            max by (namespace, pod) (
+              kube_pod_container_status_waiting_reason{
+                namespace="metar-iwxxm",
+                container="worker",
+                reason="CrashLoopBackOff"
+              }
+            ) > 0
+          for: 5m
+          labels:
+            severity: warning
+            service: metar-worker
+          annotations:
+            summary: "metar-worker CrashLoopBackOff"
+            description: >-
+              Worker pod {{ $labels.pod }} is crash-looping. Check INGEST_POLLER_URL
+              on secret metar-worker-secrets (must be https://, not REPLACE_ME_*).
+              Fail-closed: kubectl -n metar-iwxxm scale deploy/metar-worker --replicas=0
+              then bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,44 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-033 — F8 worker INGEST_POLLER_URL hardening (S041)
+
+**Session**: S041-worker-poller-hardening  
+**Features**: deepen **F8**  
+**Started**: 2026-08-04  
+**Branch**: `evolve/EV-033-worker-poller-hardening` (from `main`)  
+**Status**: **in_progress**  
+**Prior**: S040 / EV-032 **suspended** (not cancelled) during this cycle
+
+### Scope (Phase 0 — locked 2026-08-04; AskQuestion unavailable — user “proceed 1–5”)
+
+| ID | Category | Question | Decision |
+|----|----------|----------|----------|
+| E33-1 | decision | Session vs S040? | New session S041; suspend S040 |
+| E33-2 | decision | Scope? | All prevention items **1–5** + worker code refuse placeholder/non-https |
+| E33-3 | decision | Preset? | **Standard** |
+
+**Scope (verbatim)**: Harden F8 `metar-worker` so `INGEST_POLLER_URL` cutover cannot
+leave `REPLACE_ME_*` or non-HTTPS values running at replicas &gt; 0: (1) fail-closed
+scale default/preflight; (2) CI/ops validate script; (3) pin non-prod fixture URL in
+docs/env; (4) runbook — do not copy unverified Render poller URLs; (5) CrashLoop check
++ optional PrometheusRule; plus code `validate_ingest_poller_url` / exit 2 on bad URL.
+
+**Out of scope**: Completing S040/EV-032 deploy smoke; new operational ingest source
+beyond the fixture URL; Prometheus operator install on DOKS.
+
+### Intake decisions
+| ID | Category | Question | Decision | ADR |
+|----|----------|----------|----------|-----|
+| E33-1 | decision | Proceed hardening 1–5? | Yes (+ code guard) | ADR-018 deepen |
+
+### Stage log
+| Stage | Completed | Notes |
+|-------|-----------|-------|
+| 00-context | 2026-08-04 | S041 open; S040 suspended |
+| 16-evolve | | orchestrating |
+| 01–13 | | Standard path — docs+code+scripts this cycle |
+
 ## Cycle EV-032 — Official IWXXM corpus quality / WMO source parity (S040)
 
 **Session**: S040-iwxxm-corpus-quality  

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -50,8 +50,21 @@ deployable for convert/validate/dissemination; F8 worker stays a **separate** Re
 |----------|----------|-------------|
 | `SUPABASE_URL` | Yes | Supabase project URL |
 | `SUPABASE_SERVICE_ROLE_KEY` | Yes | Service-role JWT for store/quarantine writers |
-| `INGEST_POLLER_URL` | Yes | HTTPS / object-prefix fixture or feed URL |
+| `INGEST_POLLER_URL` | Yes | HTTPS JSON feed (or object-prefix listing). **Must** be `https://` — never `REPLACE_ME_*` |
 | `INGEST_POLL_INTERVAL_SEC` | Yes | Poll interval (seconds) |
+
+**Non-prod fixture URL (EV-033 — pin this when no operational feed):**
+
+```
+https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json
+```
+
+**DOKS fail-closed (EV-033):** keep `metar-worker` at **0 replicas** until
+`bash scripts/deploy/doks_worker_poller_preflight.sh --probe` passes, then
+`--scale-up`. Do **not** copy `INGEST_POLLER_URL` from suspended Render worker env
+without probing (legacy fork/branch raw URLs often 404). CrashLoop check:
+`bash scripts/deploy/check_worker_crashloop.sh`. Details:
+[deploy/doks/README-worker-hardening.md](../deploy/doks/README-worker-hardening.md).
 
 ### Non-secrets (`config/prod.json` — committed)
 

--- a/docs/env-contract.md
+++ b/docs/env-contract.md
@@ -40,8 +40,13 @@ Single source of truth for **what** each layer owns and **which name** to use ev
 | Converter engine (F6) | *(code — `packages/tac2iwxxm`)* | Not an env var |
 | F8 worker Supabase URL | `SUPABASE_URL` | Render worker / local `.env` |
 | F8 worker service role | `SUPABASE_SERVICE_ROLE_KEY` | Render worker / local `.env` |
-| F8 poller feed URL | `INGEST_POLLER_URL` | Render worker / local `.env` |
-| F8 poll interval | `INGEST_POLL_INTERVAL_SEC` | Render worker (default `30`) |
+| F8 poller feed URL | `INGEST_POLLER_URL` | DOKS `metar-worker-secrets` / Render worker / local `.env` — **https:// only**; reject `REPLACE_ME_*` |
+| F8 poll interval | `INGEST_POLL_INTERVAL_SEC` | Worker ConfigMap / Render (default `30`) |
+
+**F8 non-prod fixture (EV-033):**  
+`https://raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/apps/worker/tests/fixtures/ingest_feed.json`  
+Validate: `python3 scripts/deploy/validate_ingest_poller_url.py --probe "$INGEST_POLLER_URL"`.  
+After DOKS cutover, do not reuse unverified Render poller URLs.
 
 ### Optional / legacy ops (not required for public FE)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -278,17 +278,21 @@
 ### F8: Near-Realtime TAC Ingest → IWXXM Gate
 
 - **Status**: **Implemented** (S008 / EV-006 — ADR-018/019). Worker unit/pipeline approved;
-  live T7.4 staging smoke deferred (12/13 skipped this cycle).
+  live T7.4 staging smoke deferred (12/13 skipped this cycle). **Deepened EV-033 / S041** —
+  DOKS poller URL fail-closed (code + preflight + docs fixture pin + CrashLoop check).
 - **What it does**: Continuous/near-realtime ingest of TAC (and bulletins) → `tac-validate` →
   `tac2iwxxm` → `iwxxm-validate` (Schematron/XSD) → **store**; **quarantine** on convert
   or Schematron failure (no publish). Latency target **&lt;5–15s** E2E; scale via **worker
   replicas** (drop nothing). Product scope = F6 seven.
-- **Deployable**: Render Background Worker at `apps/worker/`; HTTPS/object poller; Supabase
-  store + separate quarantine; service-role JWT for writers. Template → `static+api+worker`.
+- **Deployable**: Background Worker at `apps/worker/` (DOKS `metar-worker` / Render);
+  HTTPS/object poller; Supabase store + separate quarantine; service-role JWT for writers.
+  Template → `static+api+worker`. `INGEST_POLLER_URL` must be real `https://` before
+  replicas &gt; 0 (`scripts/deploy/doks_worker_poller_preflight.sh`).
 - **Non-goals (F8 worker path)**: public machine-ingest auth UX; **automatic** push of ingest
   results (operator dissemination sinks are **F16–F19**, not F8 auto-push).
 - **Source**: [Context: realtime-tac-ingest](context/realtime-tac-ingest.md) R2–R15; ADR-018;
-  [execution-plan](sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md)
+  [execution-plan](sessions/S008-general-tac-iwxxm-converter/reports/execution-plan.md);
+  [deploy/doks/README-worker-hardening.md](../deploy/doks/README-worker-hardening.md)
 
 ### F9: Value-Aware Live Decode + Plain-Language Summary
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,7 +25,8 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S040-iwxxm-corpus-quality](S040-iwxxm-corpus-quality/session-brief.md) | feature | in_progress | #846 epic; #835/#741(F32)/#808 + corpus; EV-032 | evolve/EV-032-iwxxm-corpus-quality | 2026-08-04 | — |
+| [S041-worker-poller-hardening](S041-worker-poller-hardening/session-brief.md) | feature | in_progress | F8 deepen INGEST_POLLER_URL hardening (1–5 + code); EV-033 | evolve/EV-033-worker-poller-hardening | 2026-08-04 | — |
+| [S040-iwxxm-corpus-quality](S040-iwxxm-corpus-quality/session-brief.md) | feature | suspended | #846 epic; #835/#741(F32)/#808 + corpus; EV-032 — paused for S041 | evolve/EV-032-iwxxm-corpus-quality | 2026-08-04 | — (resume after S041) |
 | [S037-quality-residuals-831](S037-quality-residuals-831/session-brief.md) | feature | completed | #831/#829/#820 closed; F29 Done; residual #835; EV-030 | evolve/EV-030-quality-residuals-831 | 2026-08-02 | 2026-08-03 |
 | [S036-eight-family-ahl-rules-823](S036-eight-family-ahl-rules-823/session-brief.md) | feature | completed | #823 eight-family AHL/lint/convert/validate; EV-029; F28 Done; PR #828 | main (#828) | 2026-08-01 | 2026-08-02 |
 | [S034-wmo-decode-residual-matrix](S034-wmo-decode-residual-matrix/session-brief.md) | feature | in_progress | #815 official WMO decode residual matrix; EV-027 | evolve/EV-027-wmo-decode-residual-matrix | 2026-07-31 | — |

--- a/docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
+++ b/docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
@@ -1,9 +1,11 @@
 ---
 session_id: S040-iwxxm-corpus-quality
 type: feature
-status: in_progress
+status: suspended
 branch: evolve/EV-032-iwxxm-corpus-quality
 started_at: 2026-08-04
+suspended_at: 2026-08-04
+suspended_for: S041-worker-poller-hardening
 intent: "Official IWXXM corpus quality / WMO source parity — #846 epic; #835 A6-2 wmoPass; F32 VONA (#741); #808 release-line adoptability; corpus children."
 orchestrator: 16-evolve
 evolve_cycle_id: EV-032
@@ -23,6 +25,9 @@ ui_preview: pending — AskQuestion at routing gate (engine-heavy; default docs/
 ---
 
 # Session S040 — iwxxm-corpus-quality
+
+> **Suspended 2026-08-04** for [S041-worker-poller-hardening](../S041-worker-poller-hardening/session-brief.md) / EV-033.
+> Not completed or cancelled. Resume at `13-deploy-smoke` / T4.5 after S041. EV-032 remains `in_progress`.
 
 ## Intent
 

--- a/docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+++ b/docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
@@ -1,0 +1,38 @@
+# S041 / EV-033 — evolve progress
+
+**Session:** S041-worker-poller-hardening  
+**Cycle:** EV-033  
+**Branch:** `evolve/EV-033-worker-poller-hardening` (created from `origin/main` @ `769d3f83`)  
+**Updated:** 2026-08-04
+
+## Stage status
+
+| Stage | Status | Note |
+|-------|--------|------|
+| 00-context | completed | open_session; D-S041-open |
+| 16-evolve | in_progress | orchestrating |
+| 01-requirements | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
+| 02-verify-plan | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
+| 04-tech-plan | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
+| 07-build | in_progress | docs + code + scripts implemented; awaiting commit/PR/user verify |
+| 08–13 | pending | — |
+
+Cycle remains **in_progress** — not closed.
+
+## Implemented artifacts (uncommitted as of this note)
+
+- `deploy/doks/README-worker-hardening.md`
+- `apps/worker/src/metar_worker/poller_url.py`
+- `scripts/deploy/validate_ingest_poller_url.py`
+- `scripts/deploy/doks_worker_poller_preflight.sh`
+- `scripts/deploy/check_worker_crashloop.sh`
+- `deploy/doks/observability/prometheusrule-metar-worker.yaml`
+- `apps/worker/tests/test_validate_ingest_poller_url.py`
+- `tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py`
+- Related docs/env/Makefile/worker wiring under dirty worktree
+
+## Next
+
+1. Commit + push on `evolve/EV-033-worker-poller-hardening`
+2. Open PR; user verify
+3. Continue 08-verify-build → Phase D as routing allows

--- a/docs/sessions/S041-worker-poller-hardening/routing-plan.md
+++ b/docs/sessions/S041-worker-poller-hardening/routing-plan.md
@@ -1,0 +1,40 @@
+# Routing plan — S041-worker-poller-hardening
+
+**Preset:** Standard — approved via `D-S041-open` = proceed_1-5_plus_code  
+**Orchestrator:** 16-evolve · **Cycle:** EV-033  
+**Path:** `00→16→01→02→04→07→08→09→10→11→12→13`  
+**Skip:** `03, 05, 06` (re-add if 04 introduces new deps/ADR tooling/guardrails)  
+**Deepen:** F8 (`INGEST_POLLER_URL` cutover hardening)  
+**Branch:** `evolve/EV-033-worker-poller-hardening` (pending create)  
+**Prior:** S040/EV-032 **suspended** (not completed/cancelled)
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | scoped | **completed** | Suspend S040; open S041; D-S041-open |
+| 16-evolve | yes | orchestrator | **in_progress** | Phase 0 locked; next 01 |
+| 01-requirements | yes | delta | pending | Prevention 1–5 + code guard |
+| 02-verify-plan | yes | delta | pending | Gate A |
+| 03-plan-tooling | no | — | skipped | Re-add if new rules/hooks |
+| 04-tech-plan | yes | delta | pending | Gate B |
+| 05-verify-tech | no | — | skipped | Re-add if new deps |
+| 06-tech-tooling | no | — | skipped | — |
+| 07-build | yes | full | pending | — |
+| 08-verify-build | yes | delta | pending | — |
+| 09-qa | yes | delta | pending | — |
+| 10-e2e | yes | smoke | pending | Worker-focused as needed |
+| 11-verify-impl | yes | delta | pending | F8 deepen ACs |
+| 12-verify-deploy | yes | delta | pending | — |
+| 13-deploy-smoke | yes | full | pending | Worker / poller live checks |
+
+## Skip rationale
+
+Existing app; F8 deepen on config/CI/docs/code guards. Standard matches prior ops-hardening
+evolve cycles. No new deployable. Skip 03/05/06 unless 04 requires them.
+
+## Approved
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Session open / Phase 0 | `D-S041-open` = **proceed_1-5_plus_code** — new session + Standard + items 1–5 + code; S040 suspended | 2026-08-04 |
+
+**Note:** AskQuestion tool unavailable; decision recorded from chat approval to proceed via `/16-evolve`.

--- a/docs/sessions/S041-worker-poller-hardening/session-brief.md
+++ b/docs/sessions/S041-worker-poller-hardening/session-brief.md
@@ -1,0 +1,63 @@
+---
+session_id: S041-worker-poller-hardening
+type: feature
+status: in_progress
+branch: evolve/EV-033-worker-poller-hardening
+started_at: 2026-08-04
+intent: "Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-033
+prior_session: S040-iwxxm-corpus-quality
+context_briefs: []
+standing_docs_touched: []  # filled after 01/04
+feature_ids: []
+deepen_feature_ids: [F8]
+feature_note: "D-S041-open — F8 deepen INGEST_POLLER_URL hardening"
+ask_question: unavailable — chat proceed recorded as D-S041-open
+---
+
+# Session S041 — worker-poller-hardening
+
+## Intent
+
+Harden F8 `metar-worker` **`INGEST_POLLER_URL`** cutover so bad/missing poller config
+fail closed in ops, CI, docs, and code — without mixing into S040 corpus work.
+
+## Prior session
+
+| Item | Disposition |
+|------|-------------|
+| S040 / EV-032 | **Suspended** (not completed/cancelled) at `13-deploy-smoke` / T4.5 — resume after S041 |
+| EV-032 | Remains `in_progress` |
+
+## Scope (locked — D-S041-open = proceed_1-5_plus_code)
+
+### In
+
+1. Fail-closed scale when poller URL unset/placeholder
+2. CI preflight for worker poller URL
+3. Docs default fixture URL (no `REPLACE_ME` as runnable default)
+4. No stale Render copy of poller URL guidance
+5. CrashLoop alert when worker dies on bad poller URL
+6. **Code guard** — reject `REPLACE_ME` / non-https poller URLs
+
+### Out
+
+- Completing S040 deploy smoke / #848 merge (resume later)
+- Unrelated F8 ingest product changes
+
+## Routing
+
+**Preset:** Standard — `00→16→01→02→04→07→08→09→10→11→12→13`  
+**Skip:** `03, 05, 06` unless 04 surfaces new deps/tooling  
+See [routing-plan.md](routing-plan.md).
+
+## Branch note
+
+`evolve/EV-033-worker-poller-hardening` recorded in `git_history.branches` (`pending_create`).
+Workflow-state-manager did **not** create or check out the branch.
+
+## Links
+
+- Standing: [feature-list.md](../../feature-list.md) (F8), [tech-spec.md](../../tech-spec.md), [CORPUS.md](../../CORPUS.md)
+- Prior: [S040 session-brief](../S040-iwxxm-corpus-quality/session-brief.md)

--- a/scripts/deploy/check_worker_crashloop.sh
+++ b/scripts/deploy/check_worker_crashloop.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# EV-033 / F8 — alert-style check: fail if metar-worker is CrashLoopBackOff
+# or has excessive restarts (use in smoke / cron / CI with cluster creds).
+#
+# Usage:
+#   bash scripts/deploy/check_worker_crashloop.sh
+#   MAX_RESTARTS=3 bash scripts/deploy/check_worker_crashloop.sh
+set -euo pipefail
+
+NS="${METAR_DOKS_NAMESPACE:-metar-iwxxm}"
+SELECTOR="${METAR_WORKER_SELECTOR:-app.kubernetes.io/name=metar-worker}"
+MAX_RESTARTS="${MAX_RESTARTS:-3}"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl required" >&2
+  exit 2
+fi
+
+# Zero replicas is OK (intentional fail-closed) — not an alert.
+REPLICAS="$(kubectl -n "${NS}" get deploy metar-worker -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0)"
+if [[ "${REPLICAS}" == "0" || -z "${REPLICAS}" ]]; then
+  echo "OK: metar-worker replicas=${REPLICAS:-missing} (fail-closed / not running)"
+  exit 0
+fi
+
+POD_INFO="$(
+  kubectl -n "${NS}" get pods -l "${SELECTOR}" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.containerStatuses[0].state.waiting.reason}{"\t"}{.status.containerStatuses[0].restartCount}{"\n"}{end}' \
+    2>/dev/null || true
+)"
+
+if [[ -z "${POD_INFO}" ]]; then
+  echo "ERROR: metar-worker replicas=${REPLICAS} but no pods found" >&2
+  exit 1
+fi
+
+FAILED=0
+while IFS=$'\t' read -r name phase waiting restarts; do
+  [[ -z "${name}" ]] && continue
+  restarts="${restarts:-0}"
+  echo "pod=${name} phase=${phase} waiting=${waiting:-none} restarts=${restarts}"
+  if [[ "${waiting}" == "CrashLoopBackOff" ]]; then
+    echo "ALERT: ${name} is CrashLoopBackOff — check INGEST_POLLER_URL" >&2
+    FAILED=1
+  fi
+  if [[ "${restarts}" =~ ^[0-9]+$ ]] && [[ "${restarts}" -gt "${MAX_RESTARTS}" ]]; then
+    echo "ALERT: ${name} restartCount=${restarts} > ${MAX_RESTARTS}" >&2
+    FAILED=1
+  fi
+done <<<"${POD_INFO}"
+
+if [[ "${FAILED}" -eq 1 ]]; then
+  exit 1
+fi
+echo "OK: metar-worker pods healthy (no CrashLoopBackOff; restarts ≤ ${MAX_RESTARTS})"
+exit 0

--- a/scripts/deploy/doks_worker_poller_preflight.sh
+++ b/scripts/deploy/doks_worker_poller_preflight.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# EV-033 / F8 — fail-closed DOKS worker scale around INGEST_POLLER_URL.
+# Rejects REPLACE_ME_* / non-https; scales to 0 when --fail-closed or bad --scale-up.
+#
+# Reads metar-worker-secrets, validates the URL, optionally probes HTTPS,
+# scales to 0 when invalid, and only scales to 1 when --scale-up and valid.
+#
+# Usage:
+#   bash scripts/deploy/doks_worker_poller_preflight.sh
+#   bash scripts/deploy/doks_worker_poller_preflight.sh --probe
+#   bash scripts/deploy/doks_worker_poller_preflight.sh --probe --scale-up
+#   bash scripts/deploy/doks_worker_poller_preflight.sh --fail-closed   # scale 0 if bad
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+NS="${METAR_DOKS_NAMESPACE:-metar-iwxxm}"
+SECRET="${METAR_WORKER_SECRET:-metar-worker-secrets}"
+DEPLOY="${METAR_WORKER_DEPLOY:-metar-worker}"
+PROBE=0
+SCALE_UP=0
+FAIL_CLOSED=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --probe) PROBE=1; shift ;;
+    --scale-up) SCALE_UP=1; shift ;;
+    --fail-closed) FAIL_CLOSED=1; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl required" >&2
+  exit 2
+fi
+
+URL="$(
+  kubectl -n "${NS}" get secret "${SECRET}" -o jsonpath='{.data.INGEST_POLLER_URL}' \
+    | python3 -c 'import sys,base64; print(base64.b64decode(sys.stdin.read()).decode())'
+)"
+
+ARGS=("${URL}")
+if [[ "${PROBE}" -eq 1 ]]; then
+  ARGS+=(--probe)
+fi
+
+set +e
+python3 "${ROOT}/scripts/deploy/validate_ingest_poller_url.py" "${ARGS[@]}"
+RC=$?
+set -e
+
+if [[ "${RC}" -ne 0 ]]; then
+  echo "Preflight FAILED for ${NS}/${SECRET} INGEST_POLLER_URL" >&2
+  if [[ "${FAIL_CLOSED}" -eq 1 || "${SCALE_UP}" -eq 1 ]]; then
+    echo "Scaling ${DEPLOY} → 0 (fail-closed)" >&2
+    kubectl -n "${NS}" scale "deploy/${DEPLOY}" --replicas=0
+  fi
+  exit "${RC}"
+fi
+
+echo "Preflight OK for ${DEPLOY}"
+if [[ "${SCALE_UP}" -eq 1 ]]; then
+  kubectl -n "${NS}" scale "deploy/${DEPLOY}" --replicas=1
+  kubectl -n "${NS}" rollout status "deploy/${DEPLOY}" --timeout=120s
+fi
+exit 0

--- a/scripts/deploy/validate_ingest_poller_url.py
+++ b/scripts/deploy/validate_ingest_poller_url.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""CLI: validate INGEST_POLLER_URL (EV-033 / F8). Exit 0 OK, 2 invalid.
+
+Usage:
+  python scripts/deploy/validate_ingest_poller_url.py 'https://…'
+  INGEST_POLLER_URL=https://… python scripts/deploy/validate_ingest_poller_url.py
+  python scripts/deploy/validate_ingest_poller_url.py --probe   # GET after validate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "apps/worker/src"))
+
+from metar_worker.poller_url import (  # noqa: E402
+    DEFAULT_FIXTURE_INGEST_POLLER_URL,
+    validate_ingest_poller_url,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "url",
+        nargs="?",
+        default=os.environ.get("INGEST_POLLER_URL", ""),
+        help="Poller URL (default: $INGEST_POLLER_URL)",
+    )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="After validate, GET the URL and require JSON items/list",
+    )
+    parser.add_argument(
+        "--print-fixture",
+        action="store_true",
+        help="Print the documented non-prod fixture URL and exit 0",
+    )
+    args = parser.parse_args()
+    if args.print_fixture:
+        print(DEFAULT_FIXTURE_INGEST_POLLER_URL)
+        return 0
+
+    try:
+        url = validate_ingest_poller_url(args.url)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.probe:
+        req = Request(url, headers={"User-Agent": "validate-ingest-poller-url/1"})
+        try:
+            with urlopen(req, timeout=30) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            print(f"ERROR: probe failed for {url}: {exc}", file=sys.stderr)
+            return 2
+        if isinstance(payload, dict) and "items" in payload:
+            n = len(payload["items"]) if isinstance(payload["items"], list) else "?"
+        elif isinstance(payload, list):
+            n = len(payload)
+        else:
+            print("ERROR: feed must be JSON list or {items: [...]}", file=sys.stderr)
+            return 2
+        print(f"OK: {url} (probe items={n})")
+        return 0
+
+    print(f"OK: {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
+++ b/tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
@@ -1,0 +1,54 @@
+"""BUG/EV-033 — placeholder INGEST_POLLER_URL must fail closed (no silent loop).
+
+Regression for DOKS cutover where metar-worker-secrets kept
+``REPLACE_ME_INGEST_POLLER_URL`` and the worker could not ingest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from metar_worker.poller import fetch_jobs
+from metar_worker.poller_url import (
+    DEFAULT_FIXTURE_INGEST_POLLER_URL,
+    validate_ingest_poller_url,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_placeholder_secret_rejected() -> None:
+    with pytest.raises(ValueError, match=r"placeholder|REPLACE_ME"):
+        validate_ingest_poller_url("REPLACE_ME_INGEST_POLLER_URL")
+
+
+def test_fetch_jobs_rejects_placeholder() -> None:
+    with pytest.raises(ValueError, match="INGEST_POLLER_URL"):
+        fetch_jobs("REPLACE_ME_INGEST_POLLER_URL")
+
+
+def test_docs_pin_fixture_url() -> None:
+    deploy = (ROOT / "docs/deploy.md").read_text(encoding="utf-8")
+    env_contract = (ROOT / "docs/env-contract.md").read_text(encoding="utf-8")
+    example = (ROOT / ".env.example").read_text(encoding="utf-8")
+    for text in (deploy, env_contract, example):
+        assert DEFAULT_FIXTURE_INGEST_POLLER_URL in text or (
+            "raw.githubusercontent.com/EMPIRIC2/TAC-to-IWXXM/main/"
+            "apps/worker/tests/fixtures/ingest_feed.json" in text
+        )
+
+
+def test_preflight_script_exists() -> None:
+    script = ROOT / "scripts/deploy/doks_worker_poller_preflight.sh"
+    assert script.is_file()
+    body = script.read_text(encoding="utf-8")
+    assert "REPLACE_ME" in body
+    assert "scale" in body.lower()
+
+
+def test_crashloop_check_script_exists() -> None:
+    script = ROOT / "scripts/deploy/check_worker_crashloop.sh"
+    assert script.is_file()
+    body = script.read_text(encoding="utf-8")
+    assert "CrashLoopBackOff" in body

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,61 +3,37 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 40
-evolve_cycle_counter: 32
+session_counter: 41
+evolve_cycle_counter: 33
 active_session:
-  id: S040-iwxxm-corpus-quality
+  id: S041-worker-poller-hardening
   type: feature
   intent: |
-    Official IWXXM corpus quality / WMO source parity — epic #846; #835 A6-2 wmoPass;
-    F32 VONA (#741); #808 release-line adoptability; corpus children
+    Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)
   status: in_progress
-  branch: evolve/EV-032-iwxxm-corpus-quality
-  branch_note: created from main @ 2ed85da1 (D-S040-branch=1); EV-031 WIP stashed as S039-EV031-WIP
+  branch: evolve/EV-033-worker-poller-hardening
+  branch_note: created from origin/main @ 769d3f83; active; dirty worktree (docs+code+scripts) awaiting commit/PR
   orchestrator: 16-evolve
-  evolve_cycle_id: EV-032
-  artifacts_dir: docs/sessions/S040-iwxxm-corpus-quality/
-  prior_session: S039-doks-dns-cutover
-  github_issues:
-  - '846'
-  - '835'
-  - '741'
-  - '808'
-  feature_ids:
-  - F32
+  evolve_cycle_id: EV-033
+  artifacts_dir: docs/sessions/S041-worker-poller-hardening/
+  prior_session: S040-iwxxm-corpus-quality
+  prior_session_note: 'S040/EV-032 SUSPENDED (not completed/cancelled) for S041 poller hardening; resume after S041 — was at 13-deploy-smoke / T4.5'
+  feature_ids: []
   deepen_feature_ids:
-  - F23
-  - F4
-  - F6
-  - F2
-  - F13
+  - F8
   preset: Standard
   preset_status: approved
-  route_status: approved_D-S040-route
+  route_status: approved_D-S041-open
   phase0_choices:
-    D-S040-open: '1,1,1,1'
-    D-S040-route: '1'
-    D-S040-branch: '1'
-    D-S040-E32-M: '2,3,1,1'
-    D-S040-02-batch-f: '1,1,1,1'
-    D-S040-02-phase-a: '1'
-    D-S040-04-batch-1: '1,1,1,1'
-    D-S040-04-batch-2: '1,1,custom,1'
-    D-S040-04-plan: '1'
-    D-S040-resume: Continue → T4.2
-    D-S040-phase-c: '1'
-    D-S040-11: A1,B1,C1,D1
-    D-S040-12: ready
-    D-S040-13: '1'
+    D-S041-open: proceed_1-5_plus_code
     locked_at: '2026-08-04'
     summary: |
-      Epic #846; scope #835+#741+#808+corpus; F32 VONA; work order
-      #835→#741→#808→corpus; exclude #836 metrics UI.
-      Standard approved (D-S040-route=1); branch from main (D-S040-branch=1).
-      D-S040-phase-c=1 Continue → T4.3 (C→D / Phase D).
-      D-S040-11=A1,B1,C1,D1 (11 approved); D-S040-12=ready (12 checklist); D-S040-13=1 (deploy gate).
+      User approved separate poller hardening via /16-evolve while S040 paused.
+      Scope: prevention items 1–5 + code guard (fail-closed scale, CI preflight,
+      docs default fixture URL, no stale Render copy, CrashLoop alert,
+      code rejects REPLACE_ME/non-https). AskQuestion unavailable — chat proceed.
   decisions:
-    D-S040-13: '1'
+    D-S041-open: proceed_1-5_plus_code
   routing_plan:
   - stage: 00-context
     mode: scoped
@@ -66,13 +42,13 @@ active_session:
     started: '2026-08-04'
     completed: '2026-08-04'
     skip_rationale:
-    note: 'COMPLETE — brief+routing+scoped context; D-S040-route/branch locked; branch evolve/EV-032 cut from main @ 2ed85da1; handoff 01-requirements; #846/#835/#741/#808'
+    note: 'COMPLETE — open_session after S040 suspend; D-S041-open proceed 1-5 + code; Standard; handoff 16-evolve'
   - stage: 16-evolve
     required: true
     status: in_progress
     started: '2026-08-04'
     skip_rationale:
-    note: 'ORCHESTRATING — T4.5 IN_PROGRESS; D-S040-13=1; tip 22b4251b; push+merge #848 → redeploy API+FE → H1–H5; progress 25/28; current_stage 13-deploy-smoke; ahead_of_origin=13; PR #848; #846'
+    note: 'ORCHESTRATING — 07-build in_progress (docs+code+scripts); 01/02/04 delta lean complete; awaiting commit/PR/user verify'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -80,7 +56,7 @@ active_session:
     started: '2026-08-04'
     completed: '2026-08-04'
     skip_rationale:
-    note: 'COMPLETE (delta) — D-S040-E32-M=2,3,1,1 full pack; full F7 VONA; interview UI N/A; F32+UJ-045; handoff 02; #846'
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
   - stage: 02-verify-plan
     required: true
     mode: delta
@@ -88,7 +64,7 @@ active_session:
     started: '2026-08-04'
     completed: '2026-08-04'
     skip_rationale:
-    note: 'PASS — Batch F 1,1,1,1 (S02.M1/M2/M3); Gate A → 04; report reports/02-verify-plan-audit.md; D-S040-02-phase-a; #846'
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
   - stage: 04-tech-plan
     required: true
     mode: delta
@@ -96,162 +72,237 @@ active_session:
     started: '2026-08-04'
     completed: '2026-08-04'
     skip_rationale:
-    note: 'COMPLETE — Gate B PASS (D-S040-04-plan=1); approve M0-M4 (28 tasks); handoff 07 @ T0.1; #846'
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
   - stage: 07-build
     required: true
     status: in_progress
     started: '2026-08-04'
     skip_rationale:
-    note: 'Phase D — T4.5 IN_PROGRESS; D-S040-13=1; tip 22b4251b; push+merge #848 → redeploy API+FE → H1–H5; gates.deploy in_progress; PR #848; ahead_of_origin=13; #846'
+    note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
   - stage: 08-verify-build
     required: true
-    status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    status: pending
     skip_rationale:
-    note: 'T4.2 PASS — Overall PASS; report docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md (+ verification-report-M4.md); tip e0e595e3 [T4.2]; C→D passed (D-S040-phase-c=1); Phase D → 09+10; PR #848; #846'
-    report: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
-    report_m4: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report-M4.md
   - stage: 09-qa
     required: true
-    status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    status: pending
     skip_rationale:
-    note: 'COMPLETE 2026-08-04 — T4.3; overall pass_with_advisories; report docs/sessions/S040-iwxxm-corpus-quality/reports/qa-report.md; tip 09e60184 [T4.3] test: 09-qa and 10-e2e for UJ-045 VONA; H4–H5→T4.5/13; PR #848; #846'
-    report: docs/sessions/S040-iwxxm-corpus-quality/reports/qa-report.md
-    overall: pass_with_advisories
   - stage: 10-e2e
     required: true
-    status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    status: pending
     skip_rationale:
-    note: 'COMPLETE 2026-08-04 — T4.3; overall T0 pass; report docs/sessions/S040-iwxxm-corpus-quality/reports/e2e-report.md; tip 09e60184 [T4.3] test: 09-qa and 10-e2e for UJ-045 VONA; H4–H5→T4.5/13; PR #848; #846'
-    report: docs/sessions/S040-iwxxm-corpus-quality/reports/e2e-report.md
-    overall: pass
   - stage: 11-verify-impl
     required: true
-    status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    status: pending
     skip_rationale:
-    note: 'COMPLETE 2026-08-04 — T4.4; D-S040-11=A1,B1,C1,D1 approved; report docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md; UI preview localhost:18000 accepted; F32 ACs approved; H4–H5 waive to 13; tip fe024aac approve committed; next 12/13; PR #848; #846'
-    report: docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md
-    overall: approved
-    decision_id: D-S040-11
   - stage: 12-verify-deploy
     required: true
-    status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    status: pending
     skip_rationale:
-    note: 'COMPLETE 2026-08-04 — T4.4; D-S040-12=ready; report docs/sessions/S040-iwxxm-corpus-quality/reports/deploy-checklist.md; mitigations/rollback defaults approved; checklist ready; tip fe024aac; 13 awaiting deploy approval; pending_commit cleared; PR #848; #846'
-    report: docs/sessions/S040-iwxxm-corpus-quality/reports/deploy-checklist.md
-    overall: ready
-    decision_id: D-S040-12
   - stage: 13-deploy-smoke
     required: true
-    status: in_progress
-    started: '2026-08-04T21:35:00Z'
+    status: pending
     skip_rationale:
-    note: 'T4.5 START — D-S040-13=1 (push+merge #848 → main → redeploy API+FE → H1–H5); tip 22b4251b; ahead_of_origin=13; PR #848; #846'
-  current_stage: 13-deploy-smoke
+  current_stage: 07-build
   started_at: '2026-08-04'
   started: '2026-08-04'
-  context_briefs:
-  - docs/context/iwxxm-corpus-quality-846.md
+  context_briefs: []
   artifacts:
-  - path: docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
+  - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
     status: written
     stage: 00-context
-  - path: docs/sessions/S040-iwxxm-corpus-quality/routing-plan.md
+  - path: docs/sessions/S041-worker-poller-hardening/routing-plan.md
     status: written
     stage: 00-context
-  - path: docs/context/iwxxm-corpus-quality-846.md
-    status: written
-    stage: 00-context
-  - path: docs/sessions/S040-iwxxm-corpus-quality/README.md
-    status: written
-    stage: 00-context
-  - path: docs/decisions/evolve-decisions.md
-    status: written
-    stage: 16-evolve
-    note: EV-032 section recorded
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/01-requirements-summary.md
-    status: written
-    stage: 01-requirements
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/02-verify-plan-audit.md
-    status: written
-    stage: 02-verify-plan
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/04-tech-plan.md
-    status: draft
-    stage: 04-tech-plan
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/execution-plan.md
-    status: draft
-    stage: 04-tech-plan
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/t1.6-835-closeout.md
+  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
     status: written
     stage: 07-build
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report-M1.md
-    status: written
-    stage: 08-verify-build
-    note: 'M1 boundary PASS; mid-cycle; 08 remains pending for final'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/t2.1-vona-encode-cookbook.md
+  - path: deploy/doks/README-worker-hardening.md
     status: written
     stage: 07-build
-    note: 'T2.1 VONA encode cookbook; TC-F32-002; sha dacd72b5'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/t2.9-741-closeout.md
+  - path: apps/worker/src/metar_worker/poller_url.py
     status: written
     stage: 07-build
-    note: 'T2.9 #741 closeout; F32 Done; children #849/#850'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/t2.9-741-closeout.md
+  - path: scripts/deploy/validate_ingest_poller_url.py
     status: written
     stage: 07-build
-    note: 'T2.9 #741 closeout; F32 Done; children #849/#850'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
+  - path: scripts/deploy/doks_worker_poller_preflight.sh
     status: written
-    stage: 08-verify-build
-    note: 'T4.2 PASS; tip e0e595e3 [T4.2] recorded'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report-M4.md
+    stage: 07-build
+  - path: scripts/deploy/check_worker_crashloop.sh
     status: written
-    stage: 08-verify-build
-    note: 'T4.2 M4 boundary companion report'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/qa-report.md
+    stage: 07-build
+  - path: deploy/doks/observability/prometheusrule-metar-worker.yaml
     status: written
-    stage: 09-qa
-    note: 'T4.3 COMPLETE; overall pass_with_advisories; tip 09e60184 committed'
-  - path: docs/sessions/S040-iwxxm-corpus-quality/reports/e2e-report.md
+    stage: 07-build
+  - path: apps/worker/tests/test_validate_ingest_poller_url.py
     status: written
-    stage: 10-e2e
-    note: 'T4.3 COMPLETE; overall T0 pass; tip 09e60184 committed'
+    stage: 07-build
+  - path: tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
+    status: written
+    stage: 07-build
   decision_refs:
-  - D-S040-open
-  - D-S040-route
-  - D-S040-branch
-  - D-S040-E32-M
-  - D-S040-02-batch-f
-  - D-S040-02-phase-a
-  - D-S040-04-batch-1
-  - D-S040-04-batch-2
-  - D-S040-04-plan
-  - D-S040-resume
-  - D-S040-phase-c
-  - D-S040-11
-  - D-S040-12
-  - D-S040-13
+  - D-S041-open
   skipped:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-  note: 'T4.5 IN_PROGRESS — D-S040-13=1 (push+merge #848 → main → redeploy API+FE → H1–H5); tip 22b4251b; progress 25/28; current_stage 13-deploy-smoke; ahead_of_origin=13; PR #848; #846'
+  note: 'IN_PROGRESS — S041/EV-033 at 07-build; branch active from origin/main @ 769d3f83; 01/02/04 delta lean complete; docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
 sessions:
+- id: S041-worker-poller-hardening
+  type: feature
+  intent: |
+    Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)
+  status: in_progress
+  branch: evolve/EV-033-worker-poller-hardening
+  branch_note: created from origin/main @ 769d3f83; active; dirty worktree awaiting commit/PR
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-033
+  feature_ids: []
+  deepen_feature_ids:
+  - F8
+  artifacts_dir: docs/sessions/S041-worker-poller-hardening/
+  prior_session: S040-iwxxm-corpus-quality
+  prior_session_note: 'S040/EV-032 SUSPENDED (not completed/cancelled) for S041; resume after S041 at 13-deploy-smoke / T4.5'
+  preset: Standard
+  preset_status: approved
+  route_status: approved_D-S041-open
+  phase0_choices:
+    D-S041-open: proceed_1-5_plus_code
+    locked_at: '2026-08-04'
+    summary: |
+      User approved separate poller hardening via /16-evolve while S040 paused.
+      Scope: prevention items 1–5 + code guard. AskQuestion unavailable — chat proceed.
+  decisions:
+    D-S041-open: proceed_1-5_plus_code
+  routing_plan:
+  - stage: 00-context
+    mode: scoped
+    required: true
+    status: completed
+    started: '2026-08-04'
+    completed: '2026-08-04'
+    skip_rationale:
+    note: 'COMPLETE — open_session after S040 suspend; D-S041-open; handoff 16-evolve'
+  - stage: 16-evolve
+    required: true
+    status: in_progress
+    started: '2026-08-04'
+    skip_rationale:
+    note: 'ORCHESTRATING — 07-build in_progress; 01/02/04 delta lean complete; awaiting commit/PR/user verify'
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-04'
+    completed: '2026-08-04'
+    skip_rationale:
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-04'
+    completed: '2026-08-04'
+    skip_rationale:
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-04'
+    completed: '2026-08-04'
+    skip_rationale:
+    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+  - stage: 07-build
+    required: true
+    status: in_progress
+    started: '2026-08-04'
+    skip_rationale:
+    note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify'
+  - stage: 08-verify-build
+    required: true
+    status: pending
+    skip_rationale:
+  - stage: 09-qa
+    required: true
+    status: pending
+    skip_rationale:
+  - stage: 10-e2e
+    required: true
+    status: pending
+    skip_rationale:
+  - stage: 11-verify-impl
+    required: true
+    status: pending
+    skip_rationale:
+  - stage: 12-verify-deploy
+    required: true
+    status: pending
+    skip_rationale:
+  - stage: 13-deploy-smoke
+    required: true
+    status: pending
+    skip_rationale:
+  current_stage: 07-build
+  started_at: '2026-08-04'
+  started: '2026-08-04'
+  artifacts:
+  - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
+    status: written
+    stage: 00-context
+  - path: docs/sessions/S041-worker-poller-hardening/routing-plan.md
+    status: written
+    stage: 00-context
+  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+    status: written
+    stage: 07-build
+  - path: deploy/doks/README-worker-hardening.md
+    status: written
+    stage: 07-build
+  - path: apps/worker/src/metar_worker/poller_url.py
+    status: written
+    stage: 07-build
+  - path: scripts/deploy/validate_ingest_poller_url.py
+    status: written
+    stage: 07-build
+  - path: scripts/deploy/doks_worker_poller_preflight.sh
+    status: written
+    stage: 07-build
+  - path: scripts/deploy/check_worker_crashloop.sh
+    status: written
+    stage: 07-build
+  - path: deploy/doks/observability/prometheusrule-metar-worker.yaml
+    status: written
+    stage: 07-build
+  - path: apps/worker/tests/test_validate_ingest_poller_url.py
+    status: written
+    stage: 07-build
+  - path: tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
+    status: written
+    stage: 07-build
+  decision_refs:
+  - D-S041-open
+  skipped:
+  - 03-plan-tooling
+  - 05-verify-tech
+  - 06-tech-tooling
+  note: 'IN_PROGRESS — 07-build; branch active @ 769d3f83; 01/02/04 delta lean; awaiting commit/PR/user verify; cycle not complete'
 - id: S040-iwxxm-corpus-quality
   type: feature
   intent: |
     Official IWXXM corpus quality / WMO source parity — epic #846; #835 A6-2 wmoPass;
     F32 VONA (#741); #808 release-line adoptability; corpus children
-  status: in_progress
+  status: suspended
+  suspended_at: '2026-08-04'
+  paused_at: '2026-08-04'
+  pause_reason: |
+    User approved proceeding with separate F8 poller hardening via /16-evolve (S041/EV-033).
+    S040/EV-032 NOT completed or cancelled — resume at 13-deploy-smoke / T4.5 after S041.
+  suspended_for: S041-worker-poller-hardening
+  resume_after: S041-worker-poller-hardening
+  resume_at_stage: 13-deploy-smoke
+  resume_at_task: T4.5
   branch: evolve/EV-032-iwxxm-corpus-quality
   branch_note: created from main @ 2ed85da1 (D-S040-branch=1); EV-031 WIP stashed as S039-EV031-WIP
   orchestrator: 16-evolve
@@ -477,7 +528,7 @@ sessions:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-  note: 'T4.5 IN_PROGRESS — D-S040-13=1 (push+merge #848 → main → redeploy API+FE → H1–H5); tip 22b4251b; progress 25/28; current_stage 13-deploy-smoke; ahead_of_origin=13; PR #848; #846'
+  note: 'SUSPENDED for S041/EV-033 worker-poller-hardening — was T4.5/13-deploy-smoke in_progress (D-S040-13=1); EV-032 remains in_progress (not cancelled); tip 22b4251b; PR #848; #846'
 - id: S039-doks-dns-cutover
   type: ops
   intent: |
@@ -10914,6 +10965,34 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S041-open
+  date: '2026-08-04'
+  timestamp: '2026-08-04T23:31:10Z'
+  resolved_at: '2026-08-04'
+  session_id: S041-worker-poller-hardening
+  evolve_cycle_id: EV-033
+  skill: 00-context
+  skill_id: 00-context
+  stage: 00-context
+  category: session_open
+  status: confirmed
+  topic: Open S041 worker-poller-hardening; suspend S040 for separate /16-evolve
+  summary: |
+    User proceed items 1–5 + code guard; AskQuestion unavailable; recommended new
+    session + Standard + all five prevention items + code reject REPLACE_ME/non-https.
+    S040/EV-032 suspended (not completed/cancelled); EV-033 opened.
+  decision: |
+    D-S041-open=proceed_1-5_plus_code — Suspend S040 (status=suspended) for S041;
+    open feature session S041-worker-poller-hardening / EV-033 with Standard routing
+    (skip 03/05/06 unless needed); scope fail-closed scale, CI preflight, docs default
+    fixture URL, no stale Render copy, CrashLoop alert, code rejects REPLACE_ME/non-https.
+  user_option: proceed_1-5_plus_code
+  branch: evolve/EV-033-worker-poller-hardening
+  related_decisions:
+  - D-S040-13
+  prior_session: S040-iwxxm-corpus-quality
+  prior_evolve_cycle_id: EV-032
+  note: 'AskQuestion tool unavailable — recorded from chat approval to proceed via /16-evolve'
 - id: D-S040-13
   date: '2026-08-04'
   timestamp: '2026-08-04T21:35:00Z'
@@ -31584,6 +31663,135 @@ evolve_cycles:
   pr_number: 845
   pr_status: open
   pr_head: evolve/EV-031-platform-independence-842
+- id: EV-033
+  session_id: S041-worker-poller-hardening
+  cycle_type: feature
+  feature_ids: []
+  deepen_feature_ids:
+  - F8
+  feature_id: F8
+  feature_note: F8 deepen — INGEST_POLLER_URL cutover hardening (prevention 1–5 + code guard)
+  title: F8 worker INGEST_POLLER_URL poller hardening
+  slug: worker-poller-hardening
+  status: in_progress
+  phase: 0
+  started: '2026-08-04'
+  started_at: '2026-08-04'
+  scope_summary: |
+    Harden F8 metar-worker INGEST_POLLER_URL cutover:
+    (1) fail-closed scale when poller URL unset/placeholder;
+    (2) CI preflight for worker poller URL;
+    (3) docs default fixture URL (no REPLACE_ME as runnable default);
+    (4) no stale Render copy of poller URL guidance;
+    (5) CrashLoop alert when worker dies on bad poller URL;
+    plus code guard rejecting REPLACE_ME / non-https poller URLs.
+    Separate from S040/EV-032 (suspended, not cancelled). Standard routing.
+  branch: evolve/EV-033-worker-poller-hardening
+  branch_note: created from origin/main @ 769d3f83; active; dirty worktree awaiting commit/PR
+  tip_sha: 769d3f83
+  tip_sha_full: 769d3f8360b2bd826360f3107ada1a6ae268db0d
+  tip_note: 'branch base tip = origin/main @ 769d3f83; implementation uncommitted'
+  preset: Standard
+  preset_status: approved
+  phase0_choices:
+    D-S041-open: proceed_1-5_plus_code
+    locked_at: '2026-08-04'
+  routing_plan:
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 04-tech-plan
+    - 07-build
+    - 08-verify-build
+    - 09-qa
+    - 10-e2e
+    - 11-verify-impl
+    - 12-verify-deploy
+    - 13-deploy-smoke
+    skipped_stages:
+    - 03-plan-tooling
+    - 05-verify-tech
+    - 06-tech-tooling
+    note: Standard — skip 03/05/06 unless 04 surfaces new deps/tooling
+  current_stage: 07-build
+  gates:
+    a_to_b: passed
+    b_to_c: passed
+    c_to_d: pending
+    deploy: pending
+  checkpoints:
+    phase_a: passed
+    phase_b: passed
+    phase_c: pending
+    phase_d: pending
+    deploy: pending
+  stages:
+    00-context:
+      status: completed
+      mode: scoped
+      started: '2026-08-04'
+      completed: '2026-08-04'
+      note: 'COMPLETE — open_session; D-S041-open; handoff 16-evolve'
+    16-evolve:
+      status: in_progress
+      started: '2026-08-04'
+      note: 'ORCHESTRATING — 07-build in_progress; docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+    01-requirements:
+      status: completed
+      mode: delta
+      started: '2026-08-04'
+      completed: '2026-08-04'
+      note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    02-verify-plan:
+      status: completed
+      mode: delta
+      started: '2026-08-04'
+      completed: '2026-08-04'
+      note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    04-tech-plan:
+      status: completed
+      mode: delta
+      started: '2026-08-04'
+      completed: '2026-08-04'
+      note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    07-build:
+      status: in_progress
+      started: '2026-08-04'
+      note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+  adrs: []
+  artifacts:
+  - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
+    status: written
+  - path: docs/sessions/S041-worker-poller-hardening/routing-plan.md
+    status: written
+  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+    status: written
+  - path: deploy/doks/README-worker-hardening.md
+    status: written
+  - path: apps/worker/src/metar_worker/poller_url.py
+    status: written
+  - path: scripts/deploy/validate_ingest_poller_url.py
+    status: written
+  - path: scripts/deploy/doks_worker_poller_preflight.sh
+    status: written
+  - path: scripts/deploy/check_worker_crashloop.sh
+    status: written
+  - path: deploy/doks/observability/prometheusrule-metar-worker.yaml
+    status: written
+  - path: apps/worker/tests/test_validate_ingest_poller_url.py
+    status: written
+  - path: tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
+    status: written
+  issues: []
+  decision_refs:
+  - D-S041-open
+  notes:
+  - '2026-08-04 S041/EV-033 — 07-build IN_PROGRESS; branch active from origin/main @ 769d3f83; 01/02/04 completed (delta lean — scope in evolve-decisions; AskQuestion unavailable); docs+code+scripts + poller_url/scripts/prometheusrule/tests; awaiting commit/PR/user verify; cycle NOT completed'
+  - '2026-08-04 S041/EV-033 OPEN — D-S041-open proceed 1-5 + code; S040/EV-032 suspended (not cancelled); branch pending create; tip n/a'
+  prior_session: S040-iwxxm-corpus-quality
+  prior_evolve_cycle_id: EV-032
 - id: EV-032
   session_id: S040-iwxxm-corpus-quality
   cycle_type: feature
@@ -31598,6 +31806,11 @@ evolve_cycles:
   title: IWXXM corpus quality / WMO source parity
   slug: iwxxm-corpus-quality
   status: in_progress
+  session_status: suspended
+  session_suspended_for: S041-worker-poller-hardening
+  session_suspend_note: |
+    S040 active_session cleared for S041; EV-032 cycle NOT cancelled —
+    resume S040 at 13-deploy-smoke / T4.5 after S041 closes.
   phase: 0
   started: '2026-08-04'
   started_at: '2026-08-04'
@@ -31943,10 +32156,12 @@ git_history:
   main_merge_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
   main_tip_sha: 7c4522a
   main_tip_sha_full: 7c4522aecdc8a6bd195c3e7517894be876f5c63b
-  recommended_branch: evolve/EV-032-iwxxm-corpus-quality
-  note: 'S040/EV-032 — T4.4 COMPLETE (D-S040-11=A1,B1,C1,D1; D-S040-12=ready); 11 approved (verify-impl.md); 12 ready (deploy-checklist.md); progress 25/28; completed_through T4.4; active_task T4.5 pending; current_stage 13-deploy-smoke (awaiting deploy approval); tip fe024aac; pending_commit cleared; ahead_of_origin=12; PR #848; #846'
+  recommended_branch: evolve/EV-033-worker-poller-hardening
+  note: 'S041/EV-033 at 07-build — recommended_branch evolve/EV-033-worker-poller-hardening active from origin/main @ 769d3f83; dirty awaiting commit/PR; S040 tip remains on evolve/EV-032-iwxxm-corpus-quality; #846 parked'
 
   notes:
+  - '2026-08-04 S041/EV-033 — branch active from origin/main @ 769d3f83 (769d3f8360b2bd826360f3107ada1a6ae268db0d); current_stage 07-build; 01/02/04 completed (delta lean — scope in evolve-decisions; AskQuestion unavailable); artifacts poller_url.py + scripts/deploy/*poller* + prometheusrule + tests + README-worker-hardening; awaiting commit/PR/user verify; cycle NOT completed'
+  - '2026-08-04 S041/EV-033 OPEN — open_session; D-S041-open proceed_1-5_plus_code; session_counter 41; evolve_cycle_counter 33; S040/EV-032 SUSPENDED (not completed/cancelled) for S041; branch evolve/EV-033-worker-poller-hardening pending create; 00-context completed → 16-evolve in_progress; F8 deepen; no git branch/commit by workflow-state-manager'
   - 'S040/EV-032 — recorded git commit T4.4 @ fe024aac (fe024aac10077e365d65d0eccf12d8fb6288c9ec) [T4.4] docs: approve 11-verify-impl and ready 12 deploy checklist; tip fe024aac; pending_commit cleared; active_task T4.5 pending @ M4 / 13-deploy-smoke; progress 25/28; ahead_of_origin=12 pushed=false dirty=false; PR #848; #846'
   - '2026-08-04 S040/EV-032 — T4.4 COMPLETE (D-S040-11/12); pending_commit left (HEAD d086f694 draft ≠ approve); tip kept 09e60184; progress 25/28; active_task T4.5 pending; current_stage 13-deploy-smoke; ahead_of_origin=11; PR #848; #846'
   - '2026-08-04 S040/EV-032 — recorded git commit T4.3 @ 09e60184 (09e601847eae404f997e107b42952bfcc51db12f) [T4.3] test: 09-qa and 10-e2e for UJ-045 VONA; tip 09e60184; pending_commit cleared; active_task T4.4 in_progress @ M4 / 11-verify-impl; progress 24/28; ahead_of_origin=10 pushed=false dirty=true (workflow-state tip sync); PR #848; #846'
@@ -32376,6 +32591,22 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-033-worker-poller-hardening
+    purpose: 'S041/EV-033 F8 deepen — INGEST_POLLER_URL hardening (prevention 1–5 + code guard)'
+    base: main
+    base_sha: 769d3f83
+    base_sha_full: 769d3f8360b2bd826360f3107ada1a6ae268db0d
+    status: active
+    created: '2026-08-04'
+    created_at: '2026-08-04'
+    session_id: S041-worker-poller-hardening
+    evolve_cycle_id: EV-033
+    tip_sha: 769d3f83
+    tip_sha_full: 769d3f8360b2bd826360f3107ada1a6ae268db0d
+    exists: true
+    pushed: false
+    ahead_of_origin: 0
+    note: 'ACTIVE — created from origin/main @ 769d3f83; tip still base (implementation uncommitted); 07-build in_progress; awaiting commit/PR/user verify'
   - name: evolve/EV-032-iwxxm-corpus-quality
     purpose: 'S040/EV-032 IWXXM corpus quality / WMO source parity #846; #835/#741/#808; F32 VONA'
     base: main


### PR DESCRIPTION
## Summary
- Reject `REPLACE_ME_*` / non-`https://` `INGEST_POLLER_URL` in the worker (`poller_url.validate_ingest_poller_url`, exit 2 at start).
- Add DOKS fail-closed preflight (`doks_worker_poller_preflight.sh`), CrashLoop check, optional PrometheusRule, and pin the non-prod fixture URL in docs/`.env.example`.
- Document “do not copy unverified Render poller URLs” + Cursor rule; default worker Deployment `replicas: 0` until preflight `--scale-up`.

## Test plan
- [x] `uv run pytest apps/worker/tests/test_validate_ingest_poller_url.py tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py`
- [x] `make test-unit-worker`
- [x] Live: `bash scripts/deploy/doks_worker_poller_preflight.sh --probe`
- [x] Live: `bash scripts/deploy/check_worker_crashloop.sh`
- [ ] CI green on this PR branch

## Notes
- Session **S041** / cycle **EV-033** (deepen F8). **S040/EV-032** remains suspended, not cancelled.
- Cluster already uses the fixture poller URL; this PR hardens so cutover placeholders cannot return unnoticed.


Made with [Cursor](https://cursor.com)