### PR TITLE
[EV-036] Local pre-commit long jobs / slim remote CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,48 +24,11 @@ env:
   FRONTEND_VITE_API_BASE_URL: https://api.tac-to-iwxxm.com
 
 jobs:
-  # ============================================================================
-  # VALIDATE — format, lint, typecheck, secrets, yaml, config-guard, npm audit
-  # ============================================================================
-  validate:
-    runs-on: ubuntu-latest
-    name: Validate
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          cache: pnpm
-
-      - name: Install JavaScript dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run validate gates
-        run: make validate-ci
-
+  # EV-036: remote validate job removed — lint/format/config on local pre-commit.
+  # Unit matrix + coverage remain; Compose integration is local pre-push only.
   test:
     runs-on: ubuntu-latest
     name: Test (${{ matrix.package }})
-    needs: [validate]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +42,6 @@ jobs:
             iwxxm-validate,
             tac-validate,
             dissemination,
-            integration,
             bugs,
           ]
 
@@ -125,6 +87,7 @@ jobs:
         run: |
           uv run pytest packages/shared/tests --cov=metar_shared \
             --cov-config=packages/shared/pyproject.toml --cov-branch \
+            --cov-report=xml:packages/shared/coverage.xml \
             --cov-report=term-missing --cov-fail-under=98 -v
           pnpm --filter @metar/shared run test:coverage
 
@@ -152,6 +115,7 @@ jobs:
         run: |
           uv run pytest packages/tac2iwxxm/tests --cov=tac2iwxxm \
             --cov-config=packages/tac2iwxxm/pyproject.toml --cov-branch \
+            --cov-report=xml:packages/tac2iwxxm/coverage.xml \
             --cov-report=term-missing --cov-fail-under=95 -v
 
       - name: Install Rust toolchain (iwxxm-validate native)
@@ -173,6 +137,7 @@ jobs:
         run: |
           uv run pytest packages/iwxxm-validate/tests --cov=iwxxm_validate \
             --cov-config=packages/iwxxm-validate/pyproject.toml --cov-branch \
+            --cov-report=xml:packages/iwxxm-validate/coverage.xml \
             --cov-report=term-missing --cov-fail-under=95 -v
 
       - name: Run tac-validate unit tests with coverage
@@ -180,6 +145,7 @@ jobs:
         run: |
           uv run pytest packages/tac-validate/tests --cov=tac_validate \
             --cov-config=packages/tac-validate/pyproject.toml --cov-branch \
+            --cov-report=xml:packages/tac-validate/coverage.xml \
             --cov-report=term-missing --cov-fail-under=95 -v
 
       # F16–F19 / T0.1 — skips until packages/dissemination is scaffolded (T1.1/T1.2).
@@ -200,41 +166,19 @@ jobs:
         if: matrix.package == 'bugs'
         run: uv run pytest tests/bugs -m "not live and not live_api" --no-cov -v
 
-      - name: Set integration stack environment
-        if: matrix.package == 'integration'
-        run: |
-          PUBLISHABLE="${SUPABASE_PUBLISHABLE_KEY:-${FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY:-}}"
-          {
-            echo "METAR_CONFIG_ENV=local"
-            echo "SUPABASE_PUBLISHABLE_KEY=${PUBLISHABLE}"
-            echo "SUPABASE_SECRET_KEY=${SUPABASE_SECRET_KEY:-}"
-            echo "DATABASE_URL=${DATABASE_URL:-}"
-          } >> "$GITHUB_ENV"
-          bash scripts/frontend/prepare-config.sh
-
-      - name: Run integration tests
-        if: matrix.package == 'integration'
-        run: |
-          docker compose up -d backend frontend
-          sleep 30
-          uv run pytest tests/test_backend_frontend_integration.py tests/test_integration.py -v
-          cd apps/backend && uv run pytest tests/integration/test_h0i_connectivity.py tests/unit/test_tc_f21_auth_gone_unit.py -v --no-cov
-          cd apps/backend && uv run pytest tests/infrastructure/test_smoke.py -k "cor or conversion or workflow" -q --no-cov
-          docker compose down
-
-      # F17 / E14-04 / T3.3 — wis2box Compose harness (MQTT + HTTP dataset smoke).
-      - name: Run wis2box Compose harness hook
-        if: matrix.package == 'integration'
-        run: bash scripts/ci/run_wis2box_harness.sh
-
-      - name: Upload backend coverage artifact
-        if: always() && matrix.package == 'backend'
+      - name: Upload package coverage XML artifact
+        if: always() && contains(fromJSON('["shared","auth","backend","tac2iwxxm","iwxxm-validate","tac-validate"]'), matrix.package)
         uses: actions/upload-artifact@v4
         with:
-          name: backend-coverage-report
+          name: coverage-xml-${{ matrix.package }}
           path: |
-            apps/backend/htmlcov/
             apps/backend/coverage.xml
+            packages/shared/coverage.xml
+            packages/auth/coverage.xml
+            packages/tac2iwxxm/coverage.xml
+            packages/iwxxm-validate/coverage.xml
+            packages/tac-validate/coverage.xml
+          if-no-files-found: ignore
 
       - name: Upload frontend coverage artifact
         if: always() && matrix.package == 'frontend'
@@ -242,16 +186,90 @@ jobs:
         with:
           name: frontend-coverage-report
           path: apps/frontend/coverage/
+          if-no-files-found: ignore
 
