### PR TITLE
[BUG-2026-08-07] fix: live Output filename on Download after convert (#904)

### DIFF
--- a/apps/frontend/src/app/components/FileConverter.tsx
+++ b/apps/frontend/src/app/components/FileConverter.tsx
@@ -99,6 +99,7 @@ import {
 } from '/utils/workSessionPayload';
 import { readGuestConverterState } from '/utils/guestConverterState';
 import {
+  manualDownloadXmlName,
   manualOutputName,
   outputArchiveName,
   sanitizeOutputFilename,
@@ -134,6 +135,12 @@ interface ConvertedFile {
   /** 1-based index when manual input had multiple lines. */
   manualLineIndex?: number;
   manualLineTotal?: number;
+  /**
+   * When set, Download / ZIP member names follow the live Output filename
+   * field (#904) instead of convert-time {@link originalName}.
+   * `index` is 0-based; `total` is the manual batch size.
+   */
+  liveOutputSlot?: { index: number; total: number };
 }
 
 interface PendingFile {
@@ -861,6 +868,9 @@ export function FileConverter({
                 isManualResult && manualResultCount > 1 ? index + 1 : undefined,
               manualLineTotal:
                 isManualResult && manualResultCount > 1 ? manualResultCount : undefined,
+              liveOutputSlot: isManualResult
+                ? { index, total: manualResultCount }
+                : undefined,
               convertedContent: result.iwxxm_xml || result.xml || result.content || '',
               timestamp: Date.now(),
             });
@@ -1092,12 +1102,23 @@ export function FileConverter({
     toast.info(`Loaded ${example.label} example`);
   }, []);
 
+  const resolveDownloadXmlName = (file: ConvertedFile): string => {
+    if (file.liveOutputSlot) {
+      return manualDownloadXmlName(
+        outputFilename,
+        file.liveOutputSlot.index,
+        file.liveOutputSlot.total,
+      );
+    }
+    return file.originalName.replace(/\.(txt|metar)$/i, '.xml');
+  };
+
   const handleDownloadSingle = (file: ConvertedFile) => {
     const blob = new Blob([file.convertedContent], { type: 'text/xml' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = file.originalName.replace(/\.(txt|metar)$/i, '.xml');
+    a.download = resolveDownloadXmlName(file);
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -1111,7 +1132,7 @@ export function FileConverter({
     const zip = new JSZip();
 
     convertedFiles.forEach((file) => {
-      const filename = file.originalName.replace(/\.(txt|metar)$/i, '.xml');
+      const filename = resolveDownloadXmlName(file);
       zip.file(filename, file.convertedContent);
     });
 

--- a/apps/frontend/src/test/bug-2026-08-07-output-filename-download-stale.test.tsx
+++ b/apps/frontend/src/test/bug-2026-08-07-output-filename-download-stale.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * BUG-2026-08-07 / #904 — Output filename change after convert ignored on Download.
+ *
+ * Steps: convert with first_name → change field to second_name → Download / ZIP
+ * members must use second_name.xml (preview already updates).
+ *
+ * Runs in frontend CI (`npm test`), not pytest `tests/bugs/`.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FileConverter } from '@/app/components/FileConverter';
+
+const mockConvertMetarToIwxxm = vi.hoisted(() => vi.fn());
+const mockPersistSession = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const mockScheduleAutoSave = vi.hoisted(() => vi.fn());
+const zipEntries = vi.hoisted(() => [] as string[]);
+
+vi.mock('/utils/supabase/logout', () => ({
+  signOutWithScope: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('/utils/api', () => ({
+  convertMetarToIwxxm: mockConvertMetarToIwxxm,
+  convertTafToIwxxm: vi.fn(),
+  fetchLintIssueCatalog: vi.fn().mockResolvedValue({ issues: [] }),
+  lintTac: vi.fn().mockResolvedValue({
+    ok: true,
+    issues: [],
+    fixes: [],
+  }),
+  decodeTac: vi
+    .fn()
+    .mockResolvedValue({ product: 'METAR', segments: [], residuals: [] }),
+  fetchAirportRegion: vi.fn(),
+}));
+
+vi.mock('@/app/components/TacEditor', () => ({
+  TacEditor: ({ id, value, onChange, readOnly, 'aria-label': ariaLabel }: any) => (
+    <textarea
+      id={id}
+      value={value}
+      readOnly={readOnly}
+      aria-label={ariaLabel}
+      data-testid="tac-editor"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+vi.mock('@/app/components/DecodePanel', () => ({
+  DecodePanel: () => null,
+}));
+
+vi.mock('/utils/databaseUpload', () => ({
+  uploadConvertedFiles: vi.fn(),
+  CONVERT_AND_SEND_UPLOAD_OPTIONS: {},
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/hooks/useWorkSessionSync', () => ({
+  AUTOSAVE_DEBOUNCE_MS: 3000,
+  useWorkSessionSync: () => ({
+    isReadOnly: false,
+    saveIndicator: 'idle' as const,
+    scheduleAutoSave: mockScheduleAutoSave,
+    persistSession: mockPersistSession,
+    flushAutoSave: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock('@/app/components/WorkHistorySidebar', () => ({
+  WorkHistorySidebar: () => null,
+}));
+
+vi.mock('jszip', () => ({
+  default: class JSZip {
+    file(name: string) {
+      zipEntries.push(name);
+      return this;
+    }
+    generateAsync() {
+      return Promise.resolve(new Blob(['zip']));
+    }
+  },
+}));
+
+vi.mock('@/app/components/DatabaseUploadDialog', () => ({
+  DatabaseUploadDialog: () => null,
+}));
+vi.mock('@/app/components/UserPreferencesDialog', () => ({
+  UserPreferencesDialog: () => null,
+}));
+vi.mock('@/app/components/ThemeToggle', () => ({ ThemeToggle: () => null }));
+vi.mock('@/app/components/IcaoAutocomplete', () => ({
+  IcaoAutocomplete: () => null,
+}));
+vi.mock('@/app/components/AirportDetailsCard', () => ({
+  AirportDetailsCard: () => null,
+}));
+vi.mock('@/app/components/ErrorLogPanel', () => ({ ErrorLogPanel: () => null }));
+
+const defaultProps = {
+  onLogout: vi.fn(),
+  userEmail: 'user@example.com',
+};
+
+const SAMPLE_TAC = 'METAR KJFK 071251Z 18008KT 10SM FEW250 22/14 A2992';
+
+describe('BUG-2026-08-07 output filename download stale (#904)', () => {
+  beforeEach(() => {
+    mockConvertMetarToIwxxm.mockReset();
+    mockPersistSession.mockReset();
+    mockPersistSession.mockResolvedValue(null);
+    mockScheduleAutoSave.mockReset();
+    zipEntries.length = 0;
+    mockConvertMetarToIwxxm.mockResolvedValue({
+      results: [
+        {
+          iwxxm_xml: '<?xml version="1.0"?><iwxxm:METAR/>',
+          tac_input: SAMPLE_TAC,
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('Download uses the current Output filename after rename (not convert-time)', async () => {
+    const user = userEvent.setup();
+    let downloadedName = '';
+    const createUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:rename-download');
+    const revokeUrlSpy = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined);
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      });
+
+    const { container } = render(
+      <FileConverter {...defaultProps} accessToken="token" />,
+    );
+
+    const filenameInput = screen.getByTestId('output-filename-input');
+    await user.clear(filenameInput);
+    await user.type(filenameInput, 'first_name');
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await user.type(textarea, SAMPLE_TAC);
+    await user.click(screen.getByTestId('convert-button'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /download first_name\.txt as xml/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.clear(filenameInput);
+    await user.type(filenameInput, 'second_name');
+    expect(screen.getByTestId('output-filename-preview')).toHaveTextContent(
+      'second_name.xml',
+    );
+
+    // Card label may still show convert-time originalName; download attribute uses live field.
+    await user.click(
+      screen.getByRole('button', { name: /download first_name\.txt as xml/i }),
+    );
+
+    await waitFor(() => {
+      expect(downloadedName).toBe('second_name.xml');
+    });
+
+    createUrlSpy.mockRestore();
+    revokeUrlSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+
+  it('Download All ZIP members use the current Output filename after rename', async () => {
+    const user = userEvent.setup();
+    const createUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:rename-zip');
+    const revokeUrlSpy = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined);
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    const { container } = render(
+      <FileConverter {...defaultProps} accessToken="token" />,
+    );
+
+    const filenameInput = screen.getByTestId('output-filename-input');
+    await user.clear(filenameInput);
+    await user.type(filenameInput, 'first_name');
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await user.type(textarea, SAMPLE_TAC);
+    await user.click(screen.getByTestId('convert-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/first_name\.txt/)).toBeInTheDocument();
+    });
+
+    await user.clear(filenameInput);
+    await user.type(filenameInput, 'second_name');
+    expect(screen.getByTestId('output-filename-preview')).toHaveTextContent(
+      'second_name.xml',
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /download all 1 converted files as zip/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(zipEntries).toContain('second_name.xml');
+      expect(zipEntries).not.toContain('first_name.xml');
+    });
+
+    createUrlSpy.mockRestore();
+    revokeUrlSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+});

--- a/apps/frontend/src/utils/outputFilename.test.ts
+++ b/apps/frontend/src/utils/outputFilename.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_OUTPUT_BASENAME,
   sanitizeOutputFilename,
   manualOutputName,
+  manualDownloadXmlName,
   outputArchiveName,
 } from './outputFilename';
 
@@ -56,6 +57,22 @@ describe('manualOutputName', () => {
 
   it('sanitizes the base before applying a suffix', () => {
     expect(manualOutputName('my/out.xml', 0, 2)).toBe('out_1.txt');
+  });
+});
+
+describe('manualDownloadXmlName', () => {
+  it('uses the current field value as .xml (not a convert-time baked name)', () => {
+    expect(manualDownloadXmlName('second_name', 0, 1)).toBe('second_name.xml');
+    expect(manualDownloadXmlName('first_name', 0, 1)).toBe('first_name.xml');
+  });
+
+  it('suffixes _N for multi-line batches', () => {
+    expect(manualDownloadXmlName('report', 0, 2)).toBe('report_1.xml');
+    expect(manualDownloadXmlName('report', 1, 2)).toBe('report_2.xml');
+  });
+
+  it('falls back to manual_input.xml when blank', () => {
+    expect(manualDownloadXmlName('', 0, 1)).toBe('manual_input.xml');
   });
 });
 

--- a/apps/frontend/src/utils/outputFilename.ts
+++ b/apps/frontend/src/utils/outputFilename.ts
@@ -54,6 +54,25 @@ export function manualOutputName(base: string, index: number, total: number): st
 }
 
 /**
+ * Build the download XML filename from the *current* Output filename field.
+ *
+ * Used after convert when the operator renames the field (#904) — must not
+ * rely on the convert-time {@link manualOutputName} baked into result state.
+ *
+ * @param base - Current raw Output filename field value.
+ * @param index - Zero-based index of the manual result.
+ * @param total - Total number of manual results in the batch.
+ * @returns The `.xml` download name (sanitized + multi-line suffix).
+ */
+export function manualDownloadXmlName(
+  base: string,
+  index: number,
+  total: number,
+): string {
+  return manualOutputName(base, index, total).replace(/\.(txt|metar)$/i, '.xml');
+}
+
+/**
  * Build the "Download All" ZIP archive name.
  *
  * Uses `<base>.zip` when the user set a custom name; otherwise the historical

--- a/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+++ b/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
@@ -10,7 +10,7 @@
 | **Session** | S051-output-filename-download-stale |
 | **Remediation path** | local-first (deploy only after explicit approval) |
 | **Branch** | `fix/output-filename-download-stale` |
-| **PR** | — |
+| **PR** | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/905 |
 
 ## Error description
 

--- a/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+++ b/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
@@ -1,0 +1,104 @@
+# BUG-2026-08-07 — Output filename change after convert ignored on Download
+
+| Field | Value |
+|-------|-------|
+| **Status** | fixed (pending verify / PR) |
+| **Feature** | F1 / F10 (workbench download UX); origin #664 |
+| **Severity** | medium (wrong download name; XML correct) |
+| **Classification** | domain / UI logic (not connectivity) |
+| **GitHub** | https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904 |
+| **Session** | S051-output-filename-download-stale |
+| **Remediation path** | local-first (deploy only after explicit approval) |
+| **Branch** | `fix/output-filename-download-stale` |
+| **PR** | — |
+
+## Error description
+
+After a successful manual-input conversion on the **production** operator workbench,
+changing **Output filename (optional)** does not update the name used when downloading.
+Download still uses the name captured at convert time. Live preview under the field
+updates; download does not. XML content is correct. Likely present since custom
+output filename (#664). [Corpus: product] F1/F10 · GitHub #904.
+
+## Error logs
+
+```
+N/A — UI QoL; no server traceback. Symptom is downloaded filename vs current field.
+```
+
+## Investigation
+
+| Time (UTC) | Note |
+|------------|------|
+| 2026-08-07 | Opened from `/14-hotfix` + #904; intent = new issue |
+| 2026-08-07 | Session S051 opened; branch `fix/output-filename-download-stale` |
+| 2026-08-07 | Confirmed in code: `handleDownloadSingle` / ZIP members use `file.originalName` only; ZIP *archive* name already uses live `outputFilename` |
+
+### Hypotheses
+
+1. **Primary:** On convert, `originalName` is set via `manualOutputName(outputFilename, …)` and never updated; download reads baked `originalName` → stale after rename. Preview uses live `sanitizeOutputFilename(outputFilename)`.
+2. Upload/file-queue results incorrectly renamed — out of scope per #904 (manual only).
+
+## Repro test
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Vitest UI | `apps/frontend/src/test/bug-2026-08-07-output-filename-download-stale.test.tsx` | **RED** then **GREEN** (2026-08-07) |
+| Pytest wiring | `tests/bugs/test_bug_2026_08_07_output_filename_download_stale.py` | **RED** then **GREEN** (2026-08-07) |
+
+### Root cause (agreed)
+
+Convert bakes `originalName` via `manualOutputName`; `handleDownloadSingle` / ZIP members
+used only that baked name. Preview already used live `outputFilename`.
+
+## Fix
+
+1. Add `manualDownloadXmlName(base, index, total)` in `apps/frontend/src/utils/outputFilename.ts`.
+2. Tag manual results with `liveOutputSlot: { index, total }` on convert.
+3. `resolveDownloadXmlName` uses live `outputFilename` when `liveOutputSlot` is set; file
+   uploads keep `originalName` → `.xml`.
+4. Wire single Download + ZIP members through that resolver (archive name already live).
+
+Files: `outputFilename.ts`, `outputFilename.test.ts`, `FileConverter.tsx`, bug Vitest +
+pytest wiring, no card aria/label churn (download *attribute* is the contract).
+
+## Interview record
+
+- `hotfix_intent`: Report a new issue (option 1)
+- AskQuestion tool unavailable; markdown options fallback
+- Source link: GitHub #904
+- Batch A: `symptom_type`=Wrong output; `where_seen`=Production (operator app); `when_started`=Since #664 (likely always)
+- Batch B: `repro_frequency`=Every time; `repro_environment`=Both production and local
+- Batch C: `user_severity`=Medium; `evidence_available`=Partial (#904); `already_tried`=Nothing
+- `remediation_path`: Fix locally first — deploy only after approval
+- `confirm_hotfix_plan`: Proceed
+- Step 0.5: success=behavior; checks=full CI parity + main CI; monitoring=user watches prod
+- `bug_repro_matches`: Yes — matches (Vitest: expected `second_name.xml`, got `first_name.xml`)
+- `bug_root_cause`: Agree — proceed to fix
+- `bug_verified`: Yes — verified
+
+## Verification plan
+
+| Item | Choice |
+|------|--------|
+| **Success criterion** | After convert, rename Output filename → Download (and ZIP members) use new sanitized name; XML unchanged |
+| **Checks** | Full main CI parity (local) + `gh` CI on `main` after merge |
+| **Monitoring** | User watches production after deploy |
+
+### Verification log (local)
+
+| Check | Result |
+|-------|--------|
+| Vitest bug repro + `outputFilename` + FileConverter | pass |
+| Frontend `npm run lint` + full `npm test` (798 passed) | pass |
+| `make test-bugs` (incl. this module) | 56 passed, 5 skipped |
+| Ruff on new pytest | pass |
+| PR branch / main CI (`gh`) | pending push/merge |
+
+## Prevention & countermeasures
+
+*(pending Phase 5)*
+
+## Cursor rule
+
+*(pending Phase 5.1)*

--- a/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+++ b/docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
@@ -93,7 +93,8 @@ pytest wiring, no card aria/label churn (download *attribute* is the contract).
 | Frontend `npm run lint` + full `npm test` (798 passed) | pass |
 | `make test-bugs` (incl. this module) | 56 passed, 5 skipped |
 | Ruff on new pytest | pass |
-| PR branch / main CI (`gh`) | pending push/merge |
+| PR branch CI (`CI/CD Pipeline` [31213294994](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31213294994)) | **success** |
+| Main CI after merge | pending merge |
 
 ## Prevention & countermeasures
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,6 +25,7 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
+| [S051-output-filename-download-stale](S051-output-filename-download-stale/session-brief.md) | hotfix | in_progress | #904 output filename stale on Download; BUG-2026-08-07 | fix/output-filename-download-stale | 2026-08-07 | — |
 | [S049-operator-sources-briefing](S049-operator-sources-briefing/session-brief.md) | feature | in_progress | Operator UI source-centric runbook + PPT pack; EV-041 Lean docs | evolve/EV-041-operator-sources-briefing | 2026-08-06 | — |
 | [S048-workbench-lint-ux](S048-workbench-lint-ux/session-brief.md) | feature | completed | Workbench lint UX + prefs + official AHL/Collect + catalog source; EV-040; PR #893; #894 | evolve/EV-040-workbench-lint-ux | 2026-08-06 | 2026-08-06 |
 | [S047-sql-ingest-live-e2e](S047-sql-ingest-live-e2e/session-brief.md) | feature | completed | F16 live local multi-DB SQL ingest Playwright + teardown; EV-039; PR #891 | evolve/EV-039-sql-ingest-live-e2e → main @ fea30aba | 2026-08-06 | 2026-08-06 |
@@ -72,11 +73,11 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 ## Active session
 
-**None** (`active_session: null`).
+**[S051-output-filename-download-stale](S051-output-filename-download-stale/session-brief.md)** — hotfix / 14-hotfix  
+Fix [#904](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904): Output filename field changes after convert must apply to Download / ZIP member names.  
+Branch: `fix/output-filename-download-stale` (pending create). Bug report: `docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md`.
 
-Last closed: **[S043-rule-source-traceability](S043-rule-source-traceability/session-brief.md)** (EV-035) —
-deepen F6/F12/F15/F2 provenance map; deploy 12/13 waived; tip on
-`evolve/EV-035-rule-source-traceability`. Prior: S042 / EV-034.
+Prior closed: **[S050-remove-db-tools-operator-throughput](S050-remove-db-tools-operator-throughput/session-brief.md)** (EV-042) — PR #899 @ e3d1c7c8.
 
 Epic [#846](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/846) remains **OPEN** for residual children
 (#869/#870/#872; #871 closeable). S040 remains suspended eligible to resume (do not auto-resume).

--- a/docs/sessions/S051-output-filename-download-stale/routing-plan.md
+++ b/docs/sessions/S051-output-filename-download-stale/routing-plan.md
@@ -1,0 +1,19 @@
+# Routing plan — S051-output-filename-download-stale
+
+**Type:** hotfix · **Orchestrator:** 14-hotfix  
+**Path:** `14→(15 optional after deploy)`  
+**Status:** in_progress
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 14-hotfix | yes | full | **in_progress** | #904 / BUG-2026-08-07-output-filename-download-stale; local-first |
+| 15-service-health | no | when_deployed | pending | optional after deploy (explicit approval required) |
+
+## Intent
+
+After a successful manual-input conversion, changing **Output filename (optional)** must update the name used for Download and ZIP member names — not only the live preview under the field.
+
+## References
+
+- Bug report: `docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md`
+- GitHub: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904

--- a/docs/sessions/S051-output-filename-download-stale/session-brief.md
+++ b/docs/sessions/S051-output-filename-download-stale/session-brief.md
@@ -1,0 +1,22 @@
+# Session brief — S051-output-filename-download-stale
+
+| Field | Value |
+|-------|-------|
+| **Type** | hotfix |
+| **Intent** | Fix #904 — after convert, Output filename field changes must apply to Download / ZIP member names (BUG-2026-08-07-output-filename-download-stale) |
+| **Branch** | `fix/output-filename-download-stale` (pending create from `main@d6f6fa04`) |
+| **Orchestrator** | 14-hotfix |
+| **Bug report** | [docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md](../../bug-reports/BUG-2026-08-07-output-filename-download-stale.md) |
+| **GitHub** | [#904](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904) |
+| **Remediation** | local-first (deploy only after explicit approval) |
+| **Started** | 2026-08-07 |
+| **Status** | in_progress |
+
+## Routing
+
+1. `14-hotfix` — full (**in_progress**)
+2. `15-service-health` — optional after deploy (pending)
+
+## Notes
+
+Opened via workflow-state-manager after S050/EV-042 close. Related origin feature: #664 (S006 custom output filename).

--- a/tests/bugs/test_bug_2026_08_07_output_filename_download_stale.py
+++ b/tests/bugs/test_bug_2026_08_07_output_filename_download_stale.py
@@ -1,0 +1,30 @@
+"""BUG-2026-08-07 / #904 — Download must use current Output filename after convert.
+
+Behavioral UI repro lives in:
+``apps/frontend/src/test/bug-2026-08-07-output-filename-download-stale.test.tsx``
+(frontend ``npm test``). This module locks the wiring contract for CI ``bugs``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_FILENAME = ROOT / "apps" / "frontend" / "src" / "utils" / "outputFilename.ts"
+FILE_CONVERTER = (
+    ROOT / "apps" / "frontend" / "src" / "app" / "components" / "FileConverter.tsx"
+)
+
+
+def test_bug_2026_08_07_manual_download_helper_exported() -> None:
+    """Helper derives download XML name from the *current* field (not baked name)."""
+    src = OUTPUT_FILENAME.read_text(encoding="utf-8")
+    assert "export function manualDownloadXmlName" in src
+
+
+def test_bug_2026_08_07_fileconverter_download_uses_current_field() -> None:
+    """Single + ZIP download paths must call the current-field helper for manuals."""
+    src = FILE_CONVERTER.read_text(encoding="utf-8")
+    assert "manualDownloadXmlName" in src
+    # Stale pattern: download attribute from convert-time originalName alone.
+    assert "a.download = file.originalName.replace" not in src

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,9 +3,41 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 50
+session_counter: 51
 evolve_cycle_counter: 42
-active_session: null
+active_session:
+  id: S051-output-filename-download-stale
+  type: hotfix
+  intent: "Fix #904 — after convert, Output filename field changes must apply to Download / ZIP member names (BUG-2026-08-07-output-filename-download-stale)"
+  status: in_progress
+  branch: fix/output-filename-download-stale
+  branch_base: main@d6f6fa04
+  branch_status: pending_create
+  orchestrator: 14-hotfix
+  evolve_cycle_id: null
+  artifacts_dir: docs/sessions/S051-output-filename-download-stale/
+  bug_report: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904
+  remediation_path: local-first
+  prior_session: S050-remove-db-tools-operator-throughput
+  routing_plan:
+  - stage: 14-hotfix
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-07'
+    skip_rationale: null
+    note: 'IN_PROGRESS — #904 output filename stale on Download; BUG-2026-08-07-output-filename-download-stale'
+  - stage: 15-service-health
+    required: false
+    mode: when_deployed
+    status: pending
+    skip_rationale: null
+    note: optional after deploy (explicit approval required)
+  current_stage: 14-hotfix
+  started_at: '2026-08-07'
+  started: '2026-08-07'
+  context_briefs: []
 sessions:
 - id: S050-remove-db-tools-operator-throughput
   type: feature
@@ -13706,29 +13738,30 @@ stages:
     note: 'IN_PROGRESS — H1–H5 PASS on live DOKS; PR #893 open; tip CD awaiting merge approval; tip commit 08c805eb'
     report: docs/sessions/S048-workbench-lint-ux/reports/deploy-smoke.md
   14-hotfix:
-    status: completed
-    session_id: S028-sigmet-multiline-split
-    current_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
-    bug_status: resolved
+    status: in_progress
+    session_id: S051-output-filename-download-stale
+    current_bug: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+    bug_status: investigating
+    github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904
     remediation_path: local-first
-    started_at: '2026-07-30'
-    started: '2026-07-30'
-    completed: '2026-07-30'
-    completed_at: '2026-07-30'
-    tip_sha: 17c93bd
-    tip_sha_full: 17c93bdeba4c26a5f9d43bdc2faf1906fcae39df
-    pr_number: 796
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/796
-    pr_status: merged
-    merge_sha: 17c93bd
-    note: 'S028 COMPLETE — PR #796 merged 17c93bd; main CI Deploy PASS; live API soft-preview PASS (posList+WEAKEN); UI production_verified deferred (user moved to F9 decode deepen)'
-    prior_session_id: S012-empty-bearer-lint-tac
-    prior_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    started_at: '2026-08-07'
+    started: '2026-08-07'
+    note: 'S051 OPEN — #904 output filename change after convert ignored on Download; BUG-2026-08-07-output-filename-download-stale; local-first'
+    prior_session_id: S028-sigmet-multiline-split
+    prior_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
     prior_bug_status: resolved
-    prior_pr_number: 721
-    prior_merge_sha: 6412b21
+    prior_completed: '2026-07-30'
+    prior_completed_at: '2026-07-30'
+    prior_pr_number: 796
+    prior_merge_sha: 17c93bd
+    prior_prior_session_id: S012-empty-bearer-lint-tac
+    prior_prior_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    prior_prior_bug_status: resolved
+    prior_prior_pr_number: 721
+    prior_prior_merge_sha: 6412b21
     notes:
-    - 2026-07-30 — S028 CLOSED — PR
+    - '2026-08-07 — S051-output-filename-download-stale open (#904 / BUG-2026-08-07-output-filename-download-stale); cleared S028 as current; routing 14-hotfix + optional 15 after deploy'
+    - 2026-07-30 — S028 CLOSED — PR #796 merged 17c93bd
     - 2026-07-30 — S028-sigmet-multiline-split open (BUG-2026-07-30 SIGMET/AIRMET multi-line split); pointer docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md; cleared S012 as current.
     - 2026-07-15 — S012-empty-bearer-lint-tac open (empty Bearer on lint-tac/decode-tac + lint UX issue details); cleared stale S009 pointer.
     - 2026-07-12 — Docs reorg via /14-hotfix rejected (not a bug/hotfix); deferred until S006 complete (S006-R4).
@@ -14055,6 +14088,31 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S051-open
+  date: '2026-08-07'
+  timestamp: '2026-08-07'
+  session_id: S051-output-filename-download-stale
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: 'Open hotfix session S051 for GitHub #904 output filename download stale'
+  summary: 'open_session S051/14-hotfix for BUG-2026-08-07-output-filename-download-stale; routing 14 required + optional 15 after deploy'
+  decision: |
+    D-S051-open — workflow-state-manager open_session after S050 close.
+    active_session=S051-output-filename-download-stale; session_counter=51.
+    Intent: Fix #904 — Output filename field changes after convert must apply to Download / ZIP member names.
+    Bug report: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+    GitHub: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904
+    Remediation: local-first; deploy only after explicit approval.
+    Branch: fix/output-filename-download-stale (pending_create from main@d6f6fa04).
+    stages.14-hotfix → in_progress.
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904
+  bug_report: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
+  branch: fix/output-filename-download-stale
+  tip_sha: d6f6fa04
+  note: 'open_session applied; active_session=S051-output-filename-download-stale; session_counter=51; stages.14-hotfix in_progress'
 - id: D-S050-13
   date: '2026-08-07'
   timestamp: '2026-08-07'


### PR DESCRIPTION
## Summary
- Fixes [#904](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904): after convert, renaming **Output filename** now applies to single Download and ZIP member names (was stuck on convert-time `originalName`).
- Adds `manualDownloadXmlName` + `liveOutputSlot` on manual results; file-upload names unchanged.
- Regression: Vitest UI repro + `tests/bugs` wiring guard. Bug report: `docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md`. Session S051.

[Corpus: product] F1 / F10 workbench download UX

## Test plan
- [x] Vitest `bug-2026-08-07-output-filename-download-stale` (rename → `second_name.xml`)
- [x] `make test-bugs` (includes new pytest module)
- [x] Frontend lint + full Vitest
- [ ] CI green on PR branch
- [ ] Manual: convert → rename Output filename → Download / Download All match preview
- [ ] Deploy only after explicit approval (local-first remediation)


Made with [Cursor](https://cursor.com)