### PR TITLE
[EV-034] Automate DOKS image rollout in CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -392,8 +392,8 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # DEPLOY — build/push GHCR images (main push only). Render triggers retired (T6.5 /
-  # D-S038-t65-waive). DOKS pulls from GHCR; skip cleanly when GHCR login fails.
+  # DEPLOY — build/push GHCR images (main push only), then roll DOKS (F30 / EV-034).
+  # Render hooks optional/non-blocking (suspended OK). Skip when GHCR login fails.
   # ============================================================================
   deploy:
     runs-on: ubuntu-latest
@@ -409,6 +409,8 @@ jobs:
       RENDER_WORKER_DEPLOY_HOOK: ${{ secrets.RENDER_WORKER_DEPLOY_HOOK }}
       # Optional: REST fallback when deploy-hook+imgURL returns 5xx (BUG-2026-08-03).
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+      # Required for DOKS rollout (EV-034 / TC-F30-007) — base64 kubeconfig.
+      KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
 
     steps:
       - uses: actions/checkout@v5
@@ -521,64 +523,67 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.tags.outputs.image_tag }}
             ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:main-latest
 
-      - name: Note Render deploy hooks (suspended OK)
+      # Render is suspended (T6.5). Hooks are optional and must never fail Deploy (E34-4).
+      - name: Optional Render hooks (non-blocking)
         if: steps.guard.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
+          # BUG-2026-08-03 — keep skip-if-suspended path wired for suspended Render.
+          RENDER_SKIP_IF_SUSPENDED: "1"
         run: |
-          echo "Live traffic is DOKS (api|app.tac-to-iwxxm.com). Render hooks may skip_if_suspended."
-          [ -n "${RENDER_BACKEND_DEPLOY_HOOK}" ] && echo "✅ RENDER_BACKEND_DEPLOY_HOOK is set" || echo "⚠️  RENDER_BACKEND_DEPLOY_HOOK is missing"
-          [ -n "${RENDER_FRONTEND_DEPLOY_HOOK}" ] && echo "✅ RENDER_FRONTEND_DEPLOY_HOOK is set" || echo "⚠️  RENDER_FRONTEND_DEPLOY_HOOK is missing"
-          [ -n "${RENDER_WORKER_DEPLOY_HOOK}" ] && echo "✅ RENDER_WORKER_DEPLOY_HOOK is set" || echo "⚠️  RENDER_WORKER_DEPLOY_HOOK is missing (docker-from-git worker OK)"
+          set +e
+          echo "Live traffic is DOKS. Render hooks optional (skip-if-suspended)."
+          if [ -n "${RENDER_BACKEND_DEPLOY_HOOK:-}" ]; then
+            if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
+              python3 scripts/deploy/trigger_render_image_deploy.py \
+                --deploy-hook "${RENDER_BACKEND_DEPLOY_HOOK}" \
+                --image-url "${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${IMAGE_TAG}" \
+                --service-name metar-to-iwxxm-api \
+                --skip-if-suspended || echo "::warning::Render backend hook failed (ignored)"
+            else
+              curl -fsSL "${RENDER_BACKEND_DEPLOY_HOOK}" || echo "::warning::Render backend hook failed (ignored)"
+            fi
+          else
+            echo "RENDER_BACKEND_DEPLOY_HOOK unset — skipping"
+          fi
+          if [ -n "${RENDER_FRONTEND_DEPLOY_HOOK:-}" ]; then
+            if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
+              python3 scripts/deploy/trigger_render_image_deploy.py \
+                --deploy-hook "${RENDER_FRONTEND_DEPLOY_HOOK}" \
+                --image-url "${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${IMAGE_TAG}" \
+                --service-name metar-to-iwxxm-frontend-v4-web \
+                --skip-if-suspended || echo "::warning::Render frontend hook failed (ignored)"
+            else
+              curl -fsSL "${RENDER_FRONTEND_DEPLOY_HOOK}" || echo "::warning::Render frontend hook failed (ignored)"
+            fi
+          else
+            echo "RENDER_FRONTEND_DEPLOY_HOOK unset — skipping"
+          fi
 
-      - name: Enforce backend deploy hook presence
+      - name: Set up kubectl
         if: steps.guard.outputs.skip != 'true'
+        uses: azure/setup-kubectl@v4
+
+      # EV-034 / TC-F30-007 — fail-closed when KUBE_CONFIG missing on main Deploy.
+      - name: Roll out DOKS images
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
         run: |
-          if [ -z "${RENDER_BACKEND_DEPLOY_HOOK}" ]; then
-            echo "❌ Missing required secret: RENDER_BACKEND_DEPLOY_HOOK"
+          set -euo pipefail
+          if [ -z "${KUBE_CONFIG:-}" ]; then
+            echo "::error::Missing required secret KUBE_CONFIG (base64 kubeconfig for DOKS)"
             exit 1
           fi
-
-      # Live traffic is on DOKS (app/api.tac-to-iwxxm.com). Render services may be
-      # suspended; still push GHCR, but do not fail Deploy when Render is suspended.
-      - name: Deploy backend image to Render
-        if: steps.guard.outputs.skip != 'true' && env.RENDER_BACKEND_DEPLOY_HOOK != ''
-        env:
-          DEPLOY_HOOK: ${{ env.RENDER_BACKEND_DEPLOY_HOOK }}
-          IMAGE_URL: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
-          RENDER_SKIP_IF_SUSPENDED: "1"
-        run: |
-          if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
-            python3 scripts/deploy/trigger_render_image_deploy.py \
-              --deploy-hook "${DEPLOY_HOOK}" \
-              --image-url "${IMAGE_URL}" \
-              --service-name metar-to-iwxxm-api \
-              --skip-if-suspended
-          else
-            curl -fsSL "${DEPLOY_HOOK}"
+          mkdir -p "${HOME}/.kube"
+          # Secret is base64-encoded kubeconfig (docs/deploy.md §CD — DOKS image rollout).
+          if ! printf '%s' "${KUBE_CONFIG}" | base64 --decode > "${HOME}/.kube/config" 2>/dev/null; then
+            echo "::error::KUBE_CONFIG is not valid base64"
+            exit 1
           fi
-
-      - name: Deploy frontend image to Render
-        if: steps.guard.outputs.skip != 'true' && env.RENDER_FRONTEND_DEPLOY_HOOK != ''
-        env:
-          DEPLOY_HOOK: ${{ env.RENDER_FRONTEND_DEPLOY_HOOK }}
-          IMAGE_URL: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
-          RENDER_SKIP_IF_SUSPENDED: "1"
-        run: |
-          if [ "${RENDER_DEPLOY_MODE}" = "image" ]; then
-            python3 scripts/deploy/trigger_render_image_deploy.py \
-              --deploy-hook "${DEPLOY_HOOK}" \
-              --image-url "${IMAGE_URL}" \
-              --service-name metar-to-iwxxm-frontend-v4-web \
-              --skip-if-suspended
-          else
-            curl -fsSL "${DEPLOY_HOOK}"
-          fi
-
-      - name: Note DOKS rollout
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          echo "::notice::GHCR tags pushed. Live deploy target is DOKS (metar-iwxxm)."
-          echo "Roll out with: kubectl -n metar-iwxxm set image deploy/metar-frontend frontend=ghcr.io/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}"
-          echo "               kubectl -n metar-iwxxm set image deploy/metar-api api=ghcr.io/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}"
+          chmod 600 "${HOME}/.kube/config"
+          bash scripts/deploy/doks_rollout_images.sh "${IMAGE_TAG}"
 
       - name: CD skipped (credentials)
         if: steps.guard.outputs.skip == 'true'