-      - name: Stop service stack after integration tests
-        if: always() && matrix.package == 'integration'
-        run: docker compose down
+  # EV-036 — sticky PR comment with coverage summary (no Codecov; local artifacts only).
+  coverage-pr-comment:
+    runs-on: ubuntu-latest
+    name: Coverage PR comment
+    needs: [test]
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-xml-*
+          path: coverage-artifacts
+          merge-multiple: true
+
+      - name: Download frontend coverage artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage-report
+          path: coverage-artifacts/frontend
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Format coverage markdown
+        id: cov
+        run: |
+          python3 scripts/ci/format_coverage_pr_comment.py coverage-artifacts \
+            > coverage-pr-comment.md
+          {
+            echo "body<<EOF"
+            cat coverage-pr-comment.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- EV-036-coverage-comment -->';
+            const body = fs.readFileSync('coverage-pr-comment.md', 'utf8');
+            if (!body.includes(marker)) {
+              core.setFailed('coverage comment missing sticky marker');
+              return;
+            }
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   # F30 / EV-031 T2.3 — Postgres service + idempotent alembic upgrade head (TC-EV031-002).
   test-alembic:
     runs-on: ubuntu-latest
     name: Test (alembic / TC-EV031-002)
-    needs: [validate]
     services:
       postgres:
         image: postgres:16
@@ -299,7 +317,6 @@ jobs:
   tac2iwxxm-native:
     runs-on: ubuntu-latest
     name: tac2iwxxm PyO3 (maturin)
-    needs: [validate]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -343,7 +360,6 @@ jobs:
   e2e-smoke:
     runs-on: ubuntu-latest
     name: E2E Smoke (Playwright)
-    needs: [validate]
     env:
       METAR_CONFIG_ENV: local
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 # Fast gates (ruff/prettier/eslint/types/gitleaks/actionlint) via pre-commit framework.
-# Includes Render deploy-hook fallback regression (BUG-2026-08-03) when related files change.
+# Medium validate extras (config-guard / env-check / audit-frontend) — de-duped vs validate-fast.
+# EV-036 / M5 — long suites moved to husky pre-push (full local CI target).
 set -e
 uv run pre-commit run
+echo "husky pre-commit: make validate-ci-medium"
+make validate-ci-medium

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-# Local parity with GitHub Actions validate + unit/matrix (make ci-prepush).
-# Remote CI also runs test / tac2iwxxm-native / e2e-smoke; deploy needs test + native.
+# EV-036 / M5 — long local gate: units + Compose integration (ports 18000/18001).
+# Medium validate already ran on commit; do not re-run validate-ci here.
+# Remote CI keeps unit matrix + coverage; Compose stays local-only.
 set -e
-echo "husky pre-push: make validate-ci"
-make validate-ci
-echo "husky pre-push: make ci-prepush"
-make ci-prepush
+echo "husky pre-push: make ci (ci-prepush + test-integration)"
+echo "Requires Docker and free ports 18000/18001. Bypass only with --no-verify (not for main)."
+make ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
-# Local gates mirroring .github/workflows/ci-cd.yml validate job
-# - default (pre-commit): fast checks ≈ make validate-fast pieces
-# - husky pre-push: make validate-ci + make ci-prepush (long unit/matrix)
+# Local gates (EV-036 / M5):
+# - husky pre-commit: this file (fast) + make validate-ci-medium
+# - husky pre-push: make ci (ci-prepush + Compose integration)
+# - remote CI: unit matrix + coverage (no validate job; no Compose integration)
 # Install: make install-hooks  (husky + pre-commit)
 #
 # pre-commit 4.x default_stages includes every hook type; pin to pre-commit so

--- a/Makefile
+++ b/Makefile
@@ -595,15 +595,15 @@ test-integration:
 		exit 1; \
 	fi
 	-$(COMPOSE) down --remove-orphans
-	$(COMPOSE) up -d backend frontend
+	$(COMPOSE) up -d --build backend frontend
 	@echo "Waiting for services to become ready..."
-	@for i in $$(seq 1 45); do \
+	@for i in $$(seq 1 60); do \
 		if curl -fsS --max-time 2 -o /dev/null http://localhost:18001/health \
 			&& curl -fsS --max-time 2 -o /dev/null http://localhost:18000/; then \
 			echo "All services are reachable."; \
 			break; \
 		fi; \
-		if [ "$$i" -eq 45 ]; then \
+		if [ "$$i" -eq 60 ]; then \
 			echo "Services did not become ready in time."; \
 			$(COMPOSE) ps; \
 			$(COMPOSE) logs --tail=120 backend frontend; \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ install:
 
 install-hooks:
 	# husky owns core.hooksPath (.husky/*); pre-commit framework runs from .husky/pre-commit.
-	# Long unit/matrix suites: .husky/pre-push → make validate-ci + make ci-prepush.
+	# EV-036: commit = fast + validate-ci-medium; push = make ci (units + Compose).
 	corepack enable
 	$(PNPM) install
 	$(PNPM) exec husky
@@ -79,11 +79,11 @@ install-hooks:
 
 pre-commit-run:
 	$(UV) run pre-commit run --all-files
+	$(MAKE) validate-ci-medium
 
 pre-push-run:
-	# Same as husky pre-push (CI unit/matrix parity; not in GitHub Actions temporarily).
-	make validate-ci
-	make ci-prepush
+	# Same as husky pre-push (EV-036): units + Compose; no second validate-ci.
+	$(MAKE) ci
 
 # --- F15 issue catalog (ADR-028 / EV-011) ---
 
@@ -668,14 +668,18 @@ supabase-push:
 supabase-pull:
 	bash scripts/supabase/db-pull.sh $(NAME)
 
-validate-ci: validate-fast config-guard env-check audit-frontend
+# Medium extras after husky/pre-commit fast hooks (validate-ci without validate-fast).
+validate-ci-medium: config-guard env-check audit-frontend
 
-# Unit/matrix parity for pre-push (CI test job packages without local Compose).
+validate-ci: validate-fast validate-ci-medium
+
+# Unit/matrix suite without Compose (also run on remote CI test matrix).
 # Use `make ci` / `make test-integration` when Docker ports 18000/18001 are free.
 ci-prepush: format-check typecheck lint test-unit-workspace test-unit-backend \
 	test-unit-frontend test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate \
 	test-unit-dissemination test-unit-worker test-bugs badge-audit
 
+# EV-036 long local gate (husky pre-push): units + Compose integration.
 ci: ci-prepush test-integration
 
 acci: ci test-e2e-playwright-smoke audit-frontend

--- a/Makefile
+++ b/Makefile
@@ -598,8 +598,8 @@ test-integration:
 	$(COMPOSE) up -d backend frontend
 	@echo "Waiting for services to become ready..."
 	@for i in $$(seq 1 45); do \
-		if wget --quiet --tries=1 --timeout=2 -O /dev/null http://localhost:18001/health \
-			&& wget --quiet --tries=1 --timeout=2 -O /dev/null http://localhost:18000/; then \
+		if curl -fsS --max-time 2 -o /dev/null http://localhost:18001/health \
+			&& curl -fsS --max-time 2 -o /dev/null http://localhost:18000/; then \
 			echo "All services are reachable."; \
 			break; \
 		fi; \

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -4,6 +4,9 @@ FROM node:22-alpine AS dev
 
 WORKDIR /workspace
 
+# Compose `command` runs prepare-config.sh (bash); Alpine node image has no bash.
+RUN apk add --no-cache bash
+
 RUN corepack enable
 
 # Workspace metadata (layer cache)

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -4,8 +4,8 @@ FROM node:22-alpine AS dev
 
 WORKDIR /workspace
 
-# Compose `command` runs prepare-config.sh (bash); Alpine node image has no bash.
-RUN apk add --no-cache bash
+# Compose prepare-config.sh needs bash|sh + python3 (Alpine node image has neither by default).
+RUN apk add --no-cache bash python3
 
 RUN corepack enable
 
@@ -23,7 +23,7 @@ WORKDIR /workspace/apps/frontend
 
 EXPOSE 8000
 
-CMD ["pnpm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["pnpm", "exec", "vite", "--host", "0.0.0.0", "--port", "8000"]
 
 # Build stage
 FROM node:22-alpine AS builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,8 @@ services:
       - /workspace/apps/frontend/node_modules
     command: >
       sh -c "METAR_CONFIG_ENV=$${METAR_CONFIG_ENV:-local}
-      DEST_DIR=/workspace/apps/frontend/public bash /workspace/scripts/frontend/prepare-config.sh
-      && pnpm run dev -- --host 0.0.0.0 --port 8000"
+      DEST_DIR=/workspace/apps/frontend/public sh /workspace/scripts/frontend/prepare-config.sh
+      && pnpm exec vite --host 0.0.0.0 --port 8000"
     depends_on:
       backend:
         condition: service_healthy

--- a/docs/context/local-precommit-long-jobs.md
+++ b/docs/context/local-precommit-long-jobs.md
@@ -1,0 +1,21 @@
+# Context — local pre-commit long jobs (S044 / EV-036)
+
+**Mode:** scoped · **Date:** 2026-08-05  
+**Session:** [S044-local-precommit-long-jobs](../sessions/S044-local-precommit-long-jobs/session-brief.md)
+
+## Goal
+
+Run local-capable long quality jobs on **developer machines via pre-commit** so GitHub
+Actions spend fewer minutes. `[Corpus: product]` **M5** deepen; `[Corpus: tech-spec]` /
+`[Corpus: tests]` gate placement; ops `docs/ops/DEVELOPMENT.md`.
+
+## Baseline
+
+- **pre-commit:** fast gates (`.pre-commit-config.yaml`)
+- **pre-push:** `make validate-ci` + `make ci-prepush` (`.husky/pre-push`)
+- **CI:** `validate` + matrix `test` (+ alembic / native / e2e-smoke / deploy) in `ci-cd.yml`
+
+## Non-goals
+
+- Product UI / React workbench changes
+- Jobs requiring remote-only secrets, GHCR publish, or live prod E2E

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -9,7 +9,7 @@
 **Features**: deepen **M5** only (no new Fn — B4=1)  
 **Started**: 2026-08-05  
 **Branch**: `evolve/EV-036-local-precommit-long-jobs`  
-**Status**: Gate A PASS (amended) → **07-build**  
+**Status**: **completed** 2026-08-05 — 11 approved (`D-S044-11`); deploy 12/13 waived (`D-S044-12-13-waive`); push+PR (`D-S044-next`)  
 **Prior**: S043 / EV-035 completed
 
 ### Scope (Phase 0–02 — locked 2026-08-05; AskQuestion unavailable — chat)
@@ -28,6 +28,9 @@
 | R1 | decision | Compose integration? | **Local only** — remove remote `integration`/Compose from `ci-cd.yml`; pre-push runs `make ci` (= `ci-prepush` + `test-integration` [+ wis2box harness if part of local target]) |
 | AC | decision | M5 / TC-EV036? | **Approved** (AC3 amended with B2: remote keeps units/coverage) |
 | Gate A | decision | S02.M1/M2/M3/L1 | **1,1,1,1** with **S02.M2 modified** — units+coverage stay remote |
+| D-S044-11 | decision | 11-verify-impl? | **Approve all ACs met** — close 11 |
+| D-S044-next | decision | After 11? | **Push branch + open PR** to `main` |
+| D-S044-12-13-waive | decision | Deploy 12/13? | **Waive** — no runtime product change |
 
 **Branch created**: `evolve/EV-036-local-precommit-long-jobs` (from `main` @ 97a5c131)
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,61 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-036 — Local long jobs on pre-commit / slim CI (S044)
+
+**Session**: S044-local-precommit-long-jobs  
+**Features**: deepen **M5** only (no new Fn — B4=1)  
+**Started**: 2026-08-05  
+**Branch**: `evolve/EV-036-local-precommit-long-jobs`  
+**Status**: Gate A PASS (amended) → **07-build**  
+**Prior**: S043 / EV-035 completed
+
+### Scope (Phase 0–02 — locked 2026-08-05; AskQuestion unavailable — chat)
+
+| ID | Category | Question | Decision |
+|----|----------|----------|----------|
+| Q1 | decision | Session? | Open **S044** → **EV-036** |
+| Q2 | decision | Intent? | Local-capable long jobs on developer hooks to **save CI runner time** (4+1) |
+| Q3 | decision | UI/deploy? | **N/A tooling only** — “frontend” = Vitest/`audit-frontend` gates, not product UI |
+| B1 | decision | Local timing? | **Both** — fast+**medium on commit**; long suite on **push** |
+| B2 | decision | Remote CI? | **Amended (D-S044-02-gate-a)** — drop remote **validate** + **Compose integration**; **keep** unit matrix + coverage + **PR coverage comment**; lint/format = local only |
+| B3 | decision | Job set? | `validate-ci` + `ci-prepush` (+ **R1** Compose integration on push) |
+| B4 | decision | Fn + preset? | Deepen **M5**; **Lean** |
+| G1 | decision | Routing? | **Lean** `00→16→01→02→07→08→09→11` (skip 03–06, 10, 12/13) |
+| G2 | decision | Proceed? | Approve → branch → **01-requirements** |
+| R1 | decision | Compose integration? | **Local only** — remove remote `integration`/Compose from `ci-cd.yml`; pre-push runs `make ci` (= `ci-prepush` + `test-integration` [+ wis2box harness if part of local target]) |
+| AC | decision | M5 / TC-EV036? | **Approved** (AC3 amended with B2: remote keeps units/coverage) |
+| Gate A | decision | S02.M1/M2/M3/L1 | **1,1,1,1** with **S02.M2 modified** — units+coverage stay remote |
+
+**Branch created**: `evolve/EV-036-local-precommit-long-jobs` (from `main` @ 97a5c131)
+
+### Resource model (canonical — Gate A amend)
+
+| Tier | When | Contents | Rationale |
+|------|------|----------|-----------|
+| **Fast** | every `git commit` | format/lint/types/secrets/yaml/catalog/canaries | cheap always-on |
+| **Medium** | every `git commit` | `validate-ci` medium extras (de-duped vs fast) | config/audit before push |
+| **Long (local)** | every `git push` | `make ci` = `ci-prepush` + Compose **integration** (ports 18000/18001); no second `validate-ci` | units (local) + integration local |
+| **Remote** | PR / push CI | **No** validate job, **no** Compose integration; **keep** package **unit matrix + coverage** + sticky **PR coverage comment**; keep `tac2iwxxm-native`, `e2e-smoke`, `test-alembic`, deploy | save Compose/validate minutes; retain coverage signal |
+
+**Out of scope**: Product Fn; browser UX; family `test-*-quality` on every hook; Playwright smoke on every push (stays remote e2e-smoke); live prod E2E; GHCR/PyPI publish changes.
+
+### Corpus cites / waivers
+
+| Ref | Kind | Target | Notes |
+|-----|------|--------|-------|
+| `[Corpus: product]` | cite | M5 deepen | workspace tooling / hooks |
+| `[Corpus: tech-spec]` | cite | Makefile + hook layout | + `dependency-inventory.md` |
+| `[Corpus: tests]` | cite | `test-plan.md` Quality Gates / EV-002 dual-run amend |
+| `[docs/ops/DEVELOPMENT.md]` | cite | ops satellite | install-hooks runbook |
+
+### Proposed Lean routing (B4=1)
+
+`00 → 16 → 01 → 02 → 07 → 08 → 09 → 11`  
+Skip: `03`, `04`, `05`, `06`, `10`, `12`, `13` (no UI; no runtime deploy; tooling-only — waive 12/13 at gate)
+
+---
+
 ## Cycle EV-035 — Rule-source traceability / provenance registry (S043)
 
 **Session**: S043-rule-source-traceability  

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -132,7 +132,7 @@ via Supabase). **JWKS-only** (`D-S038-04-b1` Q2=2): do not use `SUPABASE_JWT_SEC
 | eslint | workspace TS | Lint apps/frontend, apps/e2e, packages/shared |
 | make | system | Orchestration |
 | pre-commit | dev group (pyproject) | Fast commit gates (invoked from husky) |
-| husky | root `package.json` devDependency (^9.1.7) | Git hooksPath — pre-commit + pre-push (unit/matrix) |
+| husky | root `package.json` devDependency (^9.1.7) | Git hooksPath — pre-commit (fast+medium) + pre-push (`make ci` units+Compose; EV-036) |
 | actionlint | pre-commit hook | GitHub Actions workflow lint (EV-002) |
 | yamllint | pre-commit hook | `.github/` YAML lint (EV-002) |
 | supabase/setup-cli | GitHub Action | Supabase CLI in `supabase-sync.yml` |

--- a/docs/evolve-report-EV-036.md
+++ b/docs/evolve-report-EV-036.md
@@ -1,0 +1,5 @@
+# Evolve report — EV-036
+
+See session summary: [`docs/sessions/S044-local-precommit-long-jobs/reports/evolve-summary.md`](sessions/S044-local-precommit-long-jobs/reports/evolve-summary.md).
+
+**Completed:** 2026-08-05 · **Deploy:** waived · **Deepen:** M5 · **Artifact:** husky medium-on-commit + pre-push `make ci`; remote units/coverage/PR comment

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-05 (S043 / EV-035 — rule-source provenance deepen F6/F12/F15/F2)
+> **Last updated**: 2026-08-05 (S044 / EV-036 — M5 local long hooks + slim CI; prior S043 / EV-035)
 
 ## Summary
 
@@ -44,7 +44,7 @@
 | M2 | Vendor snapshot sync (wmo-im iwxxm-*) | Planned | Platform | REQ-002, REQ-010 |
 | M3 | GIFTs as in-repo package | Deprecated (ADR-014) | Platform | REQ-003; removed with F6 cutover |
 | M4 | Auth library in backend API | Implemented | Platform | S038 / EV-031 — Supabase Auth-only restore; was Deprecated operator #783 |
-| M5 | Workspace tooling (uv + pnpm + Makefile) | Planned | Platform | REQ-005 |
+| M5 | Workspace tooling (uv + pnpm + Makefile) | Planned | Platform | REQ-005; **deepen** S044 / EV-036 local-first hooks + slim CI |
 | M6 | Vendor upstream sync (wmo-im iwxxm-*) | Planned | Platform | REQ-009 |
 
 **Status key**: Implemented = production-ready, Planned = approved in requirements interview, Experimental = works but not validated, Superseded / Deprecated = replaced by a later decision
@@ -1345,7 +1345,23 @@
 - **F6 delta**: Workspace member `tac2iwxxm`; drop gifts from test matrix at cutover; **PyO3 /
   maturin required** in CI before cutover (ADR-017).
 - **S008 package amend**: Workspace members `tac-validate`, `iwxxm-validate` in test matrix.
-- **Source**: REQ-005; EV-002; ADR-014; S008 realtime amend
+- **S044 / EV-036 deepen (local-first gates)**: Tiered local hooks save CI runner time:
+  - **Commit (pre-commit)**: existing fast gates + **medium** `validate-ci` extras (de-duped).
+  - **Push (husky pre-push)**: `make ci` = `ci-prepush` + Compose **integration** (ports
+    18000/18001; includes wis2box harness if wired into local integration target) — no second
+    `validate-ci`.
+  - **Remote (ci-cd.yml)**: drop **validate** + Compose **integration**; **keep** package
+    **unit matrix + coverage** and post a sticky **PR coverage comment**; keep
+    `tac2iwxxm-native`, `e2e-smoke`, `test-alembic`, deploy (needs graph updated). Strict
+    lint/format stays on local hooks. Family quality packs stay path-filtered / opt-in.
+- **Acceptance (EV-036)** — **approved** (`AC=1`, `R1=local`, Gate A amend `D-S044-02-gate-a`):
+  1. `make install-hooks` → commit runs fast + medium validate; push runs `make ci` (units + Compose).
+  2. `docs/ops/DEVELOPMENT.md` + `docs/test-plan.md` CI tables match the tier model.
+  3. PR CI has no validate job and no Compose integration job; **unit matrix + coverage + PR
+     coverage comment** remain.
+  4. Deploy on `main` gated by remaining remote jobs (test + alembic + native [+ e2e per graph]).
+  5. TC-EV036-001..003 green (hook wiring + workflow contract tests; dense asserts).
+- **Source**: REQ-005; EV-002; ADR-014; S008 realtime amend; **S044 / EV-036**
 
 ### M6: Upstream Vendor Sync
 

--- a/docs/ops/DEVELOPMENT.md
+++ b/docs/ops/DEVELOPMENT.md
@@ -211,34 +211,38 @@ Playwright env vars:
 
 ## CI/CD
 
-Primary workflow: `.github/workflows/ci-cd.yml`.
+Primary workflow: `.github/workflows/ci-cd.yml` (**EV-036** local-first amend).
 
-Remote CI runs **validate** then the **test** matrix, **tac2iwxxm-native**, and
-**e2e-smoke**. Husky **pre-push** mirrors validate + unit/matrix locally.
-**Deploy** on `main` requires `test` + `tac2iwxxm-native`, and skips cleanly when
-GHCR login or Render deploy-hook secrets are missing. Image deploys use
-`scripts/deploy/trigger_render_image_deploy.py` (hook + `imgURL`, with REST
-`imageUrl` fallback when `RENDER_API_KEY` is set — BUG-2026-08-03). Husky
-pre-commit runs regression guards for that path.
+| Tier | Where | What |
+|------|-------|------|
+| Fast + medium | husky **pre-commit** | Fast pre-commit hooks + `make validate-ci-medium` (config-guard, env-check, audit-frontend). Strict lint/format stay here. |
+| Long local | husky **pre-push** | `make ci` = `ci-prepush` + Compose **integration** (ports **18000/18001**). Needs Docker. |
+| Remote PR/push | GitHub Actions | **No** `validate` job; **no** Compose integration. **Keeps** package **unit matrix** + coverage + sticky **PR coverage comment**. Also `tac2iwxxm-native`, `e2e-smoke`, `test-alembic`. |
+| Deploy | `main` push only | needs `test` + `test-alembic` + `tac2iwxxm-native`; GHCR + DOKS; Render optional |
+
+Image deploys use `scripts/deploy/trigger_render_image_deploy.py` (hook + `imgURL`, with REST
+`imageUrl` fallback when `RENDER_API_KEY` is set — BUG-2026-08-03).
 
 | Job | Checks |
 |-----|--------|
-| **validate** | `make validate-ci` — format, lint, typecheck, gitleaks, actionlint/yamllint, config-guard, frontend npm audit |
-| **test** | Package unit/integration matrix (backend, auth, frontend, packages, bugs, …) |
+| **test** (matrix) | Package unit tests with coverage (`--cov-fail-under` / Vitest) |
+| **coverage-pr-comment** | Sticky PR comment from coverage XML / Vitest summary (PRs only) |
 | **tac2iwxxm-native** | PyO3 / maturin smoke |
 | **e2e-smoke** | Playwright smoke |
-| **deploy** | Docker build/push + Render hooks (`main` push only; needs test + native; skipped if CD credentials incomplete) |
+| **test-alembic** | Alembic upgrade head (TC-EV031-002) |
+| **deploy** | Docker build/push + DOKS/Render (`main` push only; skipped if CD credentials incomplete) |
 
 Local gates:
 
 ```bash
 make install-hooks    # husky (.husky/*) + pre-commit hook environments
-pre-commit run --all-files          # fast commit gates
-make pre-push-run                   # make validate-ci + make ci-prepush (same as git push)
-make validate-fast                  # format/lint/typecheck/secrets/yaml/catalog
-make validate-ci                    # CI validate job locally
-make ci-prepush                     # unit/matrix suite (no Compose) — husky pre-push
-make ci                             # ci-prepush + test-integration (needs ports 18000/18001)
+make pre-commit-run   # fast pre-commit + validate-ci-medium (same as git commit)
+make pre-push-run     # make ci (units + Compose; same as git push)
+make validate-fast    # format/lint/typecheck/secrets/yaml/catalog
+make validate-ci-medium  # config-guard + env-check + audit-frontend
+make validate-ci      # validate-fast + validate-ci-medium (manual full local validate)
+make ci-prepush       # unit/matrix suite (no Compose)
+make ci               # ci-prepush + test-integration (needs ports 18000/18001)
 make test-ev032-a6-2-canary         # EV-032 #835 A6-2 equality + catalog (pre-commit canary)
 make test-ev032-vona-canary         # EV-032 #741 VONA ADR-032 + product=vona (pre-commit canary)
 make test-tc-sigmet-quality         # TC SIGMET long pack (includes #835 A6-2 deepen)
@@ -249,19 +253,21 @@ Hooks (after `make install-hooks`; husky sets `core.hooksPath=.husky`):
 
 | Git hook | Runs |
 |----------|------|
-| **pre-commit** (husky → pre-commit) | gitleaks, ruff, prettier, eslint, tsc, basedpyright, catalog + issue-registry, actionlint/yamllint; **path-filtered** EV-032 canaries (`ev032-a6-2-tc-canary`, `ev032-vona-canary`) when encode/catalog/API paths change |
-| **pre-push** (husky) | `make validate-ci` then `make ci-prepush` (local parity with remote test matrix). Family long packs (`make test-*-quality`) stay opt-in / path-filtered CI — not dumped into every push |
+| **pre-commit** (husky → pre-commit + medium) | gitleaks, ruff, prettier, eslint, tsc, basedpyright, catalog + issue-registry, actionlint/yamllint; path-filtered canaries; then `make validate-ci-medium` |
+| **pre-push** (husky) | `make ci` (units + Compose). Family long packs (`make test-*-quality`) stay opt-in / path-filtered — not on every push |
 
 Bypass only when intentional: `git commit --no-verify` / `git push --no-verify`.
-Do **not** use `--no-verify` as a merge path for `main` — remote CI must stay green.
+Skipping pre-push skips **local Compose/integration** — remote CI will **not** catch that gap.
+Do **not** use `--no-verify` as a merge path for `main` — remote unit/coverage CI must stay green.
 
 - Python 3.12 + Node 22
 - Unit coverage gates enforced in CI (`test` job) and locally via husky / `make ci-prepush`
 - Builds API Docker image from repo root context (when CD credentials present)
 - Builds frontend static assets from `apps/frontend`
 
-Removed standalone PR workflows (merged into `ci-cd.yml` validate): `secret-scan.yml`,
-`github-yaml-lint.yml`, `frontend-audit.yml`.
+Removed from remote CI (EV-036): standalone **validate** job and Compose **integration**
+matrix entry (moved to local hooks). Historical merges into validate (EV-002): `secret-scan.yml`,
+`github-yaml-lint.yml`, `frontend-audit.yml` — still covered by local `validate-fast` / medium.
 
 Vendor schemas: weekly GitHub Action syncs wmo-im repos into `vendor/schemas/` (see
 `scripts/vendor/sync-iwxxm.sh`).

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
@@ -1,0 +1,34 @@
+# 01-requirements summary — S044 / EV-036
+
+**Mode:** delta · **Date:** 2026-08-05  
+**Features:** deepen **M5** (no new Fn)  
+**UI preview:** N/A — no UI  
+**Status:** **COMPLETE** — R1=local Compose; AC=1 → handoff **02-verify-plan**
+
+## Locked decisions
+
+| ID | Decision |
+|----|----------|
+| Q1–Q3 / B1–B4 / G1–G2 | Phase 0 + routing |
+| R1 | Remove remote Compose/`integration`; run on local pre-push via `make ci` |
+| AC | M5 ACs + TC-EV036-001..003 approved |
+
+## Resource model (final — Gate A amend)
+
+| Tier | Hook | Jobs |
+|------|------|------|
+| Fast + medium | pre-commit | fast + `validate-ci-medium` |
+| Long local | pre-push | `make ci` = `ci-prepush` + Compose integration |
+| Remote | `ci-cd.yml` | units + coverage + PR comment; native / e2e-smoke / alembic / deploy; **no** validate / Compose |
+
+## Standing doc deltas
+
+| Doc | Change |
+|-----|--------|
+| `[Corpus: product]` | M5 EV-036 deepen + approved ACs |
+| `[Corpus: tests]` | CI/CD EV-036; TC-EV036-001..003 |
+| `[Corpus: decisions]` | §EV-036 R1 + AC |
+
+## Handoff
+
+**02-verify-plan** Gate A next (Lean → then 07-build; no 04).

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
@@ -1,0 +1,42 @@
+# 02-verify-plan audit — S044 / EV-036
+
+**Date**: 2026-08-05  
+**Mode**: delta  
+**Status**: Gate A **PASS** (`D-S044-02-gate-a` — `1,1,1,1` with S02.M2 **modified**)  
+**Scope**: M5 local-first hooks + remote units/coverage ([Corpus: product|tests|decisions])
+
+## Statements (risk-classified)
+
+| ID | Statement | Confidence | Verdict |
+|----|-----------|------------|---------|
+| S02.H1 | No product UI / no H4–H5 this cycle | **high** | auto-approved |
+| S02.H2 | Deepen M5 only; no new Fn | **high** | auto-approved |
+| S02.H3 | Lean skips 03–06, 10, 12/13 | **high** | auto-approved |
+| S02.M1 | pre-commit runs fast + medium validate; pre-push runs `make ci` (units + Compose) | **medium** | **approved** |
+| S02.M2 | Remote drops validate + Compose; **keeps** unit matrix + coverage + PR coverage comment | **medium** | **modified** (was: also drop units) |
+| S02.M3 | Remote keeps `tac2iwxxm-native`, `e2e-smoke`, `test-alembic`; deploy `needs` includes `test` | **medium** | **approved** |
+| S02.L1 | Developers must have Docker + free ports 18000/18001 on every push; document `--no-verify` | **low** | **approved** |
+
+## Batch A verdicts (`1,1,1,1` + contradiction resolve `1,1,1,1`)
+
+| # | Statement | Verdict |
+|---|-----------|---------|
+| 1 | S02.M1 | Approve |
+| 2 | S02.M2 | **Modify** — keep remote units + coverage + PR comment; drop validate + Compose only |
+| 3 | S02.M3 | Approve |
+| 4 | S02.L1 | Approve |
+
+**Remote lint/format**: local pre-commit only (Q2=1) — no remote validate job.
+
+## Connectivity
+
+N/A — no browser API surface. H0c unchanged.
+
+## Consistency
+
+- feature-list M5 ↔ test-plan CI/TC-EV036 ↔ evolve-decisions §EV-036 aligned after Gate A amend.
+- B2 slim-no-units **superseded** by `D-S044-02-gate-a`.
+
+## Handoff
+
+**02 COMPLETE** → **07-build** (hooks + ci-cd + TC-EV036 + DEVELOPMENT.md).

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
@@ -1,0 +1,22 @@
+# 09-qa — S044 / EV-036 local hook smoke
+
+**Date**: 2026-08-05  
+**Result**: **PASS**
+
+## Smoke
+
+| Check | Evidence |
+|-------|----------|
+| Commit hook runs medium validate | Live on commit `d4fd6955` — husky printed `validate-ci-medium` and config-guard/env-check/audit-frontend passed |
+| pre-commit / pre-push executable | `.husky/pre-commit`, `.husky/pre-push` mode +x |
+| Wiring | pre-commit → `validate-ci-medium`; pre-push → `make ci` |
+| Dry-run targets | `make -n validate-ci-medium pre-push-run` expands expected recipes |
+| TC-EV036 | 25/25 green (08) |
+
+## Notes
+
+Full `make ci` (Compose on 18000/18001) not executed in this QA pass — contract-tested and documented; requires Docker on developer machines at push time (`D-S044-02` S02.L1).
+
+## Handoff
+
+→ **11-verify-impl**

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/evolve-summary.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/evolve-summary.md
@@ -1,0 +1,48 @@
+# Evolve summary — EV-036 / S044
+
+**Title:** Local long jobs on pre-commit / slim remote CI  
+**Branch:** `evolve/EV-036-local-precommit-long-jobs`  
+**Status:** **completed** 2026-08-05 (PR open — merge awaits approval)  
+**Features:** deepen **M5** only (no new Fn — B4=1)  
+**Preset:** Lean · **Deploy:** waived (`D-S044-12-13-waive`)
+
+## What shipped
+
+1. **pre-commit** — fast gates + `validate-ci-medium`  
+2. **pre-push** — `make ci` (units + Compose integration on 18000/18001)  
+3. **Remote CI** — drop validate + Compose; **keep** unit matrix + coverage + sticky PR coverage comment  
+4. **TC-EV036-001..003** — dense contract tests (25 asserts)  
+5. Ops docs — `DEVELOPMENT.md` + test-plan tier model
+
+## Gates
+
+| Gate | Result |
+|------|--------|
+| A (02) | PASS — amended S02.M2 (keep remote units+coverage) |
+| C→D (08/09) | PASS |
+| 11 | **APPROVED** (`D-S044-11=1`) |
+| Deploy 12/13 | **WAIVED** |
+
+## Resource model
+
+| Tier | Where | What |
+|------|-------|------|
+| Fast + medium | pre-commit | lint/format + `validate-ci-medium` |
+| Long local | pre-push | `make ci` |
+| Remote | `ci-cd.yml` | units + coverage + PR comment |
+
+## Corpus cites
+
+`[Corpus: product]` M5 · `[Corpus: tests]` · `[Corpus: tech-spec]` ·  
+`[Corpus: decisions]` EV-036 · `[docs/ops/DEVELOPMENT.md]`
+
+## Reports
+
+| Artifact | Path |
+|----------|------|
+| Requirements | `reports/01-requirements-summary.md` |
+| Audit | `reports/02-verify-plan-audit.md` |
+| Execution plan | `reports/execution-plan.md` |
+| 08 | `reports/verification-report.md` |
+| 09 | `reports/09-qa.md` |
+| 11 | `reports/verify-impl.md` |

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
@@ -1,0 +1,14 @@
+# Execution plan — S044 / EV-036 (Lean; no 04)
+
+**Branch:** `evolve/EV-036-local-precommit-long-jobs`  
+**Corpus:** `[Corpus: product]` M5 · `[Corpus: tests]` · `[Corpus: decisions]` EV-036
+
+| ID | Status | Spec | Task |
+|----|--------|------|------|
+| T1 | **completed** | M5 AC1 / TC-EV036-001 | Husky pre-commit: fast + `validate-ci-medium`; Makefile targets |
+| T2 | **completed** | M5 AC1 / TC-EV036-002 | Husky pre-push → `make ci`; no validate on push |
+| T3 | **completed** | M5 AC3–4 / TC-EV036-003 | `ci-cd.yml`: drop validate + Compose; keep units/coverage; PR coverage comment; rewire `needs` |
+| T4 | **completed** | TC-EV036-001..003 | Dense contract tests under `tests/` |
+| T5 | **completed** | DEVELOPMENT / dependency-inventory | Ops + inventory docs |
+
+Gate A amend (`D-S044-02-gate-a`): remote keeps unit matrix + coverage + PR comment.

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
@@ -1,0 +1,33 @@
+# 08-verify-build — S044 / EV-036
+
+**Date**: 2026-08-05  
+**Tip**: `d4fd6955`  
+**Mode**: delta (tooling / CI policy)  
+**Result**: **PASS**
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| `make format-check` | PASS |
+| `make lint` | PASS |
+| `make typecheck` | PASS (pre-existing tac2iwxxm warnings only) |
+| TC-EV036 + coverage formatter (25) | PASS |
+| `tests/unit/test_cors_policy.py` (H0c) | PASS |
+| CI contract regressions (m8/m10/t13/doks) | PASS (21) |
+| actionlint / yamllint on `ci-cd.yml` | PASS (pre-commit) |
+| Compose / H0i integration | **Local-only** (EV-036) — not run in this verify; exercised via husky pre-push `make ci` |
+
+## Connectivity
+
+- H0c unit CORS: green  
+- H0i Compose: deferred to local pre-push per Gate A / R1  
+- No browser UI this cycle — H4–H5 N/A  
+
+## Corpus
+
+`[Corpus: product]` M5 · `[Corpus: tests]` TC-EV036 · `[Corpus: decisions]` EV-036
+
+## Handoff
+
+**08 PASS** → **09-qa** (local hook smoke) → **11-verify-impl**.

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
@@ -1,0 +1,32 @@
+# 11-verify-impl — S044 / EV-036
+
+**Date**: 2026-08-05  
+**Branch**: `evolve/EV-036-local-precommit-long-jobs`  
+**Tips**: `d4fd6955` (impl) · `95fac992` (08/09 docs)  
+**UI preview**: N/A (tooling only)
+
+## Prior gates
+
+| Stage | Result |
+|-------|--------|
+| 08-verify-build | PASS — `reports/verification-report.md` |
+| 09-qa | PASS — `reports/09-qa.md` |
+| 10-e2e | skipped (no UI) |
+
+## M5 acceptance (EV-036 Gate A amend)
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Commit: fast + medium validate; push: `make ci` | **met** | `.husky/*`, live medium on commit |
+| 2 | DEVELOPMENT + test-plan match tier model | **met** | docs updated |
+| 3 | Remote: no validate, no Compose; **units + coverage + PR comment** | **met** | `ci-cd.yml` + `coverage-pr-comment` |
+| 4 | Deploy needs includes `test` (+ alembic + native) | **met** | workflow `deploy.needs` |
+| 5 | TC-EV036-001..003 green (dense asserts) | **met** | 25 pytest asserts green |
+
+## Feature approval (pending user)
+
+Deepen **M5** only — awaiting AskQuestion approve-all / per-AC.
+
+## Corpus
+
+`[Corpus: product]` M5 · `[Corpus: tests]` · `[Corpus: decisions]` EV-036 · `[docs/ops/DEVELOPMENT.md]`

--- a/docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
@@ -2,8 +2,9 @@
 
 **Date**: 2026-08-05  
 **Branch**: `evolve/EV-036-local-precommit-long-jobs`  
-**Tips**: `d4fd6955` (impl) · `95fac992` (08/09 docs)  
-**UI preview**: N/A (tooling only)
+**Tips**: `d4fd6955` (impl) · `95fac992` (08/09 docs) · closeout pending  
+**UI preview**: N/A (tooling only)  
+**Status**: **APPROVED** (`D-S044-11=1` — approve all ACs met)
 
 ## Prior gates
 
@@ -12,20 +13,27 @@
 | 08-verify-build | PASS — `reports/verification-report.md` |
 | 09-qa | PASS — `reports/09-qa.md` |
 | 10-e2e | skipped (no UI) |
+| 12/13 | **WAIVED** (`D-S044-12-13-waive=1` — no runtime product change) |
 
 ## M5 acceptance (EV-036 Gate A amend)
 
 | # | Criterion | Status | Evidence |
 |---|-----------|--------|----------|
-| 1 | Commit: fast + medium validate; push: `make ci` | **met** | `.husky/*`, live medium on commit |
-| 2 | DEVELOPMENT + test-plan match tier model | **met** | docs updated |
-| 3 | Remote: no validate, no Compose; **units + coverage + PR comment** | **met** | `ci-cd.yml` + `coverage-pr-comment` |
-| 4 | Deploy needs includes `test` (+ alembic + native) | **met** | workflow `deploy.needs` |
-| 5 | TC-EV036-001..003 green (dense asserts) | **met** | 25 pytest asserts green |
+| 1 | Commit: fast + medium validate; push: `make ci` | **met** ✓ | `.husky/*`, live medium on commit |
+| 2 | DEVELOPMENT + test-plan match tier model | **met** ✓ | docs updated |
+| 3 | Remote: no validate, no Compose; **units + coverage + PR comment** | **met** ✓ | `ci-cd.yml` + `coverage-pr-comment` |
+| 4 | Deploy needs includes `test` (+ alembic + native) | **met** ✓ | workflow `deploy.needs` |
+| 5 | TC-EV036-001..003 green (dense asserts) | **met** ✓ | 25 pytest asserts green |
 
-## Feature approval (pending user)
+## Feature approval
 
-Deepen **M5** only — awaiting AskQuestion approve-all / per-AC.
+Deepen **M5** only — **approved** all criteria (`D-S044-11`).
+
+| Decision | Value |
+|----------|-------|
+| D-S044-11 | approve_all_met |
+| D-S044-next | push_and_pr |
+| D-S044-12-13-waive | waived_no_runtime |
 
 ## Corpus
 

--- a/docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
@@ -1,0 +1,50 @@
+# Routing plan — S044-local-precommit-long-jobs
+
+**Preset:** Lean — **approved** (G1=1)  
+**Orchestrator:** 16-evolve · **Cycle:** EV-036  
+**Path:** `00→16→01→02→07→08→09→11`  
+**Skip:** `03, 04, 05, 06, 10, 12, 13`  
+**Branch:** `evolve/EV-036-local-precommit-long-jobs`  
+**Features:** deepen **M5** only (no new Fn)  
+**Status:** 02 COMPLETE → **07-build**
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | scoped | **completed** | S044 open; Batch B locked |
+| 16-evolve | yes | orchestrator | in_progress | Phase 0→1 |
+| 01-requirements | yes | delta | **completed** | R1=local Compose; AC=1 |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS; S02.M2 modified (keep units+coverage) |
+| 03-plan-tooling | no | — | skipped | existing hooks; no new Cursor rules expected |
+| 04-tech-plan | no | — | skipped | Lean — execution tasks in 01/07 |
+| 05-verify-tech | no | — | skipped | — |
+| 06-tech-tooling | no | — | skipped | — |
+| 07-build | yes | full | **in_progress** | T1–T5 impl done pending commit → 08; hooks/ci-cd/TC-EV036/DEVELOPMENT |
+| 08-verify-build | yes | delta | pending | |
+| 09-qa | yes | delta | pending | local hook smoke |
+| 10-e2e | no | — | skipped | no UI |
+| 11-verify-impl | yes | delta | pending | |
+| 12-verify-deploy | no | — | skipped | no runtime; confirm waive at gate |
+| 13-deploy-smoke | no | — | skipped | with 12 |
+
+## Skip rationale
+
+Tooling/hooks/CI policy only. Lean: no new deps (05/06), no formal 04 plan (tasks fit
+01→07), no browser UJ (10), no deploy surface (12/13).
+
+## Locked resource model (Gate A amend)
+
+| Tier | Hook | Jobs |
+|------|------|------|
+| Fast + medium | pre-commit | existing fast + `validate-ci-medium` (de-duped) |
+| Long local | pre-push | `make ci` = `ci-prepush` + Compose integration |
+| Remote | ci-cd.yml | no validate / no Compose; **keep units + coverage + PR comment**; native/e2e/alembic/deploy |
+
+## Approval
+
+| Gate | Decision | Date |
+|------|----------|------|
+| Phase 0 Batch A | Q1=1, Q2=4+1, Q3=N/A | 2026-08-05 |
+| Phase 0 Batch B | B1=3, B2=1→**amended**, B3=1, B4=1 | 2026-08-05 |
+| Proceed / routing | G1=1, G2=1 Lean → 01 | 2026-08-05 |
+| 01 R1 + ACs | R1=local Compose; AC=1 | 2026-08-05 |
+| Gate A / 02 | `1,1,1,1` + contradiction `1,1,1,1` — S02.M2 modified | 2026-08-05 |

--- a/docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
@@ -6,25 +6,25 @@
 **Skip:** `03, 04, 05, 06, 10, 12, 13`  
 **Branch:** `evolve/EV-036-local-precommit-long-jobs`  
 **Features:** deepen **M5** only (no new Fn)  
-**Status:** 02 COMPLETE → **07-build**
+**Status:** Phase 4 close — 11 approved; 12/13 waived; PR pending merge
 
 | Stage | Required | Mode | Status | Notes |
 |-------|----------|------|--------|-------|
 | 00-context | yes | scoped | **completed** | S044 open; Batch B locked |
-| 16-evolve | yes | orchestrator | in_progress | Phase 0→1 |
+| 16-evolve | yes | orchestrator | **completed** | Phase 4 close |
 | 01-requirements | yes | delta | **completed** | R1=local Compose; AC=1 |
 | 02-verify-plan | yes | delta | **completed** | Gate A PASS; S02.M2 modified (keep units+coverage) |
 | 03-plan-tooling | no | — | skipped | existing hooks; no new Cursor rules expected |
 | 04-tech-plan | no | — | skipped | Lean — execution tasks in 01/07 |
 | 05-verify-tech | no | — | skipped | — |
 | 06-tech-tooling | no | — | skipped | — |
-| 07-build | yes | full | **in_progress** | T1–T5 impl done pending commit → 08; hooks/ci-cd/TC-EV036/DEVELOPMENT |
-| 08-verify-build | yes | delta | pending | |
-| 09-qa | yes | delta | pending | local hook smoke |
+| 07-build | yes | full | **completed** | T1–T5 @ d4fd6955 |
+| 08-verify-build | yes | delta | **completed** | PASS |
+| 09-qa | yes | delta | **completed** | PASS |
 | 10-e2e | no | — | skipped | no UI |
-| 11-verify-impl | yes | delta | pending | |
-| 12-verify-deploy | no | — | skipped | no runtime; confirm waive at gate |
-| 13-deploy-smoke | no | — | skipped | with 12 |
+| 11-verify-impl | yes | delta | **completed** | APPROVED `D-S044-11` |
+| 12-verify-deploy | no | — | skipped | waived `D-S044-12-13-waive` |
+| 13-deploy-smoke | no | — | skipped | waived with 12 |
 
 ## Skip rationale
 
@@ -48,3 +48,6 @@ Tooling/hooks/CI policy only. Lean: no new deps (05/06), no formal 04 plan (task
 | Proceed / routing | G1=1, G2=1 Lean → 01 | 2026-08-05 |
 | 01 R1 + ACs | R1=local Compose; AC=1 | 2026-08-05 |
 | Gate A / 02 | `1,1,1,1` + contradiction `1,1,1,1` — S02.M2 modified | 2026-08-05 |
+| 11 approve | `D-S044-11=1` all ACs met | 2026-08-05 |
+| Deploy waive | `D-S044-12-13-waive=1` | 2026-08-05 |
+| Next | `D-S044-next=1` push + PR | 2026-08-05 |

--- a/docs/sessions/S044-local-precommit-long-jobs/session-brief.md
+++ b/docs/sessions/S044-local-precommit-long-jobs/session-brief.md
@@ -1,0 +1,93 @@
+---
+session_id: S044-local-precommit-long-jobs
+type: feature
+status: in_progress
+branch: evolve/EV-036-local-precommit-long-jobs
+started_at: 2026-08-05
+intent: "Offload local-capable long-running jobs onto local pre-commit to save CI runner time"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-036
+prior_session: S043-rule-source-traceability
+context_briefs:
+  - docs/context/local-precommit-long-jobs.md
+standing_docs_touched:
+  - docs/feature-list.md
+  - docs/test-plan.md
+  - docs/dependency-inventory.md
+  - docs/ops/DEVELOPMENT.md
+  - docs/decisions/evolve-decisions.md
+  - .pre-commit-config.yaml
+  - .husky/
+  - Makefile
+  - .github/workflows/ci-cd.yml
+feature_ids: []
+deepen_feature_ids:
+  - M5
+feature_note: "Deepen M5 workspace tooling (pre-commit / CI gate placement) — no product Fn; no UI"
+route_status: approved_lean
+current_stage: 07-build
+status_note: "02 COMPLETE (D-S044-02-gate-a); 07 T1–T5 impl done pending commit → 08"
+---
+
+# Session S044 — local-precommit-long-jobs
+
+## Intent
+
+Move **local-capable long-running** quality jobs onto **local pre-commit** so developers
+pay the cost before push, **saving CI runner time**. Combines “reverse EV-002” direction
+(long suites on pre-commit) with consolidating work that today lives on husky **pre-push**.
+
+## Phase 0 (locked)
+
+| ID | Decision |
+|----|----------|
+| Q1 | Open **S044** → **EV-036** |
+| Q2 | **4+1** — local-capable long jobs on developer hooks to save CI minutes |
+| Q3 | **N/A tooling only** — no product UI / no deploy surface |
+| B1 | **3** — fast+medium on **commit**; full `ci-prepush` on **push** |
+| B2 | **1** — slim remote CI — **amended by Gate A** (`D-S044-02-gate-a`): keep units+coverage+PR comment; drop validate+Compose only |
+| B3 | **1** — job set = `validate-ci` + `ci-prepush` only |
+| B4 | **1** — deepen **M5**; **Lean** routing |
+| Gate A | **PASS** — contradiction `1,1,1,1` then Gate A `1,1,1,1` amended (S02.M2 modified) |
+
+### Why “frontend” came up (Q3)
+
+Not product UI. Local gates already include **`test-unit-frontend`** (Vitest) and
+**`audit-frontend`** (npm audit) inside `make ci-prepush` / `make validate-ci`. Those are
+tooling jobs, not workbench UX. This cycle does **not** change React surfaces.
+
+## Resource model (Gate A amend)
+
+| Tier | When | Jobs |
+|------|------|------|
+| Fast + medium | `git commit` | existing fast pre-commit + `validate-ci-medium` (de-duped) |
+| Long local | `git push` | `make ci` = `ci-prepush` + Compose integration |
+| Remote | GitHub Actions | no validate / no Compose; **keep** units + coverage + PR comment; native / e2e-smoke / alembic / deploy |
+
+Corpus: `[Corpus: tech-spec]` · `[Corpus: tests]` · `[Corpus: product]` M5 · ops `docs/ops/DEVELOPMENT.md`
+
+## Scope
+
+### In
+
+- pre-commit: medium `validate-ci` / `validate-ci-medium`
+- pre-push: `make ci` (units + Compose)
+- `ci-cd.yml`: drop validate + Compose; **keep** unit matrix + coverage + PR coverage comment; rewire deploy `needs`
+- Docs + TC-EV036-001..003
+
+### Out
+
+- Product Fn / browser UI / deploy runtime product changes
+- Family quality packs / Playwright on every local push
+- Non-local jobs (GHCR publish path, live prod E2E)
+
+## Progress
+
+| Stage | Status |
+|-------|--------|
+| 02-verify-plan | **completed** — `D-S044-02-gate-a` |
+| 07-build | **in_progress** — T1–T5 implementation complete; **commit pending** → 08-verify-build |
+
+## Branch
+
+`evolve/EV-036-local-precommit-long-jobs`

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2159,37 +2159,40 @@ Before merging the PR that wires tac2iwxxm and deletes `packages/gifts`:
 
 ## CI/CD (Monorepo)
 
-**Policy (EV-002)**: Single workflow file for PR/push; dual-run locally via husky + pre-commit.
-Scheduled workflows (`vendor-sync`, load/e2e) unchanged.
-
-GitHub `ci-cd.yml` runs **validate**, then **test** / **tac2iwxxm-native** / **e2e-smoke**.
-Husky **pre-push** mirrors validate + unit/matrix locally. **Deploy** on `main` needs
-`test` + `tac2iwxxm-native`, and skips when GHCR or Render hook credentials are missing.
+**Policy (EV-002 → EV-036 amend)**: Single workflow file for PR/push. **Local-first** for
+long/Compose work: medium validate on **commit**, units+Compose on **push**. Remote CI
+**drops** redundant validate + Compose integration but **keeps** the package **unit matrix**,
+**coverage** gates, and a sticky **PR coverage comment**. Strict lint/format is enforced
+locally (pre-commit). Scheduled workflows (`vendor-sync`, load/e2e) unchanged.
 
 | Trigger | Workflow | Jobs | Checks |
 |---------|----------|------|--------|
-| PR / push `main`, `dev` | `ci-cd.yml` | **validate** | ruff format/check, prettier, eslint, basedpyright, tsc, gitleaks, actionlint/yamllint, config-guard (`tests/test_config_placeholders.py`), frontend npm audit |
-| PR / push `main`, `dev` | `ci-cd.yml` | **test**, **tac2iwxxm-native**, **e2e-smoke** | package unit/integration matrix, PyO3 smoke, Playwright smoke |
-| push `main` only | `ci-cd.yml` | **deploy** | needs test + native; Docker build/push GHCR; **DOKS kubectl rollout** (requires `KUBE_CONFIG`); Render hooks optional/non-blocking |
-| Local (husky pre-push) | `.husky/pre-push` | — | `make validate-ci` + `make ci-prepush` (unit/matrix @ package coverage gates) |
+| Local commit | husky → pre-commit | fast + medium | existing fast hooks + `validate-ci` medium extras (de-duped) |
+| Local push | husky pre-push | long | `make ci` = `ci-prepush` + Compose **integration** (ports 18000/18001; wis2box harness via local target) |
+| PR / push `main`, `dev` | `ci-cd.yml` | **remote** | **no** validate job, **no** Compose integration; **keep** unit matrix + coverage + PR coverage comment; keep `tac2iwxxm-native`, `e2e-smoke`, `test-alembic` |
+| push `main` only | `ci-cd.yml` | **deploy** | needs `test` + alembic + native (+ e2e if required); GHCR + **DOKS**; Render optional |
 | Schedule | `vendor-sync.yml` | vendor-sync | wmo-im schema sync PR (M6) |
-| Manual / schedule | `load-tests.yml`, `e2e-tests.yml` | — | out of EV-002 scope |
+| Manual / schedule | `load-tests.yml`, `e2e-tests.yml` | — | out of EV-002 / EV-036 scope |
 
-### Pre-commit / husky (local gates)
+### Pre-commit / husky (local gates) — EV-036
 
-| Hook | Tool | CI equivalent |
-|------|------|---------------|
-| Python format | `ruff format --check` | validate job |
-| Python lint | `ruff check` | validate job |
-| Python types | `basedpyright` | validate job |
-| JS format | `prettier --check` | validate job |
-| JS lint | `eslint` | validate job |
-| JS types | `tsc --noEmit` | validate job |
-| Secrets | `gitleaks` | validate job (replaces `secret-scan.yml`) |
-| Workflow YAML | `actionlint`, `yamllint` | validate job (replaces `github-yaml-lint.yml`) |
-| husky pre-push | `make validate-ci` + `make ci-prepush` | local parity with CI **test** matrix |
+| Hook | Tool | Role |
+|------|------|------|
+| pre-commit (fast) | ruff / prettier / eslint / tsc / basedpyright / gitleaks / actionlint / yamllint / catalog | always-on cheap gates (strict lint/format) |
+| pre-commit (medium) | `make validate-ci-medium` | config-guard, env-check, audit-frontend (de-duped vs fast) |
+| husky pre-push (long) | `make ci` | `ci-prepush` + Compose integration — local Compose source of truth |
+| Remote PR coverage | `coverage-pr-comment` | sticky PR comment from unit coverage artifacts |
 
-Slow Compose integration (`make ci`) stays local/manual — needs free ports 18000/18001.
+Family `test-*-quality` packs stay path-filtered / opt-in — **not** on every commit/push.
+Remote Playwright **e2e-smoke** stays on Actions (browser install cost; not every local push).
+
+### TC-EV036 (M5 / S044) — local-first CI
+
+| ID | Level | Assert |
+|----|-------|--------|
+| TC-EV036-001 | T0 | husky pre-commit runs fast pre-commit + medium validate (`validate-ci-medium` / config-guard+env-check+audit) |
+| TC-EV036-002 | T0 | `.husky/pre-push` runs `make ci` (or `ci-prepush` + `test-integration`) and does **not** re-run `validate-ci`; remote Compose `integration` matrix entry absent |
+| TC-EV036-003 | T0 | `ci-cd.yml` — no `validate:` job; unit matrix present with coverage; coverage PR comment job present; no Compose integration job; deploy `needs` includes `test` |
 
 ### Removed workflows (EV-002)
 

--- a/scripts/ci/format_coverage_pr_comment.py
+++ b/scripts/ci/format_coverage_pr_comment.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Format sticky PR coverage markdown from downloaded coverage artifacts (EV-036).
+
+Reads Cobertura ``coverage.xml`` (pytest-cov) and Vitest ``coverage-summary.json``
+under a directory tree. Prints markdown including sticky marker for github-script.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+MARKER = "<!-- EV-036-coverage-comment -->"
+
+
+def _pct_from_rate(rate: str | None) -> float | None:
+    if rate is None:
+        return None
+    try:
+        return round(float(rate) * 100.0, 2)
+    except ValueError:
+        return None
+
+
+def parse_cobertura(path: Path) -> tuple[float | None, float | None]:
+    """Return (line_pct, branch_pct) from coverage.xml."""
+    root = ET.parse(path).getroot()
+    line = _pct_from_rate(root.attrib.get("line-rate"))
+    branch = _pct_from_rate(root.attrib.get("branch-rate"))
+    return line, branch
+
+
+def parse_vitest_summary(path: Path) -> float | None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    total = data.get("total") or {}
+    lines = total.get("lines") or {}
+    pct = lines.get("pct")
+    if pct is None:
+        return None
+    return round(float(pct), 2)
+
+
+def package_label(path: Path, root: Path) -> str:
+    rel = path.relative_to(root).as_posix()
+    if "apps/backend" in rel or path.parent.name == "backend":
+        return "backend"
+    if "packages/" in rel:
+        parts = Path(rel).parts
+        try:
+            i = parts.index("packages")
+            return parts[i + 1]
+        except (ValueError, IndexError):
+            pass
+    if "frontend" in rel:
+        return "frontend"
+    return path.parent.name
+
+
+def collect_rows(root: Path) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+
+    for xml_path in sorted(root.rglob("coverage.xml")):
+        label = package_label(xml_path, root)
+        if label in seen:
+            continue
+        line, branch = parse_cobertura(xml_path)
+        seen.add(label)
+        line_s = f"{line:.2f}%" if line is not None else "—"
+        branch_s = f"{branch:.2f}%" if branch is not None else "—"
+        rows.append((label, line_s, branch_s))
+
+    for summary in sorted(root.rglob("coverage-summary.json")):
+        label = (
+            "frontend"
+            if "frontend" in summary.as_posix()
+            else package_label(summary, root)
+        )
+        if label in seen:
+            continue
+        pct = parse_vitest_summary(summary)
+        seen.add(label)
+        line_s = f"{pct:.2f}%" if pct is not None else "—"
+        rows.append((label, line_s, "—"))
+
+    return rows
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1] if len(argv) > 1 else "coverage-artifacts")
+    rows = collect_rows(root) if root.is_dir() else []
+
+    lines = [
+        MARKER,
+        "## Coverage summary (EV-036)",
+        "",
+        "Remote CI keeps the **unit matrix** with coverage gates; Compose/integration "
+        "and `validate` run locally (pre-commit / pre-push).",
+        "",
+        "| Package | Lines | Branches |",
+        "|---------|------:|---------:|",
+    ]
+    if not rows:
+        lines.append("| _(no coverage artifacts)_ | — | — |")
+    else:
+        for label, line_s, branch_s in rows:
+            lines.append(f"| `{label}` | {line_s} | {branch_s} |")
+
+    lines.extend(
+        [
+            "",
+            f"[Workflow run]({_run_url()})",
+            "",
+            "_Sticky comment — updated on each PR push. Codecov not used (EV-028)._",
+            "",
+        ]
+    )
+    sys.stdout.write("\n".join(lines))
+    return 0
+
+
+def _run_url() -> str:
+    server = __import__("os").environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = __import__("os").environ.get("GITHUB_REPOSITORY", "EMPIRIC2/TAC-to-IWXXM")
+    run_id = __import__("os").environ.get("GITHUB_RUN_ID", "")
+    if run_id:
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return f"{server}/{repo}/actions"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/frontend/prepare-config.sh
+++ b/scripts/frontend/prepare-config.sh
@@ -1,15 +1,16 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copy environment config into the static frontend build and inject publishable key.
 # Ensures api.baseUrl + Auth bootstrap (supabase.url + publishableKey) for F31.
