### PR TITLE
hotfix: restore RENDER_DEPLOY_MODE after #845

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,6 +13,7 @@ env:
   BACKEND_IMAGE: empiric2/tac-to-iwxxm/backend
   FRONTEND_IMAGE: empiric2/tac-to-iwxxm/frontend
   WORKER_IMAGE: empiric2/tac-to-iwxxm/worker
+  RENDER_DEPLOY_MODE: image
   # Canonical Supabase secrets (preferred). Deprecated FRONTEND_VITE_* kept for one-release shim.
   SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
   SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}

--- a/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
+++ b/tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py
@@ -155,6 +155,7 @@ def test_bug_2026_08_03_ci_uses_resilient_script_not_bare_curl() -> None:
     assert "&imgURL=${ENCODED_URL}" not in raw
     assert "--skip-if-suspended" in raw
     assert "RENDER_SKIP_IF_SUSPENDED" in raw
+    assert "RENDER_DEPLOY_MODE: image" in raw
 
     doc = yaml.safe_load(raw)
     assert isinstance(doc, dict)


### PR DESCRIPTION
## Summary
- Restore `RENDER_DEPLOY_MODE: image` dropped during the #845 merge conflict resolution
- Without it, Deploy used bare `curl` on the Render hook and failed with HTTP 409 (suspended services); the skip-if-suspended Python path never ran
- Strengthen the deploy-hook regression test to require the env

## Test plan
- [x] `pytest tests/bugs/test_bug_2026_08_03_render_deploy_hook_500.py`
- [ ] Main CI Deploy job succeeds (or `skipped_suspended`) after merge


Made with [Cursor](https://cursor.com)