--- a/deploy/doks/README.md
+++ b/deploy/doks/README.md
@@ -65,8 +65,20 @@ API container starts (idempotent — same as `make db-migrate` / CI `test-alembi
 Optional ad-hoc Job: `deploy/doks/base/job-alembic-upgrade.yaml`
 (`kubectl apply -f …` or included in `kubectl apply -k`).
 
+## CD image rollout (EV-034 / TC-F30-007)
+
+On push to `main`, `.github/workflows/ci-cd.yml` **Deploy** runs
+`scripts/deploy/doks_rollout_images.sh <TIMESTAMP-SHA>` after GHCR push (requires
+Actions secret `KUBE_CONFIG` — base64 kubeconfig). Manual equivalent:
+
+```bash
+bash scripts/deploy/doks_rollout_images.sh 20260805003332-5245f8d
+```
+
+See [docs/deploy.md](../../docs/deploy.md) §CD — DOKS image rollout.
+
 ## Related
 
-- [docs/deploy.md](../../docs/deploy.md) — topology + secrets
+- [docs/deploy.md](../../docs/deploy.md) — topology + secrets + CD
 - [docs/ops/doks-cutover-soak-checklist.md](../../docs/ops/doks-cutover-soak-checklist.md)
 - ADR-033

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,13 +3,45 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-034 — Automate DOKS image rollout in CD (S042)
+
+**Session**: S042-doks-cd-rollout  
+**Features**: deepen **F30** (infra/CD — no new product Fn)  
+**Started**: 2026-08-05  
+**Branch**: `evolve/EV-034-doks-cd-rollout`  
+**Status**: **in_progress** — Phase 0 locked; Standard routing approved  
+**Prior**: S041 / EV-033 lean-closed (`D-S041-1+3`); S040 / EV-032 remains suspended (`resume_after` S042)
+
+### Scope (Phase 0 — locked 2026-08-05; AskQuestion unavailable — chat `A,A,A,B,A`)
+
+| ID | Category | Question | Decision |
+|----|----------|----------|----------|
+| E34-1 | decision | Rollout targets? | **API + frontend + worker** |
+| E34-2 | decision | Image pin? | **Immutable `TIMESTAMP-SHA` tag** + `rollout status` |
+| E34-3 | decision | Cluster auth? | GitHub Actions secret **`KUBE_CONFIG`** (base64 kubeconfig) |
+| E34-4 | decision | Render steps? | **Remove / optional no-fail** — DOKS-only CD |
+| E34-5 | decision | Preset? | **Standard** `00→16→01→02→04→07→08→09→11→12→13` (skip 03/05/06; 10 optional) |
+
+**Scope (verbatim)**: After successful GHCR push on `main`, CD must `kubectl set image` +
+`rollout status` for `metar-api`, `metar-frontend`, and `metar-worker` in namespace
+`metar-iwxxm`, pinning each container to the immutable push tag
+(`ghcr.io/empiric2/tac-to-iwxxm/{backend,frontend,worker}:TIMESTAMP-SHA`). Auth via
+Actions secret `KUBE_CONFIG` (base64 kubeconfig). Render deploy-hook steps become
+optional/non-blocking (or removed); missing Render hooks must not fail Deploy.
+Missing `KUBE_CONFIG` on `main` Deploy **fails** (fail-closed). Baseline one-shot
+already live: `20260805003332-5245f8d`.
+
+**Out of scope**: New product Fn; S040 resume; changing DOKS topology/IaC beyond image
+roll; Alembic redesign (initContainer remains).
+
 ## Cycle EV-033 — F8 worker INGEST_POLLER_URL hardening (S041)
 
 **Session**: S041-worker-poller-hardening  
 **Features**: deepen **F8**  
 **Started**: 2026-08-04  
-**Branch**: `evolve/EV-033-worker-poller-hardening` (from `main`)  
-**Status**: **in_progress**  
+**Completed**: 2026-08-05  
+**Branch**: `main` @ `5245f8de` (PR #865)  
+**Status**: **completed** (lean-close `D-S041-1+3`)  
 **Prior**: S040 / EV-032 **suspended** (not cancelled) during this cycle
 
 ### Scope (Phase 0 — locked 2026-08-04; AskQuestion unavailable — user “proceed 1–5”)
@@ -19,6 +51,7 @@
 | E33-1 | decision | Session vs S040? | New session S041; suspend S040 |
 | E33-2 | decision | Scope? | All prevention items **1–5** + worker code refuse placeholder/non-https |
 | E33-3 | decision | Preset? | **Standard** |
+| E33-4 | decision | Close path? | **D-S041-1+3** lean-close (waive 09–13) + DOKS one-shot + open S042 |
 
 **Scope (verbatim)**: Harden F8 `metar-worker` so `INGEST_POLLER_URL` cutover cannot
 leave `REPLACE_ME_*` or non-HTTPS values running at replicas &gt; 0: (1) fail-closed
@@ -33,13 +66,15 @@ beyond the fixture URL; Prometheus operator install on DOKS.
 | ID | Category | Question | Decision | ADR |
 |----|----------|----------|----------|-----|
 | E33-1 | decision | Proceed hardening 1–5? | Yes (+ code guard) | ADR-018 deepen |
+| E33-4 | decision | Lean-close + DOKS one-shot? | Yes (`D-S041-1+3`) — waive 09–13; tag `20260805003332-5245f8d` | — |
 
 ### Stage log
 | Stage | Completed | Notes |
 |-------|-----------|-------|
 | 00-context | 2026-08-04 | S041 open; S040 suspended |
-| 16-evolve | | orchestrating |
-| 01–13 | | Standard path — docs+code+scripts this cycle |
+| 01–04 / 07–08 | 2026-08-04 | Standard path; #865 merged; 08 PASS |
+| 09–13 | waived 2026-08-05 | `D-S041-1+3`; deploy passed_via_ops |
+| 16-evolve | 2026-08-05 | cycle closed; see evolve-summary.md |
 
 ## Cycle EV-032 — Official IWXXM corpus quality / WMO source parity (S040)
 
@@ -48,7 +83,7 @@ beyond the fixture URL; Prometheus operator install on DOKS.
 **Issues**: [#846](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/846) (epic), [#835](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/835), [#741](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/741), [#808](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/808)  
 **Started**: 2026-08-04  
 **Branch**: `evolve/EV-032-iwxxm-corpus-quality` (from `main`)  
-**Status**: **in_progress** — Gate A PASS; entering 04-tech-plan
+**Status**: **in_progress** — **suspended** (resume_after S042; do not auto-resume)
 
 ### Scope (Phase 0 — locked 2026-08-04 via 00-context)
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -50,6 +50,24 @@ Render archive: [ops/render-decommission-archive.md](ops/render-decommission-arc
 `--skip-if-suspended` / `RENDER_SKIP_IF_SUSPENDED` so main CI Deploy skips suspended Render
 services without failing (see BUG-2026-08-03). GHCR push continues; DOKS is the prod target.
 
+### CD — DOKS image rollout (S042 / EV-034 / F30 deepen)
+
+On push to `main`, the **Deploy** job in `.github/workflows/ci-cd.yml`:
+
+1. Builds/pushes GHCR images tagged `TIMESTAMP-SHA` and `main-latest`.
+2. **Rolls DOKS** (required): `scripts/deploy/doks_rollout_images.sh <tag>` sets
+   `metar-api` / `metar-frontend` / `metar-worker` in namespace `metar-iwxxm` to
+   `ghcr.io/empiric2/tac-to-iwxxm/{backend,frontend,worker}:<tag>` and waits for
+   `kubectl rollout status`.
+3. **Render hooks** (optional): if present, may fire with `--skip-if-suspended`; missing
+   or suspended Render must **not** fail Deploy (`E34-4`).
+
+| Actions secret | Required | Description |
+|----------------|----------|-------------|
+| `KUBE_CONFIG` | **Yes** (main Deploy) | Base64-encoded kubeconfig with rights to mutate Deployments in `metar-iwxxm`. Missing ⇒ Deploy fails (fail-closed). |
+
+Encode: `base64 -w0 <kubeconfig.yaml>` (macOS: `base64 -i kubeconfig.yaml | tr -d '\n'`).
+
 **F21 Amended / F31**: Optional Auth restored via `packages/auth`. Convert remains public.
 F8 worker runs on DOKS.
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-04 (S038 / EV-031 F30/F31 Done; S040 / EV-032 F32 Done; #842/#846)
+> **Last updated**: 2026-08-05 (S042 / EV-034 F30 CD deepen — DOKS auto-rollout)
 
 ## Summary
 
@@ -37,7 +37,7 @@
 | F27 | TCA quality bar (TropicalCycloneAdvisory) | Done | Product | S027 / EV-021; #737; PR #794 |
 | F28 | SWXA quality bar (SpaceWeatherAdvisory) | Done | Product | S036 / EV-029; #823/#740 closed; PR #828 |
 | F29 | Parameterized lint/convert/validate rule matrices | Done | Product | S037 / EV-030; #831; shipped 2026-08-03 (#832) |
-| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; #842/#830/#712; public DNS live |
+| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; **deepen** S042 / EV-034 CD auto-rollout |
 | F31 | Hybrid operator sessions (guest local + Auth long-term) | Done | Product | S038 / EV-031; amends F5/F7/F21/F22 |
 | F32 | VONA quality bar (VolcanoObservatoryNoticeForAviation) | Done | Product | S040 / EV-032; #741 closed; epic #846 |
 | M1 | Monorepo layout (`apps/` + `packages/` + `vendor/`) | Planned | Platform | REQ-002–006 |
@@ -1118,13 +1118,15 @@
 
 ### F30: Platform Independence (Auth / DO DB / DOKS) — S038 / EV-031
 
-- **Status**: **Done** (S038 / EV-031; `D-S038-13` = 1) — provisional DOKS + Render suspended;
-  real public DNS/HTTPS residual under `D-S038-t63-waive`.
+- **Status**: **Done** (S038 / EV-031; `D-S038-13` = 1) — **deepen** S042 / EV-034 (CD DOKS image rollout).
 - **What it does**: Splits platform lock-in under epic [#842](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/842):
   1. **Supabase Auth only** — JWT issue/verify for optional operator login (no product PostgREST / hosted Postgres app tables).
   2. **DigitalOcean Postgres** — all product DB including F8 store/quarantine and logged-in work sessions (`DATABASE_URL`).
   3. **DOKS production cutover** — API + worker + static from Render → DigitalOcean Kubernetes; decommission Render after soak ([#712](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/712)).
   4. Amend [#830](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/830): strip Supabase **data** plane; keep Auth.
+  5. **CD auto-rollout (EV-034)**: On `main` Deploy after GHCR push, pin `metar-api` /
+     `metar-frontend` / `metar-worker` to the immutable `TIMESTAMP-SHA` tag via kubectl
+     (`KUBE_CONFIG` Actions secret). Render hooks optional/non-blocking.
 - **Convert APIs**: Remain public (no JWT) for convert/lint/validate/disseminate (`D-S038-F30`).
 - **Acceptance**:
   1. Product path boots/smokes without Supabase **database** credentials (**TC-F30-001**)
@@ -1133,8 +1135,9 @@
   4. DOKS hosts API + worker + static; cutover runbook + H0–H5 against new endpoints (**TC-F30-004**)
   5. Render decommissioned after soak or residual ticket with checklist (**TC-F30-005**)
   6. Docs/CORPUS/env-contract no longer require Supabase as data plane (**TC-F30-006**)
+  7. `main` CD rolls DOKS images to the pushed immutable tag without manual kubectl (**TC-F30-007**)
 - **Out of scope**: Convert/validate engine rewrites; long-lived dual production hosts after soak
-- **Source**: E31-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712
+- **Source**: E31-*; E34-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712; S042 / EV-034
 
 ### F31: Hybrid Operator Sessions — S038 / EV-031
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,8 +25,9 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S041-worker-poller-hardening](S041-worker-poller-hardening/session-brief.md) | feature | in_progress | F8 deepen INGEST_POLLER_URL hardening (1–5 + code); EV-033 | evolve/EV-033-worker-poller-hardening | 2026-08-04 | — |
-| [S040-iwxxm-corpus-quality](S040-iwxxm-corpus-quality/session-brief.md) | feature | suspended | #846 epic; #835/#741(F32)/#808 + corpus; EV-032 — paused for S041 | evolve/EV-032-iwxxm-corpus-quality | 2026-08-04 | — (resume after S041) |
+| [S042-doks-cd-rollout](S042-doks-cd-rollout/session-brief.md) | feature | in_progress | Automate DOKS image rollout in CD; EV-034 — routing pending approval | evolve/EV-034-doks-cd-rollout | 2026-08-05 | — |
+| [S041-worker-poller-hardening](S041-worker-poller-hardening/session-brief.md) | feature | completed | F8 deepen INGEST_POLLER_URL hardening; EV-033 lean-close D-S041-1+3 | main (#865) | 2026-08-04 | 2026-08-05 |
+| [S040-iwxxm-corpus-quality](S040-iwxxm-corpus-quality/session-brief.md) | feature | suspended | #846 epic; #835/#741(F32)/#808 + corpus; EV-032 — resume after S042 | evolve/EV-032-iwxxm-corpus-quality | 2026-08-04 | — (resume after S042) |
 | [S037-quality-residuals-831](S037-quality-residuals-831/session-brief.md) | feature | completed | #831/#829/#820 closed; F29 Done; residual #835; EV-030 | evolve/EV-030-quality-residuals-831 | 2026-08-02 | 2026-08-03 |
 | [S036-eight-family-ahl-rules-823](S036-eight-family-ahl-rules-823/session-brief.md) | feature | completed | #823 eight-family AHL/lint/convert/validate; EV-029; F28 Done; PR #828 | main (#828) | 2026-08-01 | 2026-08-02 |
 | [S034-wmo-decode-residual-matrix](S034-wmo-decode-residual-matrix/session-brief.md) | feature | in_progress | #815 official WMO decode residual matrix; EV-027 | evolve/EV-027-wmo-decode-residual-matrix | 2026-07-31 | — |
@@ -64,13 +65,15 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 ## Active session
 
-**[S027-vaa-quality](S027-vaa-quality/session-brief.md)** — VAA quality bar (#736); F26. Branch
-`evolve/EV-021-vaa-quality`. Lean+build+11 **proposed** (intake + routing pending).
+**[S042-doks-cd-rollout](S042-doks-cd-rollout/session-brief.md)** — Automate DOKS CD image
+rollout (EV-034). Standard routing **proposed** (pending approval). Branch
+`evolve/EV-034-doks-cd-rollout` (`pending_create`).
 
-Parked/other: see rows above (S016 paused; S017 process).
+Parked: **[S040-iwxxm-corpus-quality](S040-iwxxm-corpus-quality/session-brief.md)** suspended
+(`resume_after` S042 — do not auto-resume).
 
-Last closed: **[S026-airmet-quality-wmo-examples](S026-airmet-quality-wmo-examples/session-brief.md)** —
-F24 AIRMET + F25 WMO METAR/SPECI/TAF parity; PR #793 merged (`0f77194`); #731 closed.
+Last closed: **[S041-worker-poller-hardening](S041-worker-poller-hardening/session-brief.md)** —
+F8 poller hardening; lean-close `D-S041-1+3`; DOKS tag `20260805003332-5245f8d`.
 
 ## Folder layout
 

--- a/docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
+++ b/docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
@@ -27,7 +27,8 @@ ui_preview: pending — AskQuestion at routing gate (engine-heavy; default docs/
 # Session S040 — iwxxm-corpus-quality
 
 > **Suspended 2026-08-04** for [S041-worker-poller-hardening](../S041-worker-poller-hardening/session-brief.md) / EV-033.
-> Not completed or cancelled. Resume at `13-deploy-smoke` / T4.5 after S041. EV-032 remains `in_progress`.
+> Not completed or cancelled. Resume at `13-deploy-smoke` / T4.5 after S042 (CD session);
+> do not auto-resume now. EV-032 remains `in_progress`.
 
 ## Intent
 

--- a/docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+++ b/docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
@@ -2,24 +2,34 @@
 
 **Session:** S041-worker-poller-hardening  
 **Cycle:** EV-033  
-**Branch:** `evolve/EV-033-worker-poller-hardening` (created from `origin/main` @ `769d3f83`)  
-**Updated:** 2026-08-04
+**Branch:** `main` @ `5245f8de` (includes #865 merge `963a2777`, #845, #866; feature tip `753bc94d`)  
+**Updated:** 2026-08-05  
+**Status:** **completed** (lean-close `D-S041-1+3`)
 
 ## Stage status
 
 | Stage | Status | Note |
 |-------|--------|------|
 | 00-context | completed | open_session; D-S041-open |
-| 16-evolve | in_progress | orchestrating |
-| 01-requirements | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
-| 02-verify-plan | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
-| 04-tech-plan | completed | delta lean — scope in evolve-decisions; AskQuestion unavailable |
-| 07-build | in_progress | docs + code + scripts implemented; awaiting commit/PR/user verify |
-| 08–13 | pending | — |
+| 16-evolve | **completed** | lean-close D-S041-1+3; EV-033 closed |
+| 01-requirements | completed | delta lean — scope in evolve-decisions |
+| 02-verify-plan | completed | delta lean — scope in evolve-decisions |
+| 04-tech-plan | completed | delta lean — scope in evolve-decisions |
+| 07-build | completed | PR #865 MERGED @ 963a2777 |
+| 08-verify-build | completed | **PASS** @ tip `5245f8de`; verification-report.md; C→D passed |
+| 09-qa | **waived** | D-S041-1+3 lean close |
+| 10-e2e | **waived** | D-S041-1+3 lean close |
+| 11-verify-impl | **waived** | D-S041-1+3 lean close |
+| 12-verify-deploy | **waived** | D-S041-1+3 lean close |
+| 13-deploy-smoke | **waived** | formal stage waived; deploy **passed_via_ops** via DOKS one-shot |
 
-Cycle remains **in_progress** — not closed.
+Cycle **completed**. CD/DOKS automation opened as **S042 / EV-034**.
 
-## Implemented artifacts (uncommitted as of this note)
+## DOKS one-shot
+
+Tag `20260805003332-5245f8d` (~00:49Z 2026-08-05): set-image api/frontend/worker in `metar-iwxxm`; rollouts OK; live `/health` + auth OpenAPI checks recorded in evolve-summary.
+
+## Implemented artifacts (merged via #865)
 
 - `deploy/doks/README-worker-hardening.md`
 - `apps/worker/src/metar_worker/poller_url.py`
@@ -29,10 +39,19 @@ Cycle remains **in_progress** — not closed.
 - `deploy/doks/observability/prometheusrule-metar-worker.yaml`
 - `apps/worker/tests/test_validate_ingest_poller_url.py`
 - `tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py`
-- Related docs/env/Makefile/worker wiring under dirty worktree
 
-## Next
+## Verification (08)
 
-1. Commit + push on `evolve/EV-033-worker-poller-hardening`
-2. Open PR; user verify
-3. Continue 08-verify-build → Phase D as routing allows
+Report: `docs/sessions/S041-worker-poller-hardening/reports/verification-report.md`
+
+## Decisions
+
+| ID | Choice | Note |
+|----|--------|------|
+| D-S041-open | proceed_1-5_plus_code | Session open / Phase 0 |
+| D-S041-cd-defer | finish_S041_first (option 2) | Superseded for remaining Phase D by 1+3 |
+| D-S041-1+3 | lean_close_and_doks_oneshot | Waive 09–13; DOKS one-shot; open S042 |
+
+## Close
+
+See [evolve-summary.md](evolve-summary.md). S040/EV-032 remains suspended (`resume_after` S042).

--- a/docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
+++ b/docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
@@ -1,0 +1,61 @@
+# Evolve summary — EV-033 / S041 (worker poller hardening)
+
+> Date: 2026-08-05  
+> Status: **completed** (lean-close `D-S041-1+3`)  
+> Branch: `main` @ `5245f8de` (PR #865 merge `963a2777`; feature tip `753bc94d`)  
+> Features: deepen **F8**  
+> Close decision: **D-S041-1+3** = lean-close (waive 09–13) + one-shot DOKS rollout, then open CD session
+
+## What shipped
+
+F8 `metar-worker` **`INGEST_POLLER_URL`** cutover hardening (prevention 1–5 + code guard):
+
+1. Fail-closed scale when poller URL unset/placeholder
+2. CI/ops preflight for worker poller URL
+3. Docs/env default fixture URL (no `REPLACE_ME` as runnable default)
+4. Runbook — do not copy unverified Render poller URLs
+5. CrashLoop check + optional PrometheusRule
+6. Code guard rejecting `REPLACE_ME` / non-https poller URLs
+
+Merged via **PR #865**.
+
+## Stages
+
+| Stage | Result |
+|-------|--------|
+| 00 → 16 → 01 → 02 → 04 → 07 → 08 | **completed** (08 PASS @ `5245f8de`) |
+| 09-qa / 10-e2e / 11-verify-impl / 12-verify-deploy / 13-deploy-smoke | **waived** (`D-S041-1+3`) |
+| Gates A→B / B→C / C→D | **passed** |
+| Deploy gate | **passed_via_ops** (DOKS one-shot) |
+
+## DOKS one-shot (ops)
+
+| Item | Value |
+|------|-------|
+| Tag | `20260805003332-5245f8d` |
+| Source | CI Deploy run 30963357296 / #866 merge tip `5245f8de` |
+| Workloads | `metar-api`, `metar-frontend`, `metar-worker` in `metar-iwxxm` |
+| Rollouts | successful ~2026-08-05 00:49Z |
+| Live verify | `/health` 200; OpenAPI `/auth/login` + `/auth/me`; POST login → 422; GET `/auth/me` → 401; logs `metar_auth /auth router successfully` |
+
+## Artifacts
+
+- `reports/verification-report.md` (08 PASS)
+- `reports/evolve-progress.md`
+- `deploy/doks/README-worker-hardening.md`
+- `apps/worker/src/metar_worker/poller_url.py` + validate scripts/tests
+- `deploy/doks/observability/prometheusrule-metar-worker.yaml`
+
+## Follow-ups
+
+- **S042 / EV-034** — automate DOKS image rollout in CD (opened after this close)
+- **S040 / EV-032** — remains **suspended**; `resume_after` = S042 (do not auto-resume)
+- Remaining AC depth for formal 09–13 deferred by lean-close
+
+## Decisions
+
+| ID | Choice |
+|----|--------|
+| D-S041-open | proceed_1-5_plus_code |
+| D-S041-cd-defer | finish_S041_first (superseded for Phase D depth by 1+3) |
+| D-S041-1+3 | lean_close_and_doks_oneshot |

--- a/docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+++ b/docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
@@ -1,0 +1,39 @@
+# S041 / EV-033 — 08-verify-build
+
+**Session:** S041-worker-poller-hardening  
+**Cycle:** EV-033  
+**Date:** 2026-08-04  
+**Checkout:** `main` @ `5245f8de` (includes #865 merge `963a2777`, #845, #866)  
+**Result:** **PASS**
+
+## Scope
+
+Delta verify after PR [#865](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/865) merge — F8 `INGEST_POLLER_URL` fail-closed hardening.
+
+## Checks
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Format (`make format-check`) | PASS | ruff + prettier |
+| Lint (`make lint`) | PASS | ruff + eslint |
+| Typecheck (`make typecheck`) | PASS | 0 errors (pre-existing warnings in shared/tac2iwxxm) |
+| Worker poller unit + bug repro | PASS | 13 tests |
+| CORS (`tests/unit/test_cors_policy.py`) | PASS | 6 tests |
+| PR #865 CI | PASS | Validate + matrix tests green; Deploy skipped on PR (expected) |
+
+## Connectivity artifacts
+
+| Artifact | Present |
+|----------|---------|
+| `scripts/deploy/verify_connectivity.sh` | yes |
+| `scripts/deploy/doks_worker_poller_preflight.sh` | yes (EV-033) |
+| `scripts/deploy/validate_ingest_poller_url.py` | yes (EV-033) |
+
+## Blocking issues
+
+None.
+
+## Next
+
+Phase D: 09-qa → 10-e2e → 11-verify-impl → 12-verify-deploy → 13-deploy-smoke.  
+Live worker/API image rollout on DOKS is still manual (CD gap) — may block full 13 until ops rollout or EV-034 CD automation.

--- a/docs/sessions/S041-worker-poller-hardening/routing-plan.md
+++ b/docs/sessions/S041-worker-poller-hardening/routing-plan.md
@@ -2,39 +2,45 @@
 
 **Preset:** Standard — approved via `D-S041-open` = proceed_1-5_plus_code  
 **Orchestrator:** 16-evolve · **Cycle:** EV-033  
-**Path:** `00→16→01→02→04→07→08→09→10→11→12→13`  
-**Skip:** `03, 05, 06` (re-add if 04 introduces new deps/ADR tooling/guardrails)  
+**Path:** `00→16→01→02→04→07→08` (+ 09–13 **waived** lean-close)  
+**Skip:** `03, 05, 06` (original); `09–13` waived `D-S041-1+3`  
 **Deepen:** F8 (`INGEST_POLLER_URL` cutover hardening)  
-**Branch:** `evolve/EV-033-worker-poller-hardening` (pending create)  
-**Prior:** S040/EV-032 **suspended** (not completed/cancelled)
+**Branch:** `main` @ `5245f8de` (includes #865/#845/#866; feature tip `753bc94d`)  
+**Status:** **completed** 2026-08-05 (lean-close)  
+**Prior:** S040/EV-032 **suspended** — `resume_after` updated to S042 (not auto-resume)
 
 | Stage | Required | Mode | Status | Notes |
 |-------|----------|------|--------|-------|
 | 00-context | yes | scoped | **completed** | Suspend S040; open S041; D-S041-open |
-| 16-evolve | yes | orchestrator | **in_progress** | Phase 0 locked; next 01 |
-| 01-requirements | yes | delta | pending | Prevention 1–5 + code guard |
-| 02-verify-plan | yes | delta | pending | Gate A |
+| 16-evolve | yes | orchestrator | **completed** | Lean-close D-S041-1+3; EV-033 closed |
+| 01-requirements | yes | delta | **completed** | Prevention 1–5 + code guard |
+| 02-verify-plan | yes | delta | **completed** | Gate A |
 | 03-plan-tooling | no | — | skipped | Re-add if new rules/hooks |
-| 04-tech-plan | yes | delta | pending | Gate B |
+| 04-tech-plan | yes | delta | **completed** | Gate B |
 | 05-verify-tech | no | — | skipped | Re-add if new deps |
 | 06-tech-tooling | no | — | skipped | — |
-| 07-build | yes | full | pending | — |
-| 08-verify-build | yes | delta | pending | — |
-| 09-qa | yes | delta | pending | — |
-| 10-e2e | yes | smoke | pending | Worker-focused as needed |
-| 11-verify-impl | yes | delta | pending | F8 deepen ACs |
-| 12-verify-deploy | yes | delta | pending | — |
-| 13-deploy-smoke | yes | full | pending | Worker / poller live checks |
+| 07-build | yes | full | **completed** | PR #865 MERGED @ 963a2777 |
+| 08-verify-build | yes | delta | **completed** | PASS @ tip `5245f8de`; C→D passed |
+| 09-qa | yes | delta | **waived** | D-S041-1+3 lean close |
+| 10-e2e | yes | smoke | **waived** | D-S041-1+3 lean close |
+| 11-verify-impl | yes | delta | **waived** | D-S041-1+3 lean close |
+| 12-verify-deploy | yes | delta | **waived** | D-S041-1+3 lean close |
+| 13-deploy-smoke | yes | full | **waived** | Formal waived; deploy **passed_via_ops** via DOKS `20260805003332-5245f8d` |
 
-## Skip rationale
+## Skip / waive rationale
 
-Existing app; F8 deepen on config/CI/docs/code guards. Standard matches prior ops-hardening
-evolve cycles. No new deployable. Skip 03/05/06 unless 04 requires them.
+Existing app; F8 deepen on config/CI/docs/code guards. Standard matched prior ops-hardening
+evolve cycles. No new deployable. Skip 03/05/06 unless 04 required them.
+
+**Lean-close (`D-S041-1+3`):** Waive 09–13 — live worker/API verified via one-shot DOKS
+rollout; remaining AC depth deferred. CD automation continues in S042/EV-034.
 
 ## Approved
 
 | Gate | Decision | Date |
 |------|----------|------|
-| Session open / Phase 0 | `D-S041-open` = **proceed_1-5_plus_code** — new session + Standard + items 1–5 + code; S040 suspended | 2026-08-04 |
+| Session open / Phase 0 | `D-S041-open` = **proceed_1-5_plus_code** | 2026-08-04 |
+| Session priority | `D-S041-cd-defer` = **finish_S041_first** (option 2) | 2026-08-04 |
+| Lean close + DOKS | `D-S041-1+3` = **lean_close_and_doks_oneshot** — waive 09–13; DOKS one-shot; open S042 | 2026-08-05 |
 
-**Note:** AskQuestion tool unavailable; decision recorded from chat approval to proceed via `/16-evolve`.
+**Note:** AskQuestion tool unavailable for open; decisions recorded from chat approval.

--- a/docs/sessions/S041-worker-poller-hardening/session-brief.md
+++ b/docs/sessions/S041-worker-poller-hardening/session-brief.md
@@ -1,19 +1,21 @@
 ---
 session_id: S041-worker-poller-hardening
 type: feature
-status: in_progress
-branch: evolve/EV-033-worker-poller-hardening
+status: completed
+branch: main
 started_at: 2026-08-04
+completed_at: 2026-08-05
 intent: "Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)"
 orchestrator: 16-evolve
 evolve_cycle_id: EV-033
 prior_session: S040-iwxxm-corpus-quality
 context_briefs: []
-standing_docs_touched: []  # filled after 01/04
+standing_docs_touched: []
 feature_ids: []
 deepen_feature_ids: [F8]
-feature_note: "D-S041-open — F8 deepen INGEST_POLLER_URL hardening"
+feature_note: "D-S041-open — F8 deepen INGEST_POLLER_URL hardening; lean-close D-S041-1+3"
 ask_question: unavailable — chat proceed recorded as D-S041-open
+close_decision: D-S041-1+3
 ---
 
 # Session S041 — worker-poller-hardening
@@ -27,8 +29,9 @@ fail closed in ops, CI, docs, and code — without mixing into S040 corpus work.
 
 | Item | Disposition |
 |------|-------------|
-| S040 / EV-032 | **Suspended** (not completed/cancelled) at `13-deploy-smoke` / T4.5 — resume after S041 |
+| S040 / EV-032 | **Suspended** (not completed/cancelled) at `13-deploy-smoke` / T4.5 — `resume_after` S042 (not auto-resume) |
 | EV-032 | Remains `in_progress` |
+| Close | Lean-close `D-S041-1+3` 2026-08-05 — waive 09–13; DOKS one-shot `20260805003332-5245f8d`; open S042 |
 
 ## Scope (locked — D-S041-open = proceed_1-5_plus_code)
 

--- a/docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+++ b/docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
@@ -1,0 +1,20 @@
+# EV-034 / S042 — Execution plan (delta)
+
+**Cycle:** EV-034 · **Session:** S042-doks-cd-rollout  
+**Deepen:** F30 · **Spec:** evolve-decisions §EV-034; `docs/deploy.md` CD section; TC-F30-007
+
+## Tasks
+
+| ID | Type | Description | Spec Source | Depends | Status |
+|----|------|-------------|-------------|---------|--------|
+| T1.1 | docs | Lock Phase 0 + F30/deploy/test-plan delta | E34-*; feature-list F30; deploy.md; TC-F30-007 | — | completed |
+| T1.2 | impl | `scripts/deploy/doks_rollout_images.sh` | E34-1/2; TC-F30-007 | T1.1 | completed |
+| T1.3 | impl | Wire Deploy job: kubectl + `KUBE_CONFIG`; DOKS rollout; Render optional/no-fail | E34-3/4; ci-cd.yml | T1.2 | completed |
+| T1.4 | test | Light guard: script exists + workflow references rollout + no hard Render enforce | TC-F30-007 | T1.3 | completed |
+| T1.5 | docs | `deploy/doks/README.md` CD pointer | deploy.md | T1.3 | completed |
+
+## Git Strategy
+
+- Branch: `evolve/EV-034-doks-cd-rollout`
+- PR title: `[EV-034] Automate DOKS image rollout in CD`
+- Checklist: lint · typecheck · tests · no secrets · TC-F30-007 mapping · `KUBE_CONFIG` documented (not committed)

--- a/docs/sessions/S042-doks-cd-rollout/routing-plan.md
+++ b/docs/sessions/S042-doks-cd-rollout/routing-plan.md
@@ -1,0 +1,37 @@
+# Routing plan — S042-doks-cd-rollout
+
+**Preset:** Standard — **approved** (`E34-5` / Phase 0 `A,A,A,B,A`)  
+**Orchestrator:** 16-evolve · **Cycle:** EV-034  
+**Path:** `00→16→01→02→04→07→08→09→11→12→13`  
+**Skip:** `03, 05, 06` · **Optional:** `10-e2e`  
+**Branch:** `evolve/EV-034-doks-cd-rollout`  
+**Deepen:** F30 (DOKS CD image rollout)
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | scoped | **completed** | open after S041 lean-close |
+| 16-evolve | yes | orchestrator | **in_progress** | Phase 0 locked E34-1..5; orchestrating through 07 |
+| 01-requirements | yes | delta | **completed** | F30 CD deepen; no new Fn |
+| 02-verify-plan | yes | delta | **completed** | Gate A |
+| 03-plan-tooling | no | — | skipped | — |
+| 04-tech-plan | yes | delta | **completed** | Gate B; execution-plan T1.1–T1.5 |
+| 05-verify-tech | no | — | skipped | — |
+| 06-tech-tooling | no | — | skipped | — |
+| 07-build | yes | full | **in_progress** | Impl done; awaiting commit+PR+user verify |
+| 08-verify-build | yes | delta | pending | Next after commit |
+| 09-qa | yes | delta | pending | — |
+| 10-e2e | no | smoke | skipped | Optional — primary AC is pipeline→cluster |
+| 11-verify-impl | yes | delta | pending | TC-F30-007 |
+| 12-verify-deploy | yes | delta | pending | — |
+| 13-deploy-smoke | yes | full | pending | Prove automated DOKS rollout |
+
+## Skip rationale
+
+Infra/CD on existing app. No new deployable. Skip 03/05/06. Skip 10 — acceptance is
+CD→kubectl image pin, not browser UJ.
+
+## Approval
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Phase 0 / routing | `E34-1..5` = A,A,A,B,A — Standard + DOKS-only CD | 2026-08-05 |

--- a/docs/sessions/S042-doks-cd-rollout/session-brief.md
+++ b/docs/sessions/S042-doks-cd-rollout/session-brief.md
@@ -1,0 +1,62 @@
+---
+session_id: S042-doks-cd-rollout
+type: feature
+status: in_progress
+branch: evolve/EV-034-doks-cd-rollout
+started_at: 2026-08-05
+intent: "Automate DOKS image rollout in CD pipeline after main merge/GHCR push"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-034
+prior_session: S041-worker-poller-hardening
+context_briefs: []
+standing_docs_touched: []
+feature_ids: []
+deepen_feature_ids:
+  - F30
+feature_note: "Infra/CD — close ci-cd.yml kubectl Notes gap; baseline tag 20260805003332-5245f8d"
+route_status: approved_E34-1-5
+---
+
+# Session S042 — doks-cd-rollout
+
+## Intent
+
+Automate DOKS image rollout in the CD pipeline after `main` merge / GHCR push.
+Close the gap where `ci-cd.yml` only **Notes** kubectl `set-image` / rollout commands
+instead of executing them. Triggered after #845/#866 and the manual one-shot rollout of
+`20260805003332-5245f8d`.
+
+## Prior sessions
+
+| Item | Disposition |
+|------|-------------|
+| S041 / EV-033 | **Completed** (lean-close `D-S041-1+3`) |
+| S040 / EV-032 | **Suspended** — `resume_after` S042; do **not** auto-resume now |
+| DOKS baseline | Live tag `20260805003332-5245f8d` (api/frontend/worker in `metar-iwxxm`) |
+
+## Scope (Phase 0 — locked `E34-1..5` = A,A,A,B,A)
+
+### In
+
+- After GHCR push on `main`, pin `metar-api` / `metar-frontend` / `metar-worker` to
+  immutable `TIMESTAMP-SHA` via `scripts/deploy/doks_rollout_images.sh`
+- Actions secret `KUBE_CONFIG` (base64 kubeconfig) — fail-closed if missing
+- Render hooks optional / non-blocking
+- Docs + TC-F30-007 + Standard verify path
+
+### Out
+
+- Auto-resuming S040; new product Fn; Alembic redesign
+
+## Routing (approved)
+
+**Standard:** `00→16→01→02→04→07→08→09→11→12→13` (skip 03/05/06/10)
+
+## Branch
+
+`evolve/EV-034-doks-cd-rollout` (created)
+
+## Links
+
+- Standing: [tech-spec.md](../../tech-spec.md), [deploy.md](../../deploy.md), [CORPUS.md](../../CORPUS.md)
+- Prior: [S041 session-brief](../S041-worker-poller-hardening/session-brief.md), [S041 evolve-summary](../S041-worker-poller-hardening/reports/evolve-summary.md)

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-04 (S038 / EV-031 TC-F30/F31 + S040 / EV-032 TC-F32 #846/#835/#741/#808)
+> **Last updated**: 2026-08-05 (S042 / EV-034 TC-F30-007 DOKS CD auto-rollout)
 
 ## Scope
 
@@ -1650,6 +1650,18 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
   Auth keys only; ADR-033 / deploy cutover referenced
 - **Source**: F30 AC6; #830
 
+### TC-F30-007: CD auto-rolls DOKS images (EV-034)
+
+- **Level**: Ops / T3 (CD)
+- **Objective**: After `main` GHCR push, Deploy pins DOKS `metar-api` / `metar-frontend` /
+  `metar-worker` to the immutable `TIMESTAMP-SHA` tag without manual kubectl
+- **Pass criteria**:
+  1. Deploy job runs `scripts/deploy/doks_rollout_images.sh` (or equivalent) with `KUBE_CONFIG`
+  2. Cluster Deployments show the pushed tag; `rollout status` succeeds
+  3. Live smoke: `/health` 200; OpenAPI includes `/auth/*` when that tag includes Auth
+  4. Missing `KUBE_CONFIG` fails Deploy; missing Render hooks do **not** fail Deploy
+- **Source**: F30 AC7; S042 / EV-034; `E34-1..4`
+
 ### TC-F31-001: Guest convert + local-only history (UJ-045)
 
 - **Level**: T2 / T3
@@ -2085,7 +2097,7 @@ Husky **pre-push** mirrors validate + unit/matrix locally. **Deploy** on `main` 
 |---------|----------|------|--------|
 | PR / push `main`, `dev` | `ci-cd.yml` | **validate** | ruff format/check, prettier, eslint, basedpyright, tsc, gitleaks, actionlint/yamllint, config-guard (`tests/test_config_placeholders.py`), frontend npm audit |
 | PR / push `main`, `dev` | `ci-cd.yml` | **test**, **tac2iwxxm-native**, **e2e-smoke** | package unit/integration matrix, PyO3 smoke, Playwright smoke |
-| push `main` only | `ci-cd.yml` | **deploy** | needs test + native; Docker build/push GHCR, Render deploy hooks — **skip** if credentials incomplete |
+| push `main` only | `ci-cd.yml` | **deploy** | needs test + native; Docker build/push GHCR; **DOKS kubectl rollout** (requires `KUBE_CONFIG`); Render hooks optional/non-blocking |
 | Local (husky pre-push) | `.husky/pre-push` | — | `make validate-ci` + `make ci-prepush` (unit/matrix @ package coverage gates) |
 | Schedule | `vendor-sync.yml` | vendor-sync | wmo-im schema sync PR (M6) |
 | Manual / schedule | `load-tests.yml`, `e2e-tests.yml` | — | out of EV-002 scope |

--- a/scripts/deploy/doks_rollout_images.sh
+++ b/scripts/deploy/doks_rollout_images.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pin DOKS Deployments to an immutable GHCR TIMESTAMP-SHA tag and wait for rollout.
+#
+# Usage:
+#   bash scripts/deploy/doks_rollout_images.sh <image_tag>
+#   IMAGE_TAG=20260805003332-5245f8d bash scripts/deploy/doks_rollout_images.sh
+#
+# Env:
+#   DOKS_NAMESPACE   default: metar-iwxxm
+#   GHCR_OWNER_REPO  default: empiric2/tac-to-iwxxm
+#   ROLLOUT_TIMEOUT  default: 180s
+#
+# Traces: F30 AC7 / TC-F30-007 / S042 / EV-034 / E34-1..2
+set -euo pipefail
+
+TAG="${1:-${IMAGE_TAG:-}}"
+if [[ -z "${TAG}" ]]; then
+  echo "usage: $0 <image_tag>" >&2
+  exit 2
+fi
+
+NS="${DOKS_NAMESPACE:-metar-iwxxm}"
+OWNER="${GHCR_OWNER_REPO:-empiric2/tac-to-iwxxm}"
+TIMEOUT="${ROLLOUT_TIMEOUT:-180s}"
+REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
+
+API_IMG="${REGISTRY}/${OWNER}/backend:${TAG}"
+FE_IMG="${REGISTRY}/${OWNER}/frontend:${TAG}"
+WORKER_IMG="${REGISTRY}/${OWNER}/worker:${TAG}"
+
+echo "DOKS rollout ns=${NS} tag=${TAG}"
+echo "  metar-api      -> ${API_IMG}"
+echo "  metar-frontend -> ${FE_IMG}"
+echo "  metar-worker   -> ${WORKER_IMG}"
+
+kubectl -n "${NS}" set image "deploy/metar-api" "api=${API_IMG}"
+kubectl -n "${NS}" set image "deploy/metar-frontend" "frontend=${FE_IMG}"
+kubectl -n "${NS}" set image "deploy/metar-worker" "worker=${WORKER_IMG}"
+
+kubectl -n "${NS}" rollout status "deploy/metar-api" --timeout="${TIMEOUT}"
+kubectl -n "${NS}" rollout status "deploy/metar-frontend" --timeout="${TIMEOUT}"
+kubectl -n "${NS}" rollout status "deploy/metar-worker" --timeout="${TIMEOUT}"
+
+echo "DOKS rollout complete:"
+kubectl -n "${NS}" get deploy metar-api metar-frontend metar-worker \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.template.spec.containers[*]}{.name}={.image}{" "}{end}{"\n"}{end}'

--- a/tests/test_doks_cd_rollout_guard.py
+++ b/tests/test_doks_cd_rollout_guard.py
@@ -1,0 +1,33 @@
+"""TC-F30-007 — CD wires DOKS rollout; Render hooks must not hard-fail Deploy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci-cd.yml"
+SCRIPT = ROOT / "scripts" / "deploy" / "doks_rollout_images.sh"
+
+
+def test_doks_rollout_script_exists_and_targets_three_deploys() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "deploy/metar-api" in text
+    assert "deploy/metar-frontend" in text
+    assert "deploy/metar-worker" in text
+    assert "rollout status" in text
+
+
+def test_ci_cd_deploy_rolls_doks_with_kube_config() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "doks_rollout_images.sh" in text
+    assert "KUBE_CONFIG" in text
+    assert "Roll out DOKS images" in text
+    # Fail-closed on missing kubeconfig
+    assert "Missing required secret KUBE_CONFIG" in text
+
+
+def test_ci_cd_render_hooks_are_optional_non_blocking() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "Optional Render hooks (non-blocking)" in text
+    assert "continue-on-error: true" in text
+    assert "Enforce backend deploy hook presence" not in text

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -14,7 +14,7 @@ active_session:
     #845/#866 and manual rollout of 20260805003332-5245f8d.
   status: in_progress
   branch: evolve/EV-034-doks-cd-rollout
-  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; worktree dirty (07 impl uncommitted); no commit SHA invented'
+  branch_note: 'ACTIVE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-034
   artifacts_dir: docs/sessions/S042-doks-cd-rollout/
@@ -59,7 +59,7 @@ active_session:
     status: in_progress
     started: '2026-08-05'
     skip_rationale:
-    note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 in_progress awaiting commit+PR+user verify; 08 next after commit'
+    note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; 08 next after CI/merge'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -90,14 +90,19 @@ active_session:
     status: in_progress
     started: '2026-08-05'
     skip_rationale:
-    note: 'IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; no commit SHA recorded; 08 next after commit'
-    pending_commit: true
+    note: 'ESSENTIALLY COMPLETE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge/user verify; EV-034 NOT completed; 08 next after CI/merge; deepen F30'
+    pending_commit: false
+    tip_sha: 9ae9c323
+    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    pr_number: 867
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    pr_status: open
   - stage: 08-verify-build
     required: true
     mode: delta
     status: pending
     skip_rationale:
-    note: 'Next after 07 commit'
+    note: 'Next after CI green + merge / user verify on #867'
   - stage: 09-qa
     required: true
     mode: delta
@@ -138,11 +143,13 @@ active_session:
     status: written
     stage: 04-tech-plan
   - path: scripts/deploy/doks_rollout_images.sh
-    status: written_uncommitted
+    status: committed
     stage: 07-build
+    tip_sha: 9ae9c323
   - path: tests/test_doks_cd_rollout_guard.py
-    status: written_uncommitted
+    status: committed
     stage: 07-build
+    tip_sha: 9ae9c323
   decision_refs:
   - E34-1
   - E34-2
@@ -155,7 +162,15 @@ active_session:
   - 05-verify-tech
   - 06-tech-tooling
   - 10-e2e
-  note: 'IN_PROGRESS — S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; branch evolve/EV-034-doks-cd-rollout ACTIVE (checked out); base tip 5245f8de; no commit SHA invented; 08 next after commit; S040 remains suspended (resume_after S042)'
+  pr_number: 867
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+  pr_status: open
+  pr_title: '[EV-034] Automate DOKS image rollout in CD'
+  pr_base: main
+  pr_head: evolve/EV-034-doks-cd-rollout
+  tip_sha: 9ae9c323
+  tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+  note: 'IN_PROGRESS — S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; branch evolve/EV-034-doks-cd-rollout ACTIVE pushed; 08 next after CI/merge; S040 remains suspended (resume_after S042)'
 sessions:
 - id: S042-doks-cd-rollout
   type: feature
@@ -165,7 +180,7 @@ sessions:
     #845/#866 and manual rollout of 20260805003332-5245f8d.
   status: in_progress
   branch: evolve/EV-034-doks-cd-rollout
-  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; 07 impl uncommitted'
+  branch_note: 'ACTIVE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-034
   feature_ids: []
@@ -204,7 +219,7 @@ sessions:
     status: in_progress
     started: '2026-08-05'
     skip_rationale:
-    note: 'ORCHESTRATING — 01/02/04 done; 07 awaiting commit+PR'
+    note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; 08 next after CI/merge'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -232,13 +247,16 @@ sessions:
     status: in_progress
     started: '2026-08-05'
     skip_rationale:
-    note: 'Impl largely done; awaiting commit+PR+user verify; pending_commit'
-    pending_commit: true
+    note: 'ESSENTIALLY COMPLETE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge/user verify; EV-034 NOT completed; 08 next after CI/merge; deepen F30'
+    pending_commit: false
+    tip_sha: 9ae9c323
+    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
   - stage: 08-verify-build
     required: true
     mode: delta
     status: pending
     skip_rationale:
+    note: 'Next after CI green + merge / user verify on #867'
   - stage: 09-qa
     required: true
     mode: delta
@@ -289,7 +307,25 @@ sessions:
   - 05-verify-tech
   - 06-tech-tooling
   - 10-e2e
-  note: 'IN_PROGRESS — Phase 0 locked; 01/02/04 completed; 07 awaiting commit+PR; branch ACTIVE'
+  pr_number: 867
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+  pr_status: open
+  pr_title: '[EV-034] Automate DOKS image rollout in CD'
+  pr_base: main
+  pr_head: evolve/EV-034-doks-cd-rollout
+  tip_sha: 9ae9c323
+  tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+  pull_requests:
+  - id: PR-EV-034
+    number: 867
+    url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    title: '[EV-034] Automate DOKS image rollout in CD'
+    status: open
+    head: evolve/EV-034-doks-cd-rollout
+    base: main
+    tip_sha: 9ae9c323
+    note: '07-build essentially complete; pending CI green + merge; EV-034 NOT completed'
+  note: 'IN_PROGRESS — Phase 0 locked; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed'
 - id: S041-worker-poller-hardening
   type: feature
   intent: |
@@ -7243,20 +7279,26 @@ stages:
     session_id: S042-doks-cd-rollout
     evolve_cycle_id: EV-034
     mode: full
-    note: 'S042/EV-034 07-build IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; pending_commit; no commit SHA invented; 08 next after commit; deepen F30'
-    tip_sha: 5245f8de
-    tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
-    tip_note: 'S042/EV-034 branch HEAD @ 5245f8de (base); worktree dirty — 07 pending_commit; no new commit SHA'
-    pending_commit: true
+    note: 'S042/EV-034 07-build ESSENTIALLY COMPLETE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge/user verify; EV-034 NOT completed; 08 next after CI/merge; deepen F30'
+    tip_sha: 9ae9c323
+    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    tip_note: 'S042/EV-034 tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
+    pending_commit: false
     next_stage: 08-verify-build
     current_milestone: M1
     current_task: T1.5
     active_milestone: M1
     active_task: T1.5
-    active_task_status: completed_pending_commit
+    active_task_status: completed_awaiting_ci_merge
     completed_through: T1.5
     progress: 5/5
     next_task: null
+    pr_number: 867
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    pr_status: open
+    pr_title: '[EV-034] Automate DOKS image rollout in CD'
+    commit_sha: 9ae9c323
+    commit_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
     suspended_s040_progress: 25/28
     suspended_s040_completed_through: T4.4
     suspended_s040_active_task: T4.5
@@ -10768,7 +10810,7 @@ stages:
     previous_evolve_cycle_id: EV-033
     previous_completed_at: '2026-08-05'
     current_child_stage: 07-build
-    note: 'S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build in_progress awaiting commit+PR+user verify; branch ACTIVE; 08 next after commit; S040 remains suspended (resume_after S042)'
+    note: 'S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; 08 next after CI/merge; S040 remains suspended (resume_after S042)'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -21675,7 +21717,10 @@ artifacts:
   created_at: '2026-08-05'
   updated_at: '2026-08-05'
   status: written
-  note: 'T1.1–T1.5 completed in working tree; awaiting commit'
+  tip_sha: 9ae9c323
+  pr_number: 867
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+  note: 'T1.1–T1.5 committed @ 9ae9c323; PR #867 OPEN; pending CI green + merge'
 - path: docs/sessions/S042-doks-cd-rollout/session-brief.md
   type: session-brief
   stage: 00-context
@@ -21695,7 +21740,7 @@ artifacts:
   created_at: '2026-08-05'
   updated_at: '2026-08-05'
   status: approved
-  note: 'E34-1..5=A,A,A,B,A; 01/02/04 completed; 07 in_progress awaiting commit'
+  note: 'E34-1..5=A,A,A,B,A; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN'
 - path: docs/sessions/S040-iwxxm-corpus-quality/reports/deploy-checklist.md
   kind: deploy-checklist
   session_id: S040-iwxxm-corpus-quality
@@ -31853,10 +31898,26 @@ evolve_cycles:
     Triggered after #845/#866 and manual one-shot rollout of 20260805003332-5245f8d.
     Deepen F30 — no new product Fn. Phase 0 locked E34-1..5 = A,A,A,B,A.
   branch: evolve/EV-034-doks-cd-rollout
-  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; 07 impl uncommitted; no commit SHA invented'
-  tip_sha: 5245f8de
-  tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
-  tip_note: 'branch HEAD @ 5245f8de (main tip / branch base); worktree dirty — 07 artifacts uncommitted; no new commit SHA'
+  branch_note: 'ACTIVE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
+  tip_sha: 9ae9c323
+  tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+  tip_note: 'tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
+  pr_number: 867
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+  pr_status: open
+  pr_title: '[EV-034] Automate DOKS image rollout in CD'
+  pr_base: main
+  pr_head: evolve/EV-034-doks-cd-rollout
+  pull_requests:
+  - id: PR-EV-034
+    number: 867
+    url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    title: '[EV-034] Automate DOKS image rollout in CD'
+    status: open
+    head: evolve/EV-034-doks-cd-rollout
+    base: main
+    tip_sha: 9ae9c323
+    note: '07 essentially complete; pending CI green + merge; EV-034 NOT completed'
   doks_baseline_tag: 20260805003332-5245f8d
   preset: Standard
   preset_status: approved
@@ -31887,7 +31948,7 @@ evolve_cycles:
     - 06-tech-tooling
     - 10-e2e
     optional_stages: []
-    note: 'Standard approved E34-1..5 — skip 03/05/06/10; 01/02/04 completed; 07 awaiting commit'
+    note: 'Standard approved E34-1..5 — skip 03/05/06/10; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN'
   current_stage: 07-build
   gates:
     a_to_b: passed
@@ -31910,7 +31971,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-08-05'
-      note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 in_progress awaiting commit+PR+user verify; 08 next after commit'
+      note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; 08 next after CI/merge'
     01-requirements:
       status: completed
       mode: delta
@@ -31933,8 +31994,15 @@ evolve_cycles:
       status: in_progress
       mode: full
       started: '2026-08-05'
-      note: 'IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; pending_commit; no commit SHA; 08 next after commit'
-      pending_commit: true
+      note: 'ESSENTIALLY COMPLETE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge/user verify; EV-034 NOT completed; 08 next after CI/merge; deepen F30'
+      pending_commit: false
+      tip_sha: 9ae9c323
+      tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+      commit_sha: 9ae9c323
+      commit_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+      pr_number: 867
+      pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+      pr_status: open
       artifacts:
       - scripts/deploy/doks_rollout_images.sh
       - .github/workflows/ci-cd.yml
@@ -31963,6 +32031,7 @@ evolve_cycles:
   - E34-5
   - D-S042-phase0
   notes:
+  - '2026-08-05 S042/EV-034 — recorded git commit 9ae9c323 (9ae9c3235d9380f493290ab318c0e0ecf5de2efa) [EV-034] feat: automate DOKS image rollout in CD after GHCR push; pushed; PR #867 OPEN; 07 essentially complete pending CI green + merge; EV-034 NOT completed; tip 9ae9c323; ahead_of_origin=0'
   - '2026-08-05 EV-034/S042 — Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; branch evolve/EV-034-doks-cd-rollout ACTIVE; tip base 5245f8de; no commit SHA invented; 08 next after commit'
   - '2026-08-05 EV-034/S042-doks-cd-rollout OPEN — Phase 0 intake after S041 lean-close + DOKS one-shot 20260805003332-5245f8d; Standard routing proposed pending approval; branch evolve/EV-034-doks-cd-rollout pending_create; S040 remains suspended (resume_after S042)'
   prior_session: S041-worker-poller-hardening
@@ -32507,13 +32576,13 @@ evolve_cycles:
 git_history:
   current_branch: evolve/EV-034-doks-cd-rollout
   ahead_of_origin: 0
-  pushed: false
-  pending_commit: true
-  pending_commit_note: 'S042/EV-034 07-build impl uncommitted (doks_rollout_images.sh, ci-cd.yml, tests, docs); no commit SHA invented; 08 after commit+PR'
+  pushed: true
+  pending_commit: false
+  pending_commit_note: 'cleared — 9ae9c323 pushed; this workflow-state sync may leave uncommitted dirty tree (parent may amend/follow-up)'
   dirty: true
-  tip_sha: 5245f8de
-  tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
-  tip_note: 'S042/EV-034 branch HEAD @ 5245f8de (base / main tip post #866); worktree dirty — 07 artifacts pending_commit; no new commit SHA'
+  tip_sha: 9ae9c323
+  tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+  tip_note: 'S042/EV-034 tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed; workflow-state sync dirty after this update'
   stash:
   - name: S039-EV031-WIP
     note: 'Parked EV-031/S039 dirty worktree WIP before cutting evolve/EV-032 from main (D-S040-branch=1)'
@@ -32525,9 +32594,10 @@ git_history:
   main_tip_sha: 5245f8de
   main_tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
   recommended_branch: evolve/EV-034-doks-cd-rollout
-  note: 'S042/EV-034 07-build — branch ACTIVE checked out; tip base 5245f8de; pending_commit (no SHA); S040 suspended resume_after S042; #846 parked'
+  note: 'S042/EV-034 07-build essentially complete @ 9ae9c323; PR #867 OPEN pending CI green + merge; EV-034 NOT completed; S040 suspended resume_after S042; #846 parked'
 
   notes:
+  - '2026-08-05 S042/EV-034 — recorded git commit 9ae9c323 (9ae9c3235d9380f493290ab318c0e0ecf5de2efa) [EV-034] feat: automate DOKS image rollout in CD after GHCR push; pushed; PR #867 OPEN; 07 essentially complete pending CI green + merge; EV-034 NOT completed; tip 9ae9c323; ahead_of_origin=0'
   - '2026-08-05 S042/EV-034 — Phase 0 locked E34-1..5=A,A,A,B,A; branch evolve/EV-034-doks-cd-rollout ACTIVE; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; deepen F30; tip base 5245f8de; no commit SHA invented; 08 next after commit'
   - '2026-08-05 S041/EV-033 LEAN-CLOSE D-S041-1+3 + open S042/EV-034 — 09–13 waived; DOKS one-shot 20260805003332-5245f8d recorded; EV-033 completed; branch evolve/EV-034-doks-cd-rollout pending_create; S040 resume_after S042; no CD workflow code this update'
   - '2026-08-04 S041/EV-033 — branch active from origin/main @ 769d3f83 (769d3f8360b2bd826360f3107ada1a6ae268db0d); current_stage 07-build; 01/02/04 completed (delta lean — scope in evolve-decisions; AskQuestion unavailable); artifacts poller_url.py + scripts/deploy/*poller* + prometheusrule + tests + README-worker-hardening; awaiting commit/PR/user verify; cycle NOT completed'
@@ -32971,12 +33041,16 @@ git_history:
     evolve_cycle_id: EV-034
     created: '2026-08-05'
     created_at: '2026-08-05'
-    tip_sha: 5245f8de
-    tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    tip_sha: 9ae9c323
+    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
     exists: true
-    pushed: false
+    pushed: true
     ahead_of_origin: 0
-    note: 'ACTIVE — created and checked out from main @ 5245f8de; tip still base (07 impl uncommitted); awaiting commit/PR/user verify'
+    pr_number: 867
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    pr_status: open
+    pr_title: '[EV-034] Automate DOKS image rollout in CD'
+    note: 'ACTIVE — tip 9ae9c323 pushed; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
   - name: evolve/EV-033-worker-poller-hardening
     purpose: 'S041/EV-033 F8 deepen — INGEST_POLLER_URL hardening (prevention 1–5 + code guard)'
     base: main
@@ -34023,6 +34097,47 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    short: 9ae9c323
+    branch: evolve/EV-034-doks-cd-rollout
+    message: '[EV-034] feat: automate DOKS image rollout in CD after GHCR push'
+    stage: 07-build
+    skill_id: 07-build
+    stages:
+    - 07-build
+    milestone: M1
+    task: T1.1-T1.5
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    files_changed:
+    - .github/workflows/ci-cd.yml
+    - deploy/doks/README.md
+    - docs/decisions/evolve-decisions.md
+    - docs/deploy.md
+    - docs/feature-list.md
+    - docs/sessions/README.md
+    - docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
+    - docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+    - docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
+    - docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+    - docs/sessions/S041-worker-poller-hardening/routing-plan.md
+    - docs/sessions/S041-worker-poller-hardening/session-brief.md
+    - docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+    - docs/sessions/S042-doks-cd-rollout/routing-plan.md
+    - docs/sessions/S042-doks-cd-rollout/session-brief.md
+    - docs/test-plan.md
+    - scripts/deploy/doks_rollout_images.sh
+    - tests/test_doks_cd_rollout_guard.py
+    - workflow-state.yaml
+    files_changed_count: 19
+    timestamp: '2026-08-05'
+    timestamp_utc: '2026-08-05T01:06:09Z'
+    pushed: true
+    tip_sha: 9ae9c323
+    ahead_of_origin: 0
+    pr_number: 867
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
+    note: '07-build essentially complete; PR #867 OPEN; pending CI green + merge; EV-034 NOT completed'
   - sha: fe024aac10077e365d65d0eccf12d8fb6288c9ec
     short: fe024aac
     branch: evolve/EV-032-iwxxm-corpus-quality

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,159 +3,301 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 41
-evolve_cycle_counter: 33
+session_counter: 42
+evolve_cycle_counter: 34
 active_session:
-  id: S041-worker-poller-hardening
+  id: S042-doks-cd-rollout
   type: feature
   intent: |
-    Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)
+    Automate DOKS image rollout in CD pipeline after main merge/GHCR push
+    (close gap where ci-cd.yml only Notes kubectl commands). Triggered after
+    #845/#866 and manual rollout of 20260805003332-5245f8d.
   status: in_progress
-  branch: evolve/EV-033-worker-poller-hardening
-  branch_note: created from origin/main @ 769d3f83; active; dirty worktree (docs+code+scripts) awaiting commit/PR
+  branch: evolve/EV-034-doks-cd-rollout
+  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; worktree dirty (07 impl uncommitted); no commit SHA invented'
   orchestrator: 16-evolve
-  evolve_cycle_id: EV-033
-  artifacts_dir: docs/sessions/S041-worker-poller-hardening/
-  prior_session: S040-iwxxm-corpus-quality
-  prior_session_note: 'S040/EV-032 SUSPENDED (not completed/cancelled) for S041 poller hardening; resume after S041 — was at 13-deploy-smoke / T4.5'
+  evolve_cycle_id: EV-034
+  artifacts_dir: docs/sessions/S042-doks-cd-rollout/
+  prior_session: S041-worker-poller-hardening
+  prior_session_note: 'S041/EV-033 lean-closed D-S041-1+3; S040/EV-032 remains suspended — resume after S042 (CD session), not auto-resume now'
   feature_ids: []
   deepen_feature_ids:
-  - F8
+  - F30
+  feature_note: 'Deepen F30 — automate DOKS set-image/rollout after GHCR push; no new Fn'
   preset: Standard
   preset_status: approved
-  route_status: approved_D-S041-open
+  route_status: approved_E34-1-5
   phase0_choices:
-    D-S041-open: proceed_1-5_plus_code
-    locked_at: '2026-08-04'
+    E34-1: A
+    E34-2: A
+    E34-3: A
+    E34-4: B
+    E34-5: A
+    locked_at: '2026-08-05'
     summary: |
-      User approved separate poller hardening via /16-evolve while S040 paused.
-      Scope: prevention items 1–5 + code guard (fail-closed scale, CI preflight,
-      docs default fixture URL, no stale Render copy, CrashLoop alert,
-      code rejects REPLACE_ME/non-https). AskQuestion unavailable — chat proceed.
+      Phase 0 locked E34-1..5 = A,A,A,B,A — Standard; API+FE+worker;
+      TIMESTAMP-SHA tags; KUBE_CONFIG secret; Render optional/non-blocking.
+      Path 00→16→01→02→04→07→08→09→11→12→13; skip 03/05/06; 10 optional.
   decisions:
-    D-S041-open: proceed_1-5_plus_code
+    E34-1: A
+    E34-2: A
+    E34-3: A
+    E34-4: B
+    E34-5: A
+    D-S042-phase0: locked_E34-1-5
   routing_plan:
   - stage: 00-context
     mode: scoped
     required: true
     status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    started: '2026-08-05'
+    completed: '2026-08-05'
     skip_rationale:
-    note: 'COMPLETE — open_session after S040 suspend; D-S041-open proceed 1-5 + code; Standard; handoff 16-evolve'
+    note: 'COMPLETE — open_session after S041 lean-close'
   - stage: 16-evolve
     required: true
     status: in_progress
-    started: '2026-08-04'
+    started: '2026-08-05'
     skip_rationale:
-    note: 'ORCHESTRATING — 07-build in_progress (docs+code+scripts); 01/02/04 delta lean complete; awaiting commit/PR/user verify'
+    note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 in_progress awaiting commit+PR+user verify; 08 next after commit'
   - stage: 01-requirements
     required: true
     mode: delta
     status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    started: '2026-08-05'
+    completed: '2026-08-05'
     skip_rationale:
-    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    note: 'COMPLETE (delta) — F30 deepen; feature-list/deploy/test-plan/evolve-decisions'
   - stage: 02-verify-plan
     required: true
     mode: delta
     status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    started: '2026-08-05'
+    completed: '2026-08-05'
     skip_rationale:
-    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    note: 'COMPLETE (delta) — Gate A; Standard path confirmed'
   - stage: 04-tech-plan
     required: true
     mode: delta
     status: completed
-    started: '2026-08-04'
-    completed: '2026-08-04'
+    started: '2026-08-05'
+    completed: '2026-08-05'
     skip_rationale:
-    note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
+    note: 'COMPLETE (delta) — Gate B; execution-plan T1.1–T1.5'
   - stage: 07-build
     required: true
+    mode: full
     status: in_progress
-    started: '2026-08-04'
+    started: '2026-08-05'
     skip_rationale:
-    note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+    note: 'IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; no commit SHA recorded; 08 next after commit'
+    pending_commit: true
   - stage: 08-verify-build
     required: true
+    mode: delta
     status: pending
     skip_rationale:
+    note: 'Next after 07 commit'
   - stage: 09-qa
     required: true
+    mode: delta
     status: pending
     skip_rationale:
   - stage: 10-e2e
-    required: true
-    status: pending
-    skip_rationale:
+    required: false
+    mode: smoke
+    status: skipped
+    skip_rationale: 'optional smoke — primary AC is pipeline→cluster image pin, not browser UJ'
   - stage: 11-verify-impl
     required: true
+    mode: delta
     status: pending
     skip_rationale:
   - stage: 12-verify-deploy
     required: true
+    mode: delta
     status: pending
     skip_rationale:
   - stage: 13-deploy-smoke
     required: true
+    mode: full
     status: pending
     skip_rationale:
   current_stage: 07-build
-  started_at: '2026-08-04'
-  started: '2026-08-04'
+  started_at: '2026-08-05'
+  started: '2026-08-05'
   context_briefs: []
   artifacts:
-  - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
+  - path: docs/sessions/S042-doks-cd-rollout/session-brief.md
     status: written
     stage: 00-context
-  - path: docs/sessions/S041-worker-poller-hardening/routing-plan.md
-    status: written
+  - path: docs/sessions/S042-doks-cd-rollout/routing-plan.md
+    status: approved
     stage: 00-context
-  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+  - path: docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
     status: written
+    stage: 04-tech-plan
+  - path: scripts/deploy/doks_rollout_images.sh
+    status: written_uncommitted
     stage: 07-build
-  - path: deploy/doks/README-worker-hardening.md
-    status: written
-    stage: 07-build
-  - path: apps/worker/src/metar_worker/poller_url.py
-    status: written
-    stage: 07-build
-  - path: scripts/deploy/validate_ingest_poller_url.py
-    status: written
-    stage: 07-build
-  - path: scripts/deploy/doks_worker_poller_preflight.sh
-    status: written
-    stage: 07-build
-  - path: scripts/deploy/check_worker_crashloop.sh
-    status: written
-    stage: 07-build
-  - path: deploy/doks/observability/prometheusrule-metar-worker.yaml
-    status: written
-    stage: 07-build
-  - path: apps/worker/tests/test_validate_ingest_poller_url.py
-    status: written
-    stage: 07-build
-  - path: tests/bugs/test_bug_2026_08_04_worker_placeholder_poller_url.py
-    status: written
+  - path: tests/test_doks_cd_rollout_guard.py
+    status: written_uncommitted
     stage: 07-build
   decision_refs:
-  - D-S041-open
+  - E34-1
+  - E34-2
+  - E34-3
+  - E34-4
+  - E34-5
+  - D-S042-phase0
   skipped:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-  note: 'IN_PROGRESS — S041/EV-033 at 07-build; branch active from origin/main @ 769d3f83; 01/02/04 delta lean complete; docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+  - 10-e2e
+  note: 'IN_PROGRESS — S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; branch evolve/EV-034-doks-cd-rollout ACTIVE (checked out); base tip 5245f8de; no commit SHA invented; 08 next after commit; S040 remains suspended (resume_after S042)'
 sessions:
+- id: S042-doks-cd-rollout
+  type: feature
+  intent: |
+    Automate DOKS image rollout in CD pipeline after main merge/GHCR push
+    (close gap where ci-cd.yml only Notes kubectl commands). Triggered after
+    #845/#866 and manual rollout of 20260805003332-5245f8d.
+  status: in_progress
+  branch: evolve/EV-034-doks-cd-rollout
+  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; 07 impl uncommitted'
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-034
+  feature_ids: []
+  deepen_feature_ids:
+  - F30
+  artifacts_dir: docs/sessions/S042-doks-cd-rollout/
+  prior_session: S041-worker-poller-hardening
+  prior_session_note: 'S041 lean-closed; S040 suspended resume_after S042'
+  preset: Standard
+  preset_status: approved
+  route_status: approved_E34-1-5
+  phase0_choices:
+    E34-1: A
+    E34-2: A
+    E34-3: A
+    E34-4: B
+    E34-5: A
+    locked_at: '2026-08-05'
+  decisions:
+    E34-1: A
+    E34-2: A
+    E34-3: A
+    E34-4: B
+    E34-5: A
+    D-S042-phase0: locked_E34-1-5
+  routing_plan:
+  - stage: 00-context
+    mode: scoped
+    required: true
+    status: completed
+    started: '2026-08-05'
+    completed: '2026-08-05'
+    skip_rationale:
+  - stage: 16-evolve
+    required: true
+    status: in_progress
+    started: '2026-08-05'
+    skip_rationale:
+    note: 'ORCHESTRATING — 01/02/04 done; 07 awaiting commit+PR'
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    completed: '2026-08-05'
+    skip_rationale:
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    completed: '2026-08-05'
+    skip_rationale:
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    completed: '2026-08-05'
+    skip_rationale:
+  - stage: 07-build
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-05'
+    skip_rationale:
+    note: 'Impl largely done; awaiting commit+PR+user verify; pending_commit'
+    pending_commit: true
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 09-qa
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 10-e2e
+    required: false
+    mode: smoke
+    status: skipped
+    skip_rationale: 'optional smoke — primary AC is pipeline→cluster'
+  - stage: 11-verify-impl
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 12-verify-deploy
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 13-deploy-smoke
+    required: true
+    mode: full
+    status: pending
+    skip_rationale:
+  current_stage: 07-build
+  started_at: '2026-08-05'
+  started: '2026-08-05'
+  artifacts:
+  - path: docs/sessions/S042-doks-cd-rollout/session-brief.md
+    status: written
+    stage: 00-context
+  - path: docs/sessions/S042-doks-cd-rollout/routing-plan.md
+    status: approved
+    stage: 00-context
+  - path: docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+    status: written
+    stage: 04-tech-plan
+  decision_refs:
+  - E34-1
+  - E34-2
+  - E34-3
+  - E34-4
+  - E34-5
+  - D-S042-phase0
+  skipped:
+  - 03-plan-tooling
+  - 05-verify-tech
+  - 06-tech-tooling
+  - 10-e2e
+  note: 'IN_PROGRESS — Phase 0 locked; 01/02/04 completed; 07 awaiting commit+PR; branch ACTIVE'
 - id: S041-worker-poller-hardening
   type: feature
   intent: |
     Harden F8 worker INGEST_POLLER_URL cutover (prevention 1-5 + code guard)
-  status: in_progress
-  branch: evolve/EV-033-worker-poller-hardening
-  branch_note: created from origin/main @ 769d3f83; active; dirty worktree awaiting commit/PR
+  status: completed
+  completed_at: '2026-08-05'
+  branch: main
+  branch_note: 'Checkout tip main @ 5245f8de (includes #865/#845/#866); feature tip 753bc94d; DOKS one-shot 20260805003332-5245f8d'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-033
   feature_ids: []
@@ -163,10 +305,10 @@ sessions:
   - F8
   artifacts_dir: docs/sessions/S041-worker-poller-hardening/
   prior_session: S040-iwxxm-corpus-quality
-  prior_session_note: 'S040/EV-032 SUSPENDED (not completed/cancelled) for S041; resume after S041 at 13-deploy-smoke / T4.5'
+  prior_session_note: 'S040/EV-032 remained suspended during S041; resume_after updated to S042'
   preset: Standard
   preset_status: approved
-  route_status: approved_D-S041-open
+  route_status: lean_closed_D-S041-1+3
   phase0_choices:
     D-S041-open: proceed_1-5_plus_code
     locked_at: '2026-08-04'
@@ -175,6 +317,8 @@ sessions:
       Scope: prevention items 1–5 + code guard. AskQuestion unavailable — chat proceed.
   decisions:
     D-S041-open: proceed_1-5_plus_code
+    D-S041-cd-defer: finish_S041_first
+    D-S041-1+3: lean_close_and_doks_oneshot
   routing_plan:
   - stage: 00-context
     mode: scoped
@@ -186,10 +330,11 @@ sessions:
     note: 'COMPLETE — open_session after S040 suspend; D-S041-open; handoff 16-evolve'
   - stage: 16-evolve
     required: true
-    status: in_progress
+    status: completed
     started: '2026-08-04'
+    completed: '2026-08-05'
     skip_rationale:
-    note: 'ORCHESTRATING — 07-build in_progress; 01/02/04 delta lean complete; awaiting commit/PR/user verify'
+    note: 'COMPLETE — lean-close D-S041-1+3; 09–13 waived; EV-033 completed; DOKS one-shot 20260805003332-5245f8d'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -216,37 +361,60 @@ sessions:
     note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
   - stage: 07-build
     required: true
-    status: in_progress
+    status: completed
     started: '2026-08-04'
+    completed: '2026-08-04'
     skip_rationale:
-    note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify'
+    note: 'COMPLETE — PR #865 MERGED into main @ 963a2777 (2026-08-04T23:47:16Z); tip feature 753bc94d'
   - stage: 08-verify-build
     required: true
-    status: pending
+    status: completed
+    started: '2026-08-04'
+    completed: '2026-08-04'
     skip_rationale:
+    note: 'COMPLETE PASS — format/lint/typecheck; 13 worker/bug + 6 CORS; PR #865 CI green; tip main @ 5245f8de; report verification-report.md; gates.c_to_d passed'
+    report: docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+    overall: pass
+    tip_sha: 5245f8de
   - stage: 09-qa
     required: true
-    status: pending
-    skip_rationale:
+    mode: delta
+    status: skipped
+    completed: '2026-08-05'
+    skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
   - stage: 10-e2e
     required: true
-    status: pending
-    skip_rationale:
+    mode: smoke
+    status: skipped
+    completed: '2026-08-05'
+    skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
   - stage: 11-verify-impl
     required: true
-    status: pending
-    skip_rationale:
+    mode: delta
+    status: skipped
+    completed: '2026-08-05'
+    skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
   - stage: 12-verify-deploy
     required: true
-    status: pending
-    skip_rationale:
+    mode: delta
+    status: skipped
+    completed: '2026-08-05'
+    skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
   - stage: 13-deploy-smoke
     required: true
-    status: pending
-    skip_rationale:
-  current_stage: 07-build
+    mode: full
+    status: skipped
+    completed: '2026-08-05'
+    skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred; deploy gate passed_via_ops via DOKS one-shot 20260805003332-5245f8d'
+  current_stage: 16-evolve
   started_at: '2026-08-04'
   started: '2026-08-04'
+  completed_at: '2026-08-05'
   artifacts:
   - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
     status: written
@@ -256,7 +424,13 @@ sessions:
     stage: 00-context
   - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
     status: written
-    stage: 07-build
+    stage: 16-evolve
+  - path: docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+    status: written
+    stage: 08-verify-build
+  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
+    status: written
+    stage: 16-evolve
   - path: deploy/doks/README-worker-hardening.md
     status: written
     stage: 07-build
@@ -283,11 +457,18 @@ sessions:
     stage: 07-build
   decision_refs:
   - D-S041-open
+  - D-S041-cd-defer
+  - D-S041-1+3
   skipped:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-  note: 'IN_PROGRESS — 07-build; branch active @ 769d3f83; 01/02/04 delta lean; awaiting commit/PR/user verify; cycle not complete'
+  - 09-qa
+  - 10-e2e
+  - 11-verify-impl
+  - 12-verify-deploy
+  - 13-deploy-smoke
+  note: 'COMPLETED — lean-close D-S041-1+3; 08 PASS; 09–13 waived; DOKS one-shot 20260805003332-5245f8d passed_via_ops; EV-033 completed; archived 2026-08-05'
 - id: S040-iwxxm-corpus-quality
   type: feature
   intent: |
@@ -298,9 +479,10 @@ sessions:
   paused_at: '2026-08-04'
   pause_reason: |
     User approved proceeding with separate F8 poller hardening via /16-evolve (S041/EV-033).
-    S040/EV-032 NOT completed or cancelled — resume at 13-deploy-smoke / T4.5 after S041.
+    S040/EV-032 NOT completed or cancelled — resume at 13-deploy-smoke / T4.5 after S042 (CD session); do not auto-resume now.
   suspended_for: S041-worker-poller-hardening
-  resume_after: S041-worker-poller-hardening
+  resume_after: S042-doks-cd-rollout
+  resume_after_note: 'Do not auto-resume S040 now — resume after S042/EV-034 CD session (or explicit user request)'
   resume_at_stage: 13-deploy-smoke
   resume_at_task: T4.5
   branch: evolve/EV-032-iwxxm-corpus-quality
@@ -528,7 +710,7 @@ sessions:
   - 03-plan-tooling
   - 05-verify-tech
   - 06-tech-tooling
-  note: 'SUSPENDED for S041/EV-033 worker-poller-hardening — was T4.5/13-deploy-smoke in_progress (D-S040-13=1); EV-032 remains in_progress (not cancelled); tip 22b4251b; PR #848; #846'
+  note: 'SUSPENDED — remains paused during S042/EV-034 CD DOKS automation; was T4.5/13-deploy-smoke in_progress (D-S040-13=1); EV-032 in_progress (not cancelled); resume_after S042-doks-cd-rollout (not auto-resume); tip 22b4251b; PR #848; #846'
 - id: S039-doks-dns-cutover
   type: ops
   intent: |
@@ -4464,18 +4646,18 @@ stages:
   01-requirements:
     status: completed
     mode: delta
-    started_at: '2026-08-04'
-    started: '2026-08-04'
-    completed_at: '2026-08-04'
-    completed: '2026-08-04'
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    prior_session_id: S038-platform-independence-842
-    prior_evolve_cycle_id: EV-031
-    prior_started: '2026-08-03'
-    prior_completed: '2026-08-03'
-    prior_note: 'S038/EV-031 01-requirements COMPLETE (delta) — D-S038-tp=1,1,1 lean docs accepted Gate A (D-S038-01-gate-a); commit fc3bbe5; gaps deferred to 04; handoff 02-verify-plan; #842/#830/#712'
-    note: 'S040/EV-032 01-requirements COMPLETE (delta) — D-S040-E32-M=2,3,1,1; F32 VONA + UJ-045 + product=vona; handoff 02; committed @ 0f3769af; #846'
+    started_at: '2026-08-05'
+    started: '2026-08-05'
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    prior_session_id: S040-iwxxm-corpus-quality
+    prior_evolve_cycle_id: EV-032
+    prior_started: '2026-08-04'
+    prior_completed: '2026-08-04'
+    prior_note: 'S040/EV-032 01-requirements COMPLETE (delta) — D-S040-E32-M=2,3,1,1; F32 VONA + UJ-045 + product=vona; handoff 02; committed @ 0f3769af; #846'
+    note: 'S042/EV-034 01-requirements COMPLETE (delta) — F30 deepen; feature-list/deploy/test-plan/evolve-decisions; no new Fn; handoff 02'
     substeps:
       interviews:
         status: completed
@@ -5235,18 +5417,18 @@ stages:
   02-verify-plan:
     status: completed
     mode: delta
-    started_at: '2026-08-04'
-    started: '2026-08-04'
-    completed_at: '2026-08-04'
-    completed: '2026-08-04'
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    prior_session_id: S038-platform-independence-842
-    prior_evolve_cycle_id: EV-031
-    prior_started: '2026-08-03'
-    prior_completed: '2026-08-03'
-    prior_note: 'COMPLETE (delta) — Gate A PASS (D-S038-02-phase-a); Batch C 1,1,1 (D-S038-02-batch-c); C1–C5 fixed; M1–M3 keep Proposed/draft; reports/verify-plan-audit.md; handoff 04-tech-plan; #842/#830/#712'
-    note: 'S040/EV-032 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S040-02-phase-a); Batch F 1,1,1,1 (D-S040-02-batch-f); reports/02-verify-plan-audit.md; handoff 04-tech-plan; #846/#847'
+    started_at: '2026-08-05'
+    started: '2026-08-05'
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    prior_session_id: S040-iwxxm-corpus-quality
+    prior_evolve_cycle_id: EV-032
+    prior_started: '2026-08-04'
+    prior_completed: '2026-08-04'
+    prior_note: 'S040/EV-032 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S040-02-phase-a); Batch F 1,1,1,1 (D-S040-02-batch-f); reports/02-verify-plan-audit.md; handoff 04-tech-plan; #846/#847'
+    note: 'S042/EV-034 02-verify-plan COMPLETE (delta) — Gate A PASS; Standard path confirmed; handoff 04-tech-plan'
     contradictions_resolved:
     contradictions_deferred:
     decision_refs:
@@ -5913,23 +6095,23 @@ stages:
   04-tech-plan:
     status: completed
     mode: delta
-    started_at: '2026-08-04'
-    started: '2026-08-04'
-    completed_at: '2026-08-04'
-    completed: '2026-08-04'
-    previous_started_at: '2026-08-03T18:31:51Z'
-    previous_completed_at: '2026-08-03'
-    previous_session_id: S038-platform-independence-842
-    previous_evolve_cycle_id: EV-031
-    previous_note: 'COMPLETE (delta) — Gate B PASS (D-S038-04-plan=1); ADR-033 Accepted; 38 tasks M0–M7; CI auto idempotent alembic; handoff 07 @ T0.1; #842/#830/#712'
-    prior_session_id: S038-platform-independence-842
-    prior_evolve_cycle_id: EV-031
-    prior_started: '2026-08-03'
-    prior_completed: '2026-08-03'
-    prior_note: 'COMPLETE (delta) — Gate B PASS (D-S038-04-plan=1); ADR-033 Accepted; 38 tasks M0–M7; CI auto idempotent alembic; handoff 07 @ T0.1; #842/#830/#712'
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    note: 'S040/EV-032 04-tech-plan COMPLETE (delta) — Gate B PASS (D-S040-04-plan=1); approve M0-M4 (28 tasks); handoff 07 @ T0.1; #846'
+    started_at: '2026-08-05'
+    started: '2026-08-05'
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
+    previous_started_at: '2026-08-04'
+    previous_completed_at: '2026-08-04'
+    previous_session_id: S040-iwxxm-corpus-quality
+    previous_evolve_cycle_id: EV-032
+    previous_note: 'S040/EV-032 04-tech-plan COMPLETE (delta) — Gate B PASS (D-S040-04-plan=1); approve M0-M4 (28 tasks); handoff 07 @ T0.1; #846'
+    prior_session_id: S040-iwxxm-corpus-quality
+    prior_evolve_cycle_id: EV-032
+    prior_started: '2026-08-04'
+    prior_completed: '2026-08-04'
+    prior_note: 'S040/EV-032 04-tech-plan COMPLETE (delta) — Gate B PASS (D-S040-04-plan=1); approve M0-M4 (28 tasks); handoff 07 @ T0.1; #846'
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    note: 'S042/EV-034 04-tech-plan COMPLETE (delta) — Gate B; execution-plan T1.1–T1.5; handoff 07-build'
     decision_refs:
     - D-S040-04-plan
     - D-S040-04-batch-2
@@ -7042,38 +7224,43 @@ stages:
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
     status: in_progress
-    started_at: '2026-08-04'
-    started: '2026-08-04'
+    started_at: '2026-08-05'
+    started: '2026-08-05'
     completed_at:
     completed:
-    previous_started_at: '2026-08-03'
-    previous_completed_at: '2026-08-03'
-    previous_session_id: S038-platform-independence-842
-    previous_evolve_cycle_id: EV-031
-    previous_tip_sha: 14661de0
-    previous_tip_sha_full: 14661de0a69a7e6deb243224c138a7575b97be22
-    previous_note: 'COMPLETE — T6.5 under D-S038-t65-waive; tip 14661de0'
-    prior_session_id: S038-platform-independence-842
-    prior_evolve_cycle_id: EV-031
-    prior_started: '2026-08-03'
-    prior_completed: '2026-08-03'
-    prior_note: 'COMPLETE — T6.5 under D-S038-t65-waive; tip 14661de0'
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    mode: delta
-    note: 'Phase D — T4.5 IN_PROGRESS; D-S040-13=1; tip 22b4251b; push+merge #848 → redeploy API+FE → H1–H5; gates.deploy in_progress; PR #848; ahead_of_origin=13; #846'
-    tip_sha: 22b4251b
-    tip_sha_full: 22b4251b93a1e7beba5d3d2b01dbd98898bc898e
-    tip_note: 'S040/EV-032 tip 22b4251b — T4.5 START D-S040-13=1; push+merge #848 → redeploy API+FE → H1–H5; progress 25/28; ahead_of_origin=13; PR #848; #846'
-    progress: 25/28
-    current_milestone: M4
-    current_task: T4.5
-    active_milestone: M4
-    active_task: T4.5
-    active_task_status: in_progress
-    next_stage: 13-deploy-smoke
-    next_task: T4.5
-    completed_through: T4.4
+    previous_started_at: '2026-08-04'
+    previous_completed_at:
+    previous_session_id: S040-iwxxm-corpus-quality
+    previous_evolve_cycle_id: EV-032
+    previous_tip_sha: 22b4251b
+    previous_tip_sha_full: 22b4251b93a1e7beba5d3d2b01dbd98898bc898e
+    previous_note: 'S040/EV-032 Phase D — T4.5 IN_PROGRESS (suspended resume_after S042); tip 22b4251b; PR #848; #846'
+    prior_session_id: S040-iwxxm-corpus-quality
+    prior_evolve_cycle_id: EV-032
+    prior_started: '2026-08-04'
+    prior_completed:
+    prior_note: 'S040/EV-032 Phase D — T4.5 IN_PROGRESS (suspended resume_after S042); tip 22b4251b; PR #848; #846'
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    mode: full
+    note: 'S042/EV-034 07-build IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; pending_commit; no commit SHA invented; 08 next after commit; deepen F30'
+    tip_sha: 5245f8de
+    tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    tip_note: 'S042/EV-034 branch HEAD @ 5245f8de (base); worktree dirty — 07 pending_commit; no new commit SHA'
+    pending_commit: true
+    next_stage: 08-verify-build
+    current_milestone: M1
+    current_task: T1.5
+    active_milestone: M1
+    active_task: T1.5
+    active_task_status: completed_pending_commit
+    completed_through: T1.5
+    progress: 5/5
+    next_task: null
+    suspended_s040_progress: 25/28
+    suspended_s040_completed_through: T4.4
+    suspended_s040_active_task: T4.5
+    suspended_s040_note: 'S040/EV-032 T4.5 was in_progress at tip 22b4251b / PR #848 — resume_after S042'
     t4_4_complete: true
     t4_4_pending_commit: false
     t4_4_sha: fe024aac
@@ -10571,140 +10758,17 @@ stages:
   16-evolve:
     status: in_progress
     mode: orchestrator
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    started_at: '2026-08-04'
-    started: '2026-08-04'
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    started_at: '2026-08-05'
+    started: '2026-08-05'
     completed_at:
     completed:
-    current_stage: 13-deploy-smoke
-    phase: 0
-    prior_session_id: S038-platform-independence-842
-    prior_evolve_cycle_id: EV-031
-    prior_completed: '2026-08-03'
-    prior_note: 'S038/EV-031 16-evolve CLOSED — D-S038-13=1; F30/F31 Done; provisional DOKS; residuals DNS/GHCR; active_session=null'
-    note: 'ORCHESTRATING — T4.5 IN_PROGRESS; D-S040-13=1; tip 22b4251b; push+merge #848 → redeploy API+FE → H1–H5; progress 25/28; current_stage 13-deploy-smoke; ahead_of_origin=13; PR #848; #846'
-    tip_sha: 22b4251b
-    tip_sha_full: 22b4251b93a1e7beba5d3d2b01dbd98898bc898e
-    tip_note: 'S040/EV-032 tip 22b4251b — T4.5 START D-S040-13=1; push+merge #848 → redeploy API+FE → H1–H5; progress 25/28; ahead_of_origin=13; PR #848; #846'
-    progress: 25/28
-    completed_through: T4.4
-    active_task: T4.5
-    active_task_status: in_progress
-    notes:
-    - '2026-08-04 S040/EV-032 — T4.5 START D-S040-13=1; push+merge #848 → main → redeploy API+FE → H1–H5; tip 22b4251b; current_stage 13-deploy-smoke; ahead_of_origin=13; PR #848; #846'
-    - '2026-08-04 S040/EV-032 — recorded git commit T4.4 @ fe024aac (fe024aac10077e365d65d0eccf12d8fb6288c9ec) [T4.4] docs: approve 11-verify-impl and ready 12 deploy checklist; tip fe024aac; pending_commit cleared; progress 25/28; completed_through T4.4; active_task T4.5 pending; current_stage 13-deploy-smoke; ahead_of_origin=12 pushed=false; PR #848; #846'
-    - '2026-08-04 S040/EV-032 — T4.4 COMPLETE; 11 approved; 12 ready; next T4.5; pending_commit; PR #848; #846'
-    - '2026-08-03 S038/EV-031 12-verify-deploy COMPLETE (D-S038-12=1) — mitigations+rollback approved; overall pass; handoff 13-deploy-smoke; tip b4feac02; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 09-qa + 10-e2e COMPLETE @ 06d57043; 11-verify-impl STARTED (delta); awaiting UI preview + F30/F31 approval; D-S038-phase-c; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 08-verify-build COMPLETE — C→D PASS @ 67a482a1; gates.c_to_d passed; 09-qa + 10-e2e STARTED parallel (delta); D-S038-phase-c; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 — D-S038-phase-c=1 Phase C checkpoint PASS; 08-verify-build STARTED (C→D gate, post-T6.5/M7); gates.c_to_d pending until 08 PASS; tip 2cb0e562; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build COMPLETE — T6.5 PASS under D-S038-t65-waive (Render API/FE/worker suspended; LIVE_* archived; prod.json+CI DOKS/GHCR-only); all M0–M7 tasks done 35/35; tip 14661de0; Phase C complete → Phase D (09→13); #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — D-S038-t65-waive confirmed; executing T6.5 Render decommission (soak waived day 0/7); progress 34/38; tip 93f960b4; #842/#830/#712'
-    - '2026-08-04 S038/EV-031 07-build — T7.4 COMPLETE (docs stubs) — evolve-summary.md, deploy-report.md, corpus-parity-note.md; M7 COMPLETE (T7.1–T7.4); only T6.5 remains open (blocked soak calendar); progress 34/38; tip f1e2389d; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T7.2 COMPLETE — H0c 6/6, H4 2/2, H5 PASS via make test-live-connectivity-doks-provisional; report docs/sessions/S038-platform-independence-842/reports/t7.2-h4-h5-connectivity-provisional.md; T6.5 still soak-calendar blocked; next T7.3; progress 32/38; tip f23d104c; D-S038-continue; #842/#830/#712'
-    - '2026-08-04 S038/EV-031 07-build — D-S038-t63-path=1 ops-first COMPLETE @ 6fd5518d (Alembic initContainer re-enabled+verified; GHCR backend:ev031-doks + backend:20260804-b83b6e54-sslfix; main-latest NOT overwritten; secrets restored; kustomization excludes secret-*.yaml); commits 909da43e→eb30ed0d→b83b6e54→72e93204→6fd5518d; T6.3 still pending (real DNS not available); progress 28/38; tip 6fd5518d; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — DOKS cluster smoke PASS (LB 168.144.12.70; API/FE/worker Running; Host-header 200); Supabase→DO migrate APPLY+VERIFY PASS (sessions 39, ingest 77, quarantine 2); Alembic initContainer temporarily disabled (main-latest lacks alembic; schema applied via laptop migrate @ 20260803_0001); T6.3 pending awaiting_user_decision (real DNS pin vs alembic image rebuild vs both); progress 28/38; tip 1826938c; report docs/sessions/S038-platform-independence-842/reports/doks-provision-cheapest-2026-08-03.md; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T6.2 COMPLETE @ 1826938c ([T6.2] config: Alembic upgrade initContainer on DOKS API deploy); progress 28/38; tip 1826938c; next T6.3 pending (pin DNS/LIVE_*/config/prod.json); active_task T6.3 pending; live Supabase→DO apply still needs MIGRATE_TARGET_DATABASE_URL; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T6.1 COMPLETE @ 20e5bb9e ([T6.1] docs tip; infra d5c165ff: add DOKS kustomize base for API FE worker); progress 27/38; tip 20e5bb9e; next T6.2 pending; active_task T6.2 pending; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build RESUMED — M5 08 PASS @ 7a2cb7d0; T6.1 in_progress (DOKS manifests/Helm/Blueprint) @ M6; progress 26/38 until T6.1 completes; next T6.2; tip 7a2cb7d0; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 08-verify-build COMPLETE (M5 boundary) PASS @ tip 7a2cb7d0; report docs/sessions/S038-platform-independence-842/reports/verification-report-M5.md; handoff 07-build @ T6.1 in_progress; progress 26/38 until T6.1 completes; next T6.2; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 08-verify-build STARTED (M5 boundary) @ tip e2e43a83; active_task T6.1 pending (after 08); progress 26/38; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T5.4 COMPLETE @ e2e43a83 ([T5.4] test: post-migrate session CRUD and Auth-only Supabase); M5 COMPLETE (T5.1–T5.4); progress 26/38; tip e2e43a83; next 08-verify-build at M5 boundary then M6 T6.1; active_task T6.1 pending (after 08); 08-verify-build in_progress; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T5.4 STARTED (Post-migrate session CRUD against DO); active_task T5.4 in_progress; progress 25/38 until complete; tip 42179df3; prior T5.3 COMPLETE @ 42179df3; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T5.3 COMPLETE @ 42179df3 ([T5.3] feat: migrate Supabase→DO with dry-run and apply); next T5.4 @ M5; progress 25/38; tip 42179df3; live apply gated on MIGRATE_TARGET_DATABASE_URL (DO) — .env DATABASE_URL still Supabase pooler; D-S038-continue; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T5.2 COMPLETE @ 7bde343c ([T5.2] feat: verify Supabase→DO row counts and sample checksums); next T5.3 @ M5; progress 24/38; tip 7bde343c; commits c5f2bfc8→7bde343c; ahead=32 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — D-S038-continue resume @ T5.2 in_progress (verify script row counts/checksum @ M5); progress 23/38 until complete; tip c5f2bfc8; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T5.1 COMPLETE @ c5f2bfc8 ([T5.1] docs: finalize Supabase→DO table/column migration map); M4 COMPLETE + 08 PASS (@ 04fb4a98 verification-report-M4); next T5.2 @ M5; progress 23/38; tip c5f2bfc8; commits 389a3b24→04fb4a98→c5f2bfc8; ahead=31 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T4.5 COMPLETE @ 389a3b24 ([T4.5] config: Auth bootstrap contract and DOKS FE CORS placeholder); M4 COMPLETE (T4.1–T4.5); next 08-verify-build at M4 boundary then M5 T5.1; progress 22/38; tip 389a3b24; commits a44c3a40→389a3b24; ahead=29 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T4.4 COMPLETE @ a44c3a40 ([T4.4] feat: gate guest IndexedDB and disclose Auth cookies (F22)); T4.5 in_progress (/config.json Auth bootstrap + CORS) @ M4; progress 21/38; tip a44c3a40; commits 588b87c4→a44c3a40; ahead=28 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T4.3 COMPLETE @ 588b87c4 ([T4.3] feat: auto-upload local drafts on login; server session lists (F31)); next T4.4 F22 deepen privacy gates @ M4; progress 20/38; tip 588b87c4; commits 0dbd45bc→588b87c4; ahead=27 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T4.2 COMPLETE @ 0dbd45bc ([T4.2] feat: restore optional Auth FE client and login UX (F31)); next T4.3 Auto-upload eligible local drafts on login @ M4; progress 19/38; tip 0dbd45bc; commits 8f770ba5→0dbd45bc; ahead=26 not pushed; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — D-S038-continue resume @ T4.2 in_progress (restore optional Auth FE client @ M4); progress 18/38 until T4.2 completes; tip 8f770ba5; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T4.1 COMPLETE @ 8f770ba5 (guest notice/auto-upload/privacy gates TC-F31-002..005); next T4.2 restore optional Auth FE client @ M4; progress 18/38; tip 8f770ba5; commits c75b262f→8f770ba5; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — M3 COMPLETE (T3.1–T3.3) @ 9f8684fd→426eb92d; next T4.1 FE hybrid @ M4; progress 17/38; tip 426eb92d; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — M2 COMPLETE (T2.1–T2.6) @ 013d6a1→eaba4fb3; next T3.1 F8 worker Postgres tests @ M3; progress 14/38; tip eaba4fb3; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T2.1–T2.3 COMPLETE @ 013d6a1→a108b58; next T2.4 work-sessions API CRUD + JWT gate tests @ M2; progress 11/38; tip a108b58; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — T2.1 STARTED @ M2 (Alembic tests in_progress); M1 COMPLETE (T1.1–T1.4); progress 8/38; tip 323ee35; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 07-build — M1 COMPLETE (T1.1–T1.4); next T2.1 Alembic tests @ M2; progress 8/38; tip 2227c95; commits da0d2ad→2227c95; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 — D-S038-04-b2=1,1,1(+CI),1 Batches 1–2 locked (placeholder DOKS DNS; 7d soak; pg_dump+verify; CI auto idempotent alembic upgrade head; ADR-020 wire; ADR-033 accept at Gate B); execution-plan.md drafted (38 tasks M0–M7); Gate B pending (D-S038-04-plan); 04 remains in_progress; tip 6b7fd0e; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 — D-S038-04-b1=1,2,1,1 Batch 1 locked (M0–M7; JWKS-only; Alembic apps/backend; restore packages/auth c9cebfa^ strip admin); 04 remains in_progress; Batch 2 pending; tip 6b7fd0e; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 — D-S038-01-gate-a=1; 01 COMPLETE @ fc3bbe5 → 02-verify-plan in_progress; lean docs accepted Gate A; gaps deferred to 04; #842/#830/#712'
-    - '2026-08-03 S038/EV-031 — D-S038-tp=1,1,1; Test Plan TC-F30/F31/EV031 + lean standing docs drafted; 01 remains in_progress pending Gate A / lean-doc acceptance → 02-verify-plan; #842/#830/#712'
-    - '2026-08-03 S037/EV-030 — T4.1 COMPLETE (08-verify-build M3 PASS @ 1f47eb5); T3.3 fix pushed; CI 30823368642 SUCCESS; report verification-report-m3.md; active_task → T4.2 pending; progress 23/27; #831→#835'
-    - '2026-08-03 S037/EV-030 — T4.1 COMPLETE (08-verify-build M3 PASS @ 1f47eb5); T3.3 fix pushed; CI 30823368642 SUCCESS; D-S037-ui-preview=2 confirmed; H4–H5 still required at M4/13; progress 23/27; active_task → T4.2 pending @ M4; semver AskQuestion pending D-S037-semver-tac2iwxxm (tac2iwxxm 0.2.3 decode deepen); workflow-state dirty pending chore sync; PR #832 open; #831→#835'
-    - '2026-08-03 S037/EV-030 — T3.1 COMPLETE @ 00bb58f ([T3.1] test: VAA/TCA decode residual baseline inventory (#820)); tip may include 0c46df2 FIXTURE_GAPS fix after M2; M2 push CI run 30818578657 SUCCESS (https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/30818578657); FE catalog unlock shipped — UI preview AskQuestion pending (written interview; AskQuestion tool unavailable); active_task → T3.2 pending @ M3; progress 19/27; tip 00bb58f; workflow-state dirty pending chore sync; #831→#820'
-    - '2026-08-03 S037/EV-030 — M2 COMPLETE (T2.1–T2.6) @ aa8dc89; 08-verify-build M2 PASS (verification-report-m2.md); #829 closed; child #835 opened (A6-2-TC equality); PR #832 updated (PR-M2); active_task → T3.1 pending @ M3; progress 18/27; tip aa8dc89; #831→#820'
-    - '2026-08-03 S037/EV-030 — T2.4 COMPLETE @ 9f7c087 ([T2.4] feat: unlock sigmet-A6-2-TC catalog as wmoReference (#829)); active_task → T2.5 in_progress (FE catalog / Examples Vitest path smoke); progress 16/27; tip 9f7c087; PR-M1 #832 open; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T2.3 COMPLETE @ 22d4ac1 ([T2.3] docs: TC SIGMET STNR in-cycle; exceptional geometry OOS cite D-S037-T2.3-oos / S02.M2; report t2.3-tc-geometry-oos.md); D-S037-semver-none confirmed; active_task → T2.4 pending (A6-2-TC catalog unlock); progress 15/27; tip 22d4ac1; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — D-S037-semver-none (option 1) — no tac-validate semver bump (remain 0.1.1); bump deferred M2/M4 if needed; T2.3 in_progress (STNR covered in pack; exceptional TC geometry beyond WI…OF TC CENTRE → OOS cite S02.M2); tip e322dde may still be pushing; progress 14/27; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T2.2 COMPLETE @ 72c4be6 ([T2.2] feat: TC SIGMET lint codes TC_CYCLONE_IDENTITY / TC_CB_GEOMETRY / MISSING_TC_IDENTITY + catalog); PR #832 will update on push; M1 CI was green at b713056; active_task → T2.3 pending (STNR / exceptional geometry or OOS cite); progress 14/27; tip 72c4be6 ahead to push; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T2.1 COMPLETE @ b713056 ([T2.1] test: TC SIGMET tac-validate accept/negative pack (#829) / TC-EV030-004); PR #832 CI green (ci-cd run 30815192608 SUCCESS) at tip before T2.1 push; T2.1 ahead to push; active_task → T2.2 in_progress (Registry + fixtures for TC lint codes); progress 13/27; tip b713056; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — PR-M1 #832 OPEN (https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/832); M1 08 PASS; starting M2 T2.1 in_progress (#829 TC SIGMET pack); tip 1e22416 (will move); #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — D-S037-08-m1-pass — 08-verify-build M1 PASS @ tip 0151e11; report docs/sessions/S037-quality-residuals-831/reports/verification-report-m1.md; current_stage → 07-build; about to push + open PR-M1 then M2 T2.1; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — 08-verify-build STARTED at M1 boundary; M1 T1.1–T1.8 complete @ tip 0151e11; before minor PR then M2; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T1.3 COMPLETE @ ce27667 (36×20 lint pilot; 39 pass/718 skip); next T1.4 convert pilot; progress 7/27; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T1.2 COMPLETE @ cab174d (runners + skip policy; 34 passed); next T1.3 lint pilot; progress 6/27; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — T1.1 COMPLETE @ 6294557 (YAML/JSON loader + schema; 25 passed); next T1.2 runners; progress 5/27; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — 07-build M1 T1.1 in_progress (shared YAML/JSON loader + case schema tests); tip bdb87ad; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — D-S037-04-plan=1 Gate B PASS; 04 COMPLETE → 07-build; M0 COMPLETE (T0.1–T0.4); next T1.1; tip 80b1b49; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — D-S037-04-batch-2 (2,1,1,1) Batch 2 locked; execution-plan.md draft (27 tasks); Gate B pending; 04 remains in_progress; #831→#829→#820'
-    - '2026-08-03 S037/EV-030 — D-S037-04-batch-1 (1,1,1,1) Batch 1 locked; Batch 2 next; 04 remains in_progress; #831→#829→#820'
-    - '2026-08-02 S037/EV-030 D-S037-E30-M (2,1) — lean + API/catalog #829; 01 COMPLETE → 02-verify-plan in_progress; sha pending parent commit; #831→#829→#820'
-    - '2026-08-02 S037/EV-030 D-S037-fn (1,1,1) — F29 + deepen F23/F12/F2/F13/F9/F26/F27; start 01-requirements (delta); commit open; #831→#829→#820'
-    - '2026-08-02 S037/EV-030 16-evolve STARTED — D-S037-route (1) Standard; 00 COMPLETE; Phase 1 Fn allocation; EV-030 created; #831→#829→#820'
-    - '2026-08-02 S035/EV-028 CLOSED — Phase 4 close D-S035-EV028-phase4-close option 1; PR #824 @ 70312dd; #825 closeout MERGED @ 8086664; #781 closed; active_session=null'
-    - '2026-08-01 S035/EV-028 PR #824 MERGED @ 70312dd — T3.5 COMPLETE; 07/08/10/13 COMPLETE; #781 closed; main CI 30727796614 SUCCESS; Phase 4 closeout docs + AskQuestion pending; #781'
-    - '2026-08-01 S035/EV-028 T3.5 PR #824 OPEN — CI/CD green @ 30727406104; tip a6db427; pushed; ahead_of_origin=0; awaiting merge approval to close #781; #781'
-    - '2026-08-01 S035/EV-028 T3.5 STARTED @ bf9f48c — push evolve branch + open/update PR for #781 closeout; ahead 3; #781'
-    - '2026-08-01 S035/EV-028 T3.1+T3.2 COMPLETE @ 305658f — verify-build PASS (lint/typecheck/package+native tests; no codecov); packaging smoke PASS (landings); reports t31-verify-build.md + t32-packaging-smoke.md; next T3.5 PR closeout; branch ahead 2 of origin; #781'
-    - '2026-08-01 S035/EV-028 T3.4 docs committed @ 3efcb8d — smoke report + plan sync; T3.1 STARTED (lint/typecheck/tests + no codecov); then T3.2; #781'
-    - '2026-08-01 S035/EV-028 T3.4 COMPLETE (D-S035-14d) — clean-venv PyPI smoke PASS: tac-validate==0.1.1, iwxxm-validate==0.1.2 (rust_available+XSD ok), tac2iwxxm==0.1.1; report t34-pypi-install-smoke.md; next T3.5 (T3.1/T3.2 plan catch-up pending); tip 84aca02 (+ pending docs commit); #781'
-    - '2026-08-01 S035/EV-028 T3.4 STARTED (D-S035-14d) — skip cosmetic 0.1.3; clean-venv pip install smoke @ iwxxm-validate==0.1.2; tip 84aca02; #781'
-    - '2026-08-01 S035/EV-028 T3.3b COMPLETE (D-S035-14c) — 57c8dad; tag iwxxm-validate-v0.1.2; PyPI 30726416585 SUCCESS; next T3.4; #781'
-    - '2026-08-01 S035/EV-028 T3.3 OIDC 0.1.1 ×3 SUCCESS (D-S035-14a); T3.3b in_progress (D-S035-14b-scope) — native AIXM fix → iwxxm-validate 0.1.2; tip 465ac4f (unpushed docs) + WIP AIXM; #781'
-    - '2026-08-01 S035/EV-028 04 COMPLETE → 07-build STARTED — D-S035-04-plan-approve Gate B (11b/12a); @ T0.1; tip b8e37ae; #781'
-    - '2026-08-01 S035/EV-028 02 COMPLETE → 04-tech-plan STARTED — D-S035-02-phase-a Gate A PASS; D-S035-E28-S21 UJ-023; tip 19e547a; #781'
-    - '2026-08-01 S035/EV-028 01 COMPLETE → 02-verify-plan STARTED — D-S035-E28-M (7a) + D-S035-E28-E1 (8a); #781'
-    - '2026-08-01 S035/EV-028 D-S035-routing — Lean+build approved (5a); 6b bump/publish tac-validate+iwxxm-validate+tac2iwxxm 0.1.1 OIDC; 00 COMPLETE; 16 in_progress → 01-requirements; #781'
-    - '2026-08-01 S035/EV-028 00-context — branch active; session-brief in_progress; routing-plan pending_approval; #781'
-    - '2026-08-01 S035/EV-028 OPEN — create_evolve_cycle; D-S035-open (1b/2a/3b/4b); current_stage 00-context; branch evolve/EV-028-empiric2-ops-leftovers-781; #781'
-    - '2026-07-31 S034/EV-027 CLOSED — Phase 4 close D-S034-EV027-phase4-close option 1; PR #821 @ ad36aa0; #822 closeout MERGED @ 9ff0157; #815 closed; #820 open; 13 waived; active_session=null'
-    - '2026-07-31 S034/EV-027 PR #821 MERGED @ ad36aa0 (D-S034-merge=1,1) — T3.3 COMPLETE; 07 COMPLETE 14/14; #815 closed; #820 open; 13 waived; Phase 4 closeout pending'
-    - '2026-07-31 S032/EV-025 CLOSED — D-S032-EV025-phase4-close; PR #816 merged 2412312; T7.3/13 waived; #809 equality residual → next cycle'
-    - '2026-07-31 S032/EV-025 PR #816 open — https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/816; await merge'
-    - 2026-07-31 S032/EV-025 closeout=1 (D-S032-EV025-closeout); T7.3/13 deferred until API ships; PR opening; awaiting merge to close EV-025; progress 27/28
-    - 2026-07-31 S032/EV-025 T7.2 COMPLETE @ 1e46b38; 08-verify-build + 10-e2e smoke PASS; next T7.3 when ships / PR closeout; progress 27/28
-    - '2026-07-31 S032/EV-025 T7.2 COMPLETE 08+10 PASS; Gate C encode PASS; tip 1e46b38; next T7.3/13 when ships or open PR; progress 27/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T7.1 COMPLETE Gate C dig PASS @ 8bfb1b2; next T7.2 08+10; progress 26/28; 07-build nearly complete — 08-verify-build should start soon; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 M5 COMPLETE (T5.1–T5.3 #809 soft→reference); tip 5f941e7; next T6.1; progress 21/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T5.1 in_progress (#809 soft-compare TC-EV025-008); tip e9330e3; progress 18/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.7 COMPLETE @ c1a503f (Lane A dig encode PASS); M4 done; next T5.1 pending (#809 soft-compare); tip c1a503f; progress 18/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.6 COMPLETE @ 5d80611; T4.7 in_progress (Lane A dig checklist refresh); tip 5d80611; progress 17/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.6 in_progress (Addendum residuals + RecentWeather); tip 4230257; progress 16/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.5 COMPLETE (MaxMinTemperatures + ProcessedProperty + ObservingSystem) @ 07d73e3 — next T4.6 pending (Addendum residuals + RecentWeather); tip 07d73e3; progress 16/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.5 STARTED — MaxMinTemperatures + ProcessedProperty/statistical + ObservingSystem; tip 30d37a1; progress 15/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.4 COMPLETE (VariableCeilingHeight / VariableSky / VariableVisibility) @ 30d37a1 — next T4.5 MaxMinTemperatures + ProcessedProperty / statistical + ObservingSystem codelists; progress 15/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.4 STARTED — VariableCeilingHeight / VariableSky / VariableVisibility; tip e4a0383; progress 14/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.3 COMPLETE (Sector / Obscurations / SecondLocation / TowerVisibility) @ e4a0383 — next T4.4 VariableCeilingHeight / VariableSky / VariableVisibility; progress 14/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.3 STARTED — Sector / Obscurations / SecondLocation / TowerVisibility; tip cc3c40f; progress 13/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.2 COMPLETE (CharacterOfTheSky / convective clouds / HailstoneSize) @ cc3c40f — next T4.3 Sector / Obscurations / SecondLocation / TowerVisibility; progress 13/28; commits bfd8659/cc3c40f; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.1 COMPLETE (AerodromeWindShift / TC-EV025-004) @ bfd8659 — PeakWind already ✅ (no deepen); next T4.2 CharacterOfTheSky / CloudTypes / ConvectiveCloud* / HailstoneSize; progress 12/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T4.1 in_progress (AerodromeWindShift / TC-EV025-004); M3 done tip 0a268d3; progress 11/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 M3 COMPLETE (T3.1–T3.3 #812 SnowIncrease/sensors) — tip 2e25a37; next T4.1 AerodromeWindShift; progress 11/28; commits 2b51859/d4a6421/55fce51/2e25a37; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 M2 COMPLETE (T2.1–T2.3 #811 Lightning/VOP) — tip 5ebc70b; next T3.1 #812 SnowIncrease/sensors; progress 8/28; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 T2.1 in_progress (#811 Lightning/VOP red goldens TC-EV025-002); M0+M1 done tip 9d1e49a; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 M1 COMPLETE (T1.1–T1.3 @ 9d1e49a) — next T2.1 #811 Lightning/VOP; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 M0 COMPLETE (T0.1+T0.2 @ f1e19a9/02f8b4d) — next T1.1; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 Gate B=1 (D-S032-04-plan-approve) — 04 COMPLETE → 07 @ T0.1; M0 theme map + dig audit; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 04 Batch T locked 1,1,2,1,3,1 — draft execution-plan 28 tasks; Gate B pending (b_to_c still pending); T5 supersedes S02.M2; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 02-verify-plan COMPLETE (D-S032-02-phase-a) — PASS; Batch F 1,1,1; 12 auto; Gate A Lean → 04-tech-plan; report docs/sessions/S032-iwxxm-us-remarks-va/reports/02-verify-plan-audit.md; #810/#811/#812/#809'
-    - 'S032/EV-025 01-requirements COMPLETE 2026-07-31 (delta) — E25-E1=1; deepen F6/F12/F2/F13/F23; D-S032-E25-E1; report docs/sessions/S032-iwxxm-us-remarks-va/reports/01-requirements.md; handoff 02-verify-plan; #810/#811/#812/#809; advance 02-verify-plan in_progress'
-    - '2026-07-31 S032/EV-025 02-verify-plan STARTED (delta) — docs/sessions/S032-iwxxm-us-remarks-va/reports/02-verify-plan-audit.md; D-S032-E25-E1; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 01-requirements STARTED (delta) — pending E25-E1 AskQuestion; artifacts: reports/01-requirements.md + feature-list/user-journeys/test-plan + requirements-decisions; UJ-040/041 + TC-EV025; deepen F6/F12/F2/F13/F23; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 00-context COMPLETE — Phase 0 locked E25-*; artifacts written; handoff 01-requirements; #810/#811/#812/#809'
-    - '2026-07-31 S032/EV-025 OPEN — Phase 0 intake E25-1=1, E25-2=1, E25-3=1, E25-4b=2 + E25-4c=3, E25-ui=1 (D-S032-E25-phase0); Lean+build; awaiting 00 exit; #810/#811/#812/#809'
-    - '2026-07-30 S031/EV-024 COMPLETE — Phase 4 close D-S031-merge-close; PR #813 864783e; 13 PASS; #804/#807/#773'
+    previous_session_id: S041-worker-poller-hardening
+    previous_evolve_cycle_id: EV-033
+    previous_completed_at: '2026-08-05'
+    current_child_stage: 07-build
+    note: 'S042/EV-034 Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build in_progress awaiting commit+PR+user verify; branch ACTIVE; 08 next after commit; S040 remains suspended (resume_after S042)'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -10730,11 +10794,12 @@ deployment:
     t0_journeys_passed: 4
   staging:
     status: 'deployed (public DNS + TLS)'