-set -euo pipefail
+# POSIX sh — Alpine Compose frontend has no bash unless explicitly installed.
+set -eu
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CONFIG_ENV="${METAR_CONFIG_ENV:-prod}"
 SRC="${CONFIG_SRC:-$ROOT/config/${CONFIG_ENV}.json}"
 DEST_DIR="${DEST_DIR:-$ROOT/apps/frontend/public}"
 DEST="$DEST_DIR/config.json"
 
-[[ -f "$SRC" ]] || { echo "Missing $SRC" >&2; exit 1; }
+[ -f "$SRC" ] || { echo "Missing $SRC" >&2; exit 1; }
 mkdir -p "$DEST_DIR"
 
 python3 - <<'PY' "$SRC" "$DEST" "${SUPABASE_PUBLISHABLE_KEY:-${SUPABASE_ANON_KEY:-}}"

--- a/tests/test_tc_ev036_local_precommit_ci.py
+++ b/tests/test_tc_ev036_local_precommit_ci.py
@@ -1,0 +1,268 @@
+"""TC-EV036 — local-first CI / husky / slim remote workflow contracts (S044 / EV-036).
+
+Dense asserts for M5 deepen: commit medium validate, push Compose via ``make ci``,
+remote drops validate + Compose, keeps unit matrix + coverage PR comment.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+HUSKY_PRE_COMMIT = ROOT / ".husky" / "pre-commit"
+HUSKY_PRE_PUSH = ROOT / ".husky" / "pre-push"
+MAKEFILE = ROOT / "Makefile"
+CI_CD = ROOT / ".github" / "workflows" / "ci-cd.yml"
+COVERAGE_SCRIPT = ROOT / "scripts" / "ci" / "format_coverage_pr_comment.py"
+PRE_COMMIT_CFG = ROOT / ".pre-commit-config.yaml"
+
+
+@pytest.fixture(scope="module")
+def makefile_text() -> str:
+    assert MAKEFILE.is_file()
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    assert CI_CD.is_file()
+    return CI_CD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow_doc(workflow_text: str) -> dict:
+    doc = yaml.safe_load(workflow_text)
+    assert isinstance(doc, dict)
+    assert "jobs" in doc
+    return doc
+
+
+@pytest.mark.unit
+class TestTcEv036001PreCommitMediumValidate:
+    """TC-EV036-001 — husky pre-commit runs fast + medium validate."""
+
+    def test_husky_pre_commit_exists_and_executable_bit_path(self) -> None:
+        assert HUSKY_PRE_COMMIT.is_file()
+        text = HUSKY_PRE_COMMIT.read_text(encoding="utf-8")
+        assert text.startswith("#!/"), "husky pre-commit must be a shell script"
+        assert "set -e" in text
+
+    def test_husky_pre_commit_runs_pre_commit_framework(self) -> None:
+        text = HUSKY_PRE_COMMIT.read_text(encoding="utf-8")
+        assert "pre-commit run" in text
+        assert "uv run pre-commit" in text or "pre-commit run" in text
+
+    def test_husky_pre_commit_runs_validate_ci_medium(self) -> None:
+        text = HUSKY_PRE_COMMIT.read_text(encoding="utf-8")
+        assert "validate-ci-medium" in text
+        assert "make validate-ci-medium" in text
+
+    def test_husky_pre_commit_does_not_run_full_ci_or_integration(self) -> None:
+        text = HUSKY_PRE_COMMIT.read_text(encoding="utf-8")
+        assert "make ci\n" not in text and not re.search(r"\bmake ci\b", text)
+        assert "test-integration" not in text
+        assert "ci-prepush" not in text
+
+    def test_makefile_defines_validate_ci_medium(self, makefile_text: str) -> None:
+        assert re.search(r"^validate-ci-medium:", makefile_text, re.M)
+        assert "config-guard" in makefile_text
+        assert "env-check" in makefile_text
+        assert "audit-frontend" in makefile_text
+        # medium target should not pull validate-fast (de-dupe with husky fast hooks)
+        medium_block = _makefile_recipe(makefile_text, "validate-ci-medium")
+        assert "validate-fast" not in medium_block
+        assert "config-guard" in medium_block
+        assert "env-check" in medium_block
+        assert "audit-frontend" in medium_block
+
+    def test_makefile_validate_ci_composes_fast_and_medium(
+        self, makefile_text: str
+    ) -> None:
+        recipe = _makefile_recipe(makefile_text, "validate-ci")
+        assert "validate-fast" in recipe
+        assert "validate-ci-medium" in recipe
+
+    def test_pre_commit_run_target_includes_medium(self, makefile_text: str) -> None:
+        recipe = _makefile_recipe(makefile_text, "pre-commit-run")
+        assert "validate-ci-medium" in recipe
+
+    def test_pre_commit_config_documents_ev036_split(self) -> None:
+        text = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "EV-036" in text or "validate-ci-medium" in text
+        assert "pre-push" in text.lower()
+
+
+@pytest.mark.unit
+class TestTcEv036002PrePushMakeCi:
+    """TC-EV036-002 — husky pre-push runs make ci; no validate-ci; no remote Compose."""
+
+    def test_husky_pre_push_runs_make_ci(self) -> None:
+        text = HUSKY_PRE_PUSH.read_text(encoding="utf-8")
+        assert HUSKY_PRE_PUSH.is_file()
+        assert "set -e" in text
+        assert re.search(r"\bmake ci\b", text)
+        assert "18000" in text or "18001" in text or "Docker" in text
+
+    def test_husky_pre_push_does_not_rerun_validate(self) -> None:
+        text = HUSKY_PRE_PUSH.read_text(encoding="utf-8")
+        # Ignore comments; assert no make validate* invocation.
+        code_lines = [
+            ln
+            for ln in text.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        code = "\n".join(code_lines)
+        assert not re.search(r"\bmake\s+validate", code)
+        assert not re.search(r"\bvalidate-ci(-medium)?\b", code)
+
+    def test_makefile_ci_includes_integration(self, makefile_text: str) -> None:
+        recipe = _makefile_recipe(makefile_text, "ci")
+        assert "ci-prepush" in recipe
+        assert "test-integration" in recipe
+
+    def test_makefile_pre_push_run_is_make_ci(self, makefile_text: str) -> None:
+        recipe = _makefile_recipe(makefile_text, "pre-push-run")
+        assert re.search(r"\bci\b", recipe)
+        code_lines = [
+            ln
+            for ln in recipe.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        code = "\n".join(code_lines)
+        assert not re.search(r"\bvalidate-ci\b", code)
+        assert re.search(r"\bci\b", code)
+
+    def test_remote_workflow_has_no_integration_matrix_entry(
+        self, workflow_doc: dict
+    ) -> None:
+        test_job = workflow_doc["jobs"]["test"]
+        matrix = test_job["strategy"]["matrix"]["package"]
+        assert "integration" not in matrix
+        assert "backend" in matrix
+        assert "frontend" in matrix
+        assert "tac2iwxxm" in matrix
+
+    def test_remote_workflow_has_no_compose_integration_steps(
+        self, workflow_text: str
+    ) -> None:
+        assert "docker compose up -d backend frontend" not in workflow_text
+        assert "Set integration stack environment" not in workflow_text
+        assert "Run wis2box Compose harness hook" not in workflow_text
+        assert "matrix.package == 'integration'" not in workflow_text
+
+
+@pytest.mark.unit
+class TestTcEv036003RemoteUnitsCoverageNoValidate:
+    """TC-EV036-003 — no validate job; units+coverage+PR comment; deploy needs test."""
+
+    def test_no_validate_job(self, workflow_doc: dict) -> None:
+        jobs = workflow_doc["jobs"]
+        assert "validate" not in jobs
+        assert "test" in jobs
+        assert "coverage-pr-comment" in jobs
+        assert "test-alembic" in jobs
+        assert "tac2iwxxm-native" in jobs
+        assert "e2e-smoke" in jobs
+        assert "deploy" in jobs
+
+    def test_no_job_needs_validate(self, workflow_text: str) -> None:
+        assert "needs: [validate]" not in workflow_text
+        assert "needs: [validate," not in workflow_text
+
+    def test_unit_matrix_packages_present(self, workflow_doc: dict) -> None:
+        packages = set(workflow_doc["jobs"]["test"]["strategy"]["matrix"]["package"])
+        required = {
+            "shared",
+            "auth",
+            "backend",
+            "frontend",
+            "tac2iwxxm",
+            "iwxxm-validate",
+            "tac-validate",
+            "dissemination",
+            "bugs",
+        }
+        assert required.issubset(packages)
+        assert "integration" not in packages
+
+    def test_coverage_xml_and_fail_under_remain(self, workflow_text: str) -> None:
+        assert "--cov-fail-under" in workflow_text
+        assert "coverage.xml" in workflow_text
+        assert "Upload package coverage XML artifact" in workflow_text
+        assert "coverage-xml-" in workflow_text
+
+    def test_coverage_pr_comment_job_shape(self, workflow_doc: dict) -> None:
+        job = workflow_doc["jobs"]["coverage-pr-comment"]
+        assert job["needs"] == ["test"] or job["needs"] == "test"
+        assert job.get("if") == "github.event_name == 'pull_request'"
+        perms = job.get("permissions") or {}
+        assert perms.get("pull-requests") == "write"
+        step_names = [s.get("name", "") for s in job.get("steps", [])]
+        assert any("Format coverage" in n for n in step_names)
+        assert any("sticky" in n.lower() or "Post or update" in n for n in step_names)
+
+    def test_coverage_formatter_script_exists(self) -> None:
+        assert COVERAGE_SCRIPT.is_file()
+        text = COVERAGE_SCRIPT.read_text(encoding="utf-8")
+        assert "EV-036-coverage-comment" in text
+        assert "coverage.xml" in text
+
+    def test_deploy_needs_includes_test(self, workflow_doc: dict) -> None:
+        needs = workflow_doc["jobs"]["deploy"]["needs"]
+        assert "test" in needs
+        assert "test-alembic" in needs
+        assert "tac2iwxxm-native" in needs
+        assert "validate" not in needs
+
+    def test_retained_runner_only_jobs_have_no_validate_dep(
+        self, workflow_doc: dict
+    ) -> None:
+        for name in ("test-alembic", "tac2iwxxm-native", "e2e-smoke"):
+            job = workflow_doc["jobs"][name]
+            needs = job.get("needs")
+            if needs is None:
+                continue
+            if isinstance(needs, str):
+                needs = [needs]
+            assert "validate" not in needs
+
+    def test_workflow_comments_document_ev036(self, workflow_text: str) -> None:
+        assert "EV-036" in workflow_text
+        assert (
+            "local pre-commit" in workflow_text.lower()
+            or "local-push" in workflow_text.lower()
+            or "pre-push" in workflow_text.lower()
+        )
+
+
+def _makefile_recipe(makefile: str, target: str) -> str:
+    """Return the recipe lines for a simple single-line or continued Makefile target."""
+    pattern = re.compile(rf"^{re.escape(target)}:(.*)$", re.M)
+    match = pattern.search(makefile)
+    assert match is not None, f"missing Makefile target {target}"
+    # Prefer same-line prerequisites / recipe fragment plus following tab lines until next target
+    start = match.end()
+    lines = [match.group(1)]
+    for line in makefile[start:].splitlines()[1:]:
+        if (
+            not line.startswith("\t")
+            and line.strip()
+            and not line.startswith("#")
+            and re.match(r"^[A-Za-z0-9_.-]+:", line)
+        ):
+            break
+        if (
+            line.startswith("\t")
+            or line.endswith("\\")
+            or (lines and lines[-1].endswith("\\"))
+        ):
+            lines.append(line)
+        elif not line.strip():
+            continue
+        else:
+            break
+    return "\n".join(lines)

--- a/tests/unit/test_format_coverage_pr_comment.py
+++ b/tests/unit/test_format_coverage_pr_comment.py
@@ -1,0 +1,57 @@
+"""Unit tests for scripts/ci/format_coverage_pr_comment.py (EV-036)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci" / "format_coverage_pr_comment.py"
+
+
+@pytest.mark.unit
+def test_format_coverage_pr_comment_parses_xml_and_vitest(tmp_path: Path) -> None:
+    backend = tmp_path / "apps" / "backend"
+    backend.mkdir(parents=True)
+    root = Element("coverage", {"line-rate": "0.982", "branch-rate": "0.91"})
+    SubElement(root, "packages")
+    (backend / "coverage.xml").write_bytes(tostring(root))
+
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "coverage-summary.json").write_text(
+        json.dumps({"total": {"lines": {"pct": 96.5}}}),
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    out = proc.stdout
+    assert "<!-- EV-036-coverage-comment -->" in out
+    assert "## Coverage summary (EV-036)" in out
+    assert "`backend`" in out
+    assert "98.20%" in out
+    assert "91.00%" in out
+    assert "`frontend`" in out
+    assert "96.50%" in out
+    assert "Codecov not used" in out
+
+
+@pytest.mark.unit
+def test_format_coverage_pr_comment_empty_dir(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "no coverage artifacts" in proc.stdout

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -32,7 +32,7 @@ active_session:
   started: '2026-08-05'
   started_at: '2026-08-05'
   route_status: approved_lean
-  note: 'OPEN — 02 COMPLETE (D-S044-02-gate-a Gate A PASS S02.M2 modified); 07-build T1–T5 implementation complete pending commit → 08; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
+  note: 'OPEN — 08-verify-build COMPLETE PASS @ d4fd6955; 09-qa in_progress; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
   decisions:
     Q1: '1'
     Q1_note: open_S044
@@ -77,7 +77,7 @@ active_session:
     started: '2026-08-05'
     started_at: '2026-08-05'
     skip_rationale:
-    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07-build in_progress (T1–T5 impl done pending commit → 08)'
+    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07-build COMPLETE @ d4fd6955; child 08-verify-build COMPLETE PASS; child 09-qa in_progress'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -117,22 +117,40 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
+    status: completed
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    skip_rationale:
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    pending_commit: false
+    note: 'COMPLETE — T1–T5 done @ d4fd6955; local Compose on pre-push; remote units + coverage PR comment; handoff 08-verify-build'
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    skip_rationale:
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    overall: pass
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+    note: 'PASS — tip d4fd6955; artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; handoff 09-qa'
+  - stage: 09-qa
+    required: true
+    mode: delta
     status: in_progress
     started: '2026-08-05'
     started_at: '2026-08-05'
     skip_rationale:
-    note: 'T1–T5 implementation complete pending commit; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08 after commit'
-  - stage: 08-verify-build
-    required: true
-    mode: delta
-    status: pending
-    skip_rationale:
-  - stage: 09-qa
-    required: true
-    mode: delta
-    status: pending
-    skip_rationale:
-    note: local hook smoke
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    note: 'STARTED — local hook smoke after 08 PASS; tip d4fd6955'
   - stage: 10-e2e
     required: false
     status: skipped
@@ -150,8 +168,8 @@ active_session:
     required: false
     status: skipped
     skip_rationale: Lean — with 12; no deploy surface
-  current_stage: 07-build
-  current_stage_note: '07-build — T1–T5 implementation complete pending commit; handoff 08-verify-build after commit; Gate A D-S044-02-gate-a PASS (S02.M2 modified)'
+  current_stage: 09-qa
+  current_stage_note: '09-qa in_progress — 08-verify-build PASS @ d4fd6955; report verification-report.md; Lean local hook smoke'
 sessions:
 - id: S043-rule-source-traceability
   type: feature
@@ -7701,11 +7719,11 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: in_progress
+    status: completed
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at:
-    completed:
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
     previous_started_at: '2026-08-05'
     previous_completed_at: '2026-08-05'
     previous_session_id: S042-doks-cd-rollout
@@ -7724,12 +7742,12 @@ stages:
     session_id: S044-local-precommit-long-jobs
     evolve_cycle_id: EV-036
     mode: full
-    note: 'S044/EV-036 07-build — T1–T5 implementation complete pending commit; Gate A D-S044-02-gate-a; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08-verify-build after commit; no commit SHA invented'
-    tip_sha:
-    tip_sha_full:
-    tip_note: 'S044/EV-036 — no commit yet (parent pending); prior tip lineage S042 @ 9ae9c323 retained under previous_*'
-    pending_commit: true
-    pending_commit_note: 'T1–T5 implementation landed in worktree; commit not made yet by parent'
+    note: 'S044/EV-036 07-build COMPLETE — T1–T5 done @ d4fd6955; local Compose on pre-push; remote units + coverage PR comment; Gate A D-S044-02-gate-a; pending_commit false; handoff 08-verify-build'
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    tip_note: 'S044/EV-036 tip d4fd6955 — [EV-036] feat: local Compose on pre-push; remote units + coverage PR comment'
+    pending_commit: false
+    pending_commit_note: 'cleared — commit d4fd6955 recorded'
     next_stage: 08-verify-build
     current_milestone: M1
     current_task: T5
@@ -7757,15 +7775,23 @@ stages:
     - Makefile
     - docs/ops/DEVELOPMENT.md
     - docs/test-plan.md
+    - scripts/ci/format_coverage_pr_comment.py
+    - tests/test_tc_ev036_local_precommit_ci.py
+    - tests/unit/test_format_coverage_pr_comment.py
     active_session:
       session_id: S044-local-precommit-long-jobs
       evolve_cycle_id: EV-036
       skill_id: 07-build
-      status: in_progress
+      status: completed
       mode: full
       started_at: '2026-08-05'
       started: '2026-08-05'
-      note: 'T1–T5 implementation complete pending commit; handoff 08 after commit; D-S044-02-gate-a'
+      completed_at: '2026-08-05'
+      completed: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      pending_commit: false
+      note: 'COMPLETE — T1–T5 @ d4fd6955; handoff 08-verify-build; D-S044-02-gate-a'
       feature_ids: []
       deepen_feature_ids:
       - M5
@@ -7791,8 +7817,10 @@ stages:
     hotfix_pr_status: merged
     hotfix_merge_commit_sha: d3f4bb95
     hotfix_merge_commit_sha_full: d3f4bb955ca71d57506a44d5be9f346a31ae56d3
-    commit_sha: 9ae9c323
-    commit_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    commit_sha: d4fd6955
+    commit_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    prior_s042_commit_sha: 9ae9c323
+    prior_s042_commit_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
     suspended_s040_progress: 28/28
     suspended_s040_completed_through: T4.6
     suspended_s040_active_task: T4.6
@@ -8991,40 +9019,62 @@ stages:
     - 2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED host ports/disk; QA-001 api.py type narrow uncommitted; active_task T6.3 pending
     - 2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress
   09-qa:
-    status: completed
+    status: in_progress
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at: '2026-08-05'
-    completed: '2026-08-05'
-    previous_started_at: '2026-08-04'
-    previous_started: '2026-08-04'
-    previous_completed_at: '2026-08-04'
-    previous_completed: '2026-08-04'
-    previous_session_id: S040-iwxxm-corpus-quality
-    previous_evolve_cycle_id: EV-032
-    previous_tip_sha: 09e60184
-    previous_tip_sha_full: 09e601847eae404f997e107b42952bfcc51db12f
-    previous_overall: pass_with_advisories
-    previous_report: docs/sessions/S040-iwxxm-corpus-quality/reports/qa-report.md
-    previous_note: 'COMPLETE 2026-08-04 (T4.3) — pass_with_advisories; report qa-report.md; tip 09e60184 committed; H4–H5→T4.5/13; progress 24/28; next 11-verify-impl T4.4; PR #848; #846'
+    completed_at:
+    completed:
+    previous_started_at: '2026-08-05'
+    previous_started: '2026-08-05'
+    previous_completed_at: '2026-08-05'
+    previous_completed: '2026-08-05'
+    previous_session_id: S042-doks-cd-rollout
+    previous_evolve_cycle_id: EV-034
+    previous_tip_sha: d3f4bb95
+    previous_tip_sha_full: d3f4bb955ca71d57506a44d5be9f346a31ae56d3
+    previous_overall: pass
+    previous_report: docs/sessions/S042-doks-cd-rollout/reports/qa-report.md
+    previous_note: 'COMPLETE — S042/EV-034 overall pass; report docs/sessions/S042-doks-cd-rollout/reports/qa-report.md; #868 MERGED @ d3f4bb95; main CI/CD Pipeline run 31003268652 SUCCESS; 11/12/13 completed via D-S042-13=1; 10 remains skipped'
+    previous_s040_started_at: '2026-08-04'
+    previous_s040_started: '2026-08-04'
+    previous_s040_completed_at: '2026-08-04'
+    previous_s040_completed: '2026-08-04'
+    previous_s040_session_id: S040-iwxxm-corpus-quality
+    previous_s040_evolve_cycle_id: EV-032
+    previous_s040_tip_sha: 09e60184
+    previous_s040_tip_sha_full: 09e601847eae404f997e107b42952bfcc51db12f
+    previous_s040_overall: pass_with_advisories
+    previous_s040_report: docs/sessions/S040-iwxxm-corpus-quality/reports/qa-report.md
+    previous_s040_note: 'COMPLETE 2026-08-04 (T4.3) — pass_with_advisories; report qa-report.md; tip 09e60184 committed; H4–H5→T4.5/13; progress 24/28; next 11-verify-impl T4.4; PR #848; #846'
     prior_s038_session_id: S038-platform-independence-842
     prior_s038_evolve_cycle_id: EV-031
     prior_s038_tip_sha: 06d57043
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e34866
-    session_id: S042-doks-cd-rollout
-    evolve_cycle_id: EV-034
-    tip_sha: d3f4bb95
-    tip_sha_full: d3f4bb955ca71d57506a44d5be9f346a31ae56d3
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
     mode: delta
-    overall: pass
-    report: docs/sessions/S042-doks-cd-rollout/reports/qa-report.md
-    note: 'COMPLETE — S042/EV-034 overall pass; report docs/sessions/S042-doks-cd-rollout/reports/qa-report.md; #868 MERGED @ d3f4bb95; main CI/CD Pipeline run 31003268652 SUCCESS; 11/12/13 completed via D-S042-13=1; 10 remains skipped'
+    overall:
+    report:
+    note: 'IN PROGRESS — S044/EV-036 local hook smoke after 08 PASS; tip d4fd6955; expected report docs/sessions/S044-local-precommit-long-jobs/reports/qa-report.md'
     pending_commit: false
     main_ci_cd_pipeline_run: '31003268652'
     main_ci_cd_pipeline_status: in_progress
     delta_substages:
+    - id: S044-local-precommit-long-jobs-09
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 09-qa
+      status: in_progress
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      note: 'STARTED — local hook smoke after 08 PASS'
     - id: S042-doks-cd-rollout
       session_id: S042-doks-cd-rollout
       evolve_cycle_id: EV-034
@@ -9887,15 +9937,24 @@ stages:
     started: '2026-08-05'
     completed_at: '2026-08-05'
     completed: '2026-08-05'
-    previous_started_at: '2026-08-04'
-    previous_completed_at: '2026-08-04'
-    previous_session_id: S040-iwxxm-corpus-quality
-    previous_evolve_cycle_id: EV-032
-    previous_tip_sha: e0e595e3
-    previous_tip_sha_full: e0e595e323729ab3b25dca9e9db2410480724272
-    previous_note: 'COMPLETE (T4.2) — PASS @ tip e0e595e3; report docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md; also verification-report-M4.md; progress 23/28; gates.c_to_d/phase_c PASSED (D-S040-phase-c=1 Continue → T4.3); Phase D → 09+10; PR #848; #846'
-    previous_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
+    previous_started_at: '2026-08-05'
+    previous_completed_at: '2026-08-05'
+    previous_session_id: S042-doks-cd-rollout
+    previous_evolve_cycle_id: EV-034
+    previous_tip_sha: 9ae9c323
+    previous_tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    previous_note: 'COMPLETE — PASS scoped 2026-08-05; report docs/sessions/S042-doks-cd-rollout/reports/verification-report.md; PR #867 MERGED; #868 MERGED @ d3f4bb95 (D-S042-868-hold resolved; phase_c_checkpoint choice 1); gates.c_to_d passed; Phase D → 09-qa'
+    previous_report: docs/sessions/S042-doks-cd-rollout/reports/verification-report.md
     previous_overall: pass
+    previous_s040_started_at: '2026-08-04'
+    previous_s040_completed_at: '2026-08-04'
+    previous_s040_session_id: S040-iwxxm-corpus-quality
+    previous_s040_evolve_cycle_id: EV-032
+    previous_s040_tip_sha: e0e595e3
+    previous_s040_tip_sha_full: e0e595e323729ab3b25dca9e9db2410480724272
+    previous_s040_note: 'COMPLETE (T4.2) — PASS @ tip e0e595e3; report docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md; also verification-report-M4.md; progress 23/28; gates.c_to_d/phase_c PASSED (D-S040-phase-c=1 Continue → T4.3); Phase D → 09+10; PR #848; #846'
+    previous_s040_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
+    previous_s040_overall: pass
     prior_s038_started_at: '2026-08-03'
     prior_s038_completed_at: '2026-08-03'
     prior_s038_session_id: S038-platform-independence-842
@@ -9911,22 +9970,22 @@ stages:
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 1f47eb5
     prior_s037_note: 'COMPLETE (M3 gate + T4.1) — PASS @ tip 1f47eb5; report docs/sessions/S037-quality-residuals-831/reports/verification-report-m3.md; prior M2 verification-report-m2.md; CI 30823368642 SUCCESS; reopen for final M4 08; PR #832 open; #831→#835'
-    session_id: S042-doks-cd-rollout
-    evolve_cycle_id: EV-034
-    tip_sha: 9ae9c323
-    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
-    note: 'COMPLETE — PASS scoped 2026-08-05; report docs/sessions/S042-doks-cd-rollout/reports/verification-report.md; PR #867 MERGED; #868 MERGED @ d3f4bb95 (D-S042-868-hold resolved; phase_c_checkpoint choice 1); gates.c_to_d passed; Phase D → 09-qa'
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    note: 'PASS — S044/EV-036 COMPLETE @ tip d4fd6955; artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; handoff 09-qa'
     prior_s040_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
     prior_s040_report_m4: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report-M4.md
     prior_s040_overall: pass
-    expected_report: docs/sessions/S042-doks-cd-rollout/reports/verification-report.md
-    report: docs/sessions/S042-doks-cd-rollout/reports/verification-report.md
+    expected_report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
     overall: pass
-    pr_number: 867
-    pr_status: merged
-    hotfix_pr_number: 868
-    hotfix_pr_status: merged
-    hotfix_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/868
+    prior_s042_pr_number: 867
+    prior_s042_pr_status: merged
+    prior_s042_hotfix_pr_number: 868
+    prior_s042_hotfix_pr_status: merged
+    prior_s042_hotfix_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/868
     m4_overall: pass
     m4_tip_sha: 04fb4a98
     m4_report: docs/sessions/S038-platform-independence-842/reports/verification-report-M4.md
@@ -9934,19 +9993,19 @@ stages:
     m5_overall: pass
     m5_tip_sha: 7a2cb7d0
     m5_report: docs/sessions/S038-platform-independence-842/reports/verification-report-M5.md
-    active_milestone: M4
-    active_task: T4.3
-    active_task_status: in_progress
-    progress: 23/28
-    completed_through: T4.2
-    m5_boundary: true
+    active_milestone: M1
+    active_task: null
+    active_task_status: completed
+    progress: 5/5
+    completed_through: T5
+    m5_boundary: false
     m5_boundary_complete: true
     m7_pack: true
     decision_refs:
-    - D-S038-phase-c
-    - D-S038-continue
-    - D-S038-t65-waive
-    - D-S038-04-plan
+    - D-S044-02-gate-a
+    - D-S044-r1-ac
+    - D-S044-g1-g2
+    - D-S044-batch-b
     substeps:
       lint:
         status: completed
@@ -9957,11 +10016,46 @@ stages:
       tests:
         status: completed
       security:
-        status: skipped
-        note: deferred / not required for M5 boundary scoped verify
+        status: completed
+        note: Lean tooling — run if required by 08 skill
       report:
         status: completed
+    active_session:
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 08-verify-build
+      status: completed
+      mode: delta
+      started_at: '2026-08-05'
+      started: '2026-08-05'
+      completed_at: '2026-08-05'
+      completed: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      overall: pass
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+      note: 'PASS — handoff 09-qa'
+      deepen_feature_ids:
+      - M5
+      decision_refs:
+      - D-S044-02-gate-a
     delta_substages:
+    - id: S044-local-precommit-long-jobs-08
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 08-verify-build
+      status: completed
+      started_at: '2026-08-05'
+      started: '2026-08-05'
+      completed_at: '2026-08-05'
+      completed: '2026-08-05'
+      mode: evolve_delta
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      tip_note: tip d4fd6955 after 07-build COMPLETE
+      overall: pass
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+      note: 'PASS — handoff 09-qa'
     - id: S040-iwxxm-corpus-quality-T4.2
       session_id: S040-iwxxm-corpus-quality
       evolve_cycle_id: EV-032
@@ -11450,8 +11544,8 @@ stages:
     previous_completed_at: '2026-08-05'
     prior_mirror_session_id: S040-iwxxm-corpus-quality
     prior_mirror_evolve_cycle_id: EV-032
-    current_child_stage: 07-build
-    note: 'IN PROGRESS — S044/EV-036 02 COMPLETE (D-S044-02-gate-a); 07-build T1–T5 impl done pending commit → 08; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
+    current_child_stage: 08-verify-build
+    note: 'IN PROGRESS — S044/EV-036 07-build COMPLETE @ d4fd6955 (T1–T5; pending_commit false); 08-verify-build in_progress; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -22859,6 +22953,19 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+  type: session-report
+  kind: verification-report
+  stage: 08-verify-build
+  skill_id: 08-verify-build
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: completed
+  overall: pass
+  tip_sha: d4fd6955
+  note: 'PASS — handoff 09-qa'
 - path: docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
   type: session-report
   kind: verify-plan-audit
@@ -33086,7 +33193,7 @@ evolve_cycles:
   slug: local-precommit-long-jobs
   status: in_progress
   phase: 2
-  phase_note: 'Phase 2 / build — 02 COMPLETE (D-S044-02-gate-a); 07-build T1–T5 impl done pending commit → 08'
+  phase_note: 'Phase 2 / verify+qa — 08-verify-build COMPLETE PASS @ d4fd6955; 09-qa in_progress'
   started: '2026-08-05'
   started_at: '2026-08-05'
   scope_summary: |
@@ -33097,10 +33204,10 @@ evolve_cycles:
     TC-EV036-001..003 approved. Gate A amend (D-S044-02-gate-a): keep remote
     units+coverage+PR comment; drop validate+Compose; local lint only.
   branch: evolve/EV-036-local-precommit-long-jobs
-  branch_note: exists — parent creating/cutting branch now; workflow-state-manager did not git checkout/create
-  tip_sha: 97a5c131
-  tip_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
-  tip_note: '07-build impl pending commit — tip remains prior base 97a5c131; no SHA invented'
+  branch_note: active — tip d4fd6955; workflow-state-manager did not git checkout/create
+  tip_sha: d4fd6955
+  tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+  tip_note: '07-build COMPLETE @ d4fd6955 — [EV-036] feat: local Compose on pre-push; remote units + coverage PR comment'
   preset: Lean
   preset_status: approved
   preset_note: 'G1=1 Lean approved; route_status=approved_lean'
@@ -33141,11 +33248,11 @@ evolve_cycles:
     - 12-verify-deploy
     - 13-deploy-smoke
     path: 00→16→01→02→07→08→09→11
-    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime)'
-  current_stage: 07-build
+    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime); 07–08 completed; 09 in_progress'
+  current_stage: 09-qa
   current_stage_status: in_progress
