### PR TITLE
[EV-041] Operator UI sources runbook + PPT pack

### DIFF
--- a/docs/context/operator-sources-briefing.md
+++ b/docs/context/operator-sources-briefing.md
@@ -1,0 +1,36 @@
+# Context — Operator sources briefing (S049 / EV-041)
+
+> **Mode**: scoped | **Slug**: operator-sources-briefing | **Generated**: 2026-08-06  
+> **Feature**: F7 docs deepen | **Status**: active  
+> **Session**: [S049-operator-sources-briefing](../sessions/S049-operator-sources-briefing/session-brief.md)
+
+## Executive summary
+
+Docs-only cycle: explain to operators and external audiences **which ICAO/WMO/NWS
+sources and vendor schema pins** underwrite the TAC→IWXXM operator UI — and help
+assemble a briefing deck from a repo source pack (no binary `.pptx` in git).
+
+## Locked intake
+
+| Gate | Choice |
+|------|--------|
+| Deliverables | Runbook + PPT source pack + guided walkthrough |
+| Audience | Runbook = operators; PPT = external sources briefing |
+| Code | None |
+| Corpus | Path-cite domain/ops; no CORPUS membership change |
+
+## Primary corpus / path cites
+
+- [Corpus: product] F7 / F9 / F10 / F21 / F31
+- [Corpus: system-spec] runtime architecture
+- [Corpus: tech-spec] + dependency-inventory (stack slide)
+- [docs/domain/README.md] pipeline stages
+- [docs/domain/rules/RULE_SOURCE_URLS.md] master URL catalog
+- [docs/domain/rules/ACCESS_AND_CITATION.md] paywall policy
+- [docs/domain/rules/PROVENANCE_MAP.md] dig ↔ rule index
+- [docs/domain/mining/PPT-02-IWXXM-Framework-WMO-mining-notes.md] informative workshop deck
+- [vendor/manifest.json] runtime pins
+
+## Out of scope
+
+Product code; committing copyrighted PDFs/PNGs; deploy smoke; rewriting provenance catalogs.

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,48 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-041 — Operator UI runbook + source-centric PPT pack (S049)
+
+**Session**: S049-operator-sources-briefing  
+**Features**: deepen **F7** narrative (no new Fn)  
+**Started**: 2026-08-06  
+**Branch**: `evolve/EV-041-operator-sources-briefing`  
+**Status**: in_progress  
+**Prior**: S048 / EV-040 completed  
+**Corpus**: [Corpus: product §F7], [Corpus: system-spec], [Corpus: tech-spec];
+path-cites [docs/domain/README.md], [docs/domain/rules/RULE_SOURCE_URLS.md],
+[docs/domain/rules/ACCESS_AND_CITATION.md], [docs/domain/rules/PROVENANCE_MAP.md],
+[docs/domain/mining/PPT-02-IWXXM-Framework-WMO-mining-notes.md];
+[Corpus: WAIVED — ops/guides CORPUS membership; reason: path-cite only (EV-035 G3 pattern); decided: EV-041]
+
+### Scope (Phase 0 — locked 2026-08-06; plan `operator_sources_docs` → **D-S049-open**)
+
+| ID | Category | Question | Decision |
+|----|----------|----------|----------|
+| Q1 | decision | Deliverables? | Docs-only runbook + PPT **source pack** + guided `.pptx` walkthrough (no binary in git) |
+| Q2 | decision | Audience? | **Split** — runbook = operators; PPT = external sources/architecture briefing |
+| Q3 | decision | CORPUS? | Path-cite domain/ops/guides — **no** minimal-corpus membership |
+| Q4 | decision | UI preview? | **N/A** — docs-only (optional local screenshots for personal deck only) |
+
+### Preset
+
+**Lean (docs override)** — `00→16→01→02→07→08` (skip 03–06, 09–13)
+
+### Acceptance (locked — **D-S049-ac**)
+
+| AC | Criterion |
+|----|-----------|
+| AC1 | Runbook covers operator workflow **and** maps each major surface to standards/vendor/package sources |
+| AC2 | PPT pack has complete slide outline + bibliography + image pointers + build walkthrough |
+| AC3 | All citations follow ACCESS_AND_CITATION (paywall labeled; no copyrighted full text) |
+| AC4 | Walkthrough can produce a briefing deck without inventing new normative claims |
+| AC5 | Session artifacts + branch recorded; PR when requested |
+
+### In / out
+
+- **In**: `docs/ops/operator-ui-runbook.md`; `docs/guides/operator-sources-pptx/*`; this section; domain README pointer
+- **Out**: product code; `.pptx`/PDFs/PNGs in git; provenance catalog rewrite; deploy
+
 ## Cycle EV-040 — Workbench lint UX + examples + prefs (S048)
 
 **Session**: S048-workbench-lint-ux  

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -74,6 +74,9 @@ Product × role coverage: [rules/COVERAGE_MATRIX.md](./rules/COVERAGE_MATRIX.md)
 **Rules catalog strategy:** [rules/README.md](./rules/README.md) (role routing + **apply playbooks**) ·
 [rules/COVERAGE_MATRIX.md](./rules/COVERAGE_MATRIX.md) (G1–G7 gates · product × strategy cites).
 
