### PR TITLE
[BUG-2026-08-07] fix: pin Supabase CLI; strip Render frontend allow-lists

### DIFF
--- a/.github/workflows/supabase-sync.yml
+++ b/.github/workflows/supabase-sync.yml
@@ -74,11 +74,13 @@ jobs:
           fi
           echo "skip=false" >> "${GITHUB_OUTPUT}"
 
+      # Pin 2.111.0 — CLI 2.112.0 breaks `link` on api-keys inserted_at (+00:00 vs Z).
+      # Upstream: https://github.com/supabase/cli/issues/6115 (BUG-2026-08-07).
       - name: Install Supabase CLI
         if: steps.guard.outputs.skip != 'true'
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.111.0
 
       - name: Link project
         if: steps.guard.outputs.skip != 'true'
@@ -123,11 +125,12 @@ jobs:
           fi
           echo "skip=false" >> "${GITHUB_OUTPUT}"
 
+      # Same pin as migrations job (BUG-2026-08-07 / supabase/cli#6115).
       - name: Install Supabase CLI
         if: steps.guard.outputs.skip != 'true'
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.111.0
 
       - name: Provision project root for functions
         if: steps.guard.outputs.skip != 'true'

--- a/deploy/doks/base/configmap-api.yaml
+++ b/deploy/doks/base/configmap-api.yaml
@@ -13,6 +13,6 @@ data:
   LOG_LEVEL: "INFO"
   ENABLE_STATISTICS: "true"
   ENABLE_WEBHOOKS: "false"
-  # Provisional CORS (D-S038-t63-waive): Host-header FE + LB IP until real DNS.
-  METAR_CORS_ORIGINS: "http://app.doks.placeholder.metar-iwxxm.local,http://168.144.12.70,https://app.doks.placeholder.metar-iwxxm.local,https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+  # CORS: DOKS FE hosts + LB IP. Suspended Render frontend origin removed (BUG-2026-08-07).
+  METAR_CORS_ORIGINS: "https://app.tac-to-iwxxm.com,http://app.tac-to-iwxxm.com,http://168.144.12.70"
   PORT: "8000"

--- a/deploy/doks/base/configmap-frontend-runtime.yaml
+++ b/deploy/doks/base/configmap-frontend-runtime.yaml
@@ -6,18 +6,17 @@ metadata:
     app.kubernetes.io/name: metar-frontend
     app.kubernetes.io/component: frontend
 data:
-  # Provisional cutover config (D-S038-t63-waive): placeholder hosts + LB via /etc/hosts.
-  # Public Render URLs remain in committed config/prod.json until real DNS (T6.3 residual).
+  # Runtime bootstrap mirrors config/prod.json hosts (Render frontend decommissioned).
   config.json: |
     {
       "environment": "prod",
       "api": {
-        "baseUrl": "http://api.doks.placeholder.metar-iwxxm.local",
-        "frontendUrl": "http://app.doks.placeholder.metar-iwxxm.local",
+        "baseUrl": "https://api.tac-to-iwxxm.com",
+        "frontendUrl": "https://app.tac-to-iwxxm.com",
         "corsOrigins": [
-          "http://app.doks.placeholder.metar-iwxxm.local",
-          "http://168.144.12.70",
-          "https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+          "https://app.tac-to-iwxxm.com",
+          "http://app.tac-to-iwxxm.com",
+          "http://168.144.12.70"
         ]
       },
       "supabase": {

--- a/docs/bug-reports/BUG-2026-08-07-supabase-sync-cli-inserted-at.md
+++ b/docs/bug-reports/BUG-2026-08-07-supabase-sync-cli-inserted-at.md
@@ -1,0 +1,85 @@
+# BUG-2026-08-07 — Supabase Sync CI fails on `supabase link` (`inserted_at` SchemaError)
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixed (pending merge) |
+| **Feature** | M5 / ops (Supabase migrations CI) |
+| **Severity** | high (blocks `Supabase Sync` on `main` + PR checks, e.g. #901) |
+| **Classification** | integration / tooling |
+| **Remediation path** | Pin Supabase CLI below broken `latest`; strip stale onrender allow-list leftovers |
+| **Branch** | `fix/BUG-2026-08-07-supabase-sync-cli-pin` |
+| **CI runs** | https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31178626341/job/92866314571 · PR #901 https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31190674882 |
+
+## Error description
+
+GitHub Action **Supabase Sync → Sync database migrations** fails at **Link project**
+when `supabase/setup-cli` installs `version: latest` (CLI **2.112.0**). The same
+failure appears on `main` after merges and on open PRs that run the workflow
+(e.g. docs PR #901). Edge-function job is unaffected (no `link`).
+
+## Error logs
+
+```
+failed to get api keys: SchemaError(Expected a string matching the RegExp ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+  at [2]["inserted_at"])
+Try rerunning the command with --debug to troubleshoot the error.
+##[error]Process completed with exit code 1.
+```
+
+Annotation warning (non-fatal): Node.js 20 deprecated for `supabase/setup-cli@v1`.
+
+## Investigation
+
+| Time (UTC) | Note |
+|------------|------|
+| 2026-08-07 | Main run 31178626341 / job 92866314571 — fail at `supabase link` |
+| 2026-08-07 | PR #901 run 31190674882 — same SchemaError |
+| 2026-08-07 | Local CLI **2.111.0** `supabase link --project-ref ktvxijislbtgqapllmuk` succeeds |
+| 2026-08-07 | Publishable key `inserted_at` is `…+00:00` (not `Z`); index `[2]` matches CLI decode failure |
+| 2026-08-07 | Upstream: [supabase/cli#6115](https://github.com/supabase/cli/issues/6115) — regression in 2.112.0; workaround pin **2.111.0** |
+
+### Hypotheses
+
+1. **Primary (confirmed):** `version: latest` pulled CLI 2.112.0; generated API-keys schema requires `Z` suffix; Management API returns `+00:00` → `link` aborts.
+2. Secrets missing — rejected (token/password present; fail is schema decode).
+3. Project paused / network — rejected (same credentials work on 2.111.0).
+
+### Onrender callback / CORS leftovers (same hotfix)
+
+User also asked to strip callbacks to `https://metar-to-iwxxm-frontend-v4-web.onrender.com/`.
+
+| Surface | Status 2026-08-07 |
+|---------|-------------------|
+| Live Supabase Auth `site_url` / `uri_allow_list` | Already `app.tac-to-iwxxm.com` (+ local); **no** onrender |
+| Live API CORS `Origin: …onrender.com` | **400** `Disallowed CORS origin` |
+| Live `/config.json` | DOKS hosts only |
+| `deploy/doks/base/configmap-*.yaml` | Still listed onrender in CORS — **strip** |
+| `docs/ops/env-sync-runbook.md` Step 1 redirect example | Still onrender — **update** |
+| `scripts/deploy/apply_render_cors_env.sh` default | Still onrender — **retarget / deprecate default** |
+
+## Repro test
+
+- Path: `tests/bugs/test_bug_2026_08_07_supabase_sync_cli_inserted_at.py`
+- Asserts `supabase-sync.yml` pins CLI `2.111.0` (not `latest`) and DOKS/prod config omit the suspended Render frontend origin.
+
+## Fix
+
+- Pin `supabase/setup-cli` `version: 2.111.0` in `.github/workflows/supabase-sync.yml` (migrations + functions).
+- Remove `metar-to-iwxxm-frontend-v4-web.onrender.com` from DOKS base CORS ConfigMaps.
+- Update env-sync runbook Auth redirect examples to `https://app.tac-to-iwxxm.com/**`.
+- Default `FRONTEND_ORIGIN` in `apply_render_cors_env.sh` to DOKS frontend host (script remains Render-API based for archive/emergency use).
+
+## Interview record
+
+- Intent: fix CI failure on linked runs + strip onrender callbacks (user `/14-hotfix` + URLs).
+- AskQuestion tool unavailable this turn; proceeded on explicit user scope.
+
+## Prevention & countermeasures
+
+- Keep CLI pin until [supabase/cli#6115](https://github.com/supabase/cli/issues/6115) is fixed and verified.
+- Regression test guards against `version: latest` in this workflow.
+- Prefer `app.tac-to-iwxxm.com` in any Auth/CORS allow-list docs (Render decommissioned).
+
+## Cursor rule
+
+- Deferred — existing CI pin + bug test sufficient; revisit if `latest` is reintroduced elsewhere.

--- a/docs/bug-reports/BUG-2026-08-07-supabase-sync-cli-inserted-at.md
+++ b/docs/bug-reports/BUG-2026-08-07-supabase-sync-cli-inserted-at.md
@@ -8,7 +8,8 @@
 | **Classification** | integration / tooling |
 | **Remediation path** | Pin Supabase CLI below broken `latest`; strip stale onrender allow-list leftovers |
 | **Branch** | `fix/BUG-2026-08-07-supabase-sync-cli-pin` |
-| **CI runs** | https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31178626341/job/92866314571 · PR #901 https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31190674882 |
+| **PR** | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/902 (cherry-picked onto #901) |
+| **CI runs** | Fail: https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31178626341/job/92866314571 · Green: https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31201943165 |
 
 ## Error description
 

--- a/docs/dependency-inventory.md
+++ b/docs/dependency-inventory.md
@@ -135,7 +135,7 @@ via Supabase). **JWKS-only** (`D-S038-04-b1` Q2=2): do not use `SUPABASE_JWT_SEC
 | husky | root `package.json` devDependency (^9.1.7) | Git hooksPath — pre-commit (fast+medium) + pre-push (`make ci` units+Compose; EV-036) |
 | actionlint | pre-commit hook | GitHub Actions workflow lint (EV-002) |
 | yamllint | pre-commit hook | `.github/` YAML lint (EV-002) |
-| supabase/setup-cli | GitHub Action | Supabase CLI in `supabase-sync.yml` |
+| supabase/setup-cli | GitHub Action | Supabase CLI in `supabase-sync.yml` — **pin `2.111.0`** (not `latest`; CLI 2.112.0 breaks `link` on api-keys `inserted_at`, supabase/cli#6115 / BUG-2026-08-07) |
 | docker / compose | system | Local multi-service |
 | Coverage | 95% all members | pytest + Vitest gates (ADR-007); includes tac2iwxxm, tac-validate, iwxxm-validate |
 | cargo / maturin | **required before cutover** | PyO3 wheel build in CI/API image (ADR-017) |

--- a/docs/ops/env-sync-runbook.md
+++ b/docs/ops/env-sync-runbook.md
@@ -2,7 +2,7 @@
 
 > **Session**: S003-supabase-keys-config  
 > **Supabase project**: `ktvxijislbtgqapllmuk` (`https://ktvxijislbtgqapllmuk.supabase.co`)  
-> **Last updated**: 2026-06-24
+> **Last updated**: 2026-08-07 (Auth redirects → `app.tac-to-iwxxm.com`; BUG-2026-08-07)
 
 Operator checklist for keeping secrets and config aligned across environments.
 
@@ -26,7 +26,7 @@ Operator checklist for keeping secrets and config aligned across environments.
 2. **API Keys** → create **Publishable** (`sb_publishable_*`) and **Secret** (`sb_secret_*`) keys.
 3. **Database → Connect** → copy **Transaction pooler** `DATABASE_URL`.
 4. **Authentication → URL configuration** → set redirect URLs:
-   - `https://metar-to-iwxxm-frontend-v4-web.onrender.com/**`
+   - `https://app.tac-to-iwxxm.com/**` (live DOKS; do **not** re-add suspended Render hosts)
    - `http://localhost:18000/**` (local)
 5. **Authentication → Password Security** → enable **Leaked password protection** (HaveIBeenPwned).
 6. Apply SQL migrations `003` and `004` if not yet applied (see §Database advisor below).
@@ -123,8 +123,8 @@ Deprecate: `FRONTEND_VITE_SUPABASE_URL`, `FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEF
 make test-integration
 
 # Optional live signoff (credentials in .env)
-export LIVE_API_URL=https://metar-to-iwxxm-api.onrender.com
-export LIVE_FRONTEND_URL=https://metar-to-iwxxm-frontend-v4-web.onrender.com
+export LIVE_API_URL=https://api.tac-to-iwxxm.com
+export LIVE_FRONTEND_URL=https://app.tac-to-iwxxm.com
 make test-live-connectivity
 ```
 

--- a/scripts/deploy/apply_render_cors_env.sh
+++ b/scripts/deploy/apply_render_cors_env.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 
 API_BASE="https://api.render.com/v1"
 SERVICE_NAME="${RENDER_SERVICE_NAME:-metar-to-iwxxm-api}"
-FRONTEND_ORIGIN="${FRONTEND_ORIGIN:-https://metar-to-iwxxm-frontend-v4-web.onrender.com}"
+# Render frontend is suspended (S038); default to live DOKS operator origin.
+FRONTEND_ORIGIN="${FRONTEND_ORIGIN:-https://app.tac-to-iwxxm.com}"
 
 if [[ -z "${RENDER_API_KEY:-}" && -f .env ]]; then
   RENDER_API_KEY="$(grep -E '^RENDER_API_KEY=' .env | head -1 | cut -d= -f2- | tr -d '\r\"'"'"'')"

--- a/tests/bugs/test_bug_2026_08_07_supabase_sync_cli_inserted_at.py
+++ b/tests/bugs/test_bug_2026_08_07_supabase_sync_cli_inserted_at.py
@@ -1,0 +1,68 @@
+"""BUG-2026-08-07 — Supabase Sync must pin CLI; no Render frontend CORS leftovers.
+
+CLI 2.112.0 ``supabase link`` fails decoding Management API ``api-keys[].inserted_at``
+values that use a ``+00:00`` suffix (requires ``Z``). Pinning ``2.111.0`` is the
+upstream workaround (supabase/cli#6115). Suspended Render frontend origins must not
+remain in DOKS/prod CORS allow-lists.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "supabase-sync.yml"
+DOKS_API_CM = ROOT / "deploy" / "doks" / "base" / "configmap-api.yaml"
+DOKS_FE_CM = ROOT / "deploy" / "doks" / "base" / "configmap-frontend-runtime.yaml"
+PROD_CONFIG = ROOT / "config" / "prod.json"
+ENV_SYNC = ROOT / "docs" / "ops" / "env-sync-runbook.md"
+
+RENDER_FRONTEND = "https://metar-to-iwxxm-frontend-v4-web.onrender.com"
+PINNED_CLI = "2.111.0"
+
+
+def _setup_cli_versions(workflow: str) -> list[str]:
+    """Return every ``version:`` value under supabase/setup-cli steps."""
+    # Split on uses lines so we only collect the matching ``with: version``.
+    versions: list[str] = []
+    lines = workflow.splitlines()
+    for i, line in enumerate(lines):
+        if "supabase/setup-cli@" not in line:
+            continue
+        # Scan following lines until next step-level key at same indent.
+        for j in range(i + 1, min(i + 12, len(lines))):
+            m = re.match(r"^\s+version:\s*(\S+)\s*$", lines[j])
+            if m:
+                versions.append(m.group(1).strip("'\""))
+                break
+            if re.match(r"^      - ", lines[j]):
+                break
+    return versions
+
+
+def test_bug_2026_08_07_supabase_sync_pins_cli_not_latest() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    versions = _setup_cli_versions(text)
+    assert versions, "expected supabase/setup-cli version pins in supabase-sync.yml"
+    assert "latest" not in versions, (
+        "supabase-sync.yml must not use version: latest "
+        "(CLI 2.112.0 breaks link on api-keys inserted_at; see supabase/cli#6115)"
+    )
+    assert all(v == PINNED_CLI for v in versions), (
+        f"expected all setup-cli pins to be {PINNED_CLI}, got {versions}"
+    )
+
+
+def test_bug_2026_08_07_no_render_frontend_cors_allowlist() -> None:
+    for path in (DOKS_API_CM, DOKS_FE_CM, PROD_CONFIG):
+        text = path.read_text(encoding="utf-8")
+        assert RENDER_FRONTEND not in text, (
+            f"{path.relative_to(ROOT)} must not allow-list suspended Render frontend"
+        )
+
+
+def test_bug_2026_08_07_env_sync_runbook_redirects_use_doks_host() -> None:
+    text = ENV_SYNC.read_text(encoding="utf-8")
+    assert "https://app.tac-to-iwxxm.com/**" in text
+    assert f"{RENDER_FRONTEND}/**" not in text


### PR DESCRIPTION
## Summary
- Pin `supabase/setup-cli` to **2.111.0** in `supabase-sync.yml` so `supabase link` no longer fails on Management API `api-keys[].inserted_at` (`+00:00` vs `Z`) — [supabase/cli#6115](https://github.com/supabase/cli/issues/6115). Unblocks [main Sync job](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31178626341/job/92866314571) and [PR #901](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/901) Supabase Sync checks.
- Remove suspended `metar-to-iwxxm-frontend-v4-web.onrender.com` from DOKS CORS ConfigMaps, Auth redirect runbook, and Render CORS helper default. Live Auth/`/config.json` already used `app.tac-to-iwxxm.com` (verified).
- Add BUG report + regression tests under `tests/bugs/`.

[Corpus: tech-spec] · [Corpus: tests]

## Test plan
- [x] Repro red → green: `uv run pytest tests/bugs/test_bug_2026_08_07_supabase_sync_cli_inserted_at.py -v`
- [x] Pre-commit / validate-ci-medium on commit
- [ ] Remote: Supabase Sync green on this PR
- [ ] After merge: rebase/re-run #901 Supabase Sync (or cherry-pick pin onto docs branch)


Made with [Cursor](https://cursor.com)