-  current_stage_note: '07-build — T1–T5 implementation complete pending commit; handoff 08-verify-build after commit; D-S044-02-gate-a'
-  next_stage: 08-verify-build
+  current_stage_note: '09-qa in_progress — 08 PASS @ d4fd6955; report verification-report.md'
+  next_stage: 11-verify-impl
   next_stage_status: pending
   gates:
     a_to_b: passed
@@ -33159,7 +33266,7 @@ evolve_cycles:
     phase_c: pending
     phase_d: pending
     deploy: waived_expected
-    note: 'Lean tooling cycle — Gate A passed; deploy waive expected (no runtime)'
+    note: 'Lean tooling cycle — Gate A passed; 07 done; deploy waive expected (no runtime)'
   adrs: []
   artifacts:
   - path: docs/sessions/S044-local-precommit-long-jobs/
@@ -33178,9 +33285,13 @@ evolve_cycles:
     stage: 02-verify-plan
     note: D-S044-02-gate-a
   - path: docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
-    status: written
+    status: completed
     stage: 07-build
-    note: T1–T5 completed; commit pending
+    note: T1–T5 completed @ d4fd6955
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+    status: completed
+    stage: 08-verify-build
+    note: PASS
   - path: docs/feature-list.md
     status: written
     stage: 01-requirements