-    last_verified: '2026-08-04'
-    commit_deployed: b4feac02
-    commit_deployed_full: b4feac0221b6f77a3156582ac53ca45c4f75527a
-    commit_head: b4feac02
-    commit_head_full: b4feac0221b6f77a3156582ac53ca45c4f75527a
+    last_verified: '2026-08-05'
+    commit_deployed: 5245f8de
+    commit_deployed_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    commit_head: 5245f8de
+    commit_head_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    doks_tag: 20260805003332-5245f8d
     drift: false
     platform: doks
     namespace: metar-iwxxm
@@ -10750,9 +10815,10 @@ deployment:
     session_id: S039-doks-dns-cutover
     evolve_cycle_id: EV-031
     images:
-      api: ghcr.io/empiric2/tac-to-iwxxm/backend:ev031-doks
-      frontend: ghcr.io/empiric2/tac-to-iwxxm/frontend:ev031-doks
-      note: 'S039 CLOSED D-S039-15=1; DOKS public HTTPS api|app; tip b4feac02; 15-service-health completed'
+      api: ghcr.io/empiric2/tac-to-iwxxm/backend:20260805003332-5245f8d
+      frontend: ghcr.io/empiric2/tac-to-iwxxm/frontend:20260805003332-5245f8d
+      worker: ghcr.io/empiric2/tac-to-iwxxm/worker:20260805003332-5245f8d
+      note: 'DOKS one-shot 2026-08-05 ~00:49Z tag 20260805003332-5245f8d (Deploy run 30963357296); set-image api/frontend/worker ns metar-iwxxm; S041 lean-close'
     health_tiers:
       H0ci: pass
       H0c: pass