+**Operator / briefing (sources-first, EV-041):** [../ops/operator-ui-runbook.md](../ops/operator-ui-runbook.md) ·
+[../guides/operator-sources-pptx/](../guides/operator-sources-pptx/) (PPT pack — path-cite only; not CORPUS).
+
 **Canonical strategy deep dives (2026-07-14 continue · 2026-07-30 promote #797):**
 
 | Doc | Added for this pass |

--- a/docs/guides/operator-sources-pptx/README.md
+++ b/docs/guides/operator-sources-pptx/README.md
@@ -1,0 +1,37 @@
+# Operator sources — PowerPoint source pack
+
+> **Session:** S049 / EV-041  
+> **Audience:** external briefing on **standards lineage + what we built from**  
+> **Operator how-to:** [../../ops/operator-ui-runbook.md](../../ops/operator-ui-runbook.md)
+
+## What this pack is
+
+Markdown you copy into PowerPoint / Keynote / Google Slides. It does **not** include a
+binary `.pptx` or copyrighted ICAO/WMO slide PNGs (those stay local / personal).
+
+| File | Use |
+|------|-----|
+| [slide-outline.md](./slide-outline.md) | Per-slide title, bullets, speaker notes, source URLs |
+| [bibliography.md](./bibliography.md) | Curated landings (normative vs informative) |
+| [image-pointers.md](./image-pointers.md) | Where to get every figure |
+| [build-walkthrough.md](./build-walkthrough.md) | Step-by-step deck assembly |
+
+## Citation constraints
+
+Follow [ACCESS_AND_CITATION.md](../../domain/rules/ACCESS_AND_CITATION.md):
+
+- **Do** put titles, editions, section numbers, and landing URLs on slides/notes.
+- **Do not** paste multi-page Annex 3 / Manual on Codes / Doc 8896 text.
+- Label **paywall** vs **public** vs **informative** clearly.
+- Runtime SoT for schemas = `vendor/manifest.json` pin (**v2025-2**), not workshop decks.
+
+## Suggested theme (keep simple)
+
+- One dark or light professional theme — avoid generic “AI purple gradient” clichés if branding matters.
+- Prefer **your own** architecture redraw (from [Corpus: system-spec]) over third-party art.
+- Footer on every slide: `Pin: IWXXM v2025-2 · Sources: docs/guides/operator-sources-pptx`
+
+## Corpus cites
+
+[Corpus: product §F7] [Corpus: system-spec] [Corpus: tech-spec]  
+[docs/domain/rules/RULE_SOURCE_URLS.md] [docs/domain/mining/PPT-02-…]

--- a/docs/guides/operator-sources-pptx/bibliography.md
+++ b/docs/guides/operator-sources-pptx/bibliography.md
@@ -1,0 +1,68 @@
+# Bibliography — curated sources for the briefing deck
+
+Subset of [RULE_SOURCE_URLS.md](../../domain/rules/RULE_SOURCE_URLS.md) plus software
+cites. Labels: **normative** | **normative-schema** | **normative-vocabulary** |
+**informative** | **software**. Access: **public** | **paywall** | **library**.
+
+Vendor pin (runtime): IWXXM **v2025-2**, codelists **49-2**, iwxxm-us **3.0** —
+[`vendor/manifest.json`](../../../vendor/manifest.json).
+
+---
+
+## A. ICAO / WMO / NWS (domain)
+
+| Title | URL | Label | Access | Use on slides |
+|-------|-----|-------|--------|---------------|
+| ICAO Annex 3 — Meteorological Service for International Air Navigation | https://store.icao.int/en/annexes/annex-3 | normative | paywall | 2, 3, 12 |
+| ICAO Doc 8896 — Manual of Aeronautical Meteorological Practice | https://store.icao.int/en/manual-of-aeronautical-meteorological-practice-doc-8896 | normative (practice) | paywall | 3 |
+| ICAO Doc 10003 — Manual on the ICAO Meteorological Information Exchange Model | ICAO Store (see RULE_SOURCE_URLS) | normative | paywall | 3, 9 |
+| ICAO EUR Doc 014 — EUR SIGMET and AIRMET Guide (5th Ed. 2023) | https://www.icao.int/sites/default/files/EURNAT/Documents/EUR%20and%20Nat%20Docs/EUR%20Documents/EUR%20Documents/014%20-%20EUR%20SIGMET%20and%20AIRMET%20Guide/EUR-Doc-14-EN-5th-Ed-2023-rev-Dec23-clean.pdf | normative-conversion-notes (regional) | public | 3 |
+| Guidelines for the Implementation of OPMET Data Exchange using IWXXM (5th Ed.) | https://www.icao.int/sites/default/files/METP/Documents/Guidlines-for-the-Implementation-of-OPMET-Data-Exchange-using-IWXXM_5th-Edition.pdf | normative-conversion-notes | public | 2, 5, 12 |
+| WMO-No. 306 Vol I.3 — Manual on Codes Part D | https://library.wmo.int/idurl/4/35769 | normative (FM 205) | library | 3, 5 |
+| IWXXM schemas (2025-2) | https://schemas.wmo.int/iwxxm/2025-2/ | normative-schema | public | 3, 6, 12 |
+| WMO codes registry | https://codes.wmo.int/ | normative-vocabulary | public | 3, 12 |
+| Community IWXXM / AHL | https://community.wmo.int/en/activity-areas/wis/iwxxm · AHL: https://community.wmo.int/en/activity-areas/wis/iwxxm/ahl-icao-data | informative index | public | 5, 10 |
+| wmo-im/iwxxm GitHub | https://github.com/wmo-im/iwxxm (tag **v2025-2**) | normative-schema | public | 6, 12 |
+| wmo-im/iwxxm-codelists | https://github.com/wmo-im/iwxxm-codelists (tag **49-2**) | normative-vocabulary | public | 6 |
+| wmo-im/iwxxm-modelling | https://github.com/wmo-im/iwxxm-modelling (tag **v2025-2**) | informative/modelling | public | 6 |
+| wmo-im/iwxxm-translation | https://github.com/wmo-im/iwxxm-translation | informative (parity) | public | 6 |
+| IWXXM-US 3.0 schemas | https://nws.weather.gov/schemas/iwxxm-us/ (tarball per manifest) | normative-schema (US) | public | 3, 6 |
+| FMH-1 (2019) Federal Meteorological Handbook No. 1 | OFCM/ICAMS public PDF (see RULE_SOURCE_URLS / fmh1 mining notes) | normative (US TAC) | public | 3 |
+| PPT-02 IWXXM Framework (TT-AvData / ESAF workshop) | https://www.icao.int/filebrowser/download/26741?fid=26741 | informative | public | 10 |
+
+Mining digs (working notes, not SoT): [docs/domain/mining/](../../domain/mining/).
+
+---
+
+## B. In-repo standing docs (give to technical audience)
+
+| Doc | Path | Role |
+|-----|------|------|
+| Domain hub / pipeline | [docs/domain/README.md](../../domain/README.md) | Stage table |
+| URL catalog | [docs/domain/rules/RULE_SOURCE_URLS.md](../../domain/rules/RULE_SOURCE_URLS.md) | Master landings |
+| Access policy | [docs/domain/rules/ACCESS_AND_CITATION.md](../../domain/rules/ACCESS_AND_CITATION.md) | Paywall rules |
+| Provenance index | [docs/domain/rules/PROVENANCE_MAP.md](../../domain/rules/PROVENANCE_MAP.md) | Dig ↔ rule |
+| Issue codes | [docs/domain/rules/ISSUE_CATALOG.md](../../domain/rules/ISSUE_CATALOG.md) | Lint codes |
+| Operator runbook | [docs/ops/operator-ui-runbook.md](../../ops/operator-ui-runbook.md) | Day-to-day ops |
+| Product features | [docs/feature-list.md](../../feature-list.md) | F7/F9/F10… |
+| Architecture | [docs/spec.md](../../spec.md) | Components |
+| Dependencies | [docs/dependency-inventory.md](../../dependency-inventory.md) | Stack |
+
+---
+
+## C. Software stack (high level)
+
+| Component | Cite | Label |
+|-----------|------|-------|
+| FastAPI / uvicorn | dependency-inventory · apps/backend | software |
+| React 18 + Vite + TypeScript | dependency-inventory · apps/frontend | software |
+| CodeMirror 6 | F7 editor choice | software |
+| msgspec | ADR-026 HTTP DTOs | software |
+| packages/tac-validate | F12 / F15 | software |
+| packages/tac2iwxxm | F6 / F14 | software |
+| packages/iwxxm-validate | F2 / F13 | software |
+| packages/dissemination | F16–F19 / ADR-030 | software |
+| Supabase Auth (JWT only) | F31 / ADR-033 | software |
+| DigitalOcean Postgres / DOKS | F30 | software |
+
+[Corpus: tech-spec] [docs/dependency-inventory.md]

--- a/docs/guides/operator-sources-pptx/build-walkthrough.md
+++ b/docs/guides/operator-sources-pptx/build-walkthrough.md
@@ -1,0 +1,133 @@
+# Build walkthrough — assemble the `.pptx`
+
+PowerPoint-first steps; Keynote / Google Slides equivalents in parentheses.
+Work from [slide-outline.md](./slide-outline.md) and [image-pointers.md](./image-pointers.md).
+
+**Do not** commit the finished `.pptx` to git unless explicitly requested.
+
+---
+
+## 0. Setup (5 minutes)
+
+1. Open **PowerPoint** → Blank Presentation (Keynote: File → New; Slides: Blank).  
+2. Set slide size: **Widescreen 16:9** (Design → Slide Size).  
+3. Apply a simple theme (one accent color). Avoid purple-on-white cliché if you care about branding.  
+4. View → **Notes** (enable speaker notes).  
+5. Optional footer master: `Pin: IWXXM v2025-2 · Sources briefing`  
+6. Keep this pack open side-by-side with the deck.
+
+**Checklist before any content:** citation policy — titles + URLs only; no Annex 3 body text.
+
+---
+
+## Batch A — Slides 1–4 (start here in coaching)
+
+### Slide 1 — Title
+
+1. Title placeholder → paste title from outline.  
+2. Subtitle → pin line.  
+3. Notes → paste speaker notes.  
+4. Insert org logo if any (Insert → Pictures).
+
+### Slide 2 — Why IWXXM
+
+1. New slide → Title and Content.  
+2. Paste bullets.  
+3. Insert → Shapes: two rectangles “TAC” and “IWXXM”, arrow between.  
+4. Notes: dual-obligation cite + “informative PPT-02” caveat.
+
+### Slide 3 — Standards map
+
+1. Paste bullets (keep paywall labels).  
+2. Optional: Insert screenshot of https://schemas.wmo.int/iwxxm/2025-2/ (public landing).  
+3. Notes: point to RULE_SOURCE_URLS.md path for Q&A.
+
+### Slide 4 — Architecture
+
+1. Prefer **SmartArt** Process/Hierarchy or freeform boxes matching image-pointers mermaid.  
+2. Labels exactly: `apps/frontend`, `apps/backend`, three packages, `vendor/schemas`.  
+3. Notes: F21 public convert / F31 optional Auth.
+
+**Pause:** review Batch A for invented claims (none should appear).
+
+---
+
+## Batch B — Slides 5–8
+
+### Slide 5 — Pipeline
+
+1. SmartArt **Basic Process** with 7 chevrons, or numbered list.  
+2. Text from domain README stage names.  
+3. Notes: stages are separate concerns.
+
+### Slide 6 — Vendor pins
+
+1. Table 2×5: Bundle | Pin.  
+2. Or screenshot `vendor/manifest.json` (tag fields only).  
+3. Notes: conflict → defer to pin; translation suite informative.
+
+### Slide 7 — Operator UI
+
+1. Paste F7/F9/F10 bullets.  
+2. Insert 1–2 **local** screenshots (image-pointers §UI).  
+3. Caption: “Local non-deployed preview”.  
+4. Notes: runbook path for operators.
+
+### Slide 8 — Provenance
+
+1. Three boxes: Dig → ISSUE_CATALOG → Lint UI.  
+2. Notes: EV-035 / EV-040; gap/paywall labels.
+
+**Pause:** confirm no copyrighted PDF pages pasted.
+
+---
+
+## Batch C — Slides 9–12
+
+### Slide 9 — Access friction
+
+1. Insert → Table (copy from outline).  
+2. Emphasize paywall row visually (e.g. italic “purchase”).
+
+### Slide 10 — PPT-02
+
+1. Bullets from outline.  
+2. Optional figure: personal extract from `.local/.../slide-images/` **or** open official download and snip slides 6–7 only.  
+3. Notes: full attribution paragraph from image-pointers.  
+4. On-slide badge: **INFORMATIVE — not SoT**.
+
+### Slide 11 — Software stack
+
+1. Short bullet list from outline (not full inventory).  
+2. Notes: dependency-inventory.md for detail; ADR-014 GIFTs removed.
+
+### Slide 12 — Bibliography
+
+1. Paste short URL list.  
+2. Handout: print or link `bibliography.md`.  
+3. Closing line: “Operator day-to-day: docs/ops/operator-ui-runbook.md”.
+
+---
+
+## Final checklist
+
+- [ ] Every slide has speaker notes with at least one corpus/path cite or landing URL  
+- [ ] Paywalled sources labeled  
+- [ ] PPT-02 (if used) labeled informative  
+- [ ] Pin **v2025-2** appears on title and/or footer  
+- [ ] No Annex 3 / MoC multi-paragraph paste  
+- [ ] UI shots labeled non-deployed (if present)  
+- [ ] File saved outside repo (e.g. `~/Documents/TAC-to-IWXXM-sources-briefing.pptx`)  
+- [ ] Matches [bibliography.md](./bibliography.md) landings
+
+---
+
+## Coaching cadence (chat)
+
+When walking through with an agent:
+
+1. Complete **Batch A** → reply “Batch A done” (or note blockers).  
+2. Then Batch B → “Batch B done”.  
+3. Then Batch C → final checklist.  
+
+Equivalents: Keynote **Presenter Notes**; Google Slides **Speaker notes** panel.

--- a/docs/guides/operator-sources-pptx/image-pointers.md
+++ b/docs/guides/operator-sources-pptx/image-pointers.md
@@ -1,0 +1,84 @@
+# Image / figure pointers
+
+**Git policy:** do **not** commit ICAO/WMO PDFs, workshop slide PNGs, or production
+screenshots into this repo. Insert them only into your personal `.pptx`. Local digs may
+already exist under gitignored `.local/reference/`.
+
+---
+
+## Per-slide figure plan
+
+| Slide | Visual | Where to get it | Notes |
+|-------|--------|-----------------|-------|
+| 1 | Org / product logo only | Your brand assets | Optional |
+| 2 | TAC ↔ IWXXM dual diagram | **Draw** in PPT (two boxes + arrow) | Do not scrape third-party art |
+| 3 | Landings list screenshot *or* icon row | Browser: schemas.wmo.int, codes.wmo.int, ICAO store listing page | Fair-use screenshot of public landing; cite URL in notes |
+| 4 | Architecture boxes | Redraw from mermaid below / [Corpus: system-spec] | Prefer original redraw |
+| 5 | Pipeline chevrons | Draw 7 stages from domain README | Text labels match hub table |
+| 6 | `vendor/manifest.json` excerpt | Open file in editor → screenshot keys/tags only | Public file |
+| 7 | Workbench UI | **Local** Vite preview (`apps/frontend`) — non-deployed | Ask before using staging/prod |
+| 8 | Dig → catalog → lint flow | Draw 3 boxes | Cite PROVENANCE_MAP |
+| 9 | (table is visual) | — | — |
+| 10 | PPT-02 slides 6–7 (landings) | Official: [ICAO filebrowser](https://www.icao.int/filebrowser/download/26741?fid=26741); local: `.local/reference/ppt-02-iwxxm-framework-wmo/extracts/slide-images/` | **Informative**; attribute TT-AvData / ESAF; do not commit PNGs |
+| 11 | Optional stack icons | Simple text list preferred | Avoid random icon packs with unclear license |
+| 12 | None | — | — |
+
+---
+
+## Architecture mermaid (slide 4 — redraw in PPT)
+
+```mermaid
+flowchart TB
+  browser[Browser_operator_UI]
+  fe[apps_frontend]
+  api[apps_backend]
+  tv[tac_validate]
+  t2i[tac2iwxxm]
+  iv[iwxxm_validate]
+  vendor[vendor_schemas_pin]
+  browser --> fe --> api
+  api --> tv
+  api --> t2i
+  api --> iv
+  tv --> vendor
+  t2i --> vendor
+  iv --> vendor
+```
+
+ASCII source of truth: [docs/spec.md](../../spec.md) §Runtime (S038 / EV-031 target).
+
+---
+
+## PPT-02 local extract index (optional personal use)
+
+If you previously ran the mining extract:
+
+| Path (gitignored) | Contents |
+|-------------------|----------|
+| `.local/reference/ppt-02-iwxxm-framework-wmo/` | PDF + fulltext |
+| `…/extracts/slide-images/` | Rendered PNGs for slides 5, 9, 11, 12, 14, 16, 17, etc. |
+| `…/extracts/resources-landings.txt` | Slides 6–7, 10 URL list |
+
+Standing dig: [PPT-02-IWXXM-Framework-WMO-mining-notes.md](../../domain/mining/PPT-02-IWXXM-Framework-WMO-mining-notes.md).
+
+**Attribution line for speaker notes when using PPT-02 figures:**  
+“Source: WMO TT-AvData, IWXXM Framework, ESAF Virtual Regional Workshop, 22 Oct 2025
+(ICAO filebrowser). Informative — not encode/validate SoT. Runtime pin: IWXXM v2025-2.”
+
+---
+
+## UI screenshots (slide 7)
+
+1. Start local frontend (non-deployed) — see [docs/ops/DEVELOPMENT.md](../../ops/DEVELOPMENT.md).  
+2. Capture: (a) workbench with product picker + editor; (b) decode panel or lint console with source attribution.  
+3. Store under `.local/pptx-screenshots/` (create; keep gitignored) or insert straight into PPT.  
+4. Label slide: “Local non-deployed preview” if showing UI.
+
+---
+
+## Package × line matrix (optional add-on slide)
+
+Prefer a **redrawn** 2-column table (2023-1 / 2025-2) from
+[VERSION_SUPPORT_POLICY.md](../../domain/iwxxm/VERSION_SUPPORT_POLICY.md) Appendix A
+(informative capture). Do not present PPT-02 p.5 as machine SoT — defer to vendored XSD
+`version=` attributes.

--- a/docs/guides/operator-sources-pptx/slide-outline.md
+++ b/docs/guides/operator-sources-pptx/slide-outline.md
@@ -1,0 +1,263 @@
+# Slide outline — TAC-to-IWXXM sources briefing
+
+Copy each block into one slide. Speaker notes are for presenter view only.
+
+---
+
+## Slide 1 — Title
+
+**Title:** TAC → IWXXM Operator System  
+**Subtitle:** Built from ICAO / WMO / NWS sources · Runtime pin **IWXXM v2025-2**
+
+**Bullets (optional footer):**
+
+- Repository: EMPIRIC2/TAC-to-IWXXM (monorepo)
+- Briefing pack: `docs/guides/operator-sources-pptx/`
+
+**Speaker notes:** This deck is about *provenance* — which standards and schema pins
+underwrite the tool — not a feature tour. Operator click-paths live in
+`docs/ops/operator-ui-runbook.md`. [Corpus: product §F7] [Corpus: system-spec]
+
+**Figure:** none (or org logo only)
+
+**Sources:** vendor/manifest.json · feature-list F7
+
+---
+
+## Slide 2 — Why IWXXM (problem framing)
+
+**Title:** TAC presentation vs IWXXM exchange
+
+**Bullets:**
+
+- TAC remains familiar for human presentation
+- IWXXM (XML/GML) is the structured exchange form for OPMET
+- Annex 3 frames dual TAC + IWXXM obligations (cite; do not quote)
+- Operators need software to lint TAC, encode IWXXM, and validate XSD + Schematron
+
+**Speaker notes:** Informative workshop framing (PPT-02) says consumers still render TAC
+often while exchange moves to IWXXM. Do not claim TAC sunset dates as binding unless
+citing a current SARPs edition. [docs/domain/mining/PPT-02-…] [Corpus: product]
+
+**Figure:** optional simple two-column diagram “TAC text” ↔ “IWXXM XML” (draw yourself)
+
+**Sources:** ICAO Annex 3 (paywall store landing) · PPT-02 informative · OPMET Guidelines 5th (public)
+
+---
+
+## Slide 3 — Standards map
+
+**Title:** Standards & registries we built from
+
+**Bullets:**
+
+- **ICAO Annex 3** — TAC SARPs / templates — *Access: paywall*
+- **WMO-No. 306 Vol I.3** — Manual on Codes / FM 205 representations — *library*
+- **codes.wmo.int** — linked-data vocabularies — *public*
+- **schemas.wmo.int/iwxxm** — XSD + Schematron landings — *public*
+- **FMH-1 / iwxxm-us** — US METAR/SPECI REMARKS overlay — *public*
+- **EUR Doc 014** — SIGMET/AIRMET guide — *public PDF*
+
+**Speaker notes:** Full catalog: RULE_SOURCE_URLS.md. Paywalled prose never lives in the
+repo. [docs/domain/rules/RULE_SOURCE_URLS.md] [ACCESS_AND_CITATION.md]
+
+**Figure:** see image-pointers §Standards logos / landings table (screenshot of landings list OK)
+
+**Sources:** RULE_SOURCE_URLS §1–§3
+
+---
+
+## Slide 4 — What we implemented (architecture)
+
+**Title:** Monorepo components
+
+**Bullets:**
+
+- `apps/frontend` — operator workbench (React / Vite)
+- `apps/backend` — FastAPI convert / lint / validate / decode
+- `apps/worker` — near-RT ingest (F8; not auto-disseminate)
+- `packages/tac-validate` · `tac2iwxxm` · `iwxxm-validate`
+- `vendor/schemas/*` — read-only WMO / NWS snapshots
+
+**Speaker notes:** Redraw from spec.md runtime diagram. Auth optional for long-term
+sessions only (F21/F31). [Corpus: system-spec] [Corpus: product §F21/F31]
+
+**Figure:** architecture box diagram — **draw from** image-pointers §Architecture (mermaid in pack)
+
+**Sources:** docs/spec.md §System Architecture · docs/CORPUS.md
+
+---
+
+## Slide 5 — Build pipeline (TAC → validated IWXXM)
+
+**Title:** Seven-stage domain pipeline
+
+**Bullets:**
+
+1. TAC lint (Annex 3 / vocab)
+2. Convert (encode + nilReasons)
+3. Well-formed XML
+4. XSD (structure)
+5. Schematron (+ offline RDF)
+6. Golden example pairs
+7. Bulletin / AHL / ops (when used)
+
+**Speaker notes:** Stages must stay separate — Schematron pass ≠ Annex 3 SARPs proof.
+Hub table in docs/domain/README.md. Engines: tac-validate → tac2iwxxm → iwxxm-validate.
+
+**Figure:** horizontal pipeline arrows (draw) — image-pointers §Pipeline
+
+**Sources:** docs/domain/README.md · TAC_VALIDATION / IWXXM_CONVERSION / IWXXM_VALIDATION
+
+---
+
+## Slide 6 — Vendor / upstream pins
+
+**Title:** Runtime schema pins
+
+**Bullets:**
+
+- `wmo-im/iwxxm` **v2025-2**
+- `wmo-im/iwxxm-codelists` **49-2**
+- `wmo-im/iwxxm-modelling` **v2025-2**
+- `iwxxm-translation` — informative parity only
+- `iwxxm-us` **3.0** (NWS)
+
+**Speaker notes:** Pins are in vendor/manifest.json with SHAs. Conflict rule: defer to pin
+over older printed package tables. Supported operator window typically Latest + Previous
+(2025-2 + 2023-1). [Corpus: system-spec] vendor · VERSION_SUPPORT_POLICY
+
+**Figure:** screenshot of `vendor/manifest.json` keys (redact nothing secret — file is public) OR table
+
+**Sources:** vendor/manifest.json · schemas.wmo.int/iwxxm/2025-2/
+
+---
+
+## Slide 7 — Operator UI (capability → feature)
+
+**Title:** Operator workbench surfaces
+
+**Bullets:**
+
+- Multi-product workbench + sessions — **F7**
+- Value-aware decode + summary — **F9**
+- Live IWXXM preview / lint UX — **F10**
+- Golden / official examples — **F7.g**
+- Optional dissemination drawer — **F16–F19**
+- Public convert; optional Auth for storage — **F21 / F31**
+
+**Speaker notes:** This slide is the only “UI” slide — keep it capability-mapped, not a
+click tutorial. Screenshots from *local* non-deployed preview preferred.
+[Corpus: product] [docs/ops/operator-ui-runbook.md]
+
+**Figure:** 1–2 local UI screenshots (optional) — image-pointers §UI
+
+**Sources:** feature-list F7/F9/F10 · S011 session brief
+
+---
+
+## Slide 8 — Rule provenance story
+
+**Title:** From dig → rule → operator message
+
+**Bullets:**
+
+- Mine public / licensed sources → `docs/domain/mining/*`
+- Promote durable cites → RULE_SOURCE_URLS + canonical strategy docs
+- ISSUE_CATALOG codes link operators to sources
+- PROVENANCE_MAP indexes dig ↔ rule ↔ source
+- UI lint catalog shows WMO/ICAO/IWXXM attribution
+
+**Speaker notes:** S043/EV-035 built standing provenance; EV-040 surfaced attribution in UI.
+Gaps are labeled `gap` / `paywall` — never silently invented. [docs/domain/rules/PROVENANCE_MAP.md]
+
+**Figure:** simple flow Dig → Catalog → Lint console (draw)
+
+**Sources:** PROVENANCE_MAP · ISSUE_CATALOG · RULE_SOURCE_URLS
+
+---
+
+## Slide 9 — Access friction
+
+**Title:** What operators can open freely
+
+**Bullets:**
+
+| Class | Examples | In-repo handling |
+|-------|----------|------------------|
+| Paywall | Annex 3, Doc 10003 | Cite store URL only |
+| Library / captcha | WMO-306 | Mining notes + gitignored `.local/` |
+| Public machine | schemas / codes / EUR Doc 014 | Prefer for CI + goldens |
+| Informative | PPT-02 workshop deck | Corroboration only |
+
+**Speaker notes:** ACCESS_AND_CITATION.md is the standing policy. Unofficial mirror PDFs are
+not SoT. [docs/domain/rules/ACCESS_AND_CITATION.md]
+
+**Figure:** none (table is the figure)
+
+**Sources:** ACCESS_AND_CITATION.md
+
+---
+
+## Slide 10 — Informative workshop corroboration (PPT-02)
+
+**Title:** WMO TT-AvData “IWXXM Framework” (workshop)
+
+**Bullets:**
+
+- Public ICAO filebrowser deck (ESAF workshop, 2025-10-22)
+- Convenient pointer cluster to WMO + ICAO landings
+- Package × IWXXM-line matrix — **informative**; prefer vendor XSD versions
+- Translation attrs + `translationFailedTAC` reminder
+
+**Speaker notes:** Label every claim **informative**. Full dig:
+docs/domain/mining/PPT-02-IWXXM-Framework-WMO-mining-notes.md. Local slide PNGs under
+`.local/reference/ppt-02-…/extracts/slide-images/` — **do not commit**. Official download:
+https://www.icao.int/filebrowser/download/26741?fid=26741
+
+**Figure:** optional *personal* extract of PPT-02 slides 6–7 landings (cite deck) — not for git
+
+**Sources:** PPT-02 mining notes · ICAO filebrowser URL
+
+---
+
+## Slide 11 — Software stack (high level)
+
+**Title:** Implementation stack
+
+**Bullets:**
+
+- Python 3.12 · FastAPI · msgspec HTTP DTOs
+- React 18 · Vite · TypeScript · CodeMirror 6
+- `tac-validate` / `tac2iwxxm` / `iwxxm-validate` workspace packages
+- Optional Rust core in iwxxm-validate path (F13)
+- DigitalOcean Postgres + Supabase Auth (JWT) · DOKS deploy target
+
+**Speaker notes:** Details in dependency-inventory.md — do not dump every pin on the slide.
+GIFTs removed at F6 cutover (ADR-014). [Corpus: tech-spec]
+
+**Figure:** none or small stack icons (optional)
+
+**Sources:** docs/dependency-inventory.md · docs/tech-spec.md
+
+---
+
+## Slide 12 — Bibliography / further reading
+
+**Title:** Landings to keep
+
+**Bullets (short URLs on slide; full table in bibliography.md):**
+
+- https://schemas.wmo.int/iwxxm/2025-2/
+- https://codes.wmo.int/
+- https://github.com/wmo-im/iwxxm (tag v2025-2)
+- ICAO Annex 3 store listing (paywall)
+- OPMET IWXXM Exchange Guidelines 5th (public PDF)
+- Repo: `docs/domain/rules/RULE_SOURCE_URLS.md`
+
+**Speaker notes:** Hand out bibliography.md or link the repo path. Remind: purchase ICAO
+docs for normative prose. Operator runbook for day-to-day use.
+
+**Figure:** none
+
+**Sources:** bibliography.md

--- a/docs/ops/operator-ui-runbook.md
+++ b/docs/ops/operator-ui-runbook.md
@@ -1,0 +1,213 @@
+# Operator UI runbook (sources-first)
+
+> **Audience:** day-to-day operators of the TAC→IWXXM workbench  
+> **Cycle:** S049 / EV-041  
+> **Companion briefing pack:** [../guides/operator-sources-pptx/](../guides/operator-sources-pptx/)  
+> **Citation policy:** [../domain/rules/ACCESS_AND_CITATION.md](../domain/rules/ACCESS_AND_CITATION.md) — cite landings; **never** paste Annex 3 / Manual on Codes full text
+
+This runbook explains **how to use** the operator UI and, for each surface, **which
+standards, schemas, and packages** underwrite that behavior.
+[Corpus: product §F7] [Corpus: system-spec] [docs/domain/README.md]
+
+---
+
+## 1. Purpose and access model
+
+| Topic | What operators see | Source / cite |
+|-------|--------------------|---------------|
+| Convert / lint / validate / decode | Public API — **no JWT required** | [Corpus: product] F21 Amended; [Corpus: api] |
+| Long-term work sessions | Optional login (Supabase Auth) → server sessions | [Corpus: product] F31; ADR-033 |
+| Guest history | Local IndexedDB (privacy-gated) | [Corpus: product] F7.h / F22 / F31 |
+| Deploy credentials | Operator-owned env (BYO) — not pasted in-app | F7.a / #697; [Corpus: tech-spec] env-contract |
+
+**Journeys:** UJ-001/005 (convert), UJ-013/015–018 (workbench), UJ-020/021 (decode/preview),
+UJ-027–030 (dissemination when used) — [Corpus: journeys].
+
+---
+
+## 2. What the tool implements (pipeline)
+
+End-to-end strategy for profile **`annex3`** (and overlay **`iwxxm_us`** where national
+REMARKS apply). Stages are separate — do not treat XSD success as “Annex 3 compliant TAC”.
+
+| Stage | Proves | Strategy SoT | Engine |
+|-------|--------|--------------|--------|
+| 1. TAC lint | TAC matches templates + vocab | [TAC_VALIDATION.md](../domain/TAC_VALIDATION.md) | `packages/tac-validate` |
+| 2. Convert | Tokens → IWXXM structure / nilReasons | [IWXXM_CONVERSION.md](../domain/IWXXM_CONVERSION.md) | `packages/tac2iwxxm` |
+| 3–5. Well-formed + XSD + Schematron | Structure + business rules + RDF codelists | [IWXXM_VALIDATION.md](../domain/IWXXM_VALIDATION.md) | `packages/iwxxm-validate` |
+| 6. Golden pairs | Official TAC↔XML examples | `schemas.wmo.int/iwxxm/2025-2/examples/` (+ vendored) | CI / Examples catalog |
+| 7. Bulletin / ops | AHL / COLLECT / translation attrs | [ICAO_OPMET_COMPLIANCE.md](../domain/iwxxm/ICAO_OPMET_COMPLIANCE.md) | bulletin + F16–F19 |
+
+Hub: [docs/domain/README.md](../domain/README.md).
+
+**Conflict rule:** when sources disagree, defer to the **latest machine pin** in
+[`vendor/manifest.json`](../../vendor/manifest.json) / `https://schemas.wmo.int/iwxxm/<pin>/`
+over older printed tables or workshop decks.
+
+---
+
+## 3. Runtime pins (what the UI validates against)
+
+| Bundle | Pin | Upstream |
+|--------|-----|----------|
+| IWXXM schemas | **v2025-2** | [wmo-im/iwxxm](https://github.com/wmo-im/iwxxm) |
+| Codelists | **49-2** | [wmo-im/iwxxm-codelists](https://github.com/wmo-im/iwxxm-codelists) |
+| Modelling | **v2025-2** | [wmo-im/iwxxm-modelling](https://github.com/wmo-im/iwxxm-modelling) |
+| Translation suite | tip (informative) | [wmo-im/iwxxm-translation](https://github.com/wmo-im/iwxxm-translation) — not encode SoT |
+| IWXXM-US | **3.0** | NWS tarball (manifest URL) |
+
+Local trees: `vendor/schemas/*` (read-only). Version picker **Latest / Previous** aligns with
+supported lines in [VERSION_SUPPORT_POLICY.md](../domain/iwxxm/VERSION_SUPPORT_POLICY.md)
+(typically **2025-2** + **2023-1**).
+
+Public schema root: <https://schemas.wmo.int/iwxxm/2025-2/>  
+Vocabulary: <https://codes.wmo.int/>
+
+---
+
+## 4. Products and profiles
+
+| Product | Operator entry | Primary normative TAC / practice | Encode / validate |
+|---------|----------------|----------------------------------|-------------------|
+| METAR / SPECI | Workbench + My METARs filter | ICAO Annex 3 (paywall); FMH-1 for US REMARKS | pin XSD/SCH; iwxxm-us when profile set |
+| TAF | Workbench | Annex 3 App 5; WMO-306 FM forms | `taf.xsd` + SCH |
+| SIGMET / AIRMET | Workbench | Annex 3 + EUR Doc 014 (public) | `sigmet.xsd` / `airmet.xsd` |
+| VAA / TCA | Workbench | Annex 3 App 2 templates | product XSDs + SCH |
+| SWXA / VONA | When catalogued | FM 205 / pin examples | product XSDs |
+
+Coverage matrix: [COVERAGE_MATRIX.md](../domain/rules/COVERAGE_MATRIX.md).  
+Master URL catalog: [RULE_SOURCE_URLS.md](../domain/rules/RULE_SOURCE_URLS.md).
+
+**Profiles**
+
+| Profile | TAC rules | Encode | Validate |
+|---------|-----------|--------|----------|
+| `annex3` | Annex 3 + WMO-306 + codes.wmo.int | pin examples + TAC-to-XML-Guidance | vendor IWXXM 2025-2 |
+| `iwxxm_us` | FMH-1 / NWS + Annex 3 core | `extension` via iwxxm-us 3.0 | WMO base + US catalogs |
+
+---
+
+## 5. Workbench surfaces → sources
+
+### 5.1 Product / profile / IWXXM version pickers
+
+- **UI:** selects feed convert/lint/validate requests.  
+- **Sources:** F6 product model [Corpus: product §F6]; version policy
+  [VERSION_SUPPORT_POLICY.md](../domain/iwxxm/VERSION_SUPPORT_POLICY.md); pin in manifest.
+
+### 5.2 Manual TAC input modes (TAC / AHL / COLLECT)
+
+- **UI:** mode switch + auto-detect (ADR-024 / UJ-025).  
+- **Sources:** AHL format from WMO community AHL page + WMO-No. 386 heading pattern
+  (see PPT-02 mining notes §Exchange / AHL); COLLECT packing per OPMET IWXXM Exchange
+  Guidelines (public PDF — [RULE_SOURCE_URLS](../domain/rules/RULE_SOURCE_URLS.md)).  
+- **Engine:** bulletin helpers in `tac2iwxxm`; COLLECT member extract may still 501 for
+  some paths (documented deferred).
+
+### 5.3 CodeMirror editor + span highlights
+
+- **UI:** live editor; highlights lint/validate `start`/`end`.  
+- **Sources:** F7.b/#702 spans; issue codes from [ISSUE_CATALOG](../domain/rules/ISSUE_CATALOG.md)
+  (`packages/tac-validate`).  
+- **Stack:** CodeMirror 6 — [Corpus: tech-spec] dependency-inventory.
+
+### 5.4 Decode panel (Code | Explanation) + plain-language summary
+
+- **UI:** token segments + F9 value-aware summary.  
+- **API:** `POST /api/v1/decode-tac` — [Corpus: api].  
+- **Sources:** explanations are **operator-facing paraphrases**, not Annex 3 reprints;
+  residual undecoded tokens stay explicit (F7 G4). Normative templates remain Annex 3 /
+  WMO-306 (cite only).
+
+### 5.5 Lint console + issue catalog
+
+- **UI:** one line per issue; catalog shows WMO/ICAO/IWXXM source attribution (EV-040).  
+- **Sources:** ISSUE_CATALOG ↔ [RULE_SOURCE_URLS](../domain/rules/RULE_SOURCE_URLS.md) ↔
+  [PROVENANCE_MAP](../domain/rules/PROVENANCE_MAP.md) (S043 / EV-035).  
+- **API:** lint-tac + `/lint-issue-catalog`.
+
+### 5.6 Soft-fail preview / Failed-TAC cue
+
+- **UI:** best-effort IWXXM + failed-span markers; distinct failure cue (F7.c / F10).  
+- **Sources:** translation-failure retention pattern (`translationFailedTAC`) described in
+  OPMET/IWXXM practice and informative PPT-02 slide 9 — prefer vendored `common.xsd`
+  attribute names; [IWXXM_CONVERSION.md](../domain/IWXXM_CONVERSION.md).
+
+### 5.7 Live IWXXM preview + Strict Validation
+
+- **UI:** debounced convert/validate; optional XSD+Schematron on hard Convert.  
+- **Sources:** vendored XSD + `rule/iwxxm.sch` + offline RDF — [IWXXM_VALIDATION.md](../domain/IWXXM_VALIDATION.md).
+
+### 5.8 Examples catalog (golden / official demos)
+
+- **UI:** load TAC, AHL, Collect, product goldens (F7.g; EV-040 official AHL/Collect).  
+- **Sources:** WMO example trees under pin (`examples/`); US fixtures where labeled;
+  catalog rows should show provenance — do not invent TAC.
+
+### 5.9 Dissemination drawer (optional)
+
+- **UI:** one-shot BYOC destinations (memory-only credentials).  
+- **Sources:** [Corpus: product] F16–F19; ADR-029/030; egress allowlist — **not** F8 auto-push.
+- **Ops:** see dissemination docs in tech-spec / feature-list; do not store pasted secrets.
+
+### 5.10 Sessions / history
+
+- Guest: IndexedDB; Logged-in: DO Postgres via Auth (F31).  
+- **Sources:** [Corpus: product] F5/F7/F31; privacy F22.
+
+---
+
+## 6. “Where did this rule come from?”
+
+1. Note the **issue code** in the lint console or catalog.  
+2. Open [ISSUE_CATALOG.md](../domain/rules/ISSUE_CATALOG.md) (or JSON twin).  
+3. Follow links into [RULE_SOURCE_URLS.md](../domain/rules/RULE_SOURCE_URLS.md) and
+   [PROVENANCE_MAP.md](../domain/rules/PROVENANCE_MAP.md).  
+4. For dig detail, open the matching file under [docs/domain/mining/](../domain/mining/).  
+5. If Access = **paywall**, obtain the official ICAO Store / WMO Library edition — the repo
+   will not contain the PDF prose.
+
+---
+
+## 7. Citation and paywall policy (operators)
+
+| Source class | Access | Operator action |
+|--------------|--------|-----------------|
+| ICAO Annex 3, Doc 8896 / 10003 | Paywall | Cite title + section; purchase for full text |
+| WMO-No. 306 Vol I.3 | Library / captcha | Use library landing; local extracts stay gitignored |
+| codes.wmo.int / schemas.wmo.int | Public | Prefer HTTPS landings; consume via vendor pin in CI |
+| FMH-1 / iwxxm-us | Public | US profile only; still no need to paste full handbooks |
+| Workshop PPT-02 | Public informative | Never treat as encode/validate SoT |
+
+Full policy: [ACCESS_AND_CITATION.md](../domain/rules/ACCESS_AND_CITATION.md).
+
+---
+
+## 8. Typical operator flows (short)
+
+1. **Happy path** — Select product + profile + version → paste/load TAC → review decode +
+   lint → Convert (Strict on if you need Schematron) → download / disseminate.  
+2. **Repair loop** — Click lint span → fix TAC → watch live preview.  
+3. **Bulletin** — Switch to AHL or COLLECT mode → use official examples first → convert.  
+4. **US REMARKS** — Profile `iwxxm_us` → expect FMH-1 / iwxxm-us extension path.
+
+Detailed E2E IDs: [Corpus: journeys] UJ-013–021, UJ-025, UJ-032.
+
+---
+
+## 9. Deploy / env pointers (not duplicated here)
+
+| Need | Doc |
+|------|-----|
+| Deploy topology | [deploy.md](../deploy.md) |
+| Env sync | [env-sync-runbook.md](./env-sync-runbook.md) |
+| Config / env names | [Corpus: tech-spec] → env-contract / config-spec |
+| Local development | [DEVELOPMENT.md](./DEVELOPMENT.md) |
+
+---
+
+## 10. Briefing deck
+
+For stakeholder presentations on **sources used to build the tool**, use
+[../guides/operator-sources-pptx/](../guides/operator-sources-pptx/) and follow
+`build-walkthrough.md`. Do not commit the finished `.pptx` unless explicitly requested.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,6 +25,7 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
+| [S049-operator-sources-briefing](S049-operator-sources-briefing/session-brief.md) | feature | in_progress | Operator UI source-centric runbook + PPT pack; EV-041 Lean docs | evolve/EV-041-operator-sources-briefing | 2026-08-06 | — |
 | [S048-workbench-lint-ux](S048-workbench-lint-ux/session-brief.md) | feature | completed | Workbench lint UX + prefs + official AHL/Collect + catalog source; EV-040; PR #893; #894 | evolve/EV-040-workbench-lint-ux | 2026-08-06 | 2026-08-06 |
 | [S047-sql-ingest-live-e2e](S047-sql-ingest-live-e2e/session-brief.md) | feature | completed | F16 live local multi-DB SQL ingest Playwright + teardown; EV-039; PR #891 | evolve/EV-039-sql-ingest-live-e2e → main @ fea30aba | 2026-08-06 | 2026-08-06 |
 | [S046-iwxxm-corpus-residuals](S046-iwxxm-corpus-residuals/session-brief.md) | feature | completed | #846 residuals #849–#861; deepen F2/F4/F6/F7/F32; EV-038; PR #890 | main @ 619a7ac3 / DOKS 20260806144346-619a7ac | 2026-08-05 | 2026-08-06 |

--- a/docs/sessions/S049-operator-sources-briefing/evolve-plan-card.md
+++ b/docs/sessions/S049-operator-sources-briefing/evolve-plan-card.md
@@ -1,0 +1,30 @@
+# Evolve Plan Card
+
+> Cycle: EV-041 | Session: S049-operator-sources-briefing | Updated: 2026-08-06
+
+## Goal
+
+Ship a source-centric operator UI runbook and a PPT source pack, then walk through building a personal briefing `.pptx`.
+
+## Features
+
+- F7 — Multi-product operator UI (docs deepen only) — [Corpus: product §F7]
+
+## In / out of scope
+
+- In: `docs/ops/operator-ui-runbook.md`; `docs/guides/operator-sources-pptx/*`; evolve-decisions §EV-041; domain README pointer; chat PPTX walkthrough
+- Out: product code; binary pptx/PDFs in git; RULE_SOURCE_URLS rewrite; deploy; new Fn; CORPUS membership for ops/guides
+
+## Preset + routing
+
+- Preset: Lean (docs override)
+- Stages (ordered): 00 → 16 → 01 → 02 → 07 → 08
+
+## Next child stage
+
+07-build — write runbook + PPT pack (after 01/02 AC lock)
+
+## Risks / open decisions
+
+- Path-cite domain/ops (no CORPUS add) — locked like EV-035 G3
+- Screenshots optional; never commit copyrighted workshop PNGs

--- a/docs/sessions/S049-operator-sources-briefing/reports/01-requirements.md
+++ b/docs/sessions/S049-operator-sources-briefing/reports/01-requirements.md
@@ -1,0 +1,38 @@
+# 01-requirements — S049 / EV-041
+
+**Stage:** 01-requirements (delta)  
+**Date:** 2026-08-06  
+**Mode:** evolve · docs-only deepen F7 narrative
+
+## Locked gates
+
+| Gate | Choice | Meaning |
+|------|--------|---------|
+| G1 | plan | Docs-only; deepen F7 narrative — no new Fn |
+| G2 | Lean | `00→16→01→02→07→08` |
+| G3 | path-cite | No CORPUS membership for ops/guides |
+| G4 | proceed | AC1–AC5 locked → 02 |
+
+## Acceptance
+
+See [evolve-decisions.md](../../../decisions/evolve-decisions.md) §EV-041 AC1–AC5.
+
+## Spec deltas
+
+| Doc | Change |
+|-----|--------|
+| evolve-decisions.md | §EV-041 scope + ACs |
+| Session brief / routing / plan card | S049 artifacts |
+| Standing: ops runbook + guides/pptx pack | Written in 07 |
+
+## Corpus cites
+
+- `[Corpus: product §F7]`
+- `[Corpus: system-spec]`
+- `[Corpus: tech-spec]`
+- `[docs/domain/…]` path cites
+- `[Corpus: WAIVED — ops/guides CORPUS membership; decided: EV-041]`
+
+## Next
+
+**02-verify-plan** (Gate A).

--- a/docs/sessions/S049-operator-sources-briefing/reports/02-verify-plan.md
+++ b/docs/sessions/S049-operator-sources-briefing/reports/02-verify-plan.md
@@ -1,0 +1,22 @@
+# 02-verify-plan — S049 / EV-041 (Gate A)
+
+**Date:** 2026-08-06  
+**Result:** **PASS**
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| Scope maps to F7 deepen (no new Fn) | PASS |
+| ACs are doc-completeness only (no product behavior) | PASS |
+| Citation policy referenced (ACCESS_AND_CITATION) | PASS |
+| Lean skip rationale documented | PASS |
+| No contradictory CORPUS membership claim | PASS (waiver logged) |
+
+## Gate A → B
+
+**Waived B tech plan** (docs-only Lean) — proceed **07-build** after this gate.
+
+## Consistency
+
+Artifacts will cite RULE_SOURCE_URLS / vendor pin / domain README; will not paste paywalled prose.

--- a/docs/sessions/S049-operator-sources-briefing/reports/08-verify-build.md
+++ b/docs/sessions/S049-operator-sources-briefing/reports/08-verify-build.md
@@ -1,0 +1,26 @@
+# 08-verify-build — S049 / EV-041
+
+**Date:** 2026-08-06  
+**Result:** **PASS** (docs sanity)
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| Runbook exists at docs/ops/operator-ui-runbook.md | PASS |
+| PPT pack: README, slide-outline, bibliography, image-pointers, build-walkthrough | PASS |
+| ACCESS_AND_CITATION policy referenced; no Annex 3 body paste | PASS |
+| Vendor pin v2025-2 cited from manifest | PASS |
+| Domain README pointer added (path-cite) | PASS |
+| evolve-decisions §EV-041 + AC1–AC5 | PASS |
+| No product code / binary pptx | PASS |
+
+## AC mapping
+
+| AC | Status |
+|----|--------|
+| AC1 Runbook + source maps | PASS |
+| AC2 PPT pack complete | PASS |
+| AC3 Citation policy | PASS |
+| AC4 Walkthrough usable | PASS (build-walkthrough + Batch A coaching) |
+| AC5 Session/branch/PR | Session+branch done; PR on request / this cycle |

--- a/docs/sessions/S049-operator-sources-briefing/reports/evolve-summary.md
+++ b/docs/sessions/S049-operator-sources-briefing/reports/evolve-summary.md
@@ -1,0 +1,24 @@
+# Evolve summary — EV-041 / S049
+
+**Title:** Operator UI runbook + source-centric PPT pack  
+**Preset:** Lean docs  
+**Branch:** `evolve/EV-041-operator-sources-briefing`
+
+## Deliverables
+
+| Artifact | Path |
+|----------|------|
+| Operator runbook | `docs/ops/operator-ui-runbook.md` |
+| PPT source pack | `docs/guides/operator-sources-pptx/` |
+| Decisions | `docs/decisions/evolve-decisions.md` §EV-041 |
+| Domain pointer | `docs/domain/README.md` |
+
+## Routing completed
+
+`00 → 16 → 01 → 02 → 07 → 08` (09–13 skipped)
+
+## Notes
+
+- No product code; no binary `.pptx` in git  
+- Interactive PPTX coaching: Batch A in session close message; Batches B/C via walkthrough file  
+- Corpus: path-cite domain/ops/guides; CORPUS membership waived (EV-041)

--- a/docs/sessions/S049-operator-sources-briefing/reports/pptx-walkthrough-batch-a.md
+++ b/docs/sessions/S049-operator-sources-briefing/reports/pptx-walkthrough-batch-a.md
@@ -1,0 +1,36 @@
+# PPTX walkthrough — Batch A (slides 1–4)
+
+**Date:** 2026-08-06  
+**Pack:** `docs/guides/operator-sources-pptx/`  
+**Full steps:** [build-walkthrough.md](../../../guides/operator-sources-pptx/build-walkthrough.md)
+
+## Your actions now
+
+1. Open PowerPoint → Blank → 16:9.  
+2. Build **slides 1–4** using [slide-outline.md](../../../guides/operator-sources-pptx/slide-outline.md).  
+3. Figures: [image-pointers.md](../../../guides/operator-sources-pptx/image-pointers.md).  
+4. Reply **“Batch A done”** when ready for slides 5–8 (Batch B).
+
+### Slide 1 paste
+
+- Title: `TAC → IWXXM Operator System`
+- Subtitle: `Built from ICAO / WMO / NWS sources · Runtime pin IWXXM v2025-2`
+
+### Slide 2 paste
+
+- TAC presentation vs IWXXM exchange
+- Annex 3 dual obligation (cite store — do not quote)
+- Draw: TAC box ↔ IWXXM box
+
+### Slide 3 paste
+
+- Annex 3 (paywall), WMO-306 (library), codes.wmo.int, schemas.wmo.int, FMH-1/iwxxm-us, EUR Doc 014
+
+### Slide 4 paste
+
+- Boxes: frontend · backend · tac-validate · tac2iwxxm · iwxxm-validate · vendor/schemas
+
+## Batches B & C
+
+Follow build-walkthrough.md §Batch B (5–8) and §Batch C (9–12) + final checklist.
+Self-serve if chat paused; agent continues on “Batch A done”.

--- a/docs/sessions/S049-operator-sources-briefing/routing-plan.md
+++ b/docs/sessions/S049-operator-sources-briefing/routing-plan.md
@@ -1,0 +1,36 @@
+# Routing plan — S049 / EV-041
+
+**Preset:** Lean (docs-only override)  
+**Route:** `00 → 16 → 01 → 02 → 07 → 08`  
+**Skip:** `03`, `04`, `05`, `06`, `09`, `10`, `11`, `12`, `13`  
+**Branch:** `evolve/EV-041-operator-sources-briefing`  
+**Features:** deepen **F7** narrative (no new Fn)  
+**Status:** in_progress  
+**Approved:** 2026-08-06 (plan `operator_sources_docs`)
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | scoped | **completed** | S049 open |
+| 16-evolve | yes | orchestrator | **in_progress** | EV-041 — docs landed |
+| 01-requirements | yes | delta | **completed** | Doc ACs AC1–AC5 |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS |
+| 03-plan-tooling | no | — | skipped | No new Cursor rules |
+| 04-tech-plan | no | — | skipped | Docs-only; no execution-plan milestones |
+| 05-verify-tech | no | — | skipped | No tech plan |
+| 06-tech-tooling | no | — | skipped | No new deps |
+| 07-build | yes | docs | **completed** | Runbook + PPT pack |
+| 08-verify-build | yes | delta | **completed** | Link + citation sanity PASS |
+| 09-qa | no | — | skipped | No product tests |
+| 10-e2e | no | — | skipped | Docs-only |
+| 11-verify-impl | no | — | skipped | Docs-only |
+| 12-verify-deploy | no | — | skipped | No deploy |
+| 13-deploy-smoke | no | — | skipped | No deploy |
+
+## Skip rationale
+
+| Skipped | Why |
+|---------|-----|
+| 03 / 06 | No new rules or publish deps |
+| 04 / 05 | No code milestones; artifacts are standing docs under ops/guides |
+| 09–13 | No product behavior or deploy surface |
+| Lean 10/13 default | Overridden — docs-only (plan) |

--- a/docs/sessions/S049-operator-sources-briefing/session-brief.md
+++ b/docs/sessions/S049-operator-sources-briefing/session-brief.md
@@ -21,11 +21,15 @@ deepen_feature_ids:
   - F7
 feature_note: "Docs deepen F7 narrative — no new Fn; Lean docs-only"
 route_status: in_progress
-current_stage: 07-build
+current_stage: 16-evolve
 ui_preview: n/a
 preset: Lean
+pr_number: 895
+pr_status: open
+pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
 decisions:
   D-S049-open: "plan approve; deliverables=docs+walkthrough; audience=split"
+  D-S049-ac: "AC1-AC5 locked"
 ---
 
 # Session S049 — operator-sources-briefing

--- a/docs/sessions/S049-operator-sources-briefing/session-brief.md
+++ b/docs/sessions/S049-operator-sources-briefing/session-brief.md
@@ -1,0 +1,66 @@
+---
+session_id: S049-operator-sources-briefing
+type: feature
+status: in_progress
+branch: evolve/EV-041-operator-sources-briefing
+started_at: 2026-08-06
+intent: "Docs-only: source-centric operator UI runbook + PPT source pack and guided walkthrough"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-041
+prior_session: S048-workbench-lint-ux
+prior_evolve_cycle_id: EV-040
+context_briefs:
+  - docs/context/operator-sources-briefing.md
+standing_docs_touched:
+  - docs/ops/operator-ui-runbook.md
+  - docs/guides/operator-sources-pptx/
+  - docs/decisions/evolve-decisions.md
+  - docs/domain/README.md
+feature_ids: []
+deepen_feature_ids:
+  - F7
+feature_note: "Docs deepen F7 narrative — no new Fn; Lean docs-only"
+route_status: in_progress
+current_stage: 07-build
+ui_preview: n/a
+preset: Lean
+decisions:
+  D-S049-open: "plan approve; deliverables=docs+walkthrough; audience=split"
+---
+
+# Session S049 — operator-sources-briefing
+
+## Intent
+
+Produce a **source-centric** operator UI runbook and a PowerPoint **source pack**
+(outline, bibliography, image pointers, build walkthrough), then coach building a
+personal `.pptx` — without product code or committing copyrighted binaries.
+[Corpus: product §F7] [Corpus: system-spec] [docs/domain/rules/ACCESS_AND_CITATION.md]
+
+## Goal (one sentence)
+
+Ship operator + briefing docs that explain **what standards and vendor pins the tool
+was built from**, not only how to click the UI.
+
+## Scope
+
+### In
+
+- `docs/ops/operator-ui-runbook.md` — operators, with source cites per surface
+- `docs/guides/operator-sources-pptx/` — slide outline, bibliography, image pointers, walkthrough
+- Evolve decisions §EV-041; light pointer from domain README / ops
+- Interactive PPTX build coaching (chat batches)
+
+### Out of scope
+
+- Product/UI/API code; binary `.pptx` or ICAO/WMO PDFs/PNGs in git
+- Rewriting RULE_SOURCE_URLS / PROVENANCE_MAP (consume only)
+- Deploy / H4–H5; new Fn; CORPUS membership for ops/guides
+
+## Routing (Lean docs)
+
+`00 → 16 → 01 → 02 → 07 → 08` — skip 03–06, 09–13
+
+## Status
+
+Opened 2026-08-06 from approved plan `operator_sources_docs`.

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,10 +3,208 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 48
-evolve_cycle_counter: 40
-active_session: null
+session_counter: 49
+evolve_cycle_counter: 41
+active_session:
+  id: S049-operator-sources-briefing
+  type: feature
+  intent: Operator UI source-centric runbook + PPT source pack / walkthrough (docs-only)
+  status: in_progress
+  started: '2026-08-06'
+  started_at: '2026-08-06'
+  branch: evolve/EV-041-operator-sources-briefing
+  branch_base: main@73e13281
+  artifacts_dir: docs/sessions/S049-operator-sources-briefing/
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-041
+  prior_session: S048-workbench-lint-ux
+  prior_evolve_cycle_id: EV-040
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  feature_note: Docs deepen F7 narrative — no new Fn; source-centric runbook + PPT pack
+  ui_preview: n/a (docs-only; screenshots optional local)
+  preset: Lean
+  current_stage: 08-verify-build
+  route_status: in_progress
+  routing_plan:
+  - stage: 00-context
+    mode: scoped
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — S049 open; open_session; handoff 16-evolve
+  - stage: 16-evolve
+    mode: orchestrator
+    required: true
+    status: in_progress
+    started: '2026-08-06'
+    note: IN_PROGRESS — awaiting PR; session not closed
+  - stage: 01-requirements
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — docs ACs / Lean scope
+  - stage: 02-verify-plan
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — Gate A (docs)
+  - stage: 03-plan-tooling
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no new Cursor rules
+  - stage: 04-tech-plan
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no tech plan
+  - stage: 05-verify-tech
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no Gate B
+  - stage: 06-tech-tooling
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no new publish deps
+  - stage: 07-build
+    mode: full
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — runbook + PPT source pack + decisions
+  - stage: 08-verify-build
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — docs verification
+  - stage: 09-qa
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 10-e2e
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 11-verify-impl
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 12-verify-deploy
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no runtime deploy
+  - stage: 13-deploy-smoke
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no runtime deploy
 sessions:
+- id: S049-operator-sources-briefing
+  type: feature
+  intent: Operator UI source-centric runbook + PPT source pack / walkthrough (docs-only)
+  status: in_progress
+  started: '2026-08-06'
+  started_at: '2026-08-06'
+  branch: evolve/EV-041-operator-sources-briefing
+  branch_base: main@73e13281
+  artifacts_dir: docs/sessions/S049-operator-sources-briefing/
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-041
+  prior_session: S048-workbench-lint-ux
+  prior_evolve_cycle_id: EV-040
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  feature_note: Docs deepen F7 narrative — no new Fn; source-centric runbook + PPT pack
+  ui_preview: n/a (docs-only; screenshots optional local)
+  preset: Lean
+  current_stage: 08-verify-build
+  route_status: in_progress
+  routing_plan:
+  - stage: 00-context
+    mode: scoped
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — S049 open; open_session; handoff 16-evolve
+  - stage: 16-evolve
+    mode: orchestrator
+    required: true
+    status: in_progress
+    started: '2026-08-06'
+    note: IN_PROGRESS — awaiting PR; session not closed
+  - stage: 01-requirements
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — docs ACs / Lean scope
+  - stage: 02-verify-plan
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — Gate A (docs)
+  - stage: 03-plan-tooling
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no new Cursor rules
+  - stage: 04-tech-plan
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no tech plan
+  - stage: 05-verify-tech
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no Gate B
+  - stage: 06-tech-tooling
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no new publish deps
+  - stage: 07-build
+    mode: full
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — runbook + PPT source pack + decisions
+  - stage: 08-verify-build
+    mode: delta
+    required: true
+    status: completed
+    started: '2026-08-06'
+    completed: '2026-08-06'
+    note: COMPLETE — docs verification
+  - stage: 09-qa
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 10-e2e
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 11-verify-impl
+    required: false
+    status: skipped
+    note: skipped — Lean docs
+  - stage: 12-verify-deploy
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no runtime deploy
+  - stage: 13-deploy-smoke
+    required: false
+    status: skipped
+    note: skipped — Lean docs; no runtime deploy
 - id: S048-workbench-lint-ux
   type: feature
   intent: Workbench lint UX + prefs + official AHL/Collect + catalog source; fix example lint FPs
@@ -28412,6 +28610,104 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-041
+  session_id: S049-operator-sources-briefing
+  cycle_type: general
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  feature_note: Docs deepen F7 narrative — no new Fn; source-centric runbook + PPT pack
+  title: "Operator UI runbook + source-centric PPT pack"
+  status: in_progress
+  started: "2026-08-06"
+  started_at: "2026-08-06"
+  scope_summary: Docs-only: operator UI runbook + PPT source pack (outline, bibliography, image pointers, build walkthrough); Lean; path-cite domain/ops; no product code; no binary pptx in git
+  routing_plan:
+    required_stages:
+    - 01-requirements
+    - 02-verify-plan
+    - 07-build
+    - 08-verify-build
+    skipped_stages:
+    - 03-plan-tooling
+    - 04-tech-plan
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 09-qa
+    - 10-e2e
+    - 11-verify-impl
+    - 12-verify-deploy
+    - 13-deploy-smoke
+  current_stage: 08-verify-build
+  current_stage_status: completed
+  current_stage_note: COMPLETE — 01/02/07/08 done; 16-evolve in_progress awaiting PR; session open
+  stages:
+    00-context:
+      status: completed
+      started: '2026-08-06'
+      completed: '2026-08-06'
+    16-evolve:
+      status: in_progress
+      started: '2026-08-06'
+      note: awaiting PR; session not closed
+    01-requirements:
+      status: completed
+      started: '2026-08-06'
+      completed: '2026-08-06'
+    02-verify-plan:
+      status: completed
+      started: '2026-08-06'
+      completed: '2026-08-06'
+    07-build:
+      status: completed
+      started: '2026-08-06'
+      completed: '2026-08-06'
+    08-verify-build:
+      status: completed
+      started: '2026-08-06'
+      completed: '2026-08-06'
+  ui_preview: n/a (docs-only; screenshots optional local)
+  branch: evolve/EV-041-operator-sources-briefing
+  tip_sha: 73e13281
+  tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
+  tip_sha_pushed: false
+  preset: Lean
+  gates:
+    a_to_b: passed
+    a_to_b_note: docs Gate A passed
+    b_to_c: waived_lean
+    b_to_c_note: Lean docs — no 04-tech-plan / 05-verify-tech
+    c_to_d: waived
+    c_to_d_note: Lean docs — skip 09/10/11; 07/08 verified as docs pack
+    deploy: waived
+    deploy_note: Lean docs — no 12/13 runtime deploy
+  checkpoints:
+    phase_a: passed
+    phase_b: waived_lean
+    phase_b_note: Lean docs — skip 04/05
+    phase_c: passed
+    phase_c_note: 07-build + 08-verify-build docs complete
+    phase_d: waived
+    phase_d_note: Lean docs — skip 09/10/11
+    deploy: waived
+    deploy_note: Lean docs — skip 12/13
+  adrs: []
+  artifacts:
+  - path: docs/ops/operator-ui-runbook.md
+    status: completed
+    stage: 07-build
+  - path: docs/guides/operator-sources-pptx/
+    status: completed
+    stage: 07-build
+  - path: docs/decisions/evolve-decisions.md
+    status: completed
+    stage: 16-evolve
+  - path: docs/sessions/S049-operator-sources-briefing/
+    status: completed
+    stage: 00-context
+  notes:
+  - '2026-08-06 S049/EV-041 PROGRESS — 00/01/02/07/08 completed; gates a_to_b=passed; b_to_c/c_to_d/deploy waived; 16-evolve in_progress (PR pending); session open; no git commit by workflow-state-manager'
+  - '2026-08-06 S049/EV-041 OPEN — open_session; Lean docs; deepen F7; branch evolve/EV-041-operator-sources-briefing @ 73e13281; 00-context completed; next 16-evolve; no git commit by workflow-state-manager'
 - id: EV-040
   session_id: S048-workbench-lint-ux
   cycle_type: general
@@ -37778,16 +38074,16 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: evolve/EV-040-workbench-lint-ux
+  current_branch: evolve/EV-041-operator-sources-briefing
   ahead_of_origin: 0
-  pushed: true
+  pushed: false
   pending_commit: false
   pending_commit_note: null
   dirty: true
-  dirty_note: "workflow-state + session docs dirty after S048/EV-040 close (workflow-state-manager); parent to commit; also local dirty: apps/frontend/public/config.json"
-  tip_sha: 5a9f28ef
-  tip_sha_full: 5a9f28efdc1fe993fbb0d62456d5d525e2ec3157
-  tip_note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge `4be24994`); #894'
+  dirty_note: "workflow-state dirty after S049/EV-041 open_session; parent to commit; no git commit by workflow-state-manager"
+  tip_sha: 73e13281
+  tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
+  tip_note: 'S049/EV-041 OPEN — tip 73e13281 (main base); branch evolve/EV-041-operator-sources-briefing local; not pushed'
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -37798,10 +38094,11 @@ git_history:
   main_merge_sha_full: 0d8ce8859d517ae2f83ccc4fbc4dfd6d030afedc
   main_tip_sha: 0d8ce885
   main_tip_sha_full: 0d8ce8859d517ae2f83ccc4fbc4dfd6d030afedc
-  recommended_branch: evolve/EV-040-workbench-lint-ux
+  recommended_branch: evolve/EV-041-operator-sources-briefing
   note: 'S047/EV-039 — current_branch evolve/EV-040-workbench-lint-ux @ 861c5457; pushed=true ahead_of_origin=0; PR #893 OPEN; 13 in_progress H1–H5 PASS; tip CD awaiting merge; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-06 S049/EV-041 OPEN — open_session; session_counter 49; evolve_cycle_counter 41; branch evolve/EV-041-operator-sources-briefing ACTIVE @ 73e13281 (base main); 00-context completed; next 16-evolve; Lean docs deepen F7; no git commit by workflow-state-manager'
   - '2026-08-06 S048/EV-040 — tip 861c5457 (08c805ebb9c935e989ba91b2fd3012974140b2e9); recorded commits e909231d + 861c5457 (+ earlier EV-040 feat/fix/test); PR #893 OPEN; 09–12 COMPLETE; 13-deploy-smoke IN_PROGRESS — H1–H5 PASS on live DOKS; PR #893 open; tip CD awaiting merge approval; tip commit 08c805eb; session/cycle remain open; dirty=true (workflow-state); no git commit by workflow-state-manager'
   - '2026-08-06 S047/EV-039 — tip cfe1236b (cfe1236b4c3e8c5594447d44b69e4d20c7e01522) [EV-039] chore: retrigger PR CI for tip gate; branch pushed; PR #891 OPEN; ahead_of_origin=0 pushed=true; tip CI missing (check_suites only cursor app); local husky pre-push make ci passed; 13-deploy-smoke BLOCKED hard stop pending user decision; dirty=true (workflow-state); no git commit by workflow-state-manager'
   - '2026-08-06 S047/EV-039 — recorded git commits f2b2f558 (f2b2f5589a0d0bb46a8be65cb4d9c1267253c3d9) [EV-039] test: align Playwright live-mode assert with skipWebServer + 476c9c9d (476c9c9d7bb70375baa0d0cdf118be9ae53d6c48) chore(deps): pin js-yaml >=4.3.1; 09-qa PASS with advisories + 10-e2e PASS; reports qa-report.md + e2e-report.md; current_stage 11-verify-impl; tip f2b2f558; ahead_of_origin=20 pushed=false; dirty=true (workflow-state); no git commit by workflow-state-manager'
@@ -38266,6 +38563,20 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-041-operator-sources-briefing
+    status: open
+    base: main
+    base_sha: 73e13281
+    base_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
+    created: "2026-08-06"
+    session_id: S049-operator-sources-briefing
+    evolve_cycle_id: EV-041
+    tip_sha: 73e13281
+    tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
+    exists: true
+    pushed: false
+    ahead_of_origin: 0
+    note: "S049/EV-041 OPEN — open_session; Lean docs; base main@73e13281; local branch created; not pushed"
   - name: evolve/EV-040-workbench-lint-ux
     status: merged
     base: main

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -25,6 +25,16 @@ active_session:
   feature_note: Docs deepen F7 narrative — no new Fn; source-centric runbook + PPT pack
   ui_preview: n/a (docs-only; screenshots optional local)
   preset: Lean
+  tip_sha: 42ae629a
+  tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+  tip_sha_pushed: true
+  tip_sha_note: 'PR #895 OPEN @ 42ae629a; session open pending merge'
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+  pr_number: 895
+  pr_status: open
+  pr_title: '[EV-041] Operator UI sources runbook + PPT pack'
+  pr_base: main
+  pr_head: evolve/EV-041-operator-sources-briefing
   current_stage: 08-verify-build
   route_status: in_progress
   routing_plan:
@@ -40,7 +50,7 @@ active_session:
     required: true
     status: in_progress
     started: '2026-08-06'
-    note: IN_PROGRESS — awaiting PR; session not closed
+    note: IN_PROGRESS — PR #895 OPEN @ 42ae629a; session not closed
   - stage: 01-requirements
     mode: delta
     required: true
@@ -125,6 +135,16 @@ sessions:
   feature_note: Docs deepen F7 narrative — no new Fn; source-centric runbook + PPT pack
   ui_preview: n/a (docs-only; screenshots optional local)
   preset: Lean
+  tip_sha: 42ae629a
+  tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+  tip_sha_pushed: true
+  tip_sha_note: 'PR #895 OPEN @ 42ae629a; session open pending merge'
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+  pr_number: 895
+  pr_status: open
+  pr_title: '[EV-041] Operator UI sources runbook + PPT pack'
+  pr_base: main
+  pr_head: evolve/EV-041-operator-sources-briefing
   current_stage: 08-verify-build
   route_status: in_progress
   routing_plan:
@@ -140,7 +160,7 @@ sessions:
     required: true
     status: in_progress
     started: '2026-08-06'
-    note: IN_PROGRESS — awaiting PR; session not closed
+    note: IN_PROGRESS — PR #895 OPEN @ 42ae629a; session not closed
   - stage: 01-requirements
     mode: delta
     required: true
@@ -28640,7 +28660,7 @@ evolve_cycles:
     - 13-deploy-smoke
   current_stage: 08-verify-build
   current_stage_status: completed
-  current_stage_note: COMPLETE — 01/02/07/08 done; 16-evolve in_progress awaiting PR; session open
+  current_stage_note: COMPLETE — 01/02/07/08 done; PR #895 OPEN @ 42ae629a; session open pending merge
   stages:
     00-context:
       status: completed
@@ -28649,7 +28669,7 @@ evolve_cycles:
     16-evolve:
       status: in_progress
       started: '2026-08-06'
-      note: awaiting PR; session not closed
+      note: PR #895 OPEN @ 42ae629a; session not closed — awaiting merge
     01-requirements:
       status: completed
       started: '2026-08-06'
@@ -28668,9 +28688,16 @@ evolve_cycles:
       completed: '2026-08-06'
   ui_preview: n/a (docs-only; screenshots optional local)
   branch: evolve/EV-041-operator-sources-briefing
-  tip_sha: 73e13281
-  tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
-  tip_sha_pushed: false
+  tip_sha: 42ae629a
+  tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+  tip_sha_pushed: true
+  tip_sha_note: 'PR #895 OPEN @ 42ae629a; session open pending merge'
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+  pr_number: 895
+  pr_status: open
+  pr_title: '[EV-041] Operator UI sources runbook + PPT pack'
+  pr_base: main
+  pr_head: evolve/EV-041-operator-sources-briefing
   preset: Lean
   gates:
     a_to_b: passed
@@ -28705,7 +28732,13 @@ evolve_cycles:
   - path: docs/sessions/S049-operator-sources-briefing/
     status: completed
     stage: 00-context
+  - path: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+    kind: pull-request
+    status: open
+    pr_number: 895
+    stage: 16-evolve
   notes:
+  - '2026-08-06 S049/EV-041 PR #895 OPEN @ 42ae629a — tip pushed; session open pending merge; no git commit by workflow-state-manager'
   - '2026-08-06 S049/EV-041 PROGRESS — 00/01/02/07/08 completed; gates a_to_b=passed; b_to_c/c_to_d/deploy waived; 16-evolve in_progress (PR pending); session open; no git commit by workflow-state-manager'
   - '2026-08-06 S049/EV-041 OPEN — open_session; Lean docs; deepen F7; branch evolve/EV-041-operator-sources-briefing @ 73e13281; 00-context completed; next 16-evolve; no git commit by workflow-state-manager'
 - id: EV-040
@@ -38076,14 +38109,14 @@ evolve_cycles:
 git_history:
   current_branch: evolve/EV-041-operator-sources-briefing
   ahead_of_origin: 0
-  pushed: false
+  pushed: true
   pending_commit: false
   pending_commit_note: null
   dirty: true
-  dirty_note: "workflow-state dirty after S049/EV-041 open_session; parent to commit; no git commit by workflow-state-manager"
-  tip_sha: 73e13281
-  tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
-  tip_note: 'S049/EV-041 OPEN — tip 73e13281 (main base); branch evolve/EV-041-operator-sources-briefing local; not pushed'
+  dirty_note: "workflow-state dirty after S049/EV-041 PR #895 record; parent to commit; no git commit by workflow-state-manager"
+  tip_sha: 42ae629a
+  tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+  tip_note: 'S049/EV-041 PR #895 OPEN @ 42ae629a; tip pushed; session open pending merge'
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -38098,6 +38131,7 @@ git_history:
   note: 'S047/EV-039 — current_branch evolve/EV-040-workbench-lint-ux @ 861c5457; pushed=true ahead_of_origin=0; PR #893 OPEN; 13 in_progress H1–H5 PASS; tip CD awaiting merge; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-06 S049/EV-041 PR #895 OPEN @ 42ae629a — tip pushed; ahead_of_origin=0 pushed=true; session open pending merge; no git commit by workflow-state-manager'
   - '2026-08-06 S049/EV-041 OPEN — open_session; session_counter 49; evolve_cycle_counter 41; branch evolve/EV-041-operator-sources-briefing ACTIVE @ 73e13281 (base main); 00-context completed; next 16-evolve; Lean docs deepen F7; no git commit by workflow-state-manager'
   - '2026-08-06 S048/EV-040 — tip 861c5457 (08c805ebb9c935e989ba91b2fd3012974140b2e9); recorded commits e909231d + 861c5457 (+ earlier EV-040 feat/fix/test); PR #893 OPEN; 09–12 COMPLETE; 13-deploy-smoke IN_PROGRESS — H1–H5 PASS on live DOKS; PR #893 open; tip CD awaiting merge approval; tip commit 08c805eb; session/cycle remain open; dirty=true (workflow-state); no git commit by workflow-state-manager'
   - '2026-08-06 S047/EV-039 — tip cfe1236b (cfe1236b4c3e8c5594447d44b69e4d20c7e01522) [EV-039] chore: retrigger PR CI for tip gate; branch pushed; PR #891 OPEN; ahead_of_origin=0 pushed=true; tip CI missing (check_suites only cursor app); local husky pre-push make ci passed; 13-deploy-smoke BLOCKED hard stop pending user decision; dirty=true (workflow-state); no git commit by workflow-state-manager'
@@ -38571,12 +38605,18 @@ git_history:
     created: "2026-08-06"
     session_id: S049-operator-sources-briefing
     evolve_cycle_id: EV-041
-    tip_sha: 73e13281
-    tip_sha_full: 73e13281efcfffe5b869f10c86d49b6daea0331f
+    tip_sha: 42ae629a
+    tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
     exists: true
-    pushed: false
+    pushed: true
     ahead_of_origin: 0
-    note: "S049/EV-041 OPEN — open_session; Lean docs; base main@73e13281; local branch created; not pushed"
+    pr_number: 895
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+    pr_status: open
+    pr_title: "[EV-041] Operator UI sources runbook + PPT pack"
+    pr_head: evolve/EV-041-operator-sources-briefing
+    pr_base: main
+    note: "S049/EV-041 PR #895 OPEN @ 42ae629a; tip pushed; session open pending merge"
   - name: evolve/EV-040-workbench-lint-ux
     status: merged
     base: main
@@ -39754,6 +39794,26 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 42ae629a
+    short: 42ae629a
+    sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+    branch: evolve/EV-041-operator-sources-briefing
+    message: "[EV-041] docs: operator UI sources runbook and PPT pack"
+    stage: 16-evolve
+    skill_id: 16-evolve
+    stages:
+    - 16-evolve
+    - 07-build
+    session_id: S049-operator-sources-briefing
+    evolve_cycle_id: EV-041
+    files_changed_count: null
+    timestamp: "2026-08-06"
+    pushed: true
+    tip_sha: 42ae629a
+    tip_sha_full: 42ae629acae3aa373048bd4f4d4c271192844d1d
+    pr_number: 895
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/895
+    note: "S049/EV-041 — docs runbook + PPT pack; PR #895 OPEN; session open"
   - sha: 861c5457
     short: 861c5457
     sha_full: 08c805ebb9c935e989ba91b2fd3012974140b2e9


### PR DESCRIPTION
## Summary
- Source-centric operator UI runbook at `docs/ops/operator-ui-runbook.md` (workflow + standards/vendor cites per surface)
- PowerPoint source pack under `docs/guides/operator-sources-pptx/` (outline, bibliography, image pointers, build walkthrough)
- S049 / EV-041 Lean docs session artifacts; domain README pointer; evolve-decisions §EV-041

## Test plan
- [x] `make validate-fast` before commit
- [ ] Confirm no binary `.pptx` / copyrighted PDFs in diff
- [ ] Spot-check runbook links to RULE_SOURCE_URLS / ACCESS_AND_CITATION / vendor manifest
- [ ] Optional: follow Batch A in `build-walkthrough.md` locally

## Corpus
[Corpus: product §F7] [Corpus: system-spec] [Corpus: tech-spec]  
Path-cites domain/ops/guides — CORPUS membership waived (EV-041)


Made with [Cursor](https://cursor.com)