@@ -33211,6 +33322,15 @@ evolve_cycles:
   - path: docs/ops/DEVELOPMENT.md
     status: written
     stage: 07-build
+  - path: scripts/ci/format_coverage_pr_comment.py
+    status: written
+    stage: 07-build
+  - path: tests/test_tc_ev036_local_precommit_ci.py
+    status: written
+    stage: 07-build
+  - path: tests/unit/test_format_coverage_pr_comment.py
+    status: written
+    stage: 07-build
   issues: []
   decision_refs:
   - D-S044-open
@@ -33232,7 +33352,7 @@ evolve_cycles:
       status: in_progress
       started: '2026-08-05'
       started_at: '2026-08-05'
-      note: 'Phase 0–2; child 07-build (02 COMPLETE D-S044-02-gate-a; T1–T5 pending commit)'
+      note: 'Phase 0–2; child 07-build COMPLETE @ d4fd6955; child 08-verify-build COMPLETE PASS; child 09-qa in_progress'
     01-requirements:
       status: completed
       mode: delta
@@ -33250,14 +33370,36 @@ evolve_cycles:
       completed_at: '2026-08-05'
       note: 'COMPLETE — Gate A PASS D-S044-02-gate-a (S02.M2 modified); handoff 07'
     07-build:
-      status: in_progress
+      status: completed
       mode: full
       started: '2026-08-05'
       started_at: '2026-08-05'
-      note: 'T1–T5 implementation complete pending commit; handoff 08 after commit'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      pending_commit: false
+      note: 'COMPLETE — T1–T5 @ d4fd6955; handoff 08'
     08-verify-build:
-      status: pending
+      status: completed
       mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      overall: pass
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+      note: 'PASS — artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; handoff 09-qa'
+    09-qa:
+      status: in_progress
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      tip_sha: d4fd6955
+      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+      note: 'STARTED — local hook smoke after 08 PASS'
   notes:
   - '2026-08-05 S044/EV-036 OPEN — open_session; D-S044-open=1; D-S044-intent=4+1/N/A; session_counter 44; evolve_cycle_counter 36; branch evolve/EV-036-local-precommit-long-jobs pending_create; deepen M5 likely; no git branch/commit by workflow-state-manager'
   - '2026-08-05 Phase 0 LOCKED — D-S044-batch-b B1=3,B2=1,B3=1,B4=1; deepen M5; Lean preset pending G4; route_status=phase0_locked_pending_proceed; 00-context completed; 16-evolve in_progress; no git branch/commit by workflow-state-manager'
@@ -33265,6 +33407,8 @@ evolve_cycles:
   - '2026-08-05 01-requirements COMPLETE — D-S044-r1-ac R1=local_compose AC=1; remove remote Compose/integration → local pre-push make ci; M5 ACs + TC-EV036 approved; current_stage=02-verify-plan in_progress; no git commit by workflow-state-manager'
   - '2026-08-05 02-verify-plan COMPLETE — D-S044-02-gate-a Gate A PASS; contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; S02.M2 keep remote units+coverage+PR comment; drop validate+Compose; local lint only; current_stage=07-build; no commit SHA invented'
   - '2026-08-05 07-build — T1–T5 implementation complete pending commit; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08-verify-build after commit; no commit SHA invented'
+  - '2026-08-05 07-build COMPLETE @ d4fd6955 (d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b) — T1–T5; pending_commit false; tip_sha d4fd6955; current_stage 08-verify-build in_progress'
+  - '2026-08-05 08-verify-build COMPLETE PASS @ d4fd6955 — artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; current_stage 09-qa in_progress'
 - id: EV-035
   session_id: S043-rule-source-traceability
   cycle_type: feature
@@ -34333,15 +34477,15 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: main
-  ahead_of_origin: 2
+  current_branch: evolve/EV-036-local-precommit-long-jobs
+  ahead_of_origin: 1
   pushed: false
-  pending_commit: true
-  pending_commit_note: 'S044/EV-036 T1–T5 impl + workflow-state updates uncommitted; no SHA invented; prior dirty note: git_history.commits append for f6105b8f may still need follow-up'
+  pending_commit: false
+  pending_commit_note: 'cleared — d4fd6955 recorded; workflow-state tip sync may leave dirty tree for follow-up commit'
   dirty: true
-  tip_sha: 97a5c131
-  tip_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
-  tip_note: 'S044/EV-036 — 02 COMPLETE D-S044-02-gate-a; 07-build T1–T5 pending commit → 08; branch evolve/EV-036-local-precommit-long-jobs; tip main @ 97a5c131 (no SHA invented)'
+  tip_sha: d4fd6955
+  tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+  tip_note: 'S044/EV-036 — 07-build COMPLETE @ d4fd6955; 08-verify-build in_progress; branch evolve/EV-036-local-precommit-long-jobs'
   stash:
   - name: S039-EV031-WIP
     note: 'Parked EV-031/S039 dirty worktree WIP before cutting evolve/EV-032 from main (D-S040-branch=1)'
@@ -34353,9 +34497,10 @@ git_history:
   main_tip_sha: 5245f8de
   main_tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
   recommended_branch: evolve/EV-036-local-precommit-long-jobs
-  note: 'S044/EV-036 D-S044-02-gate-a Gate A PASS; current_stage 07-build T1–T5 pending commit; tip main @ 97a5c131; no commit by workflow-state-manager this update'
+  note: 'S044/EV-036 07 COMPLETE @ d4fd6955; current_stage 08-verify-build in_progress; pending_commit false; tip d4fd6955'
 
   notes:
+  - '2026-08-05 S044/EV-036 — recorded git commit d4fd6955 (d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b) [EV-036] feat: local Compose on pre-push; remote units + coverage PR comment; 07-build COMPLETE (T1–T5; pending_commit false); 08-verify-build in_progress; tip d4fd6955; ahead_of_origin=1 pushed=false'
   - '2026-08-05 S044/EV-036 D-S044-02-gate-a — Gate A PASS S02.M2 modified; 02 completed; 07-build T1–T5 impl pending commit → 08; no git commit/SHA invented by workflow-state-manager; tip main @ 97a5c131'
   - '2026-08-05 S044/EV-036 D-S044-g1-g2 — G1=1 Lean + G2=1 proceed; preset_status=approved; route_status=approved_lean; current_stage 01-requirements in_progress; branch evolve/EV-036-local-precommit-long-jobs exists:true (parent creating); no git branch/commit by workflow-state-manager; tip main @ 97a5c131'
   - '2026-08-05 S044/EV-036 OPEN — open_session; D-S044-open=1; D-S044-intent=4+1/N/A; session_counter 44; evolve_cycle_counter 36; branch evolve/EV-036-local-precommit-long-jobs pending_create; 00-context in_progress → 16-evolve Phase 0 intake; deepen M5 likely; no git branch/commit by workflow-state-manager; tip main @ 97a5c131'
@@ -34804,10 +34949,12 @@ git_history:
     evolve_cycle_id: EV-036
     created: '2026-08-05'
     created_at: '2026-08-05'
+    tip_sha: d4fd6955
+    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
     exists: true
     pushed: false
-    ahead_of_origin: 0
-    note: 'exists:true — parent creating/cutting branch now (D-S044-g1-g2 G2=1); workflow-state-manager did not git checkout/create'
+    ahead_of_origin: 1
+    note: 'active — tip d4fd6955; 07 COMPLETE; 08 in_progress; not pushed'
   - name: evolve/EV-034-doks-cd-rollout
     status: active
     base: main
@@ -35874,6 +36021,45 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    short: d4fd6955
+    branch: evolve/EV-036-local-precommit-long-jobs
+    message: '[EV-036] feat: local Compose on pre-push; remote units + coverage PR comment'
+    stage: 07-build
+    skill_id: 07-build
+    stages:
+    - 07-build
+    milestone: M1
+    task: T1-T5
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    files_changed:
+    - .github/workflows/ci-cd.yml
+    - .husky/pre-commit
+    - .husky/pre-push
+    - .pre-commit-config.yaml
+    - Makefile
+    - docs/context/local-precommit-long-jobs.md
+    - docs/decisions/evolve-decisions.md
+    - docs/dependency-inventory.md
+    - docs/feature-list.md
+    - docs/ops/DEVELOPMENT.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+    - docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
+    - docs/sessions/S044-local-precommit-long-jobs/session-brief.md
+    - docs/test-plan.md
+    - scripts/ci/format_coverage_pr_comment.py
+    - tests/test_tc_ev036_local_precommit_ci.py
+    - tests/unit/test_format_coverage_pr_comment.py
+    - workflow-state.yaml
+    files_changed_count: 20
+    timestamp: '2026-08-05'
+    timestamp_utc: '2026-08-05T15:18:51Z'
+    pushed: false
+    tip_sha: d4fd6955
+    note: 'S044/EV-036 07-build COMPLETE — T1–T5; pending_commit cleared; handoff 08-verify-build'
   - sha: f6105b8f3475aee793b1d86229e876a7694a0f10
     short: f6105b8f
     branch: main

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,9 +3,155 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 43
-evolve_cycle_counter: 35
-active_session: null
+session_counter: 44
+evolve_cycle_counter: 36
+active_session:
+  id: S044-local-precommit-long-jobs
+  type: feature
+  intent: |
+    Offload local-capable long-running jobs onto local pre-commit to save CI
+    runner time. Combines reverse-EV-002 direction (long suites on pre-commit) +
+    move long suites from husky pre-push into pre-commit. Goal = CI minutes saved.
+    Tooling/hooks/docs only — not product UI (Q3 N/A; frontend mentions = local
+    gate jobs like test-unit-frontend/audit-frontend).
+  status: in_progress
+  branch: evolve/EV-036-local-precommit-long-jobs
+  branch_note: exists — parent creating/cutting branch now; workflow-state-manager did not git checkout/create
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-036
+  feature_ids: []
+  deepen_feature_ids:
+  - M5
+  feature_note: deepen M5 workspace tooling only — no new Fn (B4=1 locked)
+  artifacts_dir: docs/sessions/S044-local-precommit-long-jobs/
+  prior_session: S043-rule-source-traceability
+  prior_evolve_cycle_id: EV-035
+  preset: Lean
+  preset_status: approved
+  preset_note: 'G1=1 Lean routing approved; G2=1 proceed → branch + 01-requirements'
+  started: '2026-08-05'
+  started_at: '2026-08-05'
+  route_status: approved_lean
+  note: 'OPEN — 02 COMPLETE (D-S044-02-gate-a Gate A PASS S02.M2 modified); 07-build T1–T5 implementation complete pending commit → 08; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
+  decisions:
+    Q1: '1'
+    Q1_note: open_S044
+    Q2: '4+1'
+    Q2_note: local_long_jobs_on_precommit_save_CI
+    Q3: 'N/A'
+    Q3_note: tooling_hooks_docs_only_not_product_UI
+    B1: '3'
+    B1_note: fast_medium_on_commit_full_ci_prepush_on_push
+    B2: '1'
+    B2_note: slim_remote_CI
+    B3: '1'
+    B3_note: validate_ci_plus_ci_prepush_job_set_only
+    B4: '1'
+    B4_note: deepen_M5_Lean_preset
+    G1: '1'
+    G1_note: Lean_routing_00_16_01_02_07_08_09_11_skip_03_06_10_12_13
+    G2: '1'
+    G2_note: approve_scope_create_branch_start_01_requirements
+    R1: local_compose
+    R1_note: remove_remote_Compose_integration_local_prepush_make_ci
+    AC: '1'
+    AC_note: M5_ACs_TC-EV036_approved
+    D-S044-02-gate-a: gate_a_pass_s02_m2_modified
+    D-S044-02-gate-a_note: 'contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; keep remote units+coverage+PR comment; drop validate+Compose; local lint only'
+    S02.M2: keep_remote_units_coverage_pr_comment
+  routing_plan:
+  - stage: 00-context
+    mode: scoped
+    required: true
+    status: completed
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    skip_rationale:
+    note: COMPLETE — S044 open; Batch B locked (D-S044-batch-b); handoff 16-evolve
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    skip_rationale:
+    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07-build in_progress (T1–T5 impl done pending commit → 08)'
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    skip_rationale:
+    note: 'COMPLETE — D-S044-r1-ac R1=local_compose AC=1; M5 ACs + TC-EV036; handoff 02-verify-plan'
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    skip_rationale:
+    note: 'PASS — Gate A D-S044-02-gate-a (contradiction 1,1,1,1 + Gate A 1,1,1,1 amended); S02.M2 keep remote units+coverage+PR comment; drop validate+Compose; local lint only; report reports/02-verify-plan-audit.md; handoff 07'
+  - stage: 03-plan-tooling
+    required: false
+    status: skipped
+    skip_rationale: Lean — existing hooks; no new Cursor rules expected
+  - stage: 04-tech-plan
+    required: false
+    status: skipped
+    skip_rationale: Lean — execution tasks in 01/07
+  - stage: 05-verify-tech
+    required: false
+    status: skipped
+    skip_rationale: Lean — no new deps / stack change
+  - stage: 06-tech-tooling
+    required: false
+    status: skipped
+    skip_rationale: Lean — no new tooling install
+  - stage: 07-build
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    skip_rationale:
+    note: 'T1–T5 implementation complete pending commit; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08 after commit'
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 09-qa
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+    note: local hook smoke
+  - stage: 10-e2e
+    required: false
+    status: skipped
+    skip_rationale: Lean — no browser UI / no product UJ
+  - stage: 11-verify-impl
+    required: true
+    mode: delta
+    status: pending
+    skip_rationale:
+  - stage: 12-verify-deploy
+    required: false
+    status: skipped
+    skip_rationale: Lean — no runtime deploy surface; confirm waive at gate
+  - stage: 13-deploy-smoke
+    required: false
+    status: skipped
+    skip_rationale: Lean — with 12; no deploy surface
+  current_stage: 07-build
+  current_stage_note: '07-build — T1–T5 implementation complete pending commit; handoff 08-verify-build after commit; Gate A D-S044-02-gate-a PASS (S02.M2 modified)'
 sessions:
 - id: S043-rule-source-traceability
   type: feature
@@ -4871,23 +5017,27 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: iwxxm-corpus-quality
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    started: '2026-08-04'
-    started_at: '2026-08-04'
-    completed: '2026-08-04'
-    completed_at: '2026-08-04'
-    tip_sha: 2ed85da1
-    tip_sha_full: 2ed85da14c99400a23dd2777f8da1f305e2423c0
-    note: 'S040/EV-032 COMPLETE — brief+routing+context; branch cut from main @ 2ed85da1; stash S039-EV031-WIP; handoff 01-requirements; #846/#835/#741/#808'
-    prior_note: 'S039 COMPLETE — brief+routing-plan; D-S039-route/branch/dns-hosts locked; handoff 07-build; #842/#712'
-    prior_session_id: S039-doks-dns-cutover
-    prior_evolve_cycle_id:
-    prior_scoped_slug: doks-dns-cutover
-    prior_completed: '2026-08-04'
-    prior_started: '2026-08-04'
+    scoped_slug: local-precommit-long-jobs
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    started: '2026-08-05'
+    started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
+    tip_sha: 97a5c131
+    tip_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
+    note: 'S044/EV-036 COMPLETE — 00-context done; Phase 0 Batch B locked (D-S044-batch-b); D-S044-g1-g2 approved Lean; handoff 16-evolve → 01-requirements; branch evolve/EV-036-local-precommit-long-jobs exists:true (parent creating)'
+    prior_note: 'S040/EV-032 COMPLETE — brief+routing+context; branch cut from main @ 2ed85da1; stash S039-EV031-WIP; handoff 01-requirements; #846/#835/#741/#808 (stages mirror was stale through S041–S043; logical prior_session S043/EV-035 completed)'
+    prior_session_id: S043-rule-source-traceability
+    prior_evolve_cycle_id: EV-035
+    prior_scoped_slug: rule-source-traceability
+    prior_completed: '2026-08-05'
+    prior_started: '2026-08-05'
+    prior_mirror_session_id: S040-iwxxm-corpus-quality
+    prior_mirror_evolve_cycle_id: EV-032
     artifacts:
+    - docs/sessions/S044-local-precommit-long-jobs/
+    - docs/sessions/S043-rule-source-traceability/
     - docs/sessions/S040-iwxxm-corpus-quality/session-brief.md
     - docs/sessions/S040-iwxxm-corpus-quality/routing-plan.md
     - docs/context/iwxxm-corpus-quality-846.md
@@ -4907,14 +5057,28 @@ stages:
     started: '2026-08-05'
     completed_at: '2026-08-05'
     completed: '2026-08-05'
-    session_id: S042-doks-cd-rollout
-    evolve_cycle_id: EV-034
-    prior_session_id: S040-iwxxm-corpus-quality
-    prior_evolve_cycle_id: EV-032
-    prior_started: '2026-08-04'
-    prior_completed: '2026-08-04'
-    prior_note: 'S040/EV-032 01-requirements COMPLETE (delta) — D-S040-E32-M=2,3,1,1; F32 VONA + UJ-045 + product=vona; handoff 02; committed @ 0f3769af; #846'
-    note: 'S042/EV-034 01-requirements COMPLETE (delta) — F30 deepen; feature-list/deploy/test-plan/evolve-decisions; no new Fn; handoff 02'
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    prior_session_id: S042-doks-cd-rollout
+    prior_evolve_cycle_id: EV-034
+    prior_started: '2026-08-05'
+    prior_completed: '2026-08-05'
+    prior_note: 'S042/EV-034 01-requirements COMPLETE (delta) — F30 deepen; feature-list/deploy/test-plan/evolve-decisions; no new Fn; handoff 02'
+    prior_prior_session_id: S040-iwxxm-corpus-quality
+    prior_prior_evolve_cycle_id: EV-032
+    prior_prior_note: 'S040/EV-032 01-requirements COMPLETE (delta) — D-S040-E32-M=2,3,1,1; F32 VONA + UJ-045 + product=vona; handoff 02; committed @ 0f3769af; #846'
+    note: 'S044/EV-036 01-requirements COMPLETE (delta) — D-S044-r1-ac R1=local_compose AC=1; M5 ACs + TC-EV036-001..003; remove remote Compose/integration → local pre-push make ci; handoff 02-verify-plan'
+    decision_refs:
+    - D-S044-r1-ac
+    - D-S044-g1-g2
+    - D-S044-batch-b
+    - D-S044-open
+    - D-S044-intent
+    artifacts:
+    - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+    - docs/feature-list.md
+    - docs/test-plan.md
+    - docs/decisions/evolve-decisions.md
     substeps:
       interviews:
         status: completed
@@ -5678,44 +5842,61 @@ stages:
     started: '2026-08-05'
     completed_at: '2026-08-05'
     completed: '2026-08-05'
-    session_id: S043-rule-source-traceability
-    evolve_cycle_id: EV-035
-    prior_session_id: S042-doks-cd-rollout
-    prior_evolve_cycle_id: EV-034
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    prior_session_id: S043-rule-source-traceability
+    prior_evolve_cycle_id: EV-035
     prior_started: '2026-08-05'
     prior_completed: '2026-08-05'
-    prior_note: 'S042/EV-034 02-verify-plan COMPLETE (delta) — Gate A PASS; Standard path confirmed; handoff 04-tech-plan'
-    note: 'S043/EV-035 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S043-02-phase-a); Batch A 1,1,1,1 (D-S043-02-batch-a); reports/02-verify-plan-audit.md + provenance-gaps.md; handoff 04-tech-plan'
+    prior_note: 'S043/EV-035 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S043-02-phase-a); Batch A 1,1,1,1 (D-S043-02-batch-a); reports/02-verify-plan-audit.md + provenance-gaps.md; handoff 04-tech-plan'
+    prior_prior_session_id: S042-doks-cd-rollout
+    prior_prior_evolve_cycle_id: EV-034
+    note: 'S044/EV-036 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S044-02-gate-a); contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; S02.M2 keep remote units+coverage+PR comment; drop validate+Compose; local lint only; report reports/02-verify-plan-audit.md; handoff 07-build'
     contradictions_resolved:
+    - 'S02.M2 B2 slim-no-units superseded — keep remote units+coverage+PR comment'
     contradictions_deferred:
     decision_refs:
+    - D-S044-02-gate-a
+    - D-S044-r1-ac
+    - D-S044-g1-g2
+    - D-S044-batch-b
     - D-S043-02-phase-a
     - D-S043-02-batch-a
-    - D-S040-02-phase-a
-    - D-S040-02-batch-f
-    - D-S040-E32-M
-    - D-S040-route
-    - D-S040-open
-    - D-S038-02-phase-a
-    - D-S038-02-batch-c
-    - D-S038-01-gate-a
-    - D-S038-tp
-    - D-S038-fn
-    - D-S038-route
-    - D-S038-open
     substeps:
       inventory:
         status: completed
       consistency_check:
         status: completed
       statement_review:
-        auto_approved: 0
+        auto_approved: 3
         pending: 0
-        reviewed: 0
+        reviewed: 4
         status: completed
+        note: 'S02.H1–H3 auto; S02.M1/M2/M3/L1 Gate A 1,1,1,1 amended (M2 modified)'
     current_document:
     current_statement:
     active_session:
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 02-verify-plan
+      status: completed
+      mode: delta
+      started_at: '2026-08-05'
+      started: '2026-08-05'
+      completed_at: '2026-08-05'
+      completed: '2026-08-05'
+      note: 'COMPLETE (delta) — Gate A PASS (D-S044-02-gate-a); S02.M2 modified; handoff 07-build'
+      feature_ids: []
+      deepen_feature_ids:
+      - M5
+      decision_refs:
+      - D-S044-02-gate-a
+      - D-S044-r1-ac
+      - D-S044-g1-g2
+      artifacts:
+      - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+      - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+    prior_active_session:
       session_id: S043-rule-source-traceability
       evolve_cycle_id: EV-035
       skill_id: 02-verify-plan
@@ -5739,6 +5920,8 @@ stages:
       - docs/sessions/S043-rule-source-traceability/reports/02-verify-plan-audit.md
       - docs/sessions/S043-rule-source-traceability/reports/provenance-gaps.md
     artifacts:
+    - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
     - docs/sessions/S043-rule-source-traceability/reports/02-verify-plan-audit.md
     - docs/sessions/S043-rule-source-traceability/reports/provenance-gaps.md
     - docs/sessions/S040-iwxxm-corpus-quality/reports/02-verify-plan-audit.md
@@ -6256,6 +6439,7 @@ stages:
       - docs/feature-list.md
       - docs/CORPUS.md
     notes:
+    - '2026-08-05 S044/EV-036 02-verify-plan COMPLETE (D-S044-02-gate-a) — Gate A PASS; contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; S02.M2 keep remote units+coverage+PR comment; drop validate+Compose; local lint only; report docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md; handoff 07-build; no commit SHA invented'
     - '2026-08-03 S038/EV-031 02-verify-plan STARTED (delta) — D-S038-01-gate-a lean docs accepted at 01 exit; commit fc3bbe5; gaps deferred to 04; #842/#830/#712'
     - '2026-08-01 S035/EV-028 02-verify-plan COMPLETE (D-S035-02-phase-a) — Gate A PASS; D-S035-E28-S21 UJ-023 amend; report docs/sessions/S035-empiric2-ops-leftovers-781/reports/verify-plan-audit.md; handoff 04-tech-plan; #781'
     - '2026-08-01 S035/EV-028 02-verify-plan STARTED (delta) — D-S035-E28-E1; #781'
@@ -7517,40 +7701,87 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: completed
+    status: in_progress
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at: '2026-08-05'
-    completed: '2026-08-05'
-    previous_started_at: '2026-08-04'
-    previous_completed_at:
-    previous_session_id: S040-iwxxm-corpus-quality
-    previous_evolve_cycle_id: EV-032
-    previous_tip_sha: 22b4251b
-    previous_tip_sha_full: 22b4251b93a1e7beba5d3d2b01dbd98898bc898e
-    previous_note: 'S040/EV-032 07-build COMPLETED after resume — D-S040-close=1; M0–M4 + Phase D; tip lineage d3f4bb95; #846'
-    prior_session_id: S040-iwxxm-corpus-quality
-    prior_evolve_cycle_id: EV-032
-    prior_started: '2026-08-04'
+    completed_at:
+    completed:
+    previous_started_at: '2026-08-05'
+    previous_completed_at: '2026-08-05'
+    previous_session_id: S042-doks-cd-rollout
+    previous_evolve_cycle_id: EV-034
+    previous_tip_sha: 9ae9c323
+    previous_tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
+    previous_note: 'S042/EV-034 07-build COMPLETE — PR #867 MERGED (CI green; Deploy skipped on PR as expected); deepen F30; hotfix #868 OPEN hold merge (static KUBE_CONFIG / no doctl); handoff 08-verify-build'
+    prior_session_id: S042-doks-cd-rollout
+    prior_evolve_cycle_id: EV-034
+    prior_started: '2026-08-05'
     prior_completed: '2026-08-05'
-    prior_note: 'S040/EV-032 07-build COMPLETED — D-S040-close=1; progress 28/28; #846 epic remains OPEN'
-    session_id: S042-doks-cd-rollout
-    evolve_cycle_id: EV-034
+    prior_note: 'S042/EV-034 07-build COMPLETE — PR #867 MERGED; deepen F30; #868; handoff 08'
+    prior_prior_session_id: S040-iwxxm-corpus-quality
+    prior_prior_evolve_cycle_id: EV-032
+    prior_prior_note: 'S040/EV-032 07-build COMPLETED — D-S040-close=1; progress 28/28; #846 epic remains OPEN'
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
     mode: full
-    note: 'S042/EV-034 07-build COMPLETE — PR #867 MERGED (CI green; Deploy skipped on PR as expected); deepen F30; hotfix #868 OPEN hold merge (static KUBE_CONFIG / no doctl); handoff 08-verify-build'
-    tip_sha: 9ae9c323
-    tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
-    tip_note: 'S042/EV-034 tip 9ae9c323; PR #867 MERGED; #868 OPEN hold merge; EV-034 NOT completed'
-    pending_commit: false
+    note: 'S044/EV-036 07-build — T1–T5 implementation complete pending commit; Gate A D-S044-02-gate-a; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08-verify-build after commit; no commit SHA invented'
+    tip_sha:
+    tip_sha_full:
+    tip_note: 'S044/EV-036 — no commit yet (parent pending); prior tip lineage S042 @ 9ae9c323 retained under previous_*'
+    pending_commit: true
+    pending_commit_note: 'T1–T5 implementation landed in worktree; commit not made yet by parent'
     next_stage: 08-verify-build
     current_milestone: M1
-    current_task: T1.5
+    current_task: T5
     active_milestone: M1
-    active_task: T1.5
+    active_task: T5
     active_task_status: completed
-    completed_through: T1.5
+    completed_through: T5
     progress: 5/5
     next_task: null
+    s044_tasks: T1-T5 completed
+    s044_impl_complete: true
+    s044_handoff: 08-verify-build
+    decision_refs_s044:
+    - D-S044-02-gate-a
+    - D-S044-r1-ac
+    - D-S044-g1-g2
+    - D-S044-batch-b
+    artifacts_s044:
+    - docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+    - .husky/pre-commit
+    - .husky/pre-push
+    - .pre-commit-config.yaml
+    - .github/workflows/ci-cd.yml
+    - Makefile
+    - docs/ops/DEVELOPMENT.md
+    - docs/test-plan.md
+    active_session:
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 07-build
+      status: in_progress
+      mode: full
+      started_at: '2026-08-05'
+      started: '2026-08-05'
+      note: 'T1–T5 implementation complete pending commit; handoff 08 after commit; D-S044-02-gate-a'
+      feature_ids: []
+      deepen_feature_ids:
+      - M5
+      decision_refs:
+      - D-S044-02-gate-a
+      - D-S044-r1-ac
+      artifacts:
+      - docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+      - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+      - .husky/pre-commit
+      - .husky/pre-push
+      - .pre-commit-config.yaml
+      - .github/workflows/ci-cd.yml
+      - Makefile
+      - docs/ops/DEVELOPMENT.md
+    # --- retained S042/S040 historical fields below ---
     pr_number: 867
     pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/867
     pr_status: merged
@@ -11206,19 +11437,21 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: completed
+    status: in_progress
     mode: orchestrator
-    session_id: S040-iwxxm-corpus-quality
-    evolve_cycle_id: EV-032
-    started_at: '2026-08-04'
-    started: '2026-08-04'
-    completed_at: '2026-08-05'
-    completed: '2026-08-05'
-    previous_session_id: S042-doks-cd-rollout
-    previous_evolve_cycle_id: EV-034
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    started_at: '2026-08-05'
+    started: '2026-08-05'
+    completed_at:
+    completed:
+    previous_session_id: S043-rule-source-traceability
+    previous_evolve_cycle_id: EV-035
     previous_completed_at: '2026-08-05'
-    current_child_stage: completed
-    note: 'COMPLETE — S040/EV-032 closed D-S040-close=1; T4.5 re-verify PASS; T4.6 evolve-summary docs/sessions/S040-iwxxm-corpus-quality/reports/evolve-summary.md; #846 epic remains OPEN; idle until next evolve'
+    prior_mirror_session_id: S040-iwxxm-corpus-quality
+    prior_mirror_evolve_cycle_id: EV-032
+    current_child_stage: 07-build
+    note: 'IN PROGRESS — S044/EV-036 02 COMPLETE (D-S044-02-gate-a); 07-build T1–T5 impl done pending commit → 08; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -11484,6 +11717,203 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S044-02-gate-a
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: gate
+  status: confirmed
+  topic: 'Gate A — Phase A checkpoint after 02-verify-plan (Lean → 07)'
+  summary: 'PASS with S02.M2 modified — keep remote units+coverage+PR comment; drop validate+Compose; local lint only → 07-build'
+  decision: |
+    D-S044-02-gate-a=gate_a_pass_s02_m2_modified — Gate A PASS for S044/EV-036.
+    Answers: contradiction batch 1,1,1,1 then Gate A 1,1,1,1 amended.
+    S02.M1 Approve (pre-commit fast+medium; pre-push make ci).
+    S02.M2 Modified — keep remote unit matrix + coverage + PR coverage comment;
+    drop remote validate + Compose only; local lint only (no remote validate job).
+    S02.M3 Approve (native/e2e-smoke/alembic; deploy needs includes test).
+    S02.L1 Approve (Docker + ports; document --no-verify).
+    Supersedes B2 slim-no-units for remote units. Advance Lean → 07-build.
+  user_option: '1,1,1,1 amended (contradiction 1,1,1,1)'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-r1-ac
+  - D-S044-g1-g2
+  - D-S044-batch-b
+  deepen_feature_ids:
+  - M5
+  feature_ids: []
+  artifacts:
+  - docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+  - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+  note: '02-verify-plan COMPLETE; current_stage=07-build; T1–T5 impl pending commit; no commit SHA invented'
+- id: D-S044-r1-ac
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: requirements
+  status: confirmed
+  topic: 'EV-036 R1 resource placement + M5 AC / TC-EV036 approval'
+  summary: 'R1=local_compose; AC=1 — remove remote Compose/integration; local pre-push via make ci; M5 ACs + TC-EV036 approved'
+  decision: |
+    D-S044-r1-ac=R1=local_compose,AC=1 — 01-requirements delta for S044/EV-036.
+    R1=local_compose: remove remote Compose/`integration` job; run Compose
+    integration on local pre-push via `make ci` (= ci-prepush + Compose).
+    Resource model: fast+medium on pre-commit (validate-ci); long local on
+    pre-push (`make ci`); remote slim ci-cd.yml (native/e2e-smoke/alembic/deploy).
+    AC=1: approve M5 acceptance criteria + TC-EV036-001..003.
+    Standing deltas: feature-list (M5), test-plan (CI/CD EV-036), evolve-decisions.
+    Handoff → 02-verify-plan Gate A (Lean → 07-build; no 04).
+  user_option: 'R1=local_compose,AC=1'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-g1-g2
+  - D-S044-batch-b
+  - D-S044-open
+  - D-S044-intent
+  deepen_feature_ids:
+  - M5
+  feature_ids: []
+  artifacts:
+  - docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+  - docs/feature-list.md
+  - docs/test-plan.md
+  - docs/decisions/evolve-decisions.md
+  note: '01-requirements COMPLETE; current_stage=02-verify-plan'
+- id: D-S044-g1-g2
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: phase0_phase1
+  category: routing
+  status: confirmed
+  topic: Approve Lean routing + proceed to 01-requirements
+  summary: 'G1=1 Lean path; G2=1 approve scope → create branch → start 01-requirements'
+  decision: |
+    D-S044-g1-g2=G1=1,G2=1 — Phase 0/1 routing approved for S044/EV-036.
+    G1=1: Lean routing 00→16→01→02→07→08→09→11 (skip 03/04/05/06/10/12/13).
+    G2=1: approve scope → create branch evolve/EV-036-local-precommit-long-jobs
+    → start 01-requirements (delta, deepen M5).
+    preset=Lean; preset_status=approved; route_status=approved_lean.
+    feature_ids=[]; deepen_feature_ids=[M5].
+  user_option: 'G1=1,G2=1'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-open
+  - D-S044-intent
+  - D-S044-batch-b
+  - D-S044-r1-ac
+  deepen_feature_ids:
+  - M5
+  feature_ids: []
+  preset: Lean
+  note: 'route_status=approved_lean; superseded current_stage by D-S044-r1-ac → 02-verify-plan'
+- id: D-S044-batch-b
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: phase0
+  category: phase0_lock
+  status: confirmed
+  topic: Phase 0 Batch B — resource model + Lean M5
+  summary: 'B1=3, B2=1, B3=1, B4=1 — fast+medium commit / ci-prepush push; slim remote CI; validate-ci+ci-prepush only; deepen M5 Lean'
+  decision: |
+    D-S044-batch-b=B1=3,B2=1,B3=1,B4=1 — Phase 0 Batch B locked for S044/EV-036.
+    B1=3: fast+medium on commit; full ci-prepush on push.
+    B2=1: slim remote CI (drop redundant validate/unit).
+    B3=1: local job set = validate-ci + ci-prepush only.
+    B4=1: deepen M5 only; Lean preset (path 00→16→01→02→07→08→09→11;
+    skip 03/04/05/06/10/12/13). Q1=1, Q2=4+1, Q3=N/A already locked.
+    preset_status pending await G4 proceed. feature_ids=[]; deepen_feature_ids=[M5].
+  user_option: 'B1=3,B2=1,B3=1,B4=1'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-open
+  - D-S044-intent
+  - D-S044-g1-g2
+  deepen_feature_ids:
+  - M5
+  feature_ids: []
+  preset: Lean
+  note: 'Phase 0 fully locked; superseded proceed by D-S044-g1-g2'
+- id: D-S044-open
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: Open S044-local-precommit-long-jobs → 16-evolve / EV-036
+  summary: 'Q1=1 — open feature session S044; allocate EV-036; prior S043/EV-035 completed'
+  decision: |
+    D-S044-open=1 — Open feature session S044-local-precommit-long-jobs with
+    orchestrator 16-evolve / evolve_cycle_id EV-036. session_counter 44;
+    evolve_cycle_counter 36. prior_session S043-rule-source-traceability
+    (EV-035 completed). Branch evolve/EV-036-local-precommit-long-jobs pending_create (parent may create;
+    workflow-state-manager did not git checkout/create). artifacts_dir
+    docs/sessions/S044-local-precommit-long-jobs/. Routing-plan draft pending approval
+    (lean/standard TBD). No auto-resume of other sessions.
+  user_option: '1'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-intent
+  - D-S044-batch-b
+  - D-S044-g1-g2
+  prior_session: S043-rule-source-traceability
+  prior_evolve_cycle_id: EV-035
+  note: 'active_session only during open (sessions[] archive on close); mirror S043 pattern'
+- id: D-S044-intent
+  date: '2026-08-05'
+  timestamp: '2026-08-05'
+  resolved_at: '2026-08-05'
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  skill: 00-context
+  skill_id: 00-context
+  stage: 00-context
+  category: intent
+  status: confirmed
+  topic: Local pre-commit long jobs to save CI minutes
+  summary: 'Q2=4+1 local long jobs on pre-commit; Q3=N/A tooling only (not product UI)'
+  decision: |
+    D-S044-intent=4+1 / N/A — Offload local-capable long-running jobs onto local
+    pre-commit to save CI runner time. Combines reverse-EV-002 direction (long
+    suites on pre-commit) + move long suites from husky pre-push into pre-commit.
+    Goal = CI minutes saved. UI/deploy N/A — tooling/hooks/docs only. User
+    clarified frontend mentions refer to test-unit-frontend/audit-frontend in
+    local gates, NOT product browser UI. Likely deepen M5 (feature_ids TBD).
+  user_option: '4+1'
+  q3_option: 'N/A'
+  branch: evolve/EV-036-local-precommit-long-jobs
+  related_decisions:
+  - D-S044-open
+  - D-S044-batch-b
+  - D-S044-g1-g2
+  deepen_feature_ids:
+  - M5
+  note: 'No browser UI work; no deploy surface expected'
 - id: D-S043-11
   date: '2026-08-05'
   timestamp: '2026-08-05'
@@ -22429,6 +22859,39 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+  type: session-report
+  kind: verify-plan-audit
+  stage: 02-verify-plan
+  skill_id: 02-verify-plan
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: completed
+  note: 'D-S044-02-gate-a Gate A PASS S02.M2 modified; handoff 07-build'
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+  type: execution-plan
+  kind: execution-plan
+  stage: 07-build
+  skill_id: 07-build
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: written
+  note: 'T1–T5 completed; commit pending; no SHA invented'
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+  type: session-report
+  kind: requirements-summary
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: completed
+  note: 'D-S044-r1-ac R1=local_compose AC=1; handoff 02-verify-plan (completed)'
 - path: docs/sessions/S041-worker-poller-hardening/reports/evolve-summary.md
   type: session-report
   kind: evolve-summary
@@ -32612,6 +33075,196 @@ evolve_cycles:
   pr_number: 845
   pr_status: open
   pr_head: evolve/EV-031-platform-independence-842