@@ -10773,6 +10839,7 @@ deployment:
       topology: pass_3_of_3
       host_header: pass_5_of_5
     notes:
+    - '2026-08-05 DOKS one-shot rollout COMPLETE ~00:49Z — tag `20260805003332-5245f8d` (CI Deploy run 30963357296 / #866 merge tip 5245f8de); set image metar-api, metar-frontend, metar-worker in ns metar-iwxxm; rollouts successful; live verify: /health 200; OpenAPI has /auth/login+/auth/me; POST /auth/login→422; GET /auth/me→401; logs show metar_auth /auth router successfully; S041 lean-close D-S041-1+3; CD automation → S042/EV-034'
     - '2026-08-04 S039 CLOSED D-S039-15=1 — 15-service-health COMPLETE; H0ci+H1–H5+Auth login PASS; D-S038-t63-waive lifted; public HTTPS; report service-health.md; active_session=null; #842/#712'
     - '2026-08-04 S039 15-service-health formal PASS pending D-S039-15 — H0ci main CI green https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/30828890624; H1/H3/H4/H5 + Auth site_url + login 200; report service-health.md; #842/#712'
     - '2026-08-04 S039 D-S039-13=1 approved — 13-deploy-smoke COMPLETE; health_tiers H0c/H1/H3/H4/H5 stay pass; handoff 15-service-health; #842/#712'
