### PR TITLE
docs: national compliance briefing cites (TAC→IWXXM)

### DIFF
--- a/docs/guides/operator-sources-pptx/README.md
+++ b/docs/guides/operator-sources-pptx/README.md
@@ -1,37 +1,35 @@
 # Operator sources — PowerPoint source pack
 
-> **Session:** S049 / EV-041  
-> **Audience:** external briefing on **standards lineage + what we built from**  
-> **Operator how-to:** [../../ops/operator-ui-runbook.md](../../ops/operator-ui-runbook.md)
+> **Session lineage:** S049 / EV-041 (sources pack) · **Audience update:** national MET /
+> aviation **authority leadership** (compliance / OPMET–IWXXM exchange)  
+> **Operator how-to (staff):** [../../ops/operator-ui-runbook.md](../../ops/operator-ui-runbook.md)
 
 ## What this pack is
 
-Markdown you copy into PowerPoint / Keynote / Google Slides. It does **not** include a
-binary `.pptx` or copyrighted ICAO/WMO slide PNGs (those stay local / personal).
+Markdown you copy into PowerPoint for a **compliance-oriented** briefing: why States
+produce IWXXM, which ICAO/WMO sources to cite, and how this tool’s lint → convert →
+XSD+Schematron path maps to those sources.
 
 | File | Use |
 |------|-----|
-| [slide-outline.md](./slide-outline.md) | Per-slide title, bullets, speaker notes, source URLs |
-| [bibliography.md](./bibliography.md) | Curated landings (normative vs informative) |
-| [image-pointers.md](./image-pointers.md) | Where to get every figure |
-| [build-walkthrough.md](./build-walkthrough.md) | Step-by-step deck assembly |
+| [citation-search-guide.md](./citation-search-guide.md) | **Start here** — cite list + search walkthrough |
+| [slide-outline.md](./slide-outline.md) | Per-slide title, bullets, speaker notes, sources |
+| [bibliography.md](./bibliography.md) | Curated landings |
+| [image-pointers.md](./image-pointers.md) | Figures |
+| [build-walkthrough.md](./build-walkthrough.md) | Deck assembly steps |
 
 ## Citation constraints
 
 Follow [ACCESS_AND_CITATION.md](../../domain/rules/ACCESS_AND_CITATION.md):
 
-- **Do** put titles, editions, section numbers, and landing URLs on slides/notes.
-- **Do not** paste multi-page Annex 3 / Manual on Codes / Doc 8896 text.
-- Label **paywall** vs **public** vs **informative** clearly.
-- Runtime SoT for schemas = `vendor/manifest.json` pin (**v2025-2**), not workshop decks.
+- Titles, editions, section numbers, landing URLs — yes.
+- Multi-page Annex 3 / MoC / Doc 8896 paste — no.
+- Label paywall / public / informative.
+- Schema SoT = `vendor/manifest.json` pin **v2025-2**.
+- Do not invent TAC sunset dates unless the State’s licensed SARPs edition says so.
 
-## Suggested theme (keep simple)
+## Footer suggestion
 
-- One dark or light professional theme — avoid generic “AI purple gradient” clichés if branding matters.
-- Prefer **your own** architecture redraw (from [Corpus: system-spec]) over third-party art.
-- Footer on every slide: `Pin: IWXXM v2025-2 · Sources: docs/guides/operator-sources-pptx`
+`IWXXM pin v2025-2 · Cite: Annex 3 · Guidelines 5th · schemas.wmo.int`
 
-## Corpus cites
-
-[Corpus: product §F7] [Corpus: system-spec] [Corpus: tech-spec]  
-[docs/domain/rules/RULE_SOURCE_URLS.md] [docs/domain/mining/PPT-02-…]
+[Corpus: product §F6/F7] [Corpus: system-spec] [docs/domain/rules/RULE_SOURCE_URLS.md]

--- a/docs/guides/operator-sources-pptx/bibliography.md
+++ b/docs/guides/operator-sources-pptx/bibliography.md
@@ -4,8 +4,24 @@ Subset of [RULE_SOURCE_URLS.md](../../domain/rules/RULE_SOURCE_URLS.md) plus sof
 cites. Labels: **normative** | **normative-schema** | **normative-vocabulary** |
 **informative** | **software**. Access: **public** | **paywall** | **library**.
 
+**Audience:** national MET / aviation authority leadership (compliance).
+**Search walkthrough:** [citation-search-guide.md](./citation-search-guide.md).
+
 Vendor pin (runtime): IWXXM **v2025-2**, codelists **49-2**, iwxxm-us **3.0** —
 [`vendor/manifest.json`](../../../vendor/manifest.json).
+
+---
+
+## A0. Leadership priority cites (print first)
+
+| Priority | Title | URL | Access |
+|----------|-------|-----|--------|
+| 1 | ICAO Annex 3 | https://store.icao.int/en/annexes/annex-3 | paywall |
+| 2 | ICAO Doc 10003 | https://store.icao.int/en/manual-on-the-icao-meteorological-information-exchange-model-doc-10003 | paywall |
+| 3 | OPMET IWXXM Exchange Guidelines 5th Ed. | https://www.icao.int/sites/default/files/METP/Documents/Guidlines-for-the-Implementation-of-OPMET-Data-Exchange-using-IWXXM_5th-Edition.pdf | public |
+| 4 | IWXXM schemas 2025-2 | https://schemas.wmo.int/iwxxm/2025-2/ | public |
+| 5 | codes.wmo.int | https://codes.wmo.int/ | public |
+| 6 | WMO-No. 306 Vol I.3 | https://library.wmo.int/idurl/4/35769 | library |
 
 ---
 