+- id: EV-036
+  session_id: S044-local-precommit-long-jobs
+  cycle_type: feature
+  feature_ids: []
+  deepen_feature_ids:
+  - M5
+  feature_note: deepen M5 workspace tooling only — no new Fn (B4=1 locked)
+  title: Local pre-commit long jobs (save CI minutes)
+  slug: local-precommit-long-jobs
+  status: in_progress
+  phase: 2
+  phase_note: 'Phase 2 / build — 02 COMPLETE (D-S044-02-gate-a); 07-build T1–T5 impl done pending commit → 08'
+  started: '2026-08-05'
+  started_at: '2026-08-05'
+  scope_summary: |
+    Offload local-capable long-running jobs onto local pre-commit/pre-push to
+    save CI runner time. Tooling/hooks/docs only — not product UI. Phase 0 locked
+    B1=3/B2=1/B3=1/B4=1; G1=1 Lean; G2=1 proceed. R1=local_compose: remove remote
+    Compose/`integration`; run on local pre-push via `make ci`. AC=1: M5 ACs +
+    TC-EV036-001..003 approved. Gate A amend (D-S044-02-gate-a): keep remote
+    units+coverage+PR comment; drop validate+Compose; local lint only.
+  branch: evolve/EV-036-local-precommit-long-jobs
+  branch_note: exists — parent creating/cutting branch now; workflow-state-manager did not git checkout/create
+  tip_sha: 97a5c131
+  tip_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
+  tip_note: '07-build impl pending commit — tip remains prior base 97a5c131; no SHA invented'
+  preset: Lean
+  preset_status: approved
+  preset_note: 'G1=1 Lean approved; route_status=approved_lean'
+  phase0_choices:
+    Q1: '1'
+    Q2: '4+1'
+    Q3: 'N/A'
+    B1: '3'
+    B2: '1'
+    B2_amended_by: D-S044-02-gate-a
+    B2_amend_note: keep remote units+coverage+PR comment (was slim-no-units)
+    B3: '1'
+    B4: '1'
+    G1: '1'
+    G2: '1'
+    R1: local_compose
+    AC: '1'
+    D-S044-02-gate-a: gate_a_pass_s02_m2_modified
+    locked_at: '2026-08-05'
+    note: 'Phase 0 locked D-S044-batch-b; G1/G2 D-S044-g1-g2; R1/AC D-S044-r1-ac; Gate A D-S044-02-gate-a; Lean deepen M5'
+  routing_plan:
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 07-build
+    - 08-verify-build
+    - 09-qa
+    - 11-verify-impl
+    optional_stages: []
+    skipped_stages:
+    - 03-plan-tooling
+    - 04-tech-plan
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 10-e2e
+    - 12-verify-deploy
+    - 13-deploy-smoke
+    path: 00→16→01→02→07→08→09→11
+    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime)'
+  current_stage: 07-build
+  current_stage_status: in_progress
+  current_stage_note: '07-build — T1–T5 implementation complete pending commit; handoff 08-verify-build after commit; D-S044-02-gate-a'
+  next_stage: 08-verify-build
+  next_stage_status: pending
+  gates:
+    a_to_b: passed
+    a_to_b_note: 'D-S044-02-gate-a Lean → 07 (no 04); S02.M2 modified'
+    b_to_c: pending
+    c_to_d: pending
+    deploy: waived_expected
+  checkpoints:
+    phase_a: passed
+    phase_b: pending
+    phase_c: pending
+    phase_d: pending
+    deploy: waived_expected
+    note: 'Lean tooling cycle — Gate A passed; deploy waive expected (no runtime)'
+  adrs: []
+  artifacts:
+  - path: docs/sessions/S044-local-precommit-long-jobs/
+    status: in_progress
+  - path: docs/sessions/S044-local-precommit-long-jobs/session-brief.md
+    status: updated
+  - path: docs/sessions/S044-local-precommit-long-jobs/routing-plan.md
+    status: updated
+  - path: docs/context/local-precommit-long-jobs.md
+    status: draft
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/01-requirements-summary.md
+    status: completed
+    stage: 01-requirements
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/02-verify-plan-audit.md
+    status: completed
+    stage: 02-verify-plan
+    note: D-S044-02-gate-a
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/execution-plan.md
+    status: written
+    stage: 07-build
+    note: T1–T5 completed; commit pending
+  - path: docs/feature-list.md
+    status: written
+    stage: 01-requirements
+    note: M5 EV-036 deepen + ACs
+  - path: docs/test-plan.md
+    status: written
+    stage: 01-requirements
+    note: CI/CD EV-036; TC-EV036-001..003
+  - path: docs/decisions/evolve-decisions.md
+    status: written
+    stage: 01-requirements
+    note: §EV-036 R1 + AC + Gate A
+  - path: .husky/pre-commit
+    status: written
+    stage: 07-build
+  - path: .husky/pre-push
+    status: written
+    stage: 07-build
+  - path: .pre-commit-config.yaml
+    status: written
+    stage: 07-build
+  - path: .github/workflows/ci-cd.yml
+    status: written
+    stage: 07-build
+  - path: Makefile
+    status: written
+    stage: 07-build
+  - path: docs/ops/DEVELOPMENT.md
+    status: written
+    stage: 07-build
+  issues: []
+  decision_refs:
+  - D-S044-open
+  - D-S044-intent
+  - D-S044-batch-b
+  - D-S044-g1-g2
+  - D-S044-r1-ac
+  - D-S044-02-gate-a
+  stages:
+    00-context:
+      status: completed
+      mode: scoped
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      note: COMPLETE — Batch B locked; handoff 16-evolve
+    16-evolve:
+      status: in_progress
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      note: 'Phase 0–2; child 07-build (02 COMPLETE D-S044-02-gate-a; T1–T5 pending commit)'
+    01-requirements:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      note: 'COMPLETE — D-S044-r1-ac R1=local_compose AC=1; handoff 02'
+    02-verify-plan:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      note: 'COMPLETE — Gate A PASS D-S044-02-gate-a (S02.M2 modified); handoff 07'
+    07-build:
+      status: in_progress
+      mode: full
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      note: 'T1–T5 implementation complete pending commit; handoff 08 after commit'
+    08-verify-build:
+      status: pending
+      mode: delta
+  notes:
+  - '2026-08-05 S044/EV-036 OPEN — open_session; D-S044-open=1; D-S044-intent=4+1/N/A; session_counter 44; evolve_cycle_counter 36; branch evolve/EV-036-local-precommit-long-jobs pending_create; deepen M5 likely; no git branch/commit by workflow-state-manager'
+  - '2026-08-05 Phase 0 LOCKED — D-S044-batch-b B1=3,B2=1,B3=1,B4=1; deepen M5; Lean preset pending G4; route_status=phase0_locked_pending_proceed; 00-context completed; 16-evolve in_progress; no git branch/commit by workflow-state-manager'
+  - '2026-08-05 Phase 0/1 ROUTING APPROVED — D-S044-g1-g2 G1=1 Lean + G2=1 proceed; preset_status=approved; route_status=approved_lean; current_stage=01-requirements in_progress; branch exists:true (parent creating); no git branch/commit by workflow-state-manager'
+  - '2026-08-05 01-requirements COMPLETE — D-S044-r1-ac R1=local_compose AC=1; remove remote Compose/integration → local pre-push make ci; M5 ACs + TC-EV036 approved; current_stage=02-verify-plan in_progress; no git commit by workflow-state-manager'
+  - '2026-08-05 02-verify-plan COMPLETE — D-S044-02-gate-a Gate A PASS; contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; S02.M2 keep remote units+coverage+PR comment; drop validate+Compose; local lint only; current_stage=07-build; no commit SHA invented'
+  - '2026-08-05 07-build — T1–T5 implementation complete pending commit; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08-verify-build after commit; no commit SHA invented'
 - id: EV-035
   session_id: S043-rule-source-traceability
   cycle_type: feature
@@ -33684,11 +34337,11 @@ git_history:
   ahead_of_origin: 2
   pushed: false
   pending_commit: true
-  pending_commit_note: 'DIRTY after close — git_history.commits append for f6105b8f not in that commit; prefer NOT amend; parent follow-up commit of workflow-state.yaml only'
+  pending_commit_note: 'S044/EV-036 T1–T5 impl + workflow-state updates uncommitted; no SHA invented; prior dirty note: git_history.commits append for f6105b8f may still need follow-up'
   dirty: true
-  tip_sha: f6105b8f
-  tip_sha_full: f6105b8f3475aee793b1d86229e876a7694a0f10
-  tip_note: 'S042 close commit on main @ f6105b8f; EV-034 completed; active_session null; yaml dirty (commit log append post-close)'
+  tip_sha: 97a5c131
+  tip_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
+  tip_note: 'S044/EV-036 — 02 COMPLETE D-S044-02-gate-a; 07-build T1–T5 pending commit → 08; branch evolve/EV-036-local-precommit-long-jobs; tip main @ 97a5c131 (no SHA invented)'
   stash:
   - name: S039-EV031-WIP
     note: 'Parked EV-031/S039 dirty worktree WIP before cutting evolve/EV-032 from main (D-S040-branch=1)'
@@ -33699,10 +34352,13 @@ git_history:
   main_merge_sha_full: 8bd111c5e25a9f46f05fa057b1557ec8d7591cd1
   main_tip_sha: 5245f8de
   main_tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
-  recommended_branch: main
-  note: 'S042/EV-034 CLOSED D-S042-13=1; tip main @ d3f4bb95; close docs commit may follow on main; no commit by workflow-state-manager this update; S040 remains suspended eligible to resume'
+  recommended_branch: evolve/EV-036-local-precommit-long-jobs
+  note: 'S044/EV-036 D-S044-02-gate-a Gate A PASS; current_stage 07-build T1–T5 pending commit; tip main @ 97a5c131; no commit by workflow-state-manager this update'
 
   notes:
+  - '2026-08-05 S044/EV-036 D-S044-02-gate-a — Gate A PASS S02.M2 modified; 02 completed; 07-build T1–T5 impl pending commit → 08; no git commit/SHA invented by workflow-state-manager; tip main @ 97a5c131'
+  - '2026-08-05 S044/EV-036 D-S044-g1-g2 — G1=1 Lean + G2=1 proceed; preset_status=approved; route_status=approved_lean; current_stage 01-requirements in_progress; branch evolve/EV-036-local-precommit-long-jobs exists:true (parent creating); no git branch/commit by workflow-state-manager; tip main @ 97a5c131'
+  - '2026-08-05 S044/EV-036 OPEN — open_session; D-S044-open=1; D-S044-intent=4+1/N/A; session_counter 44; evolve_cycle_counter 36; branch evolve/EV-036-local-precommit-long-jobs pending_create; 00-context in_progress → 16-evolve Phase 0 intake; deepen M5 likely; no git branch/commit by workflow-state-manager; tip main @ 97a5c131'
   - '2026-08-05 S042/EV-034 CLOSE D-S042-13=1 — 11/12/13 completed overall pass; EV-034 completed; active_session=null; evolve-summary docs/sessions/S042-doks-cd-rollout/reports/evolve-summary.md; close docs commit may follow on main (workflow-state + routing-plan); S040 remains suspended (eligible to resume; do not auto-resume); no git commit by workflow-state-manager'
   - '2026-08-05 S042/EV-034 — recorded git commit 9ae9c323 (9ae9c3235d9380f493290ab318c0e0ecf5de2efa) [EV-034] feat: automate DOKS image rollout in CD after GHCR push; pushed; PR #867 OPEN; 07 essentially complete pending CI green + merge; EV-034 NOT completed; tip 9ae9c323; ahead_of_origin=0'
   - '2026-08-05 S042/EV-034 — Phase 0 locked E34-1..5=A,A,A,B,A; branch evolve/EV-034-doks-cd-rollout ACTIVE; 01/02/04 completed; 07-build largely done awaiting commit+PR+user verify; deepen F30; tip base 5245f8de; no commit SHA invented; 08 next after commit'
@@ -34138,6 +34794,20 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-036-local-precommit-long-jobs
+    status: active
+    base: main
+    base_sha: 97a5c131
+    base_sha_full: 97a5c1310699bf1ed11e622af8c19fa85c03dd6d
+    purpose: S044/EV-036 local pre-commit long jobs to save CI minutes (deepen M5)
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    created: '2026-08-05'
+    created_at: '2026-08-05'
+    exists: true
+    pushed: false
+    ahead_of_origin: 0
+    note: 'exists:true — parent creating/cutting branch now (D-S044-g1-g2 G2=1); workflow-state-manager did not git checkout/create'
   - name: evolve/EV-034-doks-cd-rollout
     status: active
     base: main

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -32,7 +32,7 @@ active_session:
   started: '2026-08-05'
   started_at: '2026-08-05'
   route_status: approved_lean
-  note: 'OPEN — 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
+  note: 'NEAR-COMPLETE — D-S044-11 approve_all_met (11 closed); D-S044-12-13-waive waived_no_runtime; D-S044-next push_and_pr in progress; close_session pending PR URL + docs commit; tip 95fac992; Lean deepen M5; tooling only'
   decisions:
     Q1: '1'
     Q1_note: open_S044
@@ -59,6 +59,12 @@ active_session:
     D-S044-02-gate-a: gate_a_pass_s02_m2_modified
     D-S044-02-gate-a_note: 'contradiction 1,1,1,1 then Gate A 1,1,1,1 amended; keep remote units+coverage+PR comment; drop validate+Compose; local lint only'
     S02.M2: keep_remote_units_coverage_pr_comment
+    D-S044-11: approve_all_met
+    D-S044-11_note: '1,1,1 — approve all M5 ACs; close 11'
+    D-S044-12-13-waive: waived_no_runtime
+    D-S044-12-13-waive_note: 'waive 12/13 — no runtime product change'
+    D-S044-next: push_and_pr
+    D-S044-next_note: 'push branch + open PR to main'
   routing_plan:
   - stage: 00-context
     mode: scoped
@@ -77,7 +83,7 @@ active_session:
     started: '2026-08-05'
     started_at: '2026-08-05'
     skip_rationale:
-    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07–08 COMPLETE; child 09-qa COMPLETE PASS @ 95fac992; child 11-verify-impl in_progress'
+    note: 'Phase 4 closing / PR pending — D-S044-11 approve_all_met; D-S044-12-13-waive; D-S044-next push_and_pr; tip 95fac992; close pending PR URL'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -162,24 +168,31 @@ active_session:
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-05'
     started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
     skip_rationale:
     tip_sha: 95fac992
     tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+    overall: approved
     report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
-    note: 'STARTED — after 09 PASS @ 95fac992; report verify-impl.md'
+    report_status: approved
+    decision_id: D-S044-11
+    note: 'COMPLETE — D-S044-11 approve_all_met (all 5 M5 ACs); tip 95fac992; report verify-impl.md'
   - stage: 12-verify-deploy
     required: false
     status: skipped
-    skip_rationale: Lean — no runtime deploy surface; confirm waive at gate
+    skip_rationale: Lean — no runtime deploy surface; waived D-S044-12-13-waive
+    note: 'WAIVED — D-S044-12-13-waive waived_no_runtime'
   - stage: 13-deploy-smoke
     required: false
     status: skipped
-    skip_rationale: Lean — with 12; no deploy surface
-  current_stage: 11-verify-impl
-  current_stage_note: '11-verify-impl in_progress — 09-qa PASS @ 95fac992; reports/09-qa.md + reports/verify-impl.md'
+    skip_rationale: Lean — with 12; waived D-S044-12-13-waive
+    note: 'WAIVED — D-S044-12-13-waive waived_no_runtime'
+  current_stage: completed
+  current_stage_note: 'NEAR-COMPLETE — 11 approved (D-S044-11); 12/13 waived (D-S044-12-13-waive); push_and_pr in progress (D-S044-next); close_session pending PR URL'
 sessions:
 - id: S043-rule-source-traceability
   type: feature
@@ -9316,11 +9329,11 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa in_progress (T6.2; D-S011-EV008-c-to-d-pass)
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
-    status: in_progress
+    status: completed
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at:
-    completed:
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
     previous_started_at: '2026-08-05'
     previous_started: '2026-08-05'
     previous_completed_at: '2026-08-05'
@@ -9356,10 +9369,10 @@ stages:
     session_id: S044-local-precommit-long-jobs
     evolve_cycle_id: EV-036
     mode: delta
-    overall:
-    note: 'IN PROGRESS — S044/EV-036 after 09 PASS @ 95fac992; report docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md'
+    overall: approved
+    note: 'COMPLETE — S044/EV-036 D-S044-11 approve_all_met (all 5 M5 ACs); report docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md; tip 95fac992; 12/13 waived; push_and_pr pending'
     report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
-    report_status: in_progress
+    report_status: approved
     tip_sha: 95fac992
     tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
     tip_note: 'S044/EV-036 tip 95fac992 — [EV-036] docs: 08 verification + 09 hook smoke reports'
@@ -9367,7 +9380,7 @@ stages:
     main_ci_cd_pipeline_status: SUCCESS
     doks_tag: 20260805115809-d3f4bb9
     awaiting_user_decision: false
-    decision_id:
+    decision_id: D-S044-11
     deepen_feature_ids:
     - M5
     active_milestone:
@@ -9376,32 +9389,37 @@ stages:
     progress:
     substeps:
       collect_results:
-        status: in_progress
+        status: completed
       feature_completeness:
-        status: pending
+        status: completed
       journey_signoff:
-        status: pending
+        status: n/a
       feature_approval:
-        status: pending
+        status: completed
       fixes_applied:
         status: n/a
       scope_analysis:
-        status: pending
+        status: completed
       summary:
-        status: pending
+        status: completed
     delta_substages:
     - id: S044-local-precommit-long-jobs-11
       session_id: S044-local-precommit-long-jobs
       evolve_cycle_id: EV-036
       skill_id: 11-verify-impl
-      status: in_progress
+      status: completed
       mode: delta
       started: '2026-08-05'
       started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
       tip_sha: 95fac992
       tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
       report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
-      note: 'STARTED — after 09 PASS'
+      report_status: approved
+      overall: approved
+      decision_id: D-S044-11
+      note: 'COMPLETE — D-S044-11 approve_all_met (all 5 M5 ACs)'
       deepen_feature_ids:
       - M5
     - id: S042-doks-cd-rollout
@@ -11585,8 +11603,8 @@ stages:
     previous_completed_at: '2026-08-05'
     prior_mirror_session_id: S040-iwxxm-corpus-quality
     prior_mirror_evolve_cycle_id: EV-032
-    current_child_stage: 11-verify-impl
-    note: 'IN PROGRESS — S044/EV-036 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
+    current_child_stage: completed
+    note: 'Phase 4 closing / PR pending — S044/EV-036 D-S044-11 approve_all_met; D-S044-12-13-waive; D-S044-next push_and_pr; tip 95fac992; close pending PR URL'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -33258,8 +33276,8 @@ evolve_cycles:
   title: Local pre-commit long jobs (save CI minutes)
   slug: local-precommit-long-jobs
   status: in_progress
-  phase: 2
-  phase_note: 'Phase 2 / verify — 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress'
+  phase: 4
+  phase_note: 'Phase 4 closing / PR pending — D-S044-11 approve_all_met; D-S044-12-13-waive; D-S044-next push_and_pr; close pending PR URL'
   started: '2026-08-05'
   started_at: '2026-08-05'
   scope_summary: |
@@ -33270,10 +33288,10 @@ evolve_cycles:
     TC-EV036-001..003 approved. Gate A amend (D-S044-02-gate-a): keep remote
     units+coverage+PR comment; drop validate+Compose; local lint only.
   branch: evolve/EV-036-local-precommit-long-jobs
-  branch_note: active — tip 95fac992; workflow-state-manager did not git checkout/create
+  branch_note: 'active — tip 95fac992; push_and_pr in progress (D-S044-next); close pending PR URL'
   tip_sha: 95fac992
   tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
-  tip_note: '09-qa PASS @ 95fac992 — [EV-036] docs: 08 verification + 09 hook smoke reports; 11-verify-impl in_progress'
+  tip_note: 'NEAR-COMPLETE — tip 95fac992; D-S044-11 approve_all_met; D-S044-12-13-waive; D-S044-next push_and_pr'
   preset: Lean
   preset_status: approved
   preset_note: 'G1=1 Lean approved; route_status=approved_lean'
@@ -33314,25 +33332,26 @@ evolve_cycles:
     - 12-verify-deploy
     - 13-deploy-smoke
     path: 00→16→01→02→07→08→09→11
-    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime); 07–09 completed; 11 in_progress'
-  current_stage: 11-verify-impl
-  current_stage_status: in_progress
-  current_stage_note: '11-verify-impl in_progress — 09 PASS @ 95fac992; reports/09-qa.md + reports/verify-impl.md'
+    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy; 07–11 completed; 12/13 waived D-S044-12-13-waive; Phase 4 closing / PR pending'
+  current_stage: completed
+  current_stage_status: completed
+  current_stage_note: 'NEAR-COMPLETE — 11 approved (D-S044-11); 12/13 waived; push_and_pr in progress; close pending PR URL'
   next_stage: null
   next_stage_status: null
   gates:
     a_to_b: passed
     a_to_b_note: 'D-S044-02-gate-a Lean → 07 (no 04); S02.M2 modified'
-    b_to_c: pending
-    c_to_d: pending
-    deploy: waived_expected
+    b_to_c: passed
+    c_to_d: passed
+    deploy: waived
+    deploy_note: 'D-S044-12-13-waive waived_no_runtime — tooling only; no product runtime'
   checkpoints:
     phase_a: passed
-    phase_b: pending
-    phase_c: pending
-    phase_d: pending
-    deploy: waived_expected
-    note: 'Lean tooling cycle — Gate A passed; 07 done; deploy waive expected (no runtime)'
+    phase_b: passed
+    phase_c: passed
+    phase_d: passed
+    deploy: waived
+    note: 'Lean tooling cycle — Phase 4 closing; deploy waived (D-S044-12-13-waive); PR pending'
   adrs: []
   artifacts:
   - path: docs/sessions/S044-local-precommit-long-jobs/
@@ -33358,6 +33377,14 @@ evolve_cycles:
     status: completed
     stage: 08-verify-build
     note: PASS
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+    status: completed
+    stage: 09-qa
+    note: PASS
+  - path: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+    status: completed
+    stage: 11-verify-impl
+    note: 'D-S044-11 approve_all_met'
   - path: docs/feature-list.md
     status: written
     stage: 01-requirements
@@ -33405,6 +33432,9 @@ evolve_cycles:
   - D-S044-g1-g2
   - D-S044-r1-ac
   - D-S044-02-gate-a
+  - D-S044-11
+  - D-S044-12-13-waive
+  - D-S044-next
   stages:
     00-context:
       status: completed
@@ -33418,7 +33448,7 @@ evolve_cycles:
       status: in_progress
       started: '2026-08-05'
       started_at: '2026-08-05'