@@ -10965,6 +11032,68 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S042-phase0
+  date: '2026-08-05'
+  timestamp: '2026-08-05T01:00:00Z'
+  resolved_at: '2026-08-05'
+  session_id: S042-doks-cd-rollout
+  evolve_cycle_id: EV-034
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: phase0
+  status: confirmed
+  topic: 'Phase 0 lock E34-1..5 — Standard DOKS CD rollout'
+  summary: |
+    Phase 0 locked E34-1..5 = A,A,A,B,A — Standard routing; API+FE+worker
+    rollout; TIMESTAMP-SHA image tags; KUBE_CONFIG secret; Render optional.
+  decision: |
+    E34-1=A Standard; E34-2=A API+FE+worker; E34-3=A TIMESTAMP-SHA;
+    E34-4=B KUBE_CONFIG; E34-5=A Render optional/non-blocking.
+    Deepen F30; no new Fn. Path 00→16→01→02→04→07→08→09→11→12→13;
+    skip 03/05/06/10.
+  user_option: A,A,A,B,A
+  branch: evolve/EV-034-doks-cd-rollout
+  tip_sha: 5245f8de
+  related_decisions:
+  - E34-1
+  - E34-2
+  - E34-3
+  - E34-4
+  - E34-5
+  note: 'Routing approved; 01/02/04 completed; 07 awaiting commit — recorded by workflow-state-manager update'
+- id: D-S041-1+3
+  date: '2026-08-05'
+  timestamp: '2026-08-05T00:49:00Z'
+  resolved_at: '2026-08-05'
+  session_id: S041-worker-poller-hardening
+  evolve_cycle_id: EV-033
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: lean_close
+  status: confirmed
+  topic: Lean-close S041 (waive 09–13) and one-shot DOKS rollout, then open CD session
+  summary: |
+    User chose Decision 1+3: lean-close S041 (waive 09–13) AND one-shot DOKS
+    rollout now, then open CD session (S042/EV-034).
+  decision: |
+    D-S041-1+3=lean_close_and_doks_oneshot — Waive 09-qa/10-e2e/11-verify-impl/
+    12-verify-deploy/13-deploy-smoke; mark EV-033/16-evolve completed; record DOKS
+    one-shot 20260805003332-5245f8d as passed_via_ops; open S042 for CD/DOKS automation.
+    Keep S040/EV-032 suspended (resume_after S042); do not auto-resume S040.
+  user_option: '1+3'
+  branch: main
+  tip_sha: 5245f8de
+  doks_tag: 20260805003332-5245f8d
+  related_prs:
+  - '865'
+  - '866'
+  - '845'
+  related_decisions:
+  - D-S041-open
+  - D-S041-cd-defer
+  note: 'Supersedes finish-through-13 path from D-S041-cd-defer for remaining Phase D depth'
 - id: D-S041-open
   date: '2026-08-04'
   timestamp: '2026-08-04T23:31:10Z'