--- a/docs/guides/operator-sources-pptx/build-walkthrough.md
+++ b/docs/guides/operator-sources-pptx/build-walkthrough.md
@@ -1,7 +1,12 @@
 # Build walkthrough — assemble the `.pptx`
 
-PowerPoint-first steps; Keynote / Google Slides equivalents in parentheses.
-Work from [slide-outline.md](./slide-outline.md) and [image-pointers.md](./image-pointers.md).
+**Audience framing:** national MET / aviation **authority heads** (compliance /
+OPMET–IWXXM), not day-to-day click training.
+
+PowerPoint-first. Work from [slide-outline.md](./slide-outline.md),
+[citation-search-guide.md](./citation-search-guide.md), and [image-pointers.md](./image-pointers.md).
+
+**Before slide 1:** skim citation-search-guide §1–§2 so every claim has a landing URL.
 
 **Do not** commit the finished `.pptx` to git unless explicitly requested.
 
@@ -9,125 +14,77 @@ Work from [slide-outline.md](./slide-outline.md) and [image-pointers.md](./image
 
 ## 0. Setup (5 minutes)
 
-1. Open **PowerPoint** → Blank Presentation (Keynote: File → New; Slides: Blank).  
-2. Set slide size: **Widescreen 16:9** (Design → Slide Size).  
-3. Apply a simple theme (one accent color). Avoid purple-on-white cliché if you care about branding.  
-4. View → **Notes** (enable speaker notes).  
-5. Optional footer master: `Pin: IWXXM v2025-2 · Sources briefing`  
-6. Keep this pack open side-by-side with the deck.
-
-**Checklist before any content:** citation policy — titles + URLs only; no Annex 3 body text.
+1. Open **PowerPoint** → Blank → **Widescreen 16:9**.
+2. Formal theme; footer: `IWXXM pin v2025-2 · Cite: Annex 3 · Guidelines 5th · schemas.wmo.int`
+3. Enable speaker notes.
+4. Keep citation-search-guide open for Q&A.
 
 ---
 
-## Batch A — Slides 1–4 (start here in coaching)
+## Batch A — Slides 1–4
 
 ### Slide 1 — Title
+Paste title/subtitle from outline. Notes: compliance enablement.
 
-1. Title placeholder → paste title from outline.  
-2. Subtitle → pin line.  
-3. Notes → paste speaker notes.  
-4. Insert org logo if any (Insert → Pictures).
+### Slide 2 — Why leadership cares
+Bullets + TAC → IWXXM arrow. No invented sunset dates.
 
-### Slide 2 — Why IWXXM
+### Slide 3 — Binding sources map
+Paste SARPs / Guidelines / Schemas table. Emphasize paywall vs public.
 
-1. New slide → Title and Content.  
-2. Paste bullets.  
-3. Insert → Shapes: two rectangles “TAC” and “IWXXM”, arrow between.  
-4. Notes: dual-obligation cite + “informative PPT-02” caveat.
+### Slide 4 — Proof points
+Seven stages (lint → … → Schematron). Notes: Guidelines §5.3.2.
 
-### Slide 3 — Standards map
-
-1. Paste bullets (keep paywall labels).  
-2. Optional: Insert screenshot of https://schemas.wmo.int/iwxxm/2025-2/ (public landing).  
-3. Notes: point to RULE_SOURCE_URLS.md path for Q&A.
-
-### Slide 4 — Architecture
-
-1. Prefer **SmartArt** Process/Hierarchy or freeform boxes matching image-pointers mermaid.  
-2. Labels exactly: `apps/frontend`, `apps/backend`, three packages, `vendor/schemas`.  
-3. Notes: F21 public convert / F31 optional Auth.
-
-**Pause:** review Batch A for invented claims (none should appear).
+**Pause:** every bullet has a landing from citation-search-guide §2.
 
 ---
 
 ## Batch B — Slides 5–8
 
-### Slide 5 — Pipeline
+### Slide 5 — Software pipeline map
+Workbench · tac-validate · tac2iwxxm · iwxxm-validate · provenance + architecture boxes.
 
-1. SmartArt **Basic Process** with 7 chevrons, or numbered list.  
-2. Text from domain README stage names.  
-3. Notes: stages are separate concerns.
+### Slide 6 — Products
+METAR…TCA grid; annex3 / iwxxm_us; AHL/COLLECT.
 
-### Slide 6 — Vendor pins
+### Slide 7 — Schema pin
+v2025-2 table or schemas.wmo.int screenshot.
 
-1. Table 2×5: Bundle | Pin.  
-2. Or screenshot `vendor/manifest.json` (tag fields only).  
-3. Notes: conflict → defer to pin; translation suite informative.
+### Slide 8 — Governance & access
+Paywall vs public columns for procurement/legal.
 
-### Slide 7 — Operator UI
-
-1. Paste F7/F9/F10 bullets.  
-2. Insert 1–2 **local** screenshots (image-pointers §UI).  
-3. Caption: “Local non-deployed preview”.  
-4. Notes: runbook path for operators.
-
-### Slide 8 — Provenance
-
-1. Three boxes: Dig → ISSUE_CATALOG → Lint UI.  
-2. Notes: EV-035 / EV-040; gap/paywall labels.
-
-**Pause:** confirm no copyrighted PDF pages pasted.
+**Pause:** no copyrighted PDF pages pasted.
 
 ---
 
 ## Batch C — Slides 9–12
 
-### Slide 9 — Access friction
+### Slide 9 — Leadership actions
+Numbered checklist from outline.
 
-1. Insert → Table (copy from outline).  
-2. Emphasize paywall row visually (e.g. italic “purchase”).
+### Slide 10 — Informative workshop (optional)
+PPT-02; badge **INFORMATIVE — not SoT**.
 
-### Slide 10 — PPT-02
+### Slide 11 — References handout
+URLs from citation-search-guide §2; print §2 and §6 as leave-behind.
 
-1. Bullets from outline.  
-2. Optional figure: personal extract from `.local/.../slide-images/` **or** open official download and snip slides 6–7 only.  
-3. Notes: full attribution paragraph from image-pointers.  
-4. On-slide badge: **INFORMATIVE — not SoT**.
-
-### Slide 11 — Software stack
-
-1. Short bullet list from outline (not full inventory).  
-2. Notes: dependency-inventory.md for detail; ADR-014 GIFTs removed.
-
-### Slide 12 — Bibliography
-
-1. Paste short URL list.  
-2. Handout: print or link `bibliography.md`.  
-3. Closing line: “Operator day-to-day: docs/ops/operator-ui-runbook.md”.
+### Slide 12 — Closing
+Standards-led; software operable; staff runbook vs leadership deck.
 
 ---
 
 ## Final checklist
 
-- [ ] Every slide has speaker notes with at least one corpus/path cite or landing URL  
-- [ ] Paywalled sources labeled  
-- [ ] PPT-02 (if used) labeled informative  
-- [ ] Pin **v2025-2** appears on title and/or footer  
-- [ ] No Annex 3 / MoC multi-paragraph paste  
-- [ ] UI shots labeled non-deployed (if present)  
-- [ ] File saved outside repo (e.g. `~/Documents/TAC-to-IWXXM-sources-briefing.pptx`)  
-- [ ] Matches [bibliography.md](./bibliography.md) landings
+- [ ] Landing URL or path cite in every slide notes
+- [ ] Paywalled sources labeled; no Annex 3 body paste
+- [ ] No invented TAC sunset dates
+- [ ] PPT-02 labeled informative if used
+- [ ] Pin v2025-2 on title/footer
+- [ ] Leave-behind = citation-search-guide §2 / §6
+- [ ] File saved outside repo
 
----
+## Coaching cadence
 
-## Coaching cadence (chat)
-
-When walking through with an agent:
-
-1. Complete **Batch A** → reply “Batch A done” (or note blockers).  
-2. Then Batch B → “Batch B done”.  
-3. Then Batch C → final checklist.  
-
-Equivalents: Keynote **Presenter Notes**; Google Slides **Speaker notes** panel.
+1. Batch A → reply “Batch A done”
+2. Batch B → “Batch B done”
+3. Batch C → final checklist

--- a/docs/guides/operator-sources-pptx/citation-search-guide.md
+++ b/docs/guides/operator-sources-pptx/citation-search-guide.md
@@ -1,0 +1,127 @@
+# Citation & search guide — national compliance briefing
+
+> **Audience:** MET / aviation authority leadership (State / ANSP / Met Service heads)  
+> **Purpose:** Find **citable** ICAO/WMO landings for “why we must produce IWXXM” and “what good looks like” — without inventing deadlines or pasting paywalled SARPs text.  
+> **Policy:** [ACCESS_AND_CITATION.md](../../domain/rules/ACCESS_AND_CITATION.md)  
+> **Master URL catalog:** [RULE_SOURCE_URLS.md](../../domain/rules/RULE_SOURCE_URLS.md)
+
+Use this before finalizing slides. Prefer **landing pages + edition + section numbers** over long quotations.
+
+---
+
+## 1. What you can safely claim (and what you must not)
+
+| Claim type | Safe approach | Do not |
+|------------|---------------|--------|
+| States must provide MET service under Annex 3 | Cite **ICAO Annex 3** store listing + edition you hold | Paste Annex 3 body into the deck |
+| OPMET is exchanged as IWXXM (XML/GML) as well as TAC practice | Cite Annex 3 + **Doc 10003** + public **OPMET IWXXM Exchange Guidelines 5th** | Equate Guidelines with Annex 3 SARPs |
+| Produced IWXXM should validate XSD **and** Schematron | Cite Guidelines §5.3.2 (public PDF) + `schemas.wmo.int/iwxxm/<pin>/` | Claim “compliant” from convert alone |
+| Encoding model / FM 205 | Cite **WMO-No. 306 Vol I.3** library landing | Treat workshop PPT as SoT |
+| Operational schema line | Cite vendored pin **v2025-2** + https://schemas.wmo.int/iwxxm/2025-2/ | Invent a sunset date unless your licensed SARPs edition says it |
+| TAC sunset ~2030 | Only as **informative** workshop messaging (PPT-02) with caveat | Present as binding Annex 3 text without checking your edition |
+
+---
+
+## 2. Priority cite list (leaders’ handout)
+
+| # | Cite as | URL | Access | Role |
+|---|---------|-----|--------|------|
+| 1 | ICAO, *Annex 3 — Meteorological Service for International Air Navigation* (current Store edition) | https://store.icao.int/en/annexes/annex-3 | **Paywall** | SARPs / TAC templates — **normative** |
+| 2 | ICAO, *Doc 10003 — Manual on the ICAO Meteorological Information Exchange Model* | https://store.icao.int/en/manual-on-the-icao-meteorological-information-exchange-model-doc-10003 | **Paywall** | IWXXM exchange model — **normative** |
+| 3 | ICAO METP, *Guidelines for the Implementation of OPMET Data Exchange using IWXXM* (5th Edition, Oct 2023) | https://www.icao.int/sites/default/files/METP/Documents/Guidlines-for-the-Implementation-of-OPMET-Data-Exchange-using-IWXXM_5th-Edition.pdf | **Public** | Prep, translation, AMHS/FTBP, XSD+SCH — **guidelines** |
+| 4 | WMO, *Manual on Codes*, Vol. I.3 (Part D / FM 205 IWXXM) | https://library.wmo.int/idurl/4/35769 | **Library** | Code forms / IWXXM representations — **normative** |
+| 5 | WMO IWXXM schemas (pin **2025-2**) | https://schemas.wmo.int/iwxxm/2025-2/ | **Public** | XSD, Schematron, examples — **schema** |
+| 6 | WMO codes registry | https://codes.wmo.int/ | **Public** | Vocabularies — **schema** |
+| 7 | wmo-im/iwxxm GitHub tag `v2025-2` | https://github.com/wmo-im/iwxxm | **Public** | Schema development tree — **schema** |
+| 8 | ICAO EUR Doc 014 — EUR SIGMET and AIRMET Guide (5th Ed. 2023) | See [RULE_SOURCE_URLS.md](../../domain/rules/RULE_SOURCE_URLS.md) EUR Doc 014 row | **Public** | Regional SIGMET/AIRMET — **guidelines** (does not override Annex 3) |
+| 9 | PPT-02 *IWXXM Framework* (TT-AvData / ESAF, 22 Oct 2025) | https://www.icao.int/filebrowser/download/26741?fid=26741 | **Public** | Briefing overview — **informative only** |
+| 10 | This tool’s runbook + provenance | `docs/ops/operator-ui-runbook.md` · `docs/domain/rules/` | Repo | Software ↔ sources map |
+
+Repo digs (help find section numbers; not SoT):  
+`docs/domain/mining/icao-annex-3-mining-notes.md` · `OPMET-IWXXM-Exchange-Guidelines-5th-mining-notes.md` · `WMO-306-vI-3-2023-mining-notes.md`
+
+---
+
+## 3. Search walkthrough
+
+### A. “Is IWXXM required / how do States exchange OPMET?”
+
+1. ICAO Store → search **“Annex 3”** → open the **edition your State has adopted**.  
+2. In-PDF search: `IWXXM`, `XML`, `digital`, `dissemination`, `METAR`, `TAF`, `SIGMET`.  
+3. Record **chapter / appendix / table** numbers on slides — not paragraphs.  
+4. Download **OPMET IWXXM Exchange Guidelines 5th** (table #3) → search `translation`, `Schematron`, `AMHS`, `FTBP`.  
+5. Store search **“Doc 10003”** → use the **published** edition (not the 2014 advance draft).
+
+### B. “What schema version should we validate against?”
+
+1. https://schemas.wmo.int/iwxxm/ → open the year line agreed with your ROC/Region (this tool defaults to **2025-2**).  
+2. Confirm ReleaseNotes + `rule/iwxxm.sch` + `examples/`.  
+3. Cite: `https://schemas.wmo.int/iwxxm/2025-2/` + GitHub tag `v2025-2`.
+
+### C. “How do we prove a bulletin is exchange-ready?”
+
+1. Guidelines 5th → generation / translation / validation (repo dig: §5.3 — XSD **and** Schematron).  
+2. Pipeline: TAC lint → convert → XSD → Schematron.  
+3. Official examples: `…/2025-2/examples/` and `vendor/schemas/iwxxm/`.
+
+### D. Regional SIGMET / AIRMET / AHL
+
+1. EUR Doc 014 (public PDF).  
+2. AHL: https://community.wmo.int/en/activity-areas/wis/iwxxm/ahl-icao-data  
+3. Say: regional guides **complement** Annex 3; they do not replace it.
+
+### E. US national REMARKS
+
+1. FMH-1 (public). 2. IWXXM-US 3.0 (NWS). 3. Label as **national overlay**.
+
+### Web search strings
+
+```
+ICAO Annex 3 Meteorological Service site:store.icao.int
+ICAO Doc 10003 Meteorological Information Exchange Model
+"OPMET Data Exchange using IWXXM" Guidelines 5th Edition filetype:pdf
+site:schemas.wmo.int iwxxm 2025-2
+WMO Manual on Codes Volume I.3 FM 205
+site:library.wmo.int Manual on Codes I.3
+ICAO EUR Doc 014 SIGMET AIRMET Guide
+IWXXM Framework TT-AvData ESAF workshop
+```
+
+---
+
+## 4. Spoken citation patterns
+
+- “Per **ICAO Annex 3** [edition on file], MET service SARPs include the TAC templates we lint against — full text is in the Store edition your State adopted.”  
+- “**OPMET exchange in IWXXM** is described in ICAO’s public **OPMET IWXXM Exchange Guidelines, 5th Edition (2023)** — including translation practice and validation against schema and Schematron.”  
+- “The digital exchange model is in **ICAO Doc 10003** (Store).”  
+- “Machine validation uses WMO IWXXM **2025-2** at schemas.wmo.int; this system pins that line in `vendor/manifest.json`.”  
+- “Workshop decks (TT-AvData PPT-02) are **informative**; obligations defer to Annex 3 / Doc 10003 / regional agreements.”
+
+---
+
+## 5. Compliance need → software → source
+
+| Leadership concern | Tool | Cite |
+|--------------------|------|------|
+| Produce IWXXM from national TAC | `tac2iwxxm` + UI | Guidelines 5th · TAC-to-XML-Guidance · Annex 3 |
+| Reject bad TAC | `tac-validate` | Annex 3 · WMO-306 · ISSUE_CATALOG |
+| Prove exchange-ready XML | `iwxxm-validate` XSD+SCH | schemas.wmo.int/2025-2 · Guidelines §5.3.2 |
+| Multi-product OPMET | F6/F7 products | Annex 3 apps · COVERAGE_MATRIX |
+| Trace a rule | Lint catalog attribution | RULE_SOURCE_URLS · PROVENANCE_MAP |
+| Bulletin / AHL | AHL/COLLECT modes | Guidelines · community AHL |
+
+Staff: [operator-ui-runbook.md](../../ops/operator-ui-runbook.md).  
+Ops notes: [ICAO_OPMET_COMPLIANCE.md](../../domain/iwxxm/ICAO_OPMET_COMPLIANCE.md).
+
+---
+
+## 6. Leave-behind one-pager
+
+1. Annex 3 (Store) — SARPs  
+2. Doc 10003 (Store) — exchange model  
+3. OPMET IWXXM Guidelines 5th (public PDF) — how to implement exchange  
+4. schemas.wmo.int/iwxxm/2025-2 — validate here  
+5. codes.wmo.int — vocabularies  
+6. This system: lint → convert → XSD+SCH against pin v2025-2  
+
+[Corpus: product §F6/F7] [docs/domain/rules/ACCESS_AND_CITATION.md]

--- a/docs/guides/operator-sources-pptx/slide-outline.md
+++ b/docs/guides/operator-sources-pptx/slide-outline.md
@@ -1,263 +1,200 @@
-# Slide outline — TAC-to-IWXXM sources briefing
+# Slide outline — National compliance briefing (TAC → IWXXM)
 
-Copy each block into one slide. Speaker notes are for presenter view only.
+**Audience:** Heads of MET services / aviation authorities / State representatives
+responsible for meeting **ICAO/WMO OPMET–IWXXM** exchange expectations.
+**Tone:** Why compliance matters → which sources bind → how this tool helps prove
+lint → convert → validate. Not a click tutorial.
+
+**Citation pack:** [citation-search-guide.md](./citation-search-guide.md)
+**Policy:** cite landings + section numbers; never paste Annex 3 / MoC body text.
 
 ---
 
 ## Slide 1 — Title
 
-**Title:** TAC → IWXXM Operator System  
-**Subtitle:** Built from ICAO / WMO / NWS sources · Runtime pin **IWXXM v2025-2**
+**Title:** Meeting OPMET IWXXM Exchange Expectations
+**Subtitle:** TAC → validated IWXXM for international air navigation · Schema pin **IWXXM v2025-2**
 
-**Bullets (optional footer):**
+**Bullets:**
+- For: State MET / ANSP / aviation authority leadership
+- Scope: convert Traditional Alphanumeric Code (TAC) to IWXXM XML and prove quality
 
-- Repository: EMPIRIC2/TAC-to-IWXXM (monorepo)
-- Briefing pack: `docs/guides/operator-sources-pptx/`
+**Speaker notes:** Frame as **compliance enablement**. Obligations come from ICAO/WMO —
+this system implements lint/convert/validate against published schemas.
+[citation-search-guide.md] [Corpus: product §F6/F7]
 
-**Speaker notes:** This deck is about *provenance* — which standards and schema pins
-underwrite the tool — not a feature tour. Operator click-paths live in
-`docs/ops/operator-ui-runbook.md`. [Corpus: product §F7] [Corpus: system-spec]
-
-**Figure:** none (or org logo only)
-
-**Sources:** vendor/manifest.json · feature-list F7
+**Sources footer:** Annex 3 (Store) · OPMET Guidelines 5th (public) · schemas.wmo.int/2025-2
 
 ---
 
-## Slide 2 — Why IWXXM (problem framing)
+## Slide 2 — Why leadership cares
 
-**Title:** TAC presentation vs IWXXM exchange
+**Title:** From TAC operations to IWXXM exchange
 
 **Bullets:**
+- TAC remains widely used for **presentation** and local ops
+- International OPMET **exchange** increasingly requires **IWXXM** (XML/GML)
+- Annex 3 sets MET service / product SARPs (State-adopted edition) — *Access: paywall*
+- Public **OPMET IWXXM Exchange Guidelines (5th Ed., 2023)** describe prep, translation, exchange over AFS/AMHS
+- Authorities need: **valid TAC → correct IWXXM → XSD + Schematron pass**
 
-- TAC remains familiar for human presentation
-- IWXXM (XML/GML) is the structured exchange form for OPMET
-- Annex 3 frames dual TAC + IWXXM obligations (cite; do not quote)
-- Operators need software to lint TAC, encode IWXXM, and validate XSD + Schematron
+**Speaker notes:** Do **not** invent a global TAC sunset date unless your licensed Annex 3 /
+regional agreement states it. Workshop ~2030 talk is **informative** only (PPT-02).
 
-**Speaker notes:** Informative workshop framing (PPT-02) says consumers still render TAC
-often while exchange moves to IWXXM. Do not claim TAC sunset dates as binding unless
-citing a current SARPs edition. [docs/domain/mining/PPT-02-…] [Corpus: product]
-
-**Figure:** optional simple two-column diagram “TAC text” ↔ “IWXXM XML” (draw yourself)
-
-**Sources:** ICAO Annex 3 (paywall store landing) · PPT-02 informative · OPMET Guidelines 5th (public)
+**Cite:** Annex 3 Store · Guidelines PDF · Doc 10003 Store
 
 ---
 
-## Slide 3 — Standards map
+## Slide 3 — Binding sources map
 
-**Title:** Standards & registries we built from
+**Title:** Sources States cite for IWXXM programmes
 
 **Bullets:**
+| Layer | Instrument | Access |
+|-------|------------|--------|
+| SARPs / TAC templates | **ICAO Annex 3** | Paywall (Store) |
+| Exchange model | **ICAO Doc 10003** | Paywall (Store) |
+| Implementation of exchange | **OPMET IWXXM Guidelines 5th** | Public PDF |
+| Code forms / FM 205 | **WMO-No. 306 Vol I.3** | Library |
+| Machine schemas | **schemas.wmo.int/iwxxm/2025-2** | Public |
+| Vocabularies | **codes.wmo.int** | Public |
+| Overview only | TT-AvData workshop PPT-02 | Public **informative** |
 
-- **ICAO Annex 3** — TAC SARPs / templates — *Access: paywall*
-- **WMO-No. 306 Vol I.3** — Manual on Codes / FM 205 representations — *library*
-- **codes.wmo.int** — linked-data vocabularies — *public*
-- **schemas.wmo.int/iwxxm** — XSD + Schematron landings — *public*
-- **FMH-1 / iwxxm-us** — US METAR/SPECI REMARKS overlay — *public*
-- **EUR Doc 014** — SIGMET/AIRMET guide — *public PDF*
-
-**Speaker notes:** Full catalog: RULE_SOURCE_URLS.md. Paywalled prose never lives in the
-repo. [docs/domain/rules/RULE_SOURCE_URLS.md] [ACCESS_AND_CITATION.md]
-
-**Figure:** see image-pointers §Standards logos / landings table (screenshot of landings list OK)
-
-**Sources:** RULE_SOURCE_URLS §1–§3
+**Speaker notes:** Walk leaders through citation-search-guide §2–§3. Regional guides
+(e.g. EUR Doc 014) **complement** Annex 3 — they do not replace it.
 
 ---
 
-## Slide 4 — What we implemented (architecture)
+## Slide 4 — What “compliance-ready IWXXM” means
 
-**Title:** Monorepo components
-
-**Bullets:**
-
-- `apps/frontend` — operator workbench (React / Vite)
-- `apps/backend` — FastAPI convert / lint / validate / decode
-- `apps/worker` — near-RT ingest (F8; not auto-disseminate)
-- `packages/tac-validate` · `tac2iwxxm` · `iwxxm-validate`
-- `vendor/schemas/*` — read-only WMO / NWS snapshots
-
-**Speaker notes:** Redraw from spec.md runtime diagram. Auth optional for long-term
-sessions only (F21/F31). [Corpus: system-spec] [Corpus: product §F21/F31]
-
-**Figure:** architecture box diagram — **draw from** image-pointers §Architecture (mermaid in pack)
-
-**Sources:** docs/spec.md §System Architecture · docs/CORPUS.md
-
----
-
-## Slide 5 — Build pipeline (TAC → validated IWXXM)
-
-**Title:** Seven-stage domain pipeline
+**Title:** Proof points Regulators and ROCs expect
 
 **Bullets:**
-
-1. TAC lint (Annex 3 / vocab)
-2. Convert (encode + nilReasons)
+1. TAC matches Annex 3 / WMO templates (lint)
+2. Encode follows IWXXM structure + nilReason practice (convert)
 3. Well-formed XML
-4. XSD (structure)
-5. Schematron (+ offline RDF)
-6. Golden example pairs
-7. Bulletin / AHL / ops (when used)
+4. Passes **XSD** for the agreed IWXXM year line
+5. Passes **Schematron** (+ codelist checks)
+6. Prefer official TAC↔XML example pairs for acceptance tests
+7. Translation metadata when translating for another centre; retain TAC on failure
 
-**Speaker notes:** Stages must stay separate — Schematron pass ≠ Annex 3 SARPs proof.
-Hub table in docs/domain/README.md. Engines: tac-validate → tac2iwxxm → iwxxm-validate.
+**Speaker notes:** Guidelines 5th §5.3.2 — schema **and** Schematron. Default pin **2025-2**.
+Hub: docs/domain/README.md pipeline table.
 
-**Figure:** horizontal pipeline arrows (draw) — image-pointers §Pipeline
-
-**Sources:** docs/domain/README.md · TAC_VALIDATION / IWXXM_CONVERSION / IWXXM_VALIDATION
+**Cite:** Guidelines 5th · schemas.wmo.int/2025-2 · IWXXM_VALIDATION.md
 
 ---
 
-## Slide 6 — Vendor / upstream pins
+## Slide 5 — How this system maps
 
-**Title:** Runtime schema pins
+**Title:** Software pipeline aligned to ICAO/WMO sources
 
 **Bullets:**
+- **Operator workbench** — multi-product TAC, decode, live lint/preview (F7/F9/F10)
+- **`tac-validate`** — Annex 3 / vocab lint with source-traced issue codes
+- **`tac2iwxxm`** — TAC → IWXXM encode (vendor pin)
+- **`iwxxm-validate`** — XSD + Schematron against **v2025-2**
+- **Provenance** — RULE_SOURCE_URLS / PROVENANCE_MAP / lint catalog attribution
+- **Not a substitute** for State licensing of Annex 3 / Doc 10003
 
-- `wmo-im/iwxxm` **v2025-2**
-- `wmo-im/iwxxm-codelists` **49-2**
-- `wmo-im/iwxxm-modelling` **v2025-2**
-- `iwxxm-translation` — informative parity only
-- `iwxxm-us` **3.0** (NWS)
-
-**Speaker notes:** Pins are in vendor/manifest.json with SHAs. Conflict rule: defer to pin
-over older printed package tables. Supported operator window typically Latest + Previous
-(2025-2 + 2023-1). [Corpus: system-spec] vendor · VERSION_SUPPORT_POLICY
-
-**Figure:** screenshot of `vendor/manifest.json` keys (redact nothing secret — file is public) OR table
-
-**Sources:** vendor/manifest.json · schemas.wmo.int/iwxxm/2025-2/
+**Cite:** feature-list F6/F7 · vendor/manifest.json · operator-ui-runbook.md
 
 ---
 
-## Slide 7 — Operator UI (capability → feature)
+## Slide 6 — Products in scope
 
-**Title:** Operator workbench surfaces
+**Title:** Products covered for State programmes
 
 **Bullets:**
+- Core: METAR, SPECI, TAF, SIGMET, AIRMET, VAA, TCA
+- Extensions where pinned: SWXA, VONA
+- Profiles: **annex3** (default) · **iwxxm_us** (national REMARKS)
+- Bulletin modes: TAC / AHL / COLLECT
 
-- Multi-product workbench + sessions — **F7**
-- Value-aware decode + summary — **F9**
-- Live IWXXM preview / lint UX — **F10**
-- Golden / official examples — **F7.g**
-- Optional dissemination drawer — **F16–F19**
-- Public convert; optional Auth for storage — **F21 / F31**
-
-**Speaker notes:** This slide is the only “UI” slide — keep it capability-mapped, not a
-click tutorial. Screenshots from *local* non-deployed preview preferred.
-[Corpus: product] [docs/ops/operator-ui-runbook.md]
-
-**Figure:** 1–2 local UI screenshots (optional) — image-pointers §UI
-
-**Sources:** feature-list F7/F9/F10 · S011 session brief
+**Cite:** Annex 3 product apps · COVERAGE_MATRIX · EUR Doc 014 (regional)
 
 ---
 
-## Slide 8 — Rule provenance story
+## Slide 7 — Schema pin & version governance
 
-**Title:** From dig → rule → operator message
+**Title:** Validate against a published IWXXM line
 
 **Bullets:**
+- Runtime pin: **IWXXM v2025-2** (+ codelists **49-2**; US **3.0** when needed)
+- Public SoT: https://schemas.wmo.int/iwxxm/2025-2/
+- github.com/wmo-im/iwxxm tag `v2025-2`
+- Conflict rule: machine pin wins over older printed tables / workshop slides
 
-- Mine public / licensed sources → `docs/domain/mining/*`
-- Promote durable cites → RULE_SOURCE_URLS + canonical strategy docs
-- ISSUE_CATALOG codes link operators to sources
-- PROVENANCE_MAP indexes dig ↔ rule ↔ source
-- UI lint catalog shows WMO/ICAO/IWXXM attribution
-
-**Speaker notes:** S043/EV-035 built standing provenance; EV-040 surfaced attribution in UI.
-Gaps are labeled `gap` / `paywall` — never silently invented. [docs/domain/rules/PROVENANCE_MAP.md]
-
-**Figure:** simple flow Dig → Catalog → Lint console (draw)
-
-**Sources:** PROVENANCE_MAP · ISSUE_CATALOG · RULE_SOURCE_URLS
+**Cite:** schemas.wmo.int · vendor/manifest.json · VERSION_SUPPORT_POLICY.md
 
 ---
 
-## Slide 9 — Access friction
+## Slide 8 — Governance & access (procurement / legal)
 
-**Title:** What operators can open freely
+**Title:** What your State must hold vs what is free
 
 **Bullets:**
+- **Purchase / license:** Annex 3, Doc 10003, Doc 8896 (ICAO Store)
+- **Library access:** WMO-No. 306 Vol I.3
+- **Free for implementation & CI:** schemas.wmo.int, codes.wmo.int, OPMET Guidelines PDF, EUR Doc 014, wmo-im GitHub
+- This repository **does not** redistribute Annex 3 / Manual on Codes full text
 
-| Class | Examples | In-repo handling |
-|-------|----------|------------------|
-| Paywall | Annex 3, Doc 10003 | Cite store URL only |
-| Library / captcha | WMO-306 | Mining notes + gitignored `.local/` |
-| Public machine | schemas / codes / EUR Doc 014 | Prefer for CI + goldens |
-| Informative | PPT-02 workshop deck | Corroboration only |
-
-**Speaker notes:** ACCESS_AND_CITATION.md is the standing policy. Unofficial mirror PDFs are
-not SoT. [docs/domain/rules/ACCESS_AND_CITATION.md]
-
-**Figure:** none (table is the figure)
-
-**Sources:** ACCESS_AND_CITATION.md
+**Cite:** ACCESS_AND_CITATION.md · citation-search-guide.md §2
 
 ---
 
-## Slide 10 — Informative workshop corroboration (PPT-02)
+## Slide 9 — Recommended leadership actions
 
-**Title:** WMO TT-AvData “IWXXM Framework” (workshop)
+**Title:** Next steps for a State programme
 
 **Bullets:**
+1. Confirm Annex 3 / Doc 10003 editions on file
+2. Agree IWXXM year line with ROC/Region (align to **2025-2** or documented bilateral)
+3. Require **XSD + Schematron** in translator acceptance criteria
+4. Stand up lint → convert → validate with official example packs
+5. Monitor partial-translation / failure rates (Guidelines §7 themes)
+6. Keep regional guides as supplements only
 
-- Public ICAO filebrowser deck (ESAF workshop, 2025-10-22)
-- Convenient pointer cluster to WMO + ICAO landings
-- Package × IWXXM-line matrix — **informative**; prefer vendor XSD versions
-- Translation attrs + `translationFailedTAC` reminder
-
-**Speaker notes:** Label every claim **informative**. Full dig:
-docs/domain/mining/PPT-02-IWXXM-Framework-WMO-mining-notes.md. Local slide PNGs under
-`.local/reference/ppt-02-…/extracts/slide-images/` — **do not commit**. Official download:
-https://www.icao.int/filebrowser/download/26741?fid=26741
-
-**Figure:** optional *personal* extract of PPT-02 slides 6–7 landings (cite deck) — not for git
-
-**Sources:** PPT-02 mining notes · ICAO filebrowser URL
+**Cite:** Guidelines 5th · Doc 10003 · ICAO_OPMET_COMPLIANCE.md
 
 ---
 
-## Slide 11 — Software stack (high level)
+## Slide 10 — Informative workshop context (optional)
 
-**Title:** Implementation stack
+**Title:** Industry briefing context (not SARPs)
 
 **Bullets:**
+- TT-AvData “IWXXM Framework” (ESAF, Oct 2025) — public download
+- Useful for landings map / messaging — label **INFORMATIVE**
+- Forward messages (e.g. TAC sunset discussions) → verify against **your** Annex 3 edition / Region
 
-- Python 3.12 · FastAPI · msgspec HTTP DTOs
-- React 18 · Vite · TypeScript · CodeMirror 6
-- `tac-validate` / `tac2iwxxm` / `iwxxm-validate` workspace packages
-- Optional Rust core in iwxxm-validate path (F13)
-- DigitalOcean Postgres + Supabase Auth (JWT) · DOKS deploy target
-
-**Speaker notes:** Details in dependency-inventory.md — do not dump every pin on the slide.
-GIFTs removed at F6 cutover (ADR-014). [Corpus: tech-spec]
-
-**Figure:** none or small stack icons (optional)
-
-**Sources:** docs/dependency-inventory.md · docs/tech-spec.md
+**Cite:** https://www.icao.int/filebrowser/download/26741?fid=26741
 
 ---
 
-## Slide 12 — Bibliography / further reading
+## Slide 11 — References (handout)
 
-**Title:** Landings to keep
+**Title:** Cite these landings
 
-**Bullets (short URLs on slide; full table in bibliography.md):**
+**Bullets:**
+- Annex 3 — store.icao.int/en/annexes/annex-3
+- Doc 10003 — ICAO Store
+- OPMET IWXXM Guidelines 5th — icao.int METP PDF (public)
+- schemas.wmo.int/iwxxm/2025-2/
+- codes.wmo.int
+- library.wmo.int — Manual on Codes I.3
+- Full search steps: `docs/guides/operator-sources-pptx/citation-search-guide.md`
 
-- https://schemas.wmo.int/iwxxm/2025-2/
-- https://codes.wmo.int/
-- https://github.com/wmo-im/iwxxm (tag v2025-2)
-- ICAO Annex 3 store listing (paywall)
-- OPMET IWXXM Exchange Guidelines 5th (public PDF)
-- Repo: `docs/domain/rules/RULE_SOURCE_URLS.md`
+---
 
-**Speaker notes:** Hand out bibliography.md or link the repo path. Remind: purchase ICAO
-docs for normative prose. Operator runbook for day-to-day use.
+## Slide 12 — Closing
 
-**Figure:** none
+**Title:** Compliance is standards-led; software makes it operable
 
-**Sources:** bibliography.md
+**Bullets:**
+- SARPs and manuals define the obligation
+- Public schemas and Guidelines define the machine test
+- This system: **lint → convert → XSD + Schematron** with source-traced rules
+- Staff path: operator UI runbook · Leadership path: this deck + citation guide
+
+**Cite:** [Corpus: product §F6/F7] [docs/domain/README.md]

--- a/docs/ops/operator-ui-runbook.md
+++ b/docs/ops/operator-ui-runbook.md
@@ -220,8 +220,13 @@ Detailed E2E IDs: [Corpus: journeys] UJ-013–021, UJ-025, UJ-032.
 
 ---
 
-## 10. Briefing deck
+## 10. Briefing deck (authority / compliance audience)
 
-For stakeholder presentations on **sources used to build the tool**, use
-[../guides/operator-sources-pptx/](../guides/operator-sources-pptx/) and follow
-`build-walkthrough.md`. Do not commit the finished `.pptx` unless explicitly requested.
+For **national MET / aviation authority leadership** (TAC→IWXXM compliance /
+OPMET exchange), use:
+
+- [../guides/operator-sources-pptx/](../guides/operator-sources-pptx/) — slide outline
+- [../guides/operator-sources-pptx/citation-search-guide.md](../guides/operator-sources-pptx/citation-search-guide.md) — **sources to cite + search walkthrough**
+- `build-walkthrough.md` to assemble a personal `.pptx` (do not commit binaries)
+
+Day-to-day staff use this runbook; leaders use the deck + citation guide.


### PR DESCRIPTION
## Summary
- Reframe the EV-041 sources PPT pack for **MET / aviation authority leadership** needing TAC→IWXXM for OPMET exchange compliance
- Add `citation-search-guide.md` with priority cite list, search walkthroughs, and spoken citation patterns
- Update slide outline, bibliography A0 leave-behind, build walkthrough, and operator runbook pointer

## Test plan
- [x] Pre-commit / validate-ci-medium on commit
- [ ] Spot-check Annex 3 / Doc 10003 / Guidelines 5th / schemas.wmo.int links
- [ ] Confirm no invented TAC sunset claims; PPT-02 labeled informative


Made with [Cursor](https://cursor.com)