### PR TITLE
[EV-034] fix: static KUBE_CONFIG (no doctl)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -578,11 +578,16 @@ jobs:
           fi
           mkdir -p "${HOME}/.kube"
           # Secret is base64-encoded kubeconfig (docs/deploy.md §CD — DOKS image rollout).
+          # Must be static SA/token auth — doctl exec plugins fail on GHA runners.
           if ! printf '%s' "${KUBE_CONFIG}" | base64 --decode > "${HOME}/.kube/config" 2>/dev/null; then
             echo "::error::KUBE_CONFIG is not valid base64"
             exit 1
           fi
           chmod 600 "${HOME}/.kube/config"
+          if grep -qE 'command:[[:space:]]*doctl' "${HOME}/.kube/config"; then
+            echo "::error::KUBE_CONFIG uses doctl exec auth; use a ServiceAccount token kubeconfig (docs/deploy.md)"
+            exit 1
+          fi
           bash scripts/deploy/doks_rollout_images.sh "${IMAGE_TAG}"
 
       - name: CD skipped (credentials)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -64,9 +64,11 @@ On push to `main`, the **Deploy** job in `.github/workflows/ci-cd.yml`:
 
 | Actions secret | Required | Description |
 |----------------|----------|-------------|
-| `KUBE_CONFIG` | **Yes** (main Deploy) | Base64-encoded kubeconfig with rights to mutate Deployments in `metar-iwxxm`. Missing ⇒ Deploy fails (fail-closed). |
+| `KUBE_CONFIG` | **Yes** (main Deploy) | Base64-encoded kubeconfig with rights to mutate Deployments in `metar-iwxxm`. Must use a **static** credential (ServiceAccount token or client cert) — **not** a DigitalOcean `doctl` exec plugin (runners do not have `doctl`). Missing ⇒ Deploy fails (fail-closed). |
 
 Encode: `base64 -w0 <kubeconfig.yaml>` (macOS: `base64 -i kubeconfig.yaml | tr -d '\n'`).
+
+Recommended: SA `github-actions-deploy` in `metar-iwxxm` with Role patch/get/list/watch on Deployments (+ get/list/watch Pods for rollout status).
 
 **F21 Amended / F31**: Optional Auth restored via `packages/auth`. Convert remains public.
 F8 worker runs on DOKS.

--- a/tests/test_doks_cd_rollout_guard.py
+++ b/tests/test_doks_cd_rollout_guard.py
@@ -24,6 +24,8 @@ def test_ci_cd_deploy_rolls_doks_with_kube_config() -> None:
     assert "Roll out DOKS images" in text
     # Fail-closed on missing kubeconfig
     assert "Missing required secret KUBE_CONFIG" in text
+    # Reject doctl exec plugins (GHA runners lack doctl)
+    assert "doctl exec auth" in text
 
 
 def test_ci_cd_render_hooks_are_optional_non_blocking() -> None:


### PR DESCRIPTION
## Summary
- Main Deploy after #867 failed on **Roll out DOKS images**: kubeconfig used `doctl` exec auth (`executable doctl not found`).
- Repo secret `KUBE_CONFIG` rotated to a **ServiceAccount token** kubeconfig (`github-actions-deploy` in `metar-iwxxm`).
- Workflow now rejects doctl exec configs; docs updated.

## Test plan
- [x] Guard tests
- [ ] Re-run of failed Deploy on #867 merge run succeeds
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)