@@ -21525,6 +21654,48 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
+  type: session-report
+  kind: evolve-summary
+  stage: 16-evolve
+  skill_id: 16-evolve
+  session_id: S041-worker-poller-hardening
+  evolve_cycle_id: EV-033
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: completed
+  note: 'S041/EV-033 lean-close summary D-S041-1+3'
+- path: docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+  type: execution-plan
+  kind: execution-plan
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S042-doks-cd-rollout
+  evolve_cycle_id: EV-034
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: written
+  note: 'T1.1–T1.5 completed in working tree; awaiting commit'
+- path: docs/sessions/S042-doks-cd-rollout/session-brief.md
+  type: session-brief
+  stage: 00-context
+  skill_id: 00-context
+  session_id: S042-doks-cd-rollout
+  evolve_cycle_id: EV-034
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: written
+  note: 'Phase 0 locked; deepen F30'
+- path: docs/sessions/S042-doks-cd-rollout/routing-plan.md
+  type: routing-plan
+  stage: 00-context
+  skill_id: 00-context
+  session_id: S042-doks-cd-rollout
+  evolve_cycle_id: EV-034
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: approved
+  note: 'E34-1..5=A,A,A,B,A; 01/02/04 completed; 07 in_progress awaiting commit'
 - path: docs/sessions/S040-iwxxm-corpus-quality/reports/deploy-checklist.md
   kind: deploy-checklist
   session_id: S040-iwxxm-corpus-quality