-      note: 'Phase 0–2; child 07-build COMPLETE @ d4fd6955; child 08-verify-build COMPLETE PASS; child 09-qa in_progress'
+      note: 'Phase 4 closing / PR pending — D-S044-11; D-S044-12-13-waive; D-S044-next push_and_pr; tip 95fac992'
     01-requirements:
       status: completed
       mode: delta
@@ -33459,13 +33489,37 @@ evolve_cycles:
       report: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
       note: 'PASS — artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; handoff 09-qa'
     09-qa:
-      status: in_progress
+      status: completed
       mode: delta
       started: '2026-08-05'
       started_at: '2026-08-05'
-      tip_sha: d4fd6955
-      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
-      note: 'STARTED — local hook smoke after 08 PASS'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      tip_sha: 95fac992
+      tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+      overall: pass
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+      note: 'PASS — tip 95fac992; handoff 11-verify-impl'
+    11-verify-impl:
+      status: completed
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      tip_sha: 95fac992
+      tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+      overall: approved
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+      report_status: approved
+      decision_id: D-S044-11
+      note: 'COMPLETE — D-S044-11 approve_all_met (all 5 M5 ACs)'
+    12-verify-deploy:
+      status: skipped
+      note: 'WAIVED — D-S044-12-13-waive waived_no_runtime'
+    13-deploy-smoke:
+      status: skipped
+      note: 'WAIVED — D-S044-12-13-waive waived_no_runtime'
   notes:
   - '2026-08-05 S044/EV-036 OPEN — open_session; D-S044-open=1; D-S044-intent=4+1/N/A; session_counter 44; evolve_cycle_counter 36; branch evolve/EV-036-local-precommit-long-jobs pending_create; deepen M5 likely; no git branch/commit by workflow-state-manager'
   - '2026-08-05 Phase 0 LOCKED — D-S044-batch-b B1=3,B2=1,B3=1,B4=1; deepen M5; Lean preset pending G4; route_status=phase0_locked_pending_proceed; 00-context completed; 16-evolve in_progress; no git branch/commit by workflow-state-manager'
@@ -33475,6 +33529,7 @@ evolve_cycles:
   - '2026-08-05 07-build — T1–T5 implementation complete pending commit; artifacts execution-plan/hooks/ci-cd/TC-EV036/DEVELOPMENT; handoff 08-verify-build after commit; no commit SHA invented'
   - '2026-08-05 07-build COMPLETE @ d4fd6955 (d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b) — T1–T5; pending_commit false; tip_sha d4fd6955; current_stage 08-verify-build in_progress'
   - '2026-08-05 08-verify-build COMPLETE PASS @ d4fd6955 — artifact docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md; current_stage 09-qa in_progress'
+  - '2026-08-05 Phase 4 NEAR-COMPLETE — D-S044-11 approve_all_met; D-S044-12-13-waive waived_no_runtime; D-S044-next push_and_pr; tip 95fac992; close pending PR URL (parent follow-up); active_session retained'
 - id: EV-035
   session_id: S043-rule-source-traceability
   cycle_type: feature

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -32,7 +32,7 @@ active_session:
   started: '2026-08-05'
   started_at: '2026-08-05'
   route_status: approved_lean
-  note: 'OPEN — 08-verify-build COMPLETE PASS @ d4fd6955; 09-qa in_progress; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
+  note: 'OPEN — 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress; Lean 00→16→01→02→07→08→09→11; deepen M5; no product UI/deploy'
   decisions:
     Q1: '1'
     Q1_note: open_S044
@@ -77,7 +77,7 @@ active_session:
     started: '2026-08-05'
     started_at: '2026-08-05'
     skip_rationale:
-    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07-build COMPLETE @ d4fd6955; child 08-verify-build COMPLETE PASS; child 09-qa in_progress'
+    note: 'Phase 0/1 routing approved; 02 COMPLETE (D-S044-02-gate-a); child 07–08 COMPLETE; child 09-qa COMPLETE PASS @ 95fac992; child 11-verify-impl in_progress'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -144,13 +144,17 @@ active_session:
   - stage: 09-qa
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-05'
     started_at: '2026-08-05'
+    completed: '2026-08-05'
+    completed_at: '2026-08-05'
     skip_rationale:
-    tip_sha: d4fd6955
-    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
-    note: 'STARTED — local hook smoke after 08 PASS; tip d4fd6955'
+    tip_sha: 95fac992
+    tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+    overall: pass
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+    note: 'PASS — tip 95fac992; artifact reports/09-qa.md; handoff 11-verify-impl'
   - stage: 10-e2e
     required: false
     status: skipped
@@ -158,8 +162,14 @@ active_session:
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: pending
+    status: in_progress
+    started: '2026-08-05'
+    started_at: '2026-08-05'
     skip_rationale:
+    tip_sha: 95fac992
+    tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+    note: 'STARTED — after 09 PASS @ 95fac992; report verify-impl.md'
   - stage: 12-verify-deploy
     required: false
     status: skipped
@@ -168,8 +178,8 @@ active_session:
     required: false
     status: skipped
     skip_rationale: Lean — with 12; no deploy surface
-  current_stage: 09-qa
-  current_stage_note: '09-qa in_progress — 08-verify-build PASS @ d4fd6955; report verification-report.md; Lean local hook smoke'
+  current_stage: 11-verify-impl
+  current_stage_note: '11-verify-impl in_progress — 09-qa PASS @ 95fac992; reports/09-qa.md + reports/verify-impl.md'
 sessions:
 - id: S043-rule-source-traceability
   type: feature
@@ -9019,11 +9029,11 @@ stages:
     - 2026-07-14 S011/EV-008 T6.2 completed pass_with_advisories (qa-report.md + e2e-report.md); Playwright/compose SKIPPED host ports/disk; QA-001 api.py type narrow uncommitted; active_task T6.3 pending
     - 2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress
   09-qa:
-    status: in_progress
+    status: completed
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at:
-    completed:
+    completed_at: '2026-08-05'
+    completed: '2026-08-05'
     previous_started_at: '2026-08-05'
     previous_started: '2026-08-05'
     previous_completed_at: '2026-08-05'
@@ -9054,12 +9064,12 @@ stages:
     prior_s036_tip_sha: 0e34866
     session_id: S044-local-precommit-long-jobs
     evolve_cycle_id: EV-036
-    tip_sha: d4fd6955
-    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    tip_sha: 95fac992
+    tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
     mode: delta
-    overall:
-    report:
-    note: 'IN PROGRESS — S044/EV-036 local hook smoke after 08 PASS; tip d4fd6955; expected report docs/sessions/S044-local-precommit-long-jobs/reports/qa-report.md'
+    overall: pass
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+    note: 'PASS — S044/EV-036 COMPLETE @ tip 95fac992; artifact docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md; handoff 11-verify-impl'
     pending_commit: false
     main_ci_cd_pipeline_run: '31003268652'
     main_ci_cd_pipeline_status: in_progress
@@ -9068,13 +9078,17 @@ stages:
       session_id: S044-local-precommit-long-jobs
       evolve_cycle_id: EV-036
       skill_id: 09-qa
-      status: in_progress
+      status: completed
       mode: delta
       started: '2026-08-05'
       started_at: '2026-08-05'
-      tip_sha: d4fd6955
-      tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
-      note: 'STARTED — local hook smoke after 08 PASS'
+      completed: '2026-08-05'
+      completed_at: '2026-08-05'
+      tip_sha: 95fac992
+      tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+      overall: pass
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+      note: 'PASS — handoff 11-verify-impl'
     - id: S042-doks-cd-rollout
       session_id: S042-doks-cd-rollout
       evolve_cycle_id: EV-034
@@ -9302,22 +9316,33 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa in_progress (T6.2; D-S011-EV008-c-to-d-pass)
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
-    status: completed
+    status: in_progress
     started_at: '2026-08-05'
     started: '2026-08-05'
-    completed_at: '2026-08-05'
-    completed: '2026-08-05'
-    previous_started_at: '2026-08-04'
-    previous_started: '2026-08-04'
-    previous_completed_at: '2026-08-04'
-    previous_completed: '2026-08-04'
-    previous_session_id: S040-iwxxm-corpus-quality
-    previous_evolve_cycle_id: EV-032
-    previous_tip_sha: fe024aac
-    previous_tip_sha_full: fe024aac10077e365d65d0eccf12d8fb6288c9ec
-    previous_overall: approved
-    previous_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md
-    previous_note: 'COMPLETE 2026-08-04 — T4.4; D-S040-11=A1,B1,C1,D1 approved; report docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md; UI preview localhost:18000 accepted; F32 ACs approved; H4–H5 waive to 13; tip fe024aac approve committed; next 12/13; PR #848; #846'
+    completed_at:
+    completed:
+    previous_started_at: '2026-08-05'
+    previous_started: '2026-08-05'
+    previous_completed_at: '2026-08-05'
+    previous_completed: '2026-08-05'
+    previous_session_id: S042-doks-cd-rollout
+    previous_evolve_cycle_id: EV-034
+    previous_tip_sha: d3f4bb95
+    previous_tip_sha_full: d3f4bb955ca71d57506a44d5be9f346a31ae56d3
+    previous_overall: pass
+    previous_report: docs/sessions/S042-doks-cd-rollout/reports/verify-impl.md
+    previous_note: 'COMPLETE — overall pass; D-S042-13=1; report docs/sessions/S042-doks-cd-rollout/reports/verify-impl.md; CI 31003268652 SUCCESS; DOKS 20260805115809-d3f4bb9; tip d3f4bb95'
+    previous_s040_started_at: '2026-08-04'
+    previous_s040_started: '2026-08-04'
+    previous_s040_completed_at: '2026-08-04'
+    previous_s040_completed: '2026-08-04'
+    previous_s040_session_id: S040-iwxxm-corpus-quality
+    previous_s040_evolve_cycle_id: EV-032
+    previous_s040_tip_sha: fe024aac
+    previous_s040_tip_sha_full: fe024aac10077e365d65d0eccf12d8fb6288c9ec
+    previous_s040_overall: approved
+    previous_s040_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md
+    previous_s040_note: 'COMPLETE 2026-08-04 — T4.4; D-S040-11=A1,B1,C1,D1 approved; report docs/sessions/S040-iwxxm-corpus-quality/reports/verify-impl.md; tip fe024aac; PR #848; #846'
     prior_s038_session_id: S038-platform-independence-842
     prior_s038_evolve_cycle_id: EV-031
     prior_s038_tip_sha: b4feac02
@@ -9328,41 +9353,57 @@ stages:
     prior_s037_session_id: S037-quality-residuals-831
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 3889e4c
-    session_id: S042-doks-cd-rollout
-    evolve_cycle_id: EV-034
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
     mode: delta
-    overall: pass
-    note: 'COMPLETE — overall pass; D-S042-13=1; report docs/sessions/S042-doks-cd-rollout/reports/verify-impl.md; CI 31003268652 SUCCESS; DOKS 20260805115809-d3f4bb9; tip d3f4bb95'
-    report: docs/sessions/S042-doks-cd-rollout/reports/verify-impl.md
-    report_status: approved
-    tip_sha: d3f4bb95
-    tip_sha_full: d3f4bb955ca71d57506a44d5be9f346a31ae56d3
-    tip_note: 'main tip after #868 MERGED @ d3f4bb95; DOKS auto-rollout 20260805115809-d3f4bb9'
+    overall:
+    note: 'IN PROGRESS — S044/EV-036 after 09 PASS @ 95fac992; report docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md'
+    report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+    report_status: in_progress
+    tip_sha: 95fac992
+    tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+    tip_note: 'S044/EV-036 tip 95fac992 — [EV-036] docs: 08 verification + 09 hook smoke reports'
     main_ci_cd_pipeline_run: '31003268652'
     main_ci_cd_pipeline_status: SUCCESS
     doks_tag: 20260805115809-d3f4bb9
     awaiting_user_decision: false
-    decision_id: D-S042-13
+    decision_id:
+    deepen_feature_ids:
+    - M5
     active_milestone:
     active_task:
     active_task_status:
     progress:
     substeps:
       collect_results:
-        status: completed
+        status: in_progress
       feature_completeness:
-        status: completed
+        status: pending
       journey_signoff:
-        status: completed
+        status: pending
       feature_approval:
-        status: completed
+        status: pending
       fixes_applied:
         status: n/a
       scope_analysis:
-        status: completed
+        status: pending
       summary:
-        status: completed
+        status: pending
     delta_substages:
+    - id: S044-local-precommit-long-jobs-11
+      session_id: S044-local-precommit-long-jobs
+      evolve_cycle_id: EV-036
+      skill_id: 11-verify-impl
+      status: in_progress
+      mode: delta
+      started: '2026-08-05'
+      started_at: '2026-08-05'
+      tip_sha: 95fac992
+      tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+      report: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+      note: 'STARTED — after 09 PASS'
+      deepen_feature_ids:
+      - M5
     - id: S042-doks-cd-rollout
       session_id: S042-doks-cd-rollout
       evolve_cycle_id: EV-034
@@ -11544,8 +11585,8 @@ stages:
     previous_completed_at: '2026-08-05'
     prior_mirror_session_id: S040-iwxxm-corpus-quality
     prior_mirror_evolve_cycle_id: EV-032
-    current_child_stage: 08-verify-build
-    note: 'IN PROGRESS — S044/EV-036 07-build COMPLETE @ d4fd6955 (T1–T5; pending_commit false); 08-verify-build in_progress; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
+    current_child_stage: 11-verify-impl
+    note: 'IN PROGRESS — S044/EV-036 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress; Lean deepen M5; path 00→16→01→02→07→08→09→11; tooling/hooks/docs only'
   15-service-health:
     status: completed
     session_id: S039-doks-dns-cutover
@@ -22953,6 +22994,31 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/verify-impl.md
+  type: session-report
+  kind: verify-impl
+  stage: 11-verify-impl
+  skill_id: 11-verify-impl
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: in_progress
+  tip_sha: 95fac992
+  note: 'STARTED — 11-verify-impl after 09 PASS'
+- path: docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+  type: session-report
+  kind: qa-report
+  stage: 09-qa
+  skill_id: 09-qa
+  session_id: S044-local-precommit-long-jobs
+  evolve_cycle_id: EV-036
+  created_at: '2026-08-05'
+  updated_at: '2026-08-05'
+  status: completed
+  overall: pass
+  tip_sha: 95fac992
+  note: 'PASS — handoff 11-verify-impl'
 - path: docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
   type: session-report
   kind: verification-report
@@ -33193,7 +33259,7 @@ evolve_cycles:
   slug: local-precommit-long-jobs
   status: in_progress
   phase: 2
-  phase_note: 'Phase 2 / verify+qa — 08-verify-build COMPLETE PASS @ d4fd6955; 09-qa in_progress'
+  phase_note: 'Phase 2 / verify — 09-qa COMPLETE PASS @ 95fac992; 11-verify-impl in_progress'
   started: '2026-08-05'
   started_at: '2026-08-05'
   scope_summary: |
@@ -33204,10 +33270,10 @@ evolve_cycles:
     TC-EV036-001..003 approved. Gate A amend (D-S044-02-gate-a): keep remote
     units+coverage+PR comment; drop validate+Compose; local lint only.
   branch: evolve/EV-036-local-precommit-long-jobs
-  branch_note: active — tip d4fd6955; workflow-state-manager did not git checkout/create
-  tip_sha: d4fd6955
-  tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
-  tip_note: '07-build COMPLETE @ d4fd6955 — [EV-036] feat: local Compose on pre-push; remote units + coverage PR comment'
+  branch_note: active — tip 95fac992; workflow-state-manager did not git checkout/create
+  tip_sha: 95fac992
+  tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+  tip_note: '09-qa PASS @ 95fac992 — [EV-036] docs: 08 verification + 09 hook smoke reports; 11-verify-impl in_progress'
   preset: Lean
   preset_status: approved
   preset_note: 'G1=1 Lean approved; route_status=approved_lean'
@@ -33248,12 +33314,12 @@ evolve_cycles:
     - 12-verify-deploy
     - 13-deploy-smoke
     path: 00→16→01→02→07→08→09→11
-    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime); 07–08 completed; 09 in_progress'
-  current_stage: 09-qa
+    note: 'Lean — approved D-S044-g1-g2; skip tooling/tech-plan/e2e/deploy (no UI/runtime); 07–09 completed; 11 in_progress'
+  current_stage: 11-verify-impl
   current_stage_status: in_progress
-  current_stage_note: '09-qa in_progress — 08 PASS @ d4fd6955; report verification-report.md'
-  next_stage: 11-verify-impl
-  next_stage_status: pending
+  current_stage_note: '11-verify-impl in_progress — 09 PASS @ 95fac992; reports/09-qa.md + reports/verify-impl.md'
+  next_stage: null
+  next_stage_status: null
   gates:
     a_to_b: passed
     a_to_b_note: 'D-S044-02-gate-a Lean → 07 (no 04); S02.M2 modified'
@@ -34478,14 +34544,14 @@ evolve_cycles:
   pr_merged_sha: dfecba46
 git_history:
   current_branch: evolve/EV-036-local-precommit-long-jobs
-  ahead_of_origin: 1
+  ahead_of_origin: 2
   pushed: false
   pending_commit: false
-  pending_commit_note: 'cleared — d4fd6955 recorded; workflow-state tip sync may leave dirty tree for follow-up commit'
+  pending_commit_note: 'cleared — 95fac992 recorded; workflow-state tip sync may leave dirty tree for follow-up commit'
   dirty: true
-  tip_sha: d4fd6955
-  tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
-  tip_note: 'S044/EV-036 — 07-build COMPLETE @ d4fd6955; 08-verify-build in_progress; branch evolve/EV-036-local-precommit-long-jobs'
+  tip_sha: 95fac992
+  tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+  tip_note: 'S044/EV-036 — 09-qa PASS @ 95fac992; 11-verify-impl in_progress; branch evolve/EV-036-local-precommit-long-jobs'
   stash:
   - name: S039-EV031-WIP
     note: 'Parked EV-031/S039 dirty worktree WIP before cutting evolve/EV-032 from main (D-S040-branch=1)'
@@ -34497,9 +34563,10 @@ git_history:
   main_tip_sha: 5245f8de
   main_tip_sha_full: 5245f8de547c966a20ee5f81734248dba50a440d
   recommended_branch: evolve/EV-036-local-precommit-long-jobs
-  note: 'S044/EV-036 07 COMPLETE @ d4fd6955; current_stage 08-verify-build in_progress; pending_commit false; tip d4fd6955'
+  note: 'S044/EV-036 09 PASS @ 95fac992; current_stage 11-verify-impl in_progress; pending_commit false; tip 95fac992; ahead_of_origin=2 pushed=false'
 
   notes:
+  - '2026-08-05 S044/EV-036 — recorded git commit 95fac992 (95fac99236ef53c4d099dfa7bab72b1936127b1e) [EV-036] docs: 08 verification + 09 hook smoke reports; 09-qa COMPLETE PASS; 11-verify-impl in_progress; tip 95fac992; ahead_of_origin=2 pushed=false'
   - '2026-08-05 S044/EV-036 — recorded git commit d4fd6955 (d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b) [EV-036] feat: local Compose on pre-push; remote units + coverage PR comment; 07-build COMPLETE (T1–T5; pending_commit false); 08-verify-build in_progress; tip d4fd6955; ahead_of_origin=1 pushed=false'
   - '2026-08-05 S044/EV-036 D-S044-02-gate-a — Gate A PASS S02.M2 modified; 02 completed; 07-build T1–T5 impl pending commit → 08; no git commit/SHA invented by workflow-state-manager; tip main @ 97a5c131'
   - '2026-08-05 S044/EV-036 D-S044-g1-g2 — G1=1 Lean + G2=1 proceed; preset_status=approved; route_status=approved_lean; current_stage 01-requirements in_progress; branch evolve/EV-036-local-precommit-long-jobs exists:true (parent creating); no git branch/commit by workflow-state-manager; tip main @ 97a5c131'
@@ -34949,12 +35016,12 @@ git_history:
     evolve_cycle_id: EV-036
     created: '2026-08-05'
     created_at: '2026-08-05'
-    tip_sha: d4fd6955
-    tip_sha_full: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
+    tip_sha: 95fac992
+    tip_sha_full: 95fac99236ef53c4d099dfa7bab72b1936127b1e
     exists: true
     pushed: false
-    ahead_of_origin: 1
-    note: 'active — tip d4fd6955; 07 COMPLETE; 08 in_progress; not pushed'
+    ahead_of_origin: 2
+    note: 'active — tip 95fac992; 09 PASS; 11 in_progress; not pushed'
   - name: evolve/EV-034-doks-cd-rollout
     status: active
     base: main
@@ -36021,6 +36088,27 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 95fac99236ef53c4d099dfa7bab72b1936127b1e
+    short: 95fac992
+    branch: evolve/EV-036-local-precommit-long-jobs
+    message: '[EV-036] docs: 08 verification + 09 hook smoke reports'
+    stage: 08-verify-build/09-qa
+    skill_id: 09-qa
+    stages:
+    - 08-verify-build
+    - 09-qa
+    session_id: S044-local-precommit-long-jobs
+    evolve_cycle_id: EV-036
+    files_changed:
+    - docs/sessions/S044-local-precommit-long-jobs/reports/09-qa.md
+    - docs/sessions/S044-local-precommit-long-jobs/reports/verification-report.md
+    - workflow-state.yaml
+    files_changed_count: 3
+    timestamp: '2026-08-05'
+    timestamp_utc: '2026-08-05T15:26:13Z'
+    pushed: false
+    tip_sha: 95fac992
+    note: 'S044/EV-036 08 docs + 09-qa PASS — tip 95fac992; handoff 11-verify-impl'
   - sha: d4fd6955df69af6dff53a4c5afaa8ad5e76c0e4b
     short: d4fd6955
     branch: evolve/EV-036-local-precommit-long-jobs


### PR DESCRIPTION
## Summary
- Move long local work onto developer hooks: **pre-commit** = fast + `validate-ci-medium`; **pre-push** = `make ci` (units + Compose on 18000/18001)
- Slim remote CI: drop validate + Compose; **keep** unit matrix + coverage + sticky PR coverage comment
- Dense **TC-EV036** contract tests; Compose gate fixes (curl readiness, POSIX prepare-config, vite bind `:8000`, Alpine python3/bash)

Deepens **M5** only ([Corpus: product] · [Corpus: tests] · [Corpus: decisions] EV-036). Deploy 12/13 waived (tooling only).

## Test plan
- [x] Local pre-push `make ci` green (this push)
- [ ] Cloud `ci-cd.yml` green on PR branch
- [ ] PR coverage comment job runs on unit matrix
- [ ] Merge after CI green


Made with [Cursor](https://cursor.com)