@@ -31663,39 +31834,40 @@ evolve_cycles:
   pr_number: 845
   pr_status: open
   pr_head: evolve/EV-031-platform-independence-842
-- id: EV-033
-  session_id: S041-worker-poller-hardening
+- id: EV-034
+  session_id: S042-doks-cd-rollout
   cycle_type: feature
   feature_ids: []
   deepen_feature_ids:
-  - F8
-  feature_id: F8
-  feature_note: F8 deepen — INGEST_POLLER_URL cutover hardening (prevention 1–5 + code guard)
-  title: F8 worker INGEST_POLLER_URL poller hardening
-  slug: worker-poller-hardening
+  - F30
+  feature_note: F30 deepen — DOKS CD image rollout automation; no new Fn
+  title: Automate DOKS image rollout in CD
+  slug: doks-cd-rollout
   status: in_progress
-  phase: 0
-  started: '2026-08-04'
-  started_at: '2026-08-04'
+  phase: 2
+  started: '2026-08-05'
+  started_at: '2026-08-05'
   scope_summary: |
-    Harden F8 metar-worker INGEST_POLLER_URL cutover:
-    (1) fail-closed scale when poller URL unset/placeholder;
-    (2) CI preflight for worker poller URL;
-    (3) docs default fixture URL (no REPLACE_ME as runnable default);
-    (4) no stale Render copy of poller URL guidance;
-    (5) CrashLoop alert when worker dies on bad poller URL;
-    plus code guard rejecting REPLACE_ME / non-https poller URLs.
-    Separate from S040/EV-032 (suspended, not cancelled). Standard routing.
-  branch: evolve/EV-033-worker-poller-hardening
-  branch_note: created from origin/main @ 769d3f83; active; dirty worktree awaiting commit/PR
-  tip_sha: 769d3f83
-  tip_sha_full: 769d3f8360b2bd826360f3107ada1a6ae268db0d
-  tip_note: 'branch base tip = origin/main @ 769d3f83; implementation uncommitted'
+    Automate DOKS image rollout in the CD pipeline after main merge / GHCR push.
+    Close the gap where ci-cd.yml only Notes kubectl set-image/rollout commands.
+    Triggered after #845/#866 and manual one-shot rollout of 20260805003332-5245f8d.
+    Deepen F30 — no new product Fn. Phase 0 locked E34-1..5 = A,A,A,B,A.
+  branch: evolve/EV-034-doks-cd-rollout
+  branch_note: 'ACTIVE — created and checked out; tip base 5245f8de; 07 impl uncommitted; no commit SHA invented'
+  tip_sha: 5245f8de
+  tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+  tip_note: 'branch HEAD @ 5245f8de (main tip / branch base); worktree dirty — 07 artifacts uncommitted; no new commit SHA'
+  doks_baseline_tag: 20260805003332-5245f8d
   preset: Standard
   preset_status: approved
   phase0_choices:
-    D-S041-open: proceed_1-5_plus_code
-    locked_at: '2026-08-04'
+    E34-1: A
+    E34-2: A
+    E34-3: A
+    E34-4: B
+    E34-5: A
+    locked_at: '2026-08-05'
+    summary: 'Standard; API+FE+worker; TIMESTAMP-SHA; KUBE_CONFIG; Render optional'
   routing_plan:
     required_stages:
     - 00-context
@@ -31706,7 +31878,6 @@ evolve_cycles:
     - 07-build
     - 08-verify-build
     - 09-qa
-    - 10-e2e
     - 11-verify-impl
     - 12-verify-deploy
     - 13-deploy-smoke
@@ -31714,7 +31885,9 @@ evolve_cycles:
     - 03-plan-tooling
     - 05-verify-tech
     - 06-tech-tooling
-    note: Standard — skip 03/05/06 unless 04 surfaces new deps/tooling
+    - 10-e2e
+    optional_stages: []
+    note: 'Standard approved E34-1..5 — skip 03/05/06/10; 01/02/04 completed; 07 awaiting commit'
   current_stage: 07-build
   gates:
     a_to_b: passed
@@ -31731,13 +31904,159 @@ evolve_cycles:
     00-context:
       status: completed
       mode: scoped
+      started: '2026-08-05'
+      completed: '2026-08-05'
+      note: 'COMPLETE — open_session; Phase 0 later locked E34-1..5'
+    16-evolve:
+      status: in_progress
+      started: '2026-08-05'
+      note: 'ORCHESTRATING — Phase 0 locked; 01/02/04 completed; 07 in_progress awaiting commit+PR+user verify; 08 next after commit'
+    01-requirements:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      completed: '2026-08-05'
+      note: 'COMPLETE (delta) — F30 deepen; feature-list/deploy/test-plan/evolve-decisions'
+    02-verify-plan:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      completed: '2026-08-05'
+      note: 'COMPLETE (delta) — Gate A'
+    04-tech-plan:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      completed: '2026-08-05'
+      note: 'COMPLETE (delta) — Gate B; execution-plan T1.1–T1.5'
+    07-build:
+      status: in_progress
+      mode: full
+      started: '2026-08-05'
+      note: 'IN_PROGRESS — impl largely done (doks_rollout_images.sh, ci-cd.yml DOKS+optional Render, test_doks_cd_rollout_guard.py 3 passed, docs); awaiting commit+PR+user verify; pending_commit; no commit SHA; 08 next after commit'
+      pending_commit: true
+      artifacts:
+      - scripts/deploy/doks_rollout_images.sh
+      - .github/workflows/ci-cd.yml
+      - tests/test_doks_cd_rollout_guard.py
+      - docs/feature-list.md
+      - docs/deploy.md
+      - docs/test-plan.md
+      - deploy/doks/README.md
+      - docs/decisions/evolve-decisions.md
+      - docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+  adrs: []
+  artifacts:
+  - path: docs/sessions/S042-doks-cd-rollout/session-brief.md
+    status: written
+  - path: docs/sessions/S042-doks-cd-rollout/routing-plan.md
+    status: approved
+  - path: docs/sessions/S042-doks-cd-rollout/reports/execution-plan.md
+    status: written
+    stage: 04-tech-plan
+  issues: []
+  decision_refs:
+  - E34-1
+  - E34-2
+  - E34-3
+  - E34-4
+  - E34-5
+  - D-S042-phase0
+  notes:
+  - '2026-08-05 EV-034/S042 — Phase 0 locked E34-1..5=A,A,A,B,A; deepen F30; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; branch evolve/EV-034-doks-cd-rollout ACTIVE; tip base 5245f8de; no commit SHA invented; 08 next after commit'
+  - '2026-08-05 EV-034/S042-doks-cd-rollout OPEN — Phase 0 intake after S041 lean-close + DOKS one-shot 20260805003332-5245f8d; Standard routing proposed pending approval; branch evolve/EV-034-doks-cd-rollout pending_create; S040 remains suspended (resume_after S042)'
+  prior_session: S041-worker-poller-hardening
+  prior_evolve_cycle_id: EV-033
+- id: EV-033
+  session_id: S041-worker-poller-hardening
+  cycle_type: feature
+  feature_ids: []
+  deepen_feature_ids:
+  - F8
+  feature_id: F8
+  feature_note: F8 deepen — INGEST_POLLER_URL cutover hardening (prevention 1–5 + code guard)
+  title: F8 worker INGEST_POLLER_URL poller hardening
+  slug: worker-poller-hardening
+  status: completed
+  completed: '2026-08-05'
+  completed_at: '2026-08-05'
+  phase: 4
+  started: '2026-08-04'
+  started_at: '2026-08-04'
+  scope_summary: |
+    Harden F8 metar-worker INGEST_POLLER_URL cutover:
+    (1) fail-closed scale when poller URL unset/placeholder;
+    (2) CI preflight for worker poller URL;
+    (3) docs default fixture URL (no REPLACE_ME as runnable default);
+    (4) no stale Render copy of poller URL guidance;
+    (5) CrashLoop alert when worker dies on bad poller URL;
+    plus code guard rejecting REPLACE_ME / non-https poller URLs.
+    Separate from S040/EV-032 (suspended, not cancelled). Standard routing.
+    Lean-closed D-S041-1+3 (waive 09–13; DOKS one-shot passed_via_ops).
+  branch: main
+  branch_note: 'Checkout tip main @ 5245f8de (includes #865/#845/#866); feature tip 753bc94d; merge #865 @ 963a2777; DOKS tag 20260805003332-5245f8d'
+  tip_sha: 5245f8de
+  tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+  tip_note: 'lean-close tip main @ 5245f8de; DOKS one-shot 20260805003332-5245f8d'
+  feature_tip_sha: 753bc94d
+  feature_tip_sha_full: 753bc94d50e3f0af7dcc60e9a1cfa0c3db1c32ea
+  doks_tag: 20260805003332-5245f8d
+  doks_deploy_run: '30963357296'
+  preset: Standard
+  preset_status: approved
+  phase0_choices:
+    D-S041-open: proceed_1-5_plus_code
+    D-S041-1+3: lean_close_and_doks_oneshot
+    locked_at: '2026-08-04'
+  routing_plan:
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 04-tech-plan
+    - 07-build
+    - 08-verify-build
+    skipped_stages:
+    - 03-plan-tooling
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 09-qa
+    - 10-e2e
+    - 11-verify-impl
+    - 12-verify-deploy
+    - 13-deploy-smoke
+    note: 'Lean-close D-S041-1+3 — waive 09–13; lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+  current_stage: 16-evolve
+  gates:
+    a_to_b: passed
+    b_to_c: passed
+    c_to_d: passed
+    deploy: passed_via_ops
+    deploy_note: 'passed_via_ops — DOKS one-shot 20260805003332-5245f8d (~00:49Z 2026-08-05); live /health+auth verify'
+    deploy_decision_id: D-S041-1+3
+  checkpoints:
+    phase_a: passed
+    phase_b: passed
+    phase_c: passed
+    phase_d: waived
+    deploy: passed_via_ops
+    phase_d_note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    phase_d_decision_id: D-S041-1+3
+    deploy_note: 'passed_via_ops — DOKS one-shot 20260805003332-5245f8d'
+    deploy_decision_id: D-S041-1+3
+  stages:
+    00-context:
+      status: completed
+      mode: scoped
       started: '2026-08-04'
       completed: '2026-08-04'
       note: 'COMPLETE — open_session; D-S041-open; handoff 16-evolve'
     16-evolve:
-      status: in_progress
+      status: completed
       started: '2026-08-04'
-      note: 'ORCHESTRATING — 07-build in_progress; docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+      completed: '2026-08-05'
+      note: 'COMPLETE — lean-close D-S041-1+3; EV-033 completed; handoff S042/EV-034'
     01-requirements:
       status: completed
       mode: delta
@@ -31757,9 +32076,45 @@ evolve_cycles:
       completed: '2026-08-04'
       note: 'delta lean — scope in evolve-decisions; AskQuestion unavailable'
     07-build:
-      status: in_progress
+      status: completed
       started: '2026-08-04'
-      note: 'IN_PROGRESS — docs+code+scripts implemented; awaiting commit/PR/user verify; cycle not complete'
+      completed: '2026-08-04'
+      note: 'COMPLETE — PR #865 MERGED into main @ 963a2777 (2026-08-04T23:47:16Z); tip feature 753bc94d'
+    08-verify-build:
+      status: completed
+      started: '2026-08-04'
+      completed: '2026-08-04'
+      mode: evolve_delta
+      overall: pass
+      tip_sha: 5245f8de
+      report: docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+      note: 'COMPLETE PASS — format/lint/typecheck; 13 worker/bug + 6 CORS; PR #865 CI green; tip main @ 5245f8de; gates.c_to_d passed'
+    09-qa:
+      status: skipped
+      completed: '2026-08-05'
+      skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+      note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    10-e2e:
+      status: skipped
+      completed: '2026-08-05'
+      skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+      note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    11-verify-impl:
+      status: skipped
+      completed: '2026-08-05'
+      skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+      note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    12-verify-deploy:
+      status: skipped
+      completed: '2026-08-05'
+      skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+      note: 'WAIVED — lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+    13-deploy-smoke:
+      status: skipped
+      completed: '2026-08-05'
+      skip_rationale: 'lean close D-S041-1+3; live worker/API verified via one-shot DOKS rollout; remaining AC depth deferred'
+      overall: passed_via_ops
+      note: 'WAIVED formal 13; passed_via_ops via DOKS one-shot 20260805003332-5245f8d'
   adrs: []
   artifacts:
   - path: docs/sessions/S041-worker-poller-hardening/session-brief.md
@@ -31767,6 +32122,10 @@ evolve_cycles:
   - path: docs/sessions/S041-worker-poller-hardening/routing-plan.md
     status: written
   - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-progress.md
+    status: written
+  - path: docs/sessions/S041-worker-poller-hardening/reports/verification-report.md
+    status: written
+  - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
     status: written
   - path: deploy/doks/README-worker-hardening.md
     status: written
@@ -31787,11 +32146,18 @@ evolve_cycles:
   issues: []
   decision_refs:
   - D-S041-open
+  - D-S041-cd-defer
+  - D-S041-1+3
   notes:
-  - '2026-08-04 S041/EV-033 — 07-build IN_PROGRESS; branch active from origin/main @ 769d3f83; 01/02/04 completed (delta lean — scope in evolve-decisions; AskQuestion unavailable); docs+code+scripts + poller_url/scripts/prometheusrule/tests; awaiting commit/PR/user verify; cycle NOT completed'
-  - '2026-08-04 S041/EV-033 OPEN — D-S041-open proceed 1-5 + code; S040/EV-032 suspended (not cancelled); branch pending create; tip n/a'
+  - '2026-08-05 S041/EV-033 LEAN-CLOSE D-S041-1+3 — 09–13 waived; gates.deploy passed_via_ops (DOKS one-shot 20260805003332-5245f8d); 16-evolve+EV-033 completed; archived; open S042/EV-034'
+  - '2026-08-05 DOKS one-shot rollout COMPLETE ~00:49Z — tag `20260805003332-5245f8d` (CI Deploy run 30963357296 / #866 merge tip 5245f8de); set image metar-api, metar-frontend, metar-worker in ns metar-iwxxm; rollouts successful; live verify: /health 200; OpenAPI has /auth/login+/auth/me; POST /auth/login→422; GET /auth/me→401; logs show metar_auth /auth router successfully; S041 lean-close D-S041-1+3; CD automation → S042/EV-034'
+  - '2026-08-04 S041/EV-033 — 08-verify-build COMPLETE PASS @ tip 5245f8de; PR #865 CI green; gates.c_to_d passed'
+  - '2026-08-04 S041/EV-033 — 07-build COMPLETE; PR #865 MERGED @ 963a2777; D-S041-cd-defer then superseded by D-S041-1+3 lean-close'
+  - '2026-08-04 S041/EV-033 OPEN — D-S041-open proceed 1-5 + code; S040/EV-032 suspended'
   prior_session: S040-iwxxm-corpus-quality
   prior_evolve_cycle_id: EV-032
+  close_decision_id: D-S041-1+3
+  evolve_summary: docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
 - id: EV-032
   session_id: S040-iwxxm-corpus-quality
   cycle_type: feature
@@ -31807,10 +32173,12 @@ evolve_cycles:
   slug: iwxxm-corpus-quality
   status: in_progress
   session_status: suspended
-  session_suspended_for: S041-worker-poller-hardening
+  session_suspended_for: S042-doks-cd-rollout
+  resume_after: S042-doks-cd-rollout
   session_suspend_note: |
-    S040 active_session cleared for S041; EV-032 cycle NOT cancelled —
-    resume S040 at 13-deploy-smoke / T4.5 after S041 closes.
+    S040 remains suspended during S042/EV-034 CD DOKS automation; EV-032 cycle
+    NOT cancelled — resume at 13-deploy-smoke / T4.5 after S042 (or explicit user
+    request). Do not auto-resume now. Prior suspend was for S041 (lean-closed).
   phase: 0
   started: '2026-08-04'
   started_at: '2026-08-04'
@@ -32137,15 +32505,15 @@ evolve_cycles:
   - '2026-08-04 S040/EV-032 — D-S040-route=1 Standard approved; D-S040-branch=1 cut from main (do not carry EV-031 dirty worktree); 00-context completing; scoped brief docs/context/iwxxm-corpus-quality-846.md; #846/#835/#741/#808; exclude #836'
   - '2026-08-04 S040/EV-032 OPEN — open_session; D-S040-open=1,1,1,1; session_counter 40; evolve_cycle_counter 32; branch evolve/EV-032-iwxxm-corpus-quality (pending create); 00-context in_progress; #846/#835/#741/#808; exclude #836'
 git_history:
-  current_branch: evolve/EV-032-iwxxm-corpus-quality
-  ahead_of_origin: 12
+  current_branch: evolve/EV-034-doks-cd-rollout
+  ahead_of_origin: 0
   pushed: false
-  pending_commit: false
-  pending_commit_note: null
-  dirty: false
-  tip_sha: fe024aac
-  tip_sha_full: fe024aac10077e365d65d0eccf12d8fb6288c9ec
-  tip_note: 'S040/EV-032 tip fe024aac (fe024aac10077e365d65d0eccf12d8fb6288c9ec) [T4.4] docs: approve 11-verify-impl and ready 12 deploy checklist; pending_commit cleared; progress 25/28; completed_through T4.4; active_task T4.5 pending / 13-deploy-smoke; ahead_of_origin=12 pushed=false; PR #848; #846'
+  pending_commit: true
+  pending_commit_note: 'S042/EV-034 07-build impl uncommitted (doks_rollout_images.sh, ci-cd.yml, tests, docs); no commit SHA invented; 08 after commit+PR'
+  dirty: true
+  tip_sha: 5245f8de
+  tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+  tip_note: 'S042/EV-034 branch HEAD @ 5245f8de (base / main tip post #866); worktree dirty — 07 artifacts pending_commit; no new commit SHA'
   stash:
   - name: S039-EV031-WIP
     note: 'Parked EV-031/S039 dirty worktree WIP before cutting evolve/EV-032 from main (D-S040-branch=1)'
@@ -32154,12 +32522,14 @@ git_history:
     date: '2026-08-04'
   main_merge_sha: 8bd111c
   main_merge_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
-  main_tip_sha: 7c4522a
-  main_tip_sha_full: 7c4522aecdc8a6bd195c3e7517894be876f5c63b
-  recommended_branch: evolve/EV-033-worker-poller-hardening
-  note: 'S041/EV-033 at 07-build — recommended_branch evolve/EV-033-worker-poller-hardening active from origin/main @ 769d3f83; dirty awaiting commit/PR; S040 tip remains on evolve/EV-032-iwxxm-corpus-quality; #846 parked'
+  main_tip_sha: 5245f8de
+  main_tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+  recommended_branch: evolve/EV-034-doks-cd-rollout
+  note: 'S042/EV-034 07-build — branch ACTIVE checked out; tip base 5245f8de; pending_commit (no SHA); S040 suspended resume_after S042; #846 parked'
 
   notes:
+  - '2026-08-05 S042/EV-034 — Phase 0 locked E34-1..5=A,A,A,B,A; branch evolve/EV-034-doks-cd-rollout ACTIVE; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; deepen F30; tip base 5245f8de; no commit SHA invented; 08 next after commit'
+  - '2026-08-05 S041/EV-033 LEAN-CLOSE D-S041-1+3 + open S042/EV-034 — 09–13 waived; DOKS one-shot 20260805003332-5245f8d recorded; EV-033 completed; branch evolve/EV-034-doks-cd-rollout pending_create; S040 resume_after S042; no CD workflow code this update'
   - '2026-08-04 S041/EV-033 — branch active from origin/main @ 769d3f83 (769d3f8360b2bd826360f3107ada1a6ae268db0d); current_stage 07-build; 01/02/04 completed (delta lean — scope in evolve-decisions; AskQuestion unavailable); artifacts poller_url.py + scripts/deploy/*poller* + prometheusrule + tests + README-worker-hardening; awaiting commit/PR/user verify; cycle NOT completed'
   - '2026-08-04 S041/EV-033 OPEN — open_session; D-S041-open proceed_1-5_plus_code; session_counter 41; evolve_cycle_counter 33; S040/EV-032 SUSPENDED (not completed/cancelled) for S041; branch evolve/EV-033-worker-poller-hardening pending create; 00-context completed → 16-evolve in_progress; F8 deepen; no git branch/commit by workflow-state-manager'
   - 'S040/EV-032 — recorded git commit T4.4 @ fe024aac (fe024aac10077e365d65d0eccf12d8fb6288c9ec) [T4.4] docs: approve 11-verify-impl and ready 12 deploy checklist; tip fe024aac; pending_commit cleared; active_task T4.5 pending @ M4 / 13-deploy-smoke; progress 25/28; ahead_of_origin=12 pushed=false dirty=false; PR #848; #846'
@@ -32591,6 +32961,22 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-034-doks-cd-rollout
+    status: active
+    base: main
+    base_sha: 5245f8de
+    base_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    purpose: S042/EV-034 automate DOKS image rollout in CD after GHCR push
+    session_id: S042-doks-cd-rollout
+    evolve_cycle_id: EV-034
+    created: '2026-08-05'
+    created_at: '2026-08-05'
+    tip_sha: 5245f8de
+    tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
+    exists: true
+    pushed: false
+    ahead_of_origin: 0
+    note: 'ACTIVE — created and checked out from main @ 5245f8de; tip still base (07 impl uncommitted); awaiting commit/PR/user verify'
   - name: evolve/EV-033-worker-poller-hardening
     purpose: 'S041/EV-033 F8 deepen — INGEST_POLLER_URL hardening (prevention 1–5 + code guard)'
     base: main


### PR DESCRIPTION
## Summary
- After GHCR push on `main`, Deploy pins DOKS `metar-api` / `metar-frontend` / `metar-worker` to the immutable `TIMESTAMP-SHA` tag via `scripts/deploy/doks_rollout_images.sh` (Actions secret `KUBE_CONFIG`).
- Render deploy hooks become optional / non-blocking (`continue-on-error`); missing Render hooks no longer fail Deploy.
- Deepens F30 with **TC-F30-007**; records S041 lean-close + S042 / EV-034 session docs.

## Test plan
- [x] `tests/test_doks_cd_rollout_guard.py` (3)
- [x] BUG-2026-08-03 Render hook regression still green
- [x] Pre-push `validate-ci` + unit matrix
- [ ] CI green on PR branch
- [ ] After merge: Deploy job rolls DOKS (confirm cluster images match new tag); live `/auth/login` + `/health`
- [ ] Confirm repo secret `KUBE_CONFIG` is set (already applied from local DOKS kubeconfig)

## Spec
- [Corpus: product] F30 AC7 · [Corpus: tests] TC-F30-007 · evolve-decisions §EV-034 (`E34-1..5`)


Made with [Cursor](https://cursor.com)