### PR TITLE
[EV-043] DOKS staging + dual-branch CI/CD (#886)

### DIFF
--- a/.cursor/rules/optional/ci-after-push.mdc
+++ b/.cursor/rules/optional/ci-after-push.mdc
@@ -12,7 +12,9 @@ session, open a PR as ready, or mark work complete after `git push` without watc
 
 | Branch | Workflow | Must pass |
 |--------|----------|-----------|
-| Any | `.github/workflows/ci-cd.yml` | `backend-tests` (and other jobs for touched areas) |
+| Any | `.github/workflows/ci-cd.yml` | Test matrix (+ alembic/native as required) |
+| `stage` | same | **Deploy (stage)** + **Staging smoke** (after merge/push) |
+| `main` | same | **Deploy (main)** to prod; PRs need **Staging gate** |
 
 Workflows live at **monorepo root** (`../` from this backend package when checked out alone).
 

--- a/.cursor/rules/optional/doks-promote-from-stage.mdc
+++ b/.cursor/rules/optional/doks-promote-from-stage.mdc
@@ -1,0 +1,40 @@
+---
+description: Dual DOKS env_role + promote-from-stage (EV-043 / ADR-034 / #886)
+globs:
+  - .github/workflows/ci-cd.yml
+  - deploy/doks/**
+  - scripts/deploy/**
+  - docs/deploy.md
+alwaysApply: false
+---
+
+# DOKS promote-from-stage (F30 / ADR-034)
+
+## Environments
+
+| `env_role` | Branch | Namespace | Hosts |
+|------------|--------|-----------|-------|
+| `staging` | `stage` | `metar-iwxxm-staging` | `api\|app.staging.tac-to-iwxxm.com` |
+| `prod` | `main` | `metar-iwxxm` | `api\|app.tac-to-iwxxm.com` |
+
+Do **not** label staging URLs as production. Sole-stack language applies only when staging
+is absent; after EV-043 both exist.
+
+## Promote path
+
+1. Feature → PR → `stage` (required CI).
+2. Merge to `stage` → auto Deploy staging + **Staging smoke**.
+3. Promote: PR **`stage` → `main` only**. CI `staging-gate` must pass.
+4. Merge to `main` → auto Deploy production.
+
+Never push directly to `stage`/`main` when rulesets are enabled. Solo-dev: PR is the
+manual gate (no Environment reviewers required).
+
+## Secrets
+
+Staging `DATABASE_URL` must use DB `metar_iwxxm_staging` (or dedicated staging instance) —
+never prod `defaultdb`. Do not copy prod secrets into staging ConfigMaps/docs.
+
+## Citations
+
+[Corpus: product §F30] [Corpus: adr/ADR-034] [Corpus: deploy]

--- a/.cursor/skills/12-verify-deploy/SKILL.md
+++ b/.cursor/skills/12-verify-deploy/SKILL.md
@@ -6,7 +6,11 @@ description: >
   secrets, browser connectivity readiness (CORS + VITE_*), data management, rollback plan,
   and resource allocation against the deployment spec.
 ---
-
+<!--
+Personal skill (project-agnostic). Paths like docs/ and workflow-state.yaml refer to the
+*active workspace project*, not this skills directory. Fill {{PLACEHOLDER}} tokens from
+the project's docs/CORPUS.md, feature-list, and deploy docs.
+-->
 # 12 — Verify Deploy Strategy
 
 Pre-deploy gate verifying that the deployment strategy planned in Stage 04 still holds
@@ -15,13 +19,42 @@ after implementation, and all deployment prerequisites are met.
 **Preamble:** [pipeline-preamble.md](../pipeline-preamble.md) — shared conventions for stages 00–19.
 **Sessions:** [sessions-reference.md](../sessions-reference.md) — requires `active_session` unless waived; reports under `docs/sessions/{id}/reports/`.
 **Cross-cutting:** [considerations.md](../considerations.md), [connectivity-gates.md](../connectivity-gates.md).
-**State agent:** [workflow-state-manager](../../agents/workflow-state-manager.md) — mandatory read/update.
+**State agent:** project `.cursor/agents/workflow-state-manager.md` if present; else edit `workflow-state.yaml` per [workflow-state-reference.md](../workflow-state-reference.md) — mandatory read/update.
 
 ## Connectivity (stage 12)
 
 Run **Agent 6** and populate deploy-checklist connectivity rows (H0c, VITE matrix, CORS origins,
 `verify_connectivity.sh` planned). Sign-off means “ready for 13 including H4–H5,” not API-only.
 See connectivity-gates §Stage 12.
+
+## Single-env / live role
+
+Before marking deploy-ready, resolve **what the target stack is**:
+
+| Situation | `env_role` | Agent behavior |
+|-----------|------------|----------------|
+| Distinct non-prod + prod stacks exist | `staging` then `prod` | Keep separate checklists; never treat staging URLs as prod |
+| **Only one** deployed stack (names may still say “staging”) | `staging_as_live` / **live = prod** | Treat that stack as **production** in AskQuestions, checklists, and reports |
+| Explicit second env planned but not provisioned | `staging_as_live` | Same as sole-stack; do not imply a safer non-prod cutover target |
+
+**TAC-to-IWXXM (ADR-034 / EV-043):** Dual DOKS envs — `stage`→`metar-iwxxm-staging`
+(`api\|app.staging.tac-to-iwxxm.com`); `main`→`metar-iwxxm` (prod hosts). Prefer
+`env_role: staging` then `prod`. Promote = PR **stage→main** after **Staging smoke** /
+**Staging gate** green. Do not use sole-stack language when both namespaces exist.
+
+Record `env_role` on the deploy checklist and in the session note. Prefer a project ADR when the
+workspace documents single-env topology.
+
+## CI/CD tip gate
+
+Tip SHA must have **required** workflows green before deploy-ready / promote:
+
+- Always: project CI workflow(s)
+- On default branch / live cutover: deploy-preflight and any CD the project treats as a gate
+
+**Red, cancelled, or missing run** → **hard stop**. Do not continue 12→13 or promote without an
+explicit **waiver AskQuestion** (first option = wait/fix; last = explain). Prefer the project’s
+CI watch script (if present) and treat non-zero exit as blocking.
 
 ## Prerequisites
 
@@ -112,7 +145,7 @@ Launch parallel agents:
 - Read [connectivity-gates.md](../connectivity-gates.md)
 - Verify `tests/unit/test_cors_policy.py` exists and passes (`H0c`)
 - Verify each FastAPI `create_app` uses `deployed-service_shared_schemas.cors.configure_cors`
-- Cross-check `docs/ops/staging-secrets-matrix.md`: every `VITE_*` row has a matching API URL + `METAR_CORS_ORIGINS` entry
+- Cross-check `docs/ops/staging-secrets-matrix.md`: every `VITE_*` row has a matching API URL + `{{ENV_PREFIX}}_CORS_ORIGINS` entry
 - Confirm `scripts/deploy/verify_connectivity.sh` and `tests/smoke/test_staging_connectivity.py` are present
 - Return: pass/fail + missing wiring items (do **not** assume H1–H3 alone is enough)
 
@@ -146,7 +179,7 @@ Common failure modes to check:
 - Network/port binding issues
 - Cold start timeout
 - Memory exhaustion
-- **Auth/CORS / browser connectivity** — static frontend on different origin than API; mitigated by `METAR_CORS_ORIGINS` + H4/H5 gates (see connectivity-gates)
+- **Auth/CORS / browser connectivity** — static frontend on different origin than API; mitigated by `{{ENV_PREFIX}}_CORS_ORIGINS` + H4/H5 gates (see connectivity-gates)
 
 ### Phase 3 — Rollback Plan Review
 
@@ -187,7 +220,7 @@ Write `{artifacts_dir}/reports/deploy-checklist.md``:
 - [ ] Rollback plan reviewed
 - [ ] H0c CORS unit tests pass (`pytest tests/unit/test_cors_policy.py`)
 - [ ] Frontend `VITE_*` ↔ API URL matrix complete (connectivity-gates §Wiring)
-- [ ] `METAR_CORS_ORIGINS` documented per API service for staging/prod
+- [ ] `{{ENV_PREFIX}}_CORS_ORIGINS` documented per API service for staging/prod
 - [ ] Post-deploy H4–H5 command documented (`verify_connectivity.sh`)
 
 ## Failure Mitigations
@@ -247,3 +280,6 @@ Next step: 13-deploy-smoke
 3. **Rollback is required**: Every deployment must have a documented rollback procedure.
 4. **User approves risks**: Every accepted risk requires explicit user acknowledgment.
 5. **Checklist persists**: The deploy checklist is a reusable artifact for future deploys.
+6. **Single-env honesty**: If only one stack exists, call it **live/prod** in user-facing text —
+   do not imply a safer “staging-only” cutover.
+7. **CI/CD tip green**: Red tip SHA blocks deploy-ready unless the user waives.

--- a/.cursor/skills/13-deploy-smoke/SKILL.md
+++ b/.cursor/skills/13-deploy-smoke/SKILL.md
@@ -5,7 +5,11 @@ description: >
   CORS + frontend bundle wiring), health checks, changelog, and monitoring baseline. Final
   pipeline stage. Blocking — user must approve deployment results.
 ---
-
+<!--
+Personal skill (project-agnostic). Paths like docs/ and workflow-state.yaml refer to the
+*active workspace project*, not this skills directory. Fill {{PLACEHOLDER}} tokens from
+the project's docs/CORPUS.md, feature-list, and deploy docs.
+-->
 # 13 — Deploy & Smoke Check
 
 Deploy the application and verify it works with smoke tests and health checks.
@@ -13,12 +17,38 @@ Deploy the application and verify it works with smoke tests and health checks.
 **Preamble:** [pipeline-preamble.md](../pipeline-preamble.md) — shared conventions for stages 00–19.
 **Sessions:** [sessions-reference.md](../sessions-reference.md) — requires `active_session` unless waived; reports under `docs/sessions/{id}/reports/`.
 **Cross-cutting:** [considerations.md](../considerations.md), [connectivity-gates.md](../connectivity-gates.md).
-**State agent:** [workflow-state-manager](../../agents/workflow-state-manager.md) — mandatory read/update.
+**State agent:** project `.cursor/agents/workflow-state-manager.md` if present; else edit `workflow-state.yaml` per [workflow-state-reference.md](../workflow-state-reference.md) — mandatory read/update.
 
 ## Connectivity (stage 13)
 
 Mandatory sequence: **H0c** (pre) → deploy → **H1–H3** → **`verify_connectivity.sh`** (H4–H5).
 Do not mark `deployed` without H4–H5 pass or user-waived checklist entry. See connectivity-gates §Stage 13.
+
+## Single-env / live role
+
+Inherit `env_role` from 12 (or re-resolve). If `staging_as_live` / sole stack:
+
+- Smokes and promotes target **production traffic** — say so in every AskQuestion and report.
+- Do not describe the cutover as “staging-only” when no distinct prod stack exists.
+- Prefer labeling results as **live** even when hostnames still contain `staging`.
+
+**TAC-to-IWXXM (ADR-034):** When staging exists, smoke **staging** at
+`api|app.staging.tac-to-iwxxm.com` (or CI **Staging smoke**) before promoting via PR
+`stage`→`main`; then smoke **prod** at `api|app.tac-to-iwxxm.com`. Never call staging URLs
+production.
+
+## CI/CD tip gate
+
+Before deploy, promote, or cutover CLI: tip SHA required workflows must be **green**.
+Red/cancelled → **hard stop** unless the user explicitly waives via AskQuestion.
+
+## Health ≠ primary-journey-ready
+
+Liveness/`/health` (and dependency probes) can pass while the **primary user journey** fails.
+
+- **H3** (primary journey smoke): timeout, hang, or hard error = **FAIL** even if H1 health is green.
+- Do not mark `health_tiers.h3: pass` on health-only evidence.
+- On H3 P0 failure during an evolve cycle: recommend pause **16-evolve** → **14-hotfix**.
 
 ## Prerequisites
 
@@ -125,13 +155,14 @@ Record every commit in `workflow-state.yaml` §`git_history.commits` with
 
 ### Phase 1.5 — Pre-deploy integration (T1)
 
-Before production deploy:
+Before production / live deploy (`env_role: prod` or `staging_as_live`):
 
-1. T0 green: `pytest tests/e2e/ -m "e2e and not live"`
-2. **H0c green:** `pytest tests/unit/test_cors_policy.py` (browser CORS on all FastAPI apps)
-3. Migrations apply on staging DB: `alembic upgrade head`
-4. Optional: `scripts/rag_smoke.py` against local TestClient
-5. **Connectivity readiness (12):** `{artifacts_dir}/reports/deploy-checklist.md`` includes H0c + `VITE_*` / `METAR_CORS_ORIGINS` rows per [connectivity-gates.md](../connectivity-gates.md)
+1. T0 green: `pytest tests/e2e/ -m "e2e and not live"` (or project equivalent)
+2. **H0c green:** CORS unit gate when the project uses connectivity-gates
+3. Migrations apply on **target** DB (the live stack when single-env)
+4. Optional: local smoke against TestClient
+5. **Connectivity readiness (12):** deploy-checklist includes H0c + frontend/API origin rows
+6. **CI/CD tip green**: project CI watch for tip SHA — hard stop if red
 
 **Deploy gate**: T1 fail → 14-hotfix or fix-in-place; do not deploy.
 
@@ -161,22 +192,24 @@ Capture full stdout/stderr.
 Run **backend** smokes first, then **browser connectivity** (H4–H5). Backend-only pass is **not**
 sufficient for deployed service hybrid deploys — see [connectivity-gates.md](../connectivity-gates.md).
 
-**Operator env (staging):**
+**Operator env (live stack — names may still say “staging”):**
 
 ```bash
-uv run --with pydo --with pyyaml scripts/deploy/do_apps.py urls --frontend
-# Set METAR_STAGING_ADMIN_API_URL from Modal deploy output
-export METAR_STAGING_ADMIN_API_URL=https://deployed-service--deployed-service-data-management-fastapi-app.modal.run
+# Resolve URLs via project deploy helpers; export API/frontend bases for smokes
+export {{ENV_PREFIX}}_STAGING_ADMIN_API_URL=https://{{STAGING_URL_HOST}}
 ```
 
+When `env_role` is `staging_as_live` / sole stack, state in the report: **these URLs are production**.
+
 **Agent 1 — API connectivity (H1)**:
-- `bash scripts/deploy/staging_smoke.sh` or `tests/smoke/test_staging_health.py -m live`
-- Verify TLS, `/health` 200 on ChatRAG + write API
-- Return: pass/fail, response times
+- Project staging/live smoke script or health tests (`-m live` when used)
+- Verify TLS and liveness/`/health` on public APIs; dependency probes ok when applicable
+- Return: pass/fail, response times — **H1 green alone does not pass the stage**
 
 **Agent 2 — Functional smoke (H2–H3)**:
-- H2: DB pool + Alembic head (`staging_h2.py`)
-- H3: `POST /api/v1/ask` with fixture question (warm LLM first if cold — see deploy-report)
+- H2: DB / migration head (or project equivalent)
+- H3: primary user-journey request (warm cold dependencies first if needed)
+- **H3 timeout / hang / error = FAIL** even if H1 health is green
 - Negative API paths per test-plan / config-spec where applicable
 - Return: pass/fail, response details
 

--- a/.cursor/skills/15-service-health/SKILL.md
+++ b/.cursor/skills/15-service-health/SKILL.md
@@ -8,7 +8,11 @@ description: >
   bugs. Use for production health, ambiguous API/DB errors, periodic ops, post-deploy verification,
   or confirming main CI passes after merge/hotfix.
 ---
-
+<!--
+Personal skill (project-agnostic). Paths like docs/ and workflow-state.yaml refer to the
+*active workspace project*, not this skills directory. Fill {{PLACEHOLDER}} tokens from
+the project's docs/CORPUS.md, feature-list, and deploy docs.
+-->
 # 15 — Service Health
 
 Investigate the **live** deployment: correct version, database ready, API paths working,
@@ -20,7 +24,7 @@ and alignment with `docs/deploy.md` §Integration — without assuming a hotfix 
 **Preamble:** [pipeline-preamble.md](../pipeline-preamble.md)
 **Sessions:** [sessions-reference.md](../sessions-reference.md) — requires `active_session` unless waived; reports under `docs/sessions/{id}/reports/`.
 **Cross-cutting:** [considerations.md](../considerations.md), [deployment-catalog.md](../deployment-catalog.md), [connectivity-gates.md](../connectivity-gates.md).
-**State agent:** [workflow-state-manager](../../agents/workflow-state-manager.md)
+**State agent:** project `.cursor/agents/workflow-state-manager.md` if present; else edit `workflow-state.yaml` per [workflow-state-reference.md](../workflow-state-reference.md)
 
 ## Connectivity (stage 15)
 
@@ -60,6 +64,24 @@ Per-run reports under `docs/service-health-reports/` (ephemeral).
 | **Behavior** | Do primary API flows work end-to-end? | Approved smokes return expected status/body |
 
 Record **Infra overall**, **E2E overall**, and **Overall** separately in the report.
+
+## Health ≠ primary-journey-ready
+
+Liveness/`/health` and dependency probes can be green while the **primary user journey** fails
+(hang, timeout, wrong runtime).
+
+- If H3 is in scope: **H3 fail or hang ⇒ Overall FAIL** (and Behavior FAIL) even when H1 is PASS.
+- Do not report Overall PASS on infra-only evidence when the requested depth includes H3.
+- On H3 P0 during an active evolve cycle: recommend pause **16-evolve** → **14-hotfix**.
+
+## Single-env / live role
+
+If only one deployed stack exists (`env_role: staging_as_live`), label checks and reports as
+**live/prod** — do not imply a safer non-prod target.
+
+**TAC-to-IWXXM (ADR-034):** Dual DOKS — use `env_role: staging` vs `prod` and the matching
+hosts (`*.staging.tac-to-iwxxm.com` vs `api|app.tac-to-iwxxm.com`). Do not use sole-stack
+language when `metar-iwxxm-staging` is provisioned.
 
 ## Health tiers (default recommendations)
 

--- a/.cursor/skills/16-evolve/SKILL.md
+++ b/.cursor/skills/16-evolve/SKILL.md
@@ -2,14 +2,18 @@
 name: 16-evolve
 description: >
   Orchestrator for feature and new_service sessions: adds product capabilities, scope/API/arch
-  changes, breaking refactors, new dependencies, and multi-doc spec updates. Requires active_session
-  (opened by 00-context) with type feature or new_service. Mandates [Corpus:] citations for every
-  change/reference; interviews via AskQuestion when CORPUS docs are missing before implementing.
-  Interviews the user, routes selectively through stages 00–15 in delta mode per routing-plan.md.
-  Use after 00-context for structured change on an existing app — not for surgical bugs (14-hotfix)
-  or greenfield (pipeline).
+  changes, breaking refactors, new dependencies, and multi-doc spec updates. Uses Cursor Plan
+  mode as the default orchestrator for intake, Fn allocation, impact, and routing (Phase 0–1),
+  then Agent mode to run routed child stages; 04/07 keep their own Plan→Agent batch loops.
+  Requires active_session (00-context) with type feature or new_service. Every change must cite
+  the project doc corpus. Use after 00-context for structured change on an existing app — not
+  for surgical bugs (14-hotfix) or greenfield (pipeline).
 ---
-
+<!--
+Personal skill (project-agnostic). Paths like docs/ and workflow-state.yaml refer to the
+*active workspace project*, not this skills directory. Fill {{PLACEHOLDER}} tokens from
+the project's docs/CORPUS.md, feature-list, and deploy docs.
+-->
 # 16 — Evolve (Features & Large Changes)
 
 Take an **existing** service from change request (including **multiple new features in one
@@ -19,27 +23,42 @@ cycle**) through updated specs, verified plans, implementation, and redeploy —
 **Protocol:** [protocol-card.md](../protocol-card.md) — corpus-first, Lean/Standard/Full, batched state.
 **Detail:** [reference.md](reference.md) · [pipeline-preamble.md](../pipeline-preamble.md)
 **Sessions:** [sessions-reference.md](../sessions-reference.md) — requires `feature` or `new_service` active_session.
-**Routing:** [docs/skill-routing.md](../../docs/skill-routing.md) — when to use evolve vs hotfix vs pipeline.
+**Routing:** `docs/skill-routing.md` (active project) — when to use evolve vs hotfix vs pipeline.
 **Plan ↔ Agent:** [plan-mode-loop.md](../plan-mode-loop.md) — **Plan mode is the default
   orchestrator** for Phase 0–1 (scope → Fn → routing); Agent runs child stages; 04/07 Plan
   separately for execution batches.
-**State agent:** [workflow-state-manager](../../agents/workflow-state-manager.md) — mandatory read/update.
+**State agent:** project `.cursor/agents/workflow-state-manager.md` if present; else edit `workflow-state.yaml` per [workflow-state-reference.md](../workflow-state-reference.md) — mandatory read/update.
 
-**Corpus:** Open [docs/CORPUS.md](../../docs/CORPUS.md) rows for **touched features only** — not the
-entire minimal corpus on every cycle. Domain/guides opt-in. Enforced by
-[docs-corpus.mdc](../../rules/core/docs-corpus.mdc).
-
-**Corpus citations (mandatory):** Every change, claim, scope decision, routing rationale, and
-cross-doc reference in the cycle must carry `[Corpus: <id>]` or `[Corpus: <id> §section]`.
-Ephemeral session/bug/ARCHIVE docs are not substitutes. If no CORPUS row covers the work →
-**block** and interview (AskQuestion) about adding documentation — do not invent standing
-docs or implement from chat. See §Corpus citation gate.
+**Corpus:** Open `docs/CORPUS.md` (active project) rows for **touched features only** — not the
+entire minimal corpus on every cycle. Domain/guides opt-in. See **Doc corpus citations** below
+(and always-apply rule `doc-corpus-citations` — canonical:
+`packages/agent-tooling/docs/conventions/doc-corpus-citations.md`).
 
 **Connectivity:** Browser-facing changes → applicable [connectivity-gates.md](../connectivity-gates.md)
 rows (at minimum 01/04 delta, 07, 12–13 with H4–H5 when UI ships).
 
 **User is the source of truth.** Interview before editing specs or code. Every ambiguous,
 uncertain, or contradictory finding uses **AskQuestion** — never guess.
+
+## Doc corpus citations (mandatory)
+
+Every **change**, **claim**, and **reference** in an evolve cycle must cite the doc corpus.
+
+| Form | When |
+|------|------|
+| `[Corpus: <id>]` | `docs/CORPUS.md` exists and lists the row |
+| `[path §section]` | No corpus id yet — still cite the standing doc |
+| `[Corpus: WAIVED — <topic>; reason: …; decided: EV-NNN\|date]` | Coverage missing and user chose proceed |
+
+**Missing coverage** (`CORPUS.md` absent, no row, or no authoritative section):
+
+1. **Interview** via AskQuestion — recommend **add doc/row now**; always offer waive-and-proceed and re-scope.
+2. **Proceed only** with an explicit **waiver citation** (table above) if the user chooses waive.
+3. Log the waiver under `docs/decisions/evolve-decisions.md` §Cycle {id}.
+4. **Do not** invent normative docs silently; draft only after the user picks add-now.
+
+Pass citation obligations to child stages in evolve context (`corpus_cites` / waiver ids). Checkpoint
+digests and impact/routing plans must list cites (or waivers) for each Fn and artifact edit.
 
 ## When to use
 
@@ -151,6 +170,8 @@ only when the user already approved a complete evolve-plan-card this turn.
 
 **Every user-facing question must use the AskQuestion tool** — same protocol as
 [14-hotfix](../14-hotfix/SKILL.md) and [considerations.md](../considerations.md) §7.
+If the AskQuestion tool is unavailable, use the **markdown numbered-options fallback** in
+considerations §7 — same option rules; do not invent answers.
 
 | Situation | Pattern |
 |-----------|---------|
@@ -158,12 +179,12 @@ only when the user already approved a complete evolve-plan-card this turn.
 | Single gate or approval | One AskQuestion; first option = recommendation; last = `Let me explain / provide more context` |
 | Impact / stage routing | Present recommended stage list; user confirms or adjusts |
 | Ambiguity / contradiction | Category label in prompt: `[Decision]`, `[Ambiguity]`, `[Contradiction]`, `[Uncertainty]` |
+| **Missing corpus coverage** | AskQuestion: add doc/row now (recommended) / waive-and-proceed / re-scope; record cite or waiver |
 | Phase gate failure | List unmet criteria; **block** until resolved (no silent proceed) |
 | Phase checkpoint (A–D, deploy) | Progress digest + AskQuestion before next phase |
 | **UI in scope** | AskQuestion: offer a **non-deployed** (local) UI preview — see §UI preview |
-| **Missing CORPUS coverage** | AskQuestion `[Decision]`: add/update corpus docs before continuing — see §Corpus citation gate |
 
-Do not post interview prompts as markdown lists expecting inline replies.
+Do not invent user answers. Prefer the AskQuestion tool; markdown lists are allowed only as the §7 fallback.
 
 ## UI preview (when the cycle includes UI)
 
@@ -218,6 +239,25 @@ On invocation:
 After every substep: agent `update` on the active cycle (status, `current_stage`, artifacts, ADRs,
 checkpoints, `git_history`).
 
+### Mid-evolve interrupt → 14-hotfix
+
+When **live** H3 (or other P0 production) fails during an `in_progress` evolve cycle (often
+from 13-deploy-smoke or 15-service-health):
+
+1. **AskQuestion** immediately (do not silently keep building the next milestone):
+   - **Pause evolve and open 14-hotfix** (recommended)
+   - Continue evolve with explicit waiver (record risk)
+   - Investigate only (stay on 15) then re-AskQuestion
+   - Let me explain / provide more context
+2. If pause+14: set `evolve_cycles[].interrupted_by_hotfix: true`, `interrupt_reason`, and
+   `hotfix_ref` (BUG/PR when known). Update `HANDOFF.md` with an **Interrupt** section
+   (symptom, tip SHA, next = 14-hotfix).
+3. Resume **16-evolve** only after hotfix close AskQuestion clears the interrupt flag
+   (or the user explicitly abandons the cycle).
+
+Deploy gates still require tip CI/CD green and honest `env_role` (`staging` vs `prod` when
+dual DOKS envs exist — ADR-034; sole stack = live/prod only when staging is absent).
+
 ### Git branch and commit-as-you-go
 
 Each evolve cycle works on `evolve/{cycle-id}-{slug}`. Record branch via agent on creation.
@@ -252,45 +292,6 @@ Evolve summary + optional 14-hotfix / 15-service-health / 17-retrospective
 **Checkpoints:** mandatory digest + AskQuestion after phases A, B, C, D, and deploy
 ```
 
-## Corpus citation gate
-
-Before editing specs or code (and again at each phase gate), map every in-scope change to
-CORPUS rows. Cite in intake notes, routing plan, evolve-decisions, ADRs, commits/PRs, and
-child-stage deltas.
-
-| Change kind | Required citation |
-|-------------|-------------------|
-| New/changed Fn or acceptance | `[Corpus: product]` (+ `[Corpus: journeys]` if UI/E2E) |
-| Components / arch / constraints | `[Corpus: system-spec]` (+ `[Corpus: adr/…]` if decided) |
-| Config / env / deploy / deps | `[Corpus: tech-spec]` (+ satellite path) |
-| HTTP contract | `[Corpus: api]` |
-| Tests / smoke / CI gates | `[Corpus: tests]` |
-| Interview / evolve “why” | `[Corpus: decisions]` or `[Corpus: adr/…]` |
-
-**Missing doc procedure** (block until resolved):
-
-1. Name the gap: change + which CORPUS id/section is absent or insufficient.
-2. AskQuestion `[Decision]` — recommend the CORPUS path to add or extend.
-3. On approval: write the doc (update `docs/CORPUS.md` if membership changes; ADR/`decisions/`
-   when the choice is non-obvious), then continue with citations.
-4. On waiver: record in `docs/decisions/evolve-decisions.md` §Cycle {id}; do not implement
-   the uncovered slice.
-
-```
-prompt: "[Decision] No CORPUS coverage for <change>. Add documentation?
-
-  Needed: <product|system-spec|tech-spec|api|tests|adr|decisions> — <gap>"
-
-options:
-  1. "Add to <recommended path> — then continue"
-  2. "Add ADR / decisions entry only — then continue"
-  3. "New CORPUS member (update docs/CORPUS.md) — then continue"
-  4. "Waive for this change — document waiver"
-  5. "Let me explain / provide more context"
-```
-
-Detail checklist: [reference.md](reference.md) §Corpus citation checklist.
-
 ## Phase 0 — Change / feature intake
 
 **Default:** enter **Plan mode** (see §Plan mode as orchestrator) before locking scope.
@@ -306,17 +307,16 @@ Interview until the change is concrete enough for Fn allocation and impact analy
 |-------|--------|
 | **Intent** | What to change, why now, success criteria |
 | **Scope** | In/out of scope, breaking vs compatible, features affected |
-| **Corpus map** | CORPUS ids/sections that cover each change; gaps → §Corpus citation gate |
 | **Constraints** | Cost, latency, data, deploy target |
 
-Surface **immediately** via AskQuestion anything ambiguous, uncertain, or contradictory —
-including missing CORPUS coverage.
+Surface **immediately** via AskQuestion anything ambiguous, uncertain, or contradictory.
+Map each in-scope area to a corpus cite (or interview for missing docs / waiver) before the
+proceed gate.
 
 **Approval gate:** AskQuestion — "Proceed to allocate Fn(s) and impact analysis on this scope?"
-Include confirmed `[Corpus: …]` citations (or approved doc-add / waiver) in the prompt.
 
 Record approved scope in `docs/decisions/evolve-decisions.md` §Cycle {id} — Scope (via committed doc;
-agent records cycle metadata). Each scope bullet must cite CORPUS.
+agent records cycle metadata). Include **Corpus cites / waivers** for the approved scope.
 Update **Evolve Plan Card** Goal / In-Out / Features.
 
 ## Phase 1 — Fn allocation, impact analysis, routing
@@ -324,11 +324,8 @@ Update **Evolve Plan Card** Goal / In-Out / Features.
 Stay in or re-enter **Plan mode** until preset + stage list are approved; then **Agent**
 writes artifacts.
 
-1. **Multi-feature default:** one cycle, multiple Fn — assign next Fn ids from `feature-list.md`
-   (`[Corpus: product]`).
-2. List **docs to update** (CORPUS paths only for design gates) and **routing_plan** —
-   [reference.md](reference.md) (Stage routing matrix). Every listed doc change cites
-   `[Corpus: …]`; gaps → §Corpus citation gate before routing approval.
+1. **Multi-feature default:** one cycle, multiple Fn — assign next Fn ids from `feature-list.md`.
+2. List **docs to update** and **routing_plan** — [reference.md](reference.md) (Stage routing matrix).
 3. **Presets** (AskQuestion; default **Lean** on existing apps — see protocol-card):
 
    | Preset | Required stages (typical) |
@@ -355,6 +352,8 @@ feature_ids: [F19, F20, F21]
 scope: <approved Phase 0>
 affected_artifacts: [paths]
 delta_only: true
+corpus_cites: ["[Corpus: id]", "[docs/… §…]"]
+corpus_waivers: []   # explicit WAIVED cites if any
 ```
 
 Child skills invoke **workflow-state-manager** themselves; 16-evolve verifies transition checks
@@ -373,10 +372,10 @@ For **11-verify-impl** (when routed), include **per–acceptance-criterion** sta
 
 | Gate | Criteria |
 |------|----------|
-| **A→B** | Fn in feature-list; delta specs; 02 pass; 03 if routed; every delta cites CORPUS |
-| **B→C** | Execution-plan tasks approved; 05 pass; 06 if routed; tech deltas cite CORPUS |
-| **C→D** | All Fn tasks done; latest 08 pass; commits/PRs cite CORPUS for scope |
-| **Deploy** | 09+10 pass; 11+12 user-approved; deploy approved |
+| **A→B** | Fn in feature-list; delta specs; 02 pass; 03 if routed |
+| **B→C** | Execution-plan tasks approved; 05 pass; 06 if routed |
+| **C→D** | All Fn tasks done; latest 08 pass |
+| **Deploy** | 09+10 pass; 11+12 user-approved; deploy approved; tip CI/CD green unless waived; `env_role` honest (`staging`/`prod` or sole stack = live/prod) |
 
 On failure: list unmet criteria → AskQuestion → fix in place per considerations §2.
 
@@ -414,8 +413,8 @@ Same as pipeline — never re-run entire phases for verification failures.
 7. **Do not `@`-attach** full skill bodies — name + routing-plan is enough.
 8. **UI preview** — when UI is in scope, AskQuestion for a **non-deployed** preview; never
    present staging/production as that preview unless the user explicitly requests it.
-9. **Corpus citations** — every change/reference includes `[Corpus: …]`; missing coverage →
-   AskQuestion doc-add interview before continuing (never invent standing docs).
+9. **Corpus cites** — every change/reference includes `[Corpus: …]` / path+§ or an explicit
+   `[Corpus: WAIVED — …]` after interview; never silent undocumented invent.
 10. **Plan orchestrates, Agent executes** — Phase 0–1 (and re-routes) in Plan mode; persist
     Evolve Plan Card in Agent; do not implement feature code while still in Plan.
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,9 +3,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, stage]
   pull_request:
-    branches: [main, dev]
+    branches: [main, stage]
 
 env:
   REGISTRY: ghcr.io
@@ -20,10 +20,28 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   FRONTEND_VITE_SUPABASE_URL: ${{ secrets.FRONTEND_VITE_SUPABASE_URL }}
   FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
+  # Default bake URLs are prod; Deploy jobs override per environment (EV-043).
   FRONTEND_VITE_APP_URL: https://app.tac-to-iwxxm.com
   FRONTEND_VITE_API_BASE_URL: https://api.tac-to-iwxxm.com
 
 jobs:
+  # EV-043 / TC-F30-012 — PRs to main must promote from stage after Staging smoke.
+  staging-gate:
+    runs-on: ubuntu-latest
+    name: Staging gate
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    permissions:
+      contents: read
+      checks: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Enforce promote-from-stage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STAGING_API_URL: https://api.staging.tac-to-iwxxm.com
+        run: bash scripts/ci/staging_gate.sh
+
   # EV-036: remote validate job removed — lint/format/config on local pre-commit.
   # Unit matrix + coverage remain; Compose integration is local pre-push only.
   test:
@@ -408,14 +426,15 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # DEPLOY — build/push GHCR images (main push only), then roll DOKS (F30 / EV-034).
-  # Render hooks optional/non-blocking (suspended OK). Skip when GHCR login fails.
+  # DEPLOY — build/push GHCR images, then roll DOKS (F30 / EV-034 / EV-043).
+  # stage → staging ns; main → prod ns. Render hooks optional (main only).
   # ============================================================================
   deploy:
     runs-on: ubuntu-latest
-    name: Deploy
+    name: Deploy (${{ github.ref_name }})
     needs: [test, test-alembic, tac2iwxxm-native]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     permissions:
       contents: read
       packages: write
@@ -423,15 +442,31 @@ jobs:
       RENDER_BACKEND_DEPLOY_HOOK: ${{ secrets.RENDER_BACKEND_DEPLOY_HOOK }}
       RENDER_FRONTEND_DEPLOY_HOOK: ${{ secrets.RENDER_FRONTEND_DEPLOY_HOOK }}
       RENDER_WORKER_DEPLOY_HOOK: ${{ secrets.RENDER_WORKER_DEPLOY_HOOK }}
-      # Optional: REST fallback when deploy-hook+imgURL returns 5xx (BUG-2026-08-03).
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-      # Required for DOKS rollout (EV-034 / TC-F30-007) — base64 kubeconfig.
       KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
 
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: false
+
+      - name: Resolve deploy target
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "namespace=metar-iwxxm" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=main-latest" >> "$GITHUB_OUTPUT"
+            echo "app_url=https://app.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "api_url=https://api.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "env_role=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "namespace=metar-iwxxm-staging" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=stage-latest" >> "$GITHUB_OUTPUT"
+            echo "app_url=https://app.staging.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "api_url=https://api.staging.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "env_role=staging" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Guard CD credentials (skip if GHCR unavailable)
         id: guard
@@ -447,7 +482,6 @@ jobs:
             exit 0
           fi
 
-          # Probe GHCR write access under the current org (EMPIRIC2).
           if ! printf '%s' "${REGISTRY_PASSWORD}" | docker login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin; then
             echo "::notice::GHCR login failed — skipping Deploy"
             echo "skip=true" >> "${GITHUB_OUTPUT}"
@@ -506,7 +540,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:main-latest
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.target.outputs.latest_tag }}
 
       - name: Build and push frontend Docker image
         if: steps.guard.outputs.skip != 'true'
@@ -520,12 +554,12 @@ jobs:
           build-args: |
             VITE_SUPABASE_URL=${{ env.FRONTEND_VITE_SUPABASE_URL }}
             VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=${{ env.FRONTEND_VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-            VITE_APP_URL=${{ env.FRONTEND_VITE_APP_URL }}
-            VITE_API_BASE_URL=${{ env.FRONTEND_VITE_API_BASE_URL }}
+            VITE_APP_URL=${{ steps.target.outputs.app_url }}
+            VITE_API_BASE_URL=${{ steps.target.outputs.api_url }}
             VITE_FRONTEND_DEPLOY_MARK=${{ github.sha }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.image_tag }}
-            ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:main-latest
+            ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.target.outputs.latest_tag }}
 
       - name: Build and push worker Docker image
         if: steps.guard.outputs.skip != 'true'
@@ -537,15 +571,13 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.tags.outputs.image_tag }}
-            ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:main-latest
+            ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.target.outputs.latest_tag }}
 
-      # Render is suspended (T6.5). Hooks are optional and must never fail Deploy (E34-4).
-      - name: Optional Render hooks (non-blocking)
-        if: steps.guard.outputs.skip != 'true'
+      - name: Optional Render hooks (non-blocking, main/prod only)
+        if: steps.guard.outputs.skip != 'true' && github.ref == 'refs/heads/main'
         continue-on-error: true
         env:
           IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
-          # BUG-2026-08-03 — keep skip-if-suspended path wired for suspended Render.
           RENDER_SKIP_IF_SUSPENDED: "1"
         run: |
           set +e
@@ -581,11 +613,11 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         uses: azure/setup-kubectl@v4
 
-      # EV-034 / TC-F30-007 — fail-closed when KUBE_CONFIG missing on main Deploy.
       - name: Roll out DOKS images
         if: steps.guard.outputs.skip != 'true'
         env:
           IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
+          DOKS_NAMESPACE: ${{ steps.target.outputs.namespace }}
         run: |
           set -euo pipefail
           if [ -z "${KUBE_CONFIG:-}" ]; then
@@ -593,8 +625,6 @@ jobs:
             exit 1
           fi
           mkdir -p "${HOME}/.kube"
-          # Secret is base64-encoded kubeconfig (docs/deploy.md §CD — DOKS image rollout).
-          # Must be static SA/token auth — doctl exec plugins fail on GHA runners.
           if ! printf '%s' "${KUBE_CONFIG}" | base64 --decode > "${HOME}/.kube/config" 2>/dev/null; then
             echo "::error::KUBE_CONFIG is not valid base64"
             exit 1
@@ -604,8 +634,27 @@ jobs:
             echo "::error::KUBE_CONFIG uses doctl exec auth; use a ServiceAccount token kubeconfig (docs/deploy.md)"
             exit 1
           fi
+          echo "Rolling DOKS env_role=${{ steps.target.outputs.env_role }} ns=${DOKS_NAMESPACE} tag=${IMAGE_TAG}"
           bash scripts/deploy/doks_rollout_images.sh "${IMAGE_TAG}"
 
       - name: CD skipped (credentials)
         if: steps.guard.outputs.skip == 'true'
         run: echo "Deploy skipped — GHCR package write unavailable for EMPIRIC2."
+
+  staging-smoke:
+    runs-on: ubuntu-latest
+    name: Staging smoke
+    needs: [deploy]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/stage' && needs.deploy.result == 'success'
+    permissions:
+      contents: read
+    env:
+      LIVE_API_URL: https://api.staging.tac-to-iwxxm.com
+      LIVE_FRONTEND_URL: https://app.staging.tac-to-iwxxm.com
+      STAGING_SMOKE_PYTEST: "0"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Wait briefly for ingress/TLS
+        run: sleep 20
+      - name: Run staging smoke
+        run: bash scripts/deploy/staging_smoke.sh

--- a/config/staging.json
+++ b/config/staging.json
@@ -1,0 +1,28 @@
+{
+  "environment": "staging",
+  "api": {
+    "baseUrl": "https://api.staging.tac-to-iwxxm.com",
+    "corsOrigins": [
+      "https://app.staging.tac-to-iwxxm.com",
+      "http://app.staging.tac-to-iwxxm.com",
+      "http://168.144.12.70"
+    ],
+    "frontendUrl": "https://app.staging.tac-to-iwxxm.com"
+  },
+  "supabase": {
+    "url": "https://ktvxijislbtgqapllmuk.supabase.co"
+  },
+  "validation": {
+    "wmoOnline": true,
+    "wmoTimeoutSeconds": 5,
+    "schematronUseDocker": false
+  },
+  "observability": {
+    "logLevel": "INFO",
+    "enableStatistics": true
+  },
+  "liveE2e": {
+    "apiUrl": "https://api.staging.tac-to-iwxxm.com",
+    "frontendUrl": "https://app.staging.tac-to-iwxxm.com"
+  }
+}

--- a/deploy/doks/README.md
+++ b/deploy/doks/README.md
@@ -1,84 +1,58 @@
-# DOKS IaC (F30 / #712 / T6.1)
+# DOKS IaC (F30 / #712 / EV-043 #886)
 
-Kustomize base for DigitalOcean Kubernetes — API, static FE (nginx), and F8 worker.
+Kustomize **base** + **overlays** for DigitalOcean Kubernetes — API, static FE (nginx), and F8 worker.
 
-| Workload | Kind | Image (override) | Public |
-|----------|------|------------------|--------|
-| `metar-api` | Deployment + Service + Ingress | `ghcr.io/EMPIRIC2/TAC-to-IWXXM/backend:main-latest` | `api.doks.placeholder.metar-iwxxm.local` |
-| `metar-frontend` | Deployment + Service + Ingress | `ghcr.io/EMPIRIC2/TAC-to-IWXXM/frontend:main-latest` | `app.doks.placeholder.metar-iwxxm.local` |
-| `metar-worker` | Deployment | `ghcr.io/EMPIRIC2/TAC-to-IWXXM/worker:main-latest` | no |
+| Overlay | Namespace | Hosts |
+|---------|-----------|-------|
+| `overlays/prod` | `metar-iwxxm` | `api.tac-to-iwxxm.com`, `app.tac-to-iwxxm.com` |
+| `overlays/staging` | `metar-iwxxm-staging` | `api.staging.tac-to-iwxxm.com`, `app.staging.tac-to-iwxxm.com` |
 
-Placeholder hostnames remain until real DNS. **`D-S038-t63-waive`** pins provisional
-`LIVE_*` / `liveE2e` to these hosts + LB `168.144.12.70` (Host-header or `/etc/hosts`).
-Public `config/prod.json` `api.baseUrl` stays on Render until real DNS.
-FE runtime `/config.json` is overridden by ConfigMap `metar-frontend-runtime-config`.
-Smoke: `bash scripts/deploy/doks_host_header_smoke.sh`.
-
-## Secrets (create out-of-band)
-
-```bash
-kubectl -n metar-iwxxm create secret generic metar-api-secrets \
-  --from-literal=DATABASE_URL='postgresql://…' \
-  --from-literal=SUPABASE_URL='https://….supabase.co' \
-  --from-literal=SUPABASE_JWKS_URL='' \
-  --from-literal=SUPABASE_PUBLISHABLE_KEY='…' \
-  --from-literal=DISSEMINATION_EGRESS_ALLOWLIST='…'
-
-kubectl -n metar-iwxxm create secret generic metar-worker-secrets \
-  --from-literal=DATABASE_URL='postgresql://…' \
-  --from-literal=INGEST_POLLER_URL='https://…'
-```
-
-Templated stubs live in `base/secret-*.yaml` for reference only — they are
-**not** listed in `kustomization.yaml` (applying stubs would overwrite live secrets).
-
-API `DATABASE_URL` must be `postgresql+asyncpg://…?ssl=require` (not `sslmode=`).
-Sync work-sessions rewrite `ssl=` → `sslmode=` in code; until `backend:ev031-doks` is
-republished, apply `bash scripts/ops/apply_doks_work_session_ssl_fix.sh`.
-
-Provisional live harness (Host-header / Chromium resolver-rules; see
-`scripts/deploy/doks_provisional_live_env.sh`):
-
-- Playwright F31 (T7.1): `make test-live-e2e-doks-provisional`
-- H4–H5 (T7.2): `make test-live-connectivity-doks-provisional`
-- TC-EV031 topology (T7.3): `make test-live-topology-doks-provisional`
+LB: `168.144.12.70`. Staging DNS at Porkbun — see [docs/ops/doks-staging-dns-runbook.md](../../docs/ops/doks-staging-dns-runbook.md).
+Promote path: [ADR-034](../../docs/adr/ADR-034-doks-staging-promote-from-stage.md).
 
 ## Apply
 
 ```bash
 # Secrets first (out-of-band), then:
-kubectl apply -k deploy/doks/base
+kubectl apply -k deploy/doks/overlays/staging
+kubectl apply -k deploy/doks/overlays/prod
 # preview:
-kubectl kustomize deploy/doks/base
+kubectl kustomize deploy/doks/overlays/staging
 ```
 
-Until EV-031 merges, DOKS API image is pinned to
-`ghcr.io/empiric2/tac-to-iwxxm/backend:ev031-doks` (alembic-capable; does not
-overwrite Render `main-latest`).
+`deploy/doks/base` remains the shared resource set; prefer overlays for apply.
 
-## Release migrate (T6.2)
+## Secrets (create out-of-band)
 
-API Deployment includes an **initContainer** `alembic-upgrade` that runs
-`python -m alembic -c alembic.ini upgrade head` against `DATABASE_URL` before the
-API container starts (idempotent — same as `make db-migrate` / CI `test-alembic`).
+Staging must use DB `metar_iwxxm_staging` (never prod `defaultdb`). Example:
 
-Optional ad-hoc Job: `deploy/doks/base/job-alembic-upgrade.yaml`
-(`kubectl apply -f …` or included in `kubectl apply -k`).
+```bash
+kubectl -n metar-iwxxm-staging create secret generic metar-api-secrets \
+  --from-literal=DATABASE_URL='postgresql+asyncpg://…/metar_iwxxm_staging?ssl=require' \
+  --from-literal=SUPABASE_URL='https://….supabase.co' \
+  --from-literal=SUPABASE_JWKS_URL='' \
+  --from-literal=SUPABASE_PUBLISHABLE_KEY='…' \
+  --from-literal=DISSEMINATION_EGRESS_ALLOWLIST='…'
+```
 
-## CD image rollout (EV-034 / TC-F30-007)
+Also copy `ghcr-pull` and (if still required) `work-session-ssl-fix` into the staging namespace.
 
-On push to `main`, `.github/workflows/ci-cd.yml` **Deploy** runs
-`scripts/deploy/doks_rollout_images.sh <TIMESTAMP-SHA>` after GHCR push (requires
-Actions secret `KUBE_CONFIG` — base64 kubeconfig). Manual equivalent:
+## CD image rollout (EV-034 / EV-043)
+
+| Branch | Namespace | Script env |
+|--------|-----------|------------|
+| `stage` | `metar-iwxxm-staging` | `DOKS_NAMESPACE=metar-iwxxm-staging` |
+| `main` | `metar-iwxxm` | default |
 
 ```bash
 bash scripts/deploy/doks_rollout_images.sh 20260805003332-5245f8d
+DOKS_NAMESPACE=metar-iwxxm-staging bash scripts/deploy/doks_rollout_images.sh 20260805003332-5245f8d
 ```
 
 See [docs/deploy.md](../../docs/deploy.md) §CD — DOKS image rollout.
 
 ## Related
 
-- [docs/deploy.md](../../docs/deploy.md) — topology + secrets + CD
-- [docs/ops/doks-cutover-soak-checklist.md](../../docs/ops/doks-cutover-soak-checklist.md)
-- ADR-033
+- [docs/deploy.md](../../docs/deploy.md)
+- [docs/ops/doks-staging-dns-runbook.md](../../docs/ops/doks-staging-dns-runbook.md)
+- ADR-033, ADR-034

--- a/deploy/doks/overlays/prod/kustomization.yaml
+++ b/deploy/doks/overlays/prod/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metar-iwxxm
+resources:
+  - ../../base
+patches:
+  - path: patch-ingress-api.yaml
+  - path: patch-ingress-frontend.yaml
+  - path: patch-configmap-api.yaml
+  - path: patch-configmap-frontend.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/environment: production
+    includeSelectors: false

--- a/deploy/doks/overlays/prod/patch-configmap-api.yaml
+++ b/deploy/doks/overlays/prod/patch-configmap-api.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metar-api-config
+data:
+  METAR_CONFIG_ENV: "prod"
+  METAR_CORS_ORIGINS: "https://app.tac-to-iwxxm.com,http://app.tac-to-iwxxm.com,http://168.144.12.70"

--- a/deploy/doks/overlays/prod/patch-configmap-frontend.yaml
+++ b/deploy/doks/overlays/prod/patch-configmap-frontend.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metar-frontend-runtime-config
+data:
+  config.json: |
+    {
+      "environment": "prod",
+      "api": {
+        "baseUrl": "https://api.tac-to-iwxxm.com",
+        "frontendUrl": "https://app.tac-to-iwxxm.com",
+        "corsOrigins": [
+          "https://app.tac-to-iwxxm.com",
+          "http://app.tac-to-iwxxm.com",
+          "http://168.144.12.70"
+        ]
+      },
+      "supabase": {
+        "url": "https://ktvxijislbtgqapllmuk.supabase.co"
+      }
+    }

--- a/deploy/doks/overlays/prod/patch-ingress-api.yaml
+++ b/deploy/doks/overlays/prod/patch-ingress-api.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metar-api
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.tac-to-iwxxm.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: metar-api
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - api.tac-to-iwxxm.com
+      secretName: metar-api-tls

--- a/deploy/doks/overlays/prod/patch-ingress-frontend.yaml
+++ b/deploy/doks/overlays/prod/patch-ingress-frontend.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metar-frontend
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: app.tac-to-iwxxm.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: metar-frontend
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - app.tac-to-iwxxm.com
+      secretName: metar-frontend-tls

--- a/deploy/doks/overlays/staging/kustomization.yaml
+++ b/deploy/doks/overlays/staging/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metar-iwxxm-staging
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: Namespace
+      name: metar-iwxxm
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: metar-iwxxm-staging
+      - op: replace
+        path: /metadata/labels/app.kubernetes.io~1name
+        value: metar-iwxxm-staging
+  - path: patch-ingress-api.yaml
+  - path: patch-ingress-frontend.yaml
+  - path: patch-configmap-api.yaml
+  - path: patch-configmap-frontend.yaml
+  - path: patch-resources.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/environment: staging
+    includeSelectors: false

--- a/deploy/doks/overlays/staging/patch-configmap-api.yaml
+++ b/deploy/doks/overlays/staging/patch-configmap-api.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metar-api-config
+data:
+  METAR_CONFIG_ENV: "staging"
+  METAR_CORS_ORIGINS: "https://app.staging.tac-to-iwxxm.com,http://app.staging.tac-to-iwxxm.com,http://168.144.12.70"

--- a/deploy/doks/overlays/staging/patch-configmap-frontend.yaml
+++ b/deploy/doks/overlays/staging/patch-configmap-frontend.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metar-frontend-runtime-config
+data:
+  config.json: |
+    {
+      "environment": "staging",
+      "api": {
+        "baseUrl": "https://api.staging.tac-to-iwxxm.com",
+        "frontendUrl": "https://app.staging.tac-to-iwxxm.com",
+        "corsOrigins": [
+          "https://app.staging.tac-to-iwxxm.com",
+          "http://app.staging.tac-to-iwxxm.com",
+          "http://168.144.12.70"
+        ]
+      },
+      "supabase": {
+        "url": "https://ktvxijislbtgqapllmuk.supabase.co"
+      }
+    }

--- a/deploy/doks/overlays/staging/patch-ingress-api.yaml
+++ b/deploy/doks/overlays/staging/patch-ingress-api.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metar-api
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.staging.tac-to-iwxxm.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: metar-api
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - api.staging.tac-to-iwxxm.com
+      secretName: metar-api-tls

--- a/deploy/doks/overlays/staging/patch-ingress-frontend.yaml
+++ b/deploy/doks/overlays/staging/patch-ingress-frontend.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metar-frontend
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: app.staging.tac-to-iwxxm.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: metar-frontend
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - app.staging.tac-to-iwxxm.com
+      secretName: metar-frontend-tls

--- a/deploy/doks/overlays/staging/patch-resources.yaml
+++ b/deploy/doks/overlays/staging/patch-resources.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metar-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 768Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metar-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metar-worker
+spec:
+  template:
+    spec:
+      containers:
+        - name: worker
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/docs/adr/ADR-034-doks-staging-promote-from-stage.md
+++ b/docs/adr/ADR-034-doks-staging-promote-from-stage.md
@@ -1,0 +1,40 @@
+# ADR-034: DOKS staging + promote-from-stage CD (F30 deepen / #886)
+
+> **Status**: Accepted (S052 / EV-043; D-S052-* Phase 0 locks)  
+> **Date**: 2026-08-08  
+> **Deciders**: User (issue #886 + Evolve Plan Card)  
+> **Amends**: [ADR-033](ADR-033-platform-independence-auth-do-doks.md) (single prod DOKS → dual env)  
+> **Related**: F30; [docs/deploy.md](../deploy.md); EV-034 CD rollout  
+> **Session**: S052-doks-staging-prod-branch-deploys / EV-043
+
+## Context
+
+Production already runs on DOKS (`metar-iwxxm`, `api|app.tac-to-iwxxm.com`). Issue #886 asks
+for staging + prod environments, protected branches, and deploy wiring. Solo-dev workflow
+needs a **manual promote** without multi-reviewer Environment gates: PRs are the gate.
+
+## Decision
+
+1. **Same DOKS cluster, two namespaces** — prod `metar-iwxxm`; staging `metar-iwxxm-staging`.
+2. **Branches** — `stage` → staging CD; `main` → prod CD. Both require PRs (no direct push /
+   no force-push via rulesets when admin can apply them).
+3. **DNS** — Staging: `api.staging.tac-to-iwxxm.com` / `app.staging.tac-to-iwxxm.com` → LB
+   `168.144.12.70`. Prod hosts unchanged.
+4. **Secrets isolation** — Staging uses DB `metar_iwxxm_staging` on DO Postgres; never share
+   prod `DATABASE_URL`.
+5. **Promote path** — Only PRs from `stage` → `main`. CI job `staging-gate` requires green
+   **Staging smoke** for the tip SHA. After merge to `main`, prod Deploy runs automatically.
+6. **Solo-dev** — No required Environment reviewers; the PR is the manual step.
+7. **IaC** — Kustomize overlays `deploy/doks/overlays/{staging,prod}`.
+
+## Consequences
+
+- Skills 12/13/15/16 and ci-after-push must distinguish `env_role: staging | prod`.
+- Hotfixes that skip staging violate the gate unless explicitly waived.
+- DNS for staging lives at the domain registrar (Porkbun NS), not DigitalOcean DNS.
+
+## Alternatives considered
+
+- App Platform dual apps — rejected (diverges from F30 DOKS).
+- Environment approval for prod — rejected for solo-dev friction.
+- Second DOKS cluster — deferred (cost); namespace isolation sufficient for now.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,7 +36,8 @@
 | [ADR-030](ADR-030-dissemination-package-architecture.md) | `packages/dissemination` + sink/API/wis2box/EDIS architecture (F16–F19) | Accepted |
 | [ADR-031](ADR-031-public-app-indexeddb-history.md) | Public unauthenticated app + IndexedDB local history (F21/F22) | **Partially superseded by ADR-033** |
 | [ADR-032](ADR-032-wmo-default-golden-glossary.md) | WMO default golden parity + extensible decode glossary | Accepted |
-| [ADR-033](ADR-033-platform-independence-auth-do-doks.md) | Platform independence — Auth-only Supabase, DO Postgres, DOKS (F30/F31) | **Proposed** |
+| [ADR-033](ADR-033-platform-independence-auth-do-doks.md) | Platform independence — Auth-only Supabase, DO Postgres, DOKS (F30/F31) | **Accepted** (amended by ADR-034) |
+| [ADR-034](ADR-034-doks-staging-promote-from-stage.md) | DOKS staging + promote-from-stage CD (F30 deepen / #886) | **Accepted** |
 
 ## Process
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,50 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-043 — DOKS staging + prod protected-branch CI/CD (S052)
+
+**Session**: S052-doks-staging-prod-branch-deploys  
+**Features**: deepen **F30**  
+**Started**: 2026-08-08  
+**Branch**: `evolve/EV-043-doks-staging-prod`  
+**Status**: in_progress  
+**Issues**: [#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886)  
+**Corpus**: [Corpus: product §F30], [Corpus: deploy], [Corpus: tech-spec],
+[Corpus: tests], [Corpus: adr/ADR-033], [Corpus: adr/ADR-034]
+
+### Scope (Phase 0 — locked 2026-08-08)
+
+| ID | Decision |
+|----|----------|
+| D-S052-open | Open S052 / EV-043 for #886 |
+| D-S052-scope | Add DOKS **staging** + keep prod |
+| D-S052-product | **DOKS** (same cluster `metar-iwxxm`) |
+| D-S052-gh | Create/protect `stage` + `main`; GH Envs `staging` / `production` |
+| D-S052-cd | Auto CI/CD both: `stage`→staging, `main`→prod |
+| D-S052-manual | Solo-dev: **PR is the manual gate** (no required reviewers) |
+| D-S052-promote | PRs to `main` must be from `stage` + **staging-gate** (Staging smoke green) |
+| D-S052-dns | `api.staging.tac-to-iwxxm.com` / `app.staging.tac-to-iwxxm.com` → LB `168.144.12.70` |
+
+### Acceptance (F30 deepen — TC-F30-008..012)
+
+| AC | Criterion | TC |
+|----|-----------|-----|
+| AC1 | Staging ns `metar-iwxxm-staging` + secrets isolated from prod | TC-F30-008 |
+| AC2 | Staging DNS + TLS for api/app.staging hosts | TC-F30-009 |
+| AC3 | Push/merge to `stage` deploys staging; to `main` deploys prod | TC-F30-010 |
+| AC4 | `stage`/`main` require PR; no force-push (rulesets) | TC-F30-011 |
+| AC5 | PR to `main` fails unless head=`stage` and Staging smoke green | TC-F30-012 |
+
+### Preset
+
+**Standard** — include 03 for promote/env_role rule; skip 06.
+
+### Gate A (02)
+
+Pass when F30 deepen AC + test-plan smokes + this section committed — proceed 03/04.
+
+---
+
 ## Cycle EV-042 — Remove dissemination destinations + operator throughput + mass ingest (S050)
 
 **Session**: S050-remove-db-tools-operator-throughput  

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,9 +2,9 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Platform**: **DOKS** (F30 primary) · Render **suspended** (T6.5 / `D-S038-t65-waive`)
-> **Last updated**: 2026-08-03 (S038 / EV-031 — T6.5 Render decommission)
+> **Last updated**: 2026-08-08 (S052 / EV-043 — dual-env staging + prod / #886)
 
-## Topology (F30 target — DOKS)
+## Topology (F30 — DOKS dual env)
 
 | Workload | Type | Source | Notes |
 |----------|------|--------|-------|
@@ -12,9 +12,16 @@
 | metar-frontend | Static / CDN or nginx | `apps/frontend` Vite build | `/config.json` inject |
 | metar-worker | Deployment (Background) | `apps/worker` image | No public HTTP; `DATABASE_URL` |
 
-**IaC (T6.1 / #712):** Kustomize base at [`deploy/doks/`](../deploy/doks/) —
-`kubectl apply -k deploy/doks/base`. Secrets stubbed as `REPLACE_ME_*` (create
-out-of-band). Placeholder Ingress hosts until **T6.3**.
+| `env_role` | Branch | Namespace | Hosts |
+|------------|--------|-----------|-------|
+| staging | `stage` | `metar-iwxxm-staging` | `https://api.staging.tac-to-iwxxm.com`, `https://app.staging.tac-to-iwxxm.com` |
+| prod | `main` | `metar-iwxxm` | `https://api.tac-to-iwxxm.com`, `https://app.tac-to-iwxxm.com` |
+
+**IaC (T6.1 / #712 / EV-043):** Kustomize overlays at
+[`deploy/doks/overlays/{staging,prod}`](../deploy/doks/) —
+`kubectl apply -k deploy/doks/overlays/staging` (or `prod`). Secrets create out-of-band.
+Staging DNS: [ops/doks-staging-dns-runbook.md](ops/doks-staging-dns-runbook.md). Promote path:
+[ADR-034](adr/ADR-034-doks-staging-promote-from-stage.md).
 
 **Release migrate (T6.2):** API Deployment **initContainer** runs idempotent
 `alembic upgrade head` (same as `make db-migrate` / CI). Optional Job:
@@ -23,16 +30,16 @@ out-of-band). Placeholder Ingress hosts until **T6.3**.
 **Product DB**: DigitalOcean Postgres (`DATABASE_URL`) — sessions + F8 store/quarantine.  
 **Auth**: Supabase Auth only (**JWKS**). No Supabase product DB on default path (ADR-033).
 
-### DOKS public hostnames (T6.3 — prod DNS)
+### DOKS public hostnames (T6.3 + EV-043 staging)
 
-Canonical in `config/prod.json` and live harness (T6.5):
-
-| Role | URL |
-|------|-----|
-| API | `https://api.tac-to-iwxxm.com` |
-| Frontend | `https://app.tac-to-iwxxm.com` |
-| Worker | (no public URL — in-cluster only) |
-| LB | `168.144.12.70` (legacy Host-header smoke only) |
+| Role | Prod | Staging |
+|------|------|---------|
+| API | `https://api.tac-to-iwxxm.com` | `https://api.staging.tac-to-iwxxm.com` |
+| Frontend | `https://app.tac-to-iwxxm.com` | `https://app.staging.tac-to-iwxxm.com` |
+| Worker | (in-cluster) | (in-cluster) |
+| LB | `168.144.12.70` | same LB (Host-based routing) |
+| Config profile | `config/prod.json` | `config/staging.json` |
+| Product DB | DO Postgres `defaultdb` | DO Postgres `metar_iwxxm_staging` |
 
 Soak checklist (closed early under `D-S038-t65-waive`):
 [ops/doks-cutover-soak-checklist.md](ops/doks-cutover-soak-checklist.md).
@@ -50,25 +57,32 @@ Render archive: [ops/render-decommission-archive.md](ops/render-decommission-arc
 `--skip-if-suspended` / `RENDER_SKIP_IF_SUSPENDED` so main CI Deploy skips suspended Render
 services without failing (see BUG-2026-08-03). GHCR push continues; DOKS is the prod target.
 
-### CD — DOKS image rollout (S042 / EV-034 / F30 deepen)
+### CD — DOKS image rollout (S042 / EV-034 / EV-043 dual env)
 
-On push to `main`, the **Deploy** job in `.github/workflows/ci-cd.yml`:
+| Branch | GH Environment | Namespace | Latest tag | Post-deploy |
+|--------|----------------|-----------|------------|-------------|
+| `stage` | `staging` | `metar-iwxxm-staging` | `stage-latest` | **Staging smoke** job |
+| `main` | `production` | `metar-iwxxm` | `main-latest` | (prod smoke via 13 / Makefile) |
 
-1. Builds/pushes GHCR images tagged `TIMESTAMP-SHA` and `main-latest`.
-2. **Rolls DOKS** (required): `scripts/deploy/doks_rollout_images.sh <tag>` sets
-   `metar-api` / `metar-frontend` / `metar-worker` in namespace `metar-iwxxm` to
-   `ghcr.io/empiric2/tac-to-iwxxm/{backend,frontend,worker}:<tag>` and waits for
-   `kubectl rollout status`.
-3. **Render hooks** (optional): if present, may fire with `--skip-if-suspended`; missing
-   or suspended Render must **not** fail Deploy (`E34-4`).
+On push to `stage` or `main`, **Deploy** in `.github/workflows/ci-cd.yml`:
+
+1. Builds/pushes GHCR images tagged `TIMESTAMP-SHA` and `{stage\|main}-latest`.
+2. **Rolls DOKS** with `DOKS_NAMESPACE` set per branch via
+   `scripts/deploy/doks_rollout_images.sh <tag>`.
+3. **Render hooks** (optional, **main only**): `--skip-if-suspended` (`E34-4`).
+
+**Promote:** Feature → PR → `stage` → Staging smoke → PR **`stage`→`main`** (job
+**Staging gate** / `scripts/ci/staging_gate.sh`) → prod Deploy. Solo-dev: PR is the
+manual gate (no Environment reviewers). See [ADR-034](adr/ADR-034-doks-staging-promote-from-stage.md).
 
 | Actions secret | Required | Description |
 |----------------|----------|-------------|
-| `KUBE_CONFIG` | **Yes** (main Deploy) | Base64-encoded kubeconfig with rights to mutate Deployments in `metar-iwxxm`. Must use a **static** credential (ServiceAccount token or client cert) — **not** a DigitalOcean `doctl` exec plugin (runners do not have `doctl`). Missing ⇒ Deploy fails (fail-closed). |
+| `KUBE_CONFIG` | **Yes** (Deploy) | Base64 kubeconfig that can mutate Deployments in **both** `metar-iwxxm` and `metar-iwxxm-staging` (ClusterRole `github-actions-deploy`). Static SA/token — not `doctl` exec. Missing ⇒ Deploy fails (fail-closed). |
 
 Encode: `base64 -w0 <kubeconfig.yaml>` (macOS: `base64 -i kubeconfig.yaml | tr -d '\n'`).
 
-Recommended: SA `github-actions-deploy` in `metar-iwxxm` with Role patch/get/list/watch on Deployments (+ get/list/watch Pods for rollout status).
+Branch protection / Environments (admin): `bash scripts/deploy/apply_gh_branch_rulesets.sh`
++ [ops/doks-staging-dns-runbook.md](ops/doks-staging-dns-runbook.md).
 
 **F21 Amended / F31**: Optional Auth restored via `packages/auth`. Convert remains public.
 F8 worker runs on DOKS.

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -37,7 +37,7 @@
 | F27 | TCA quality bar (TropicalCycloneAdvisory) | Done | Product | S027 / EV-021; #737; PR #794 |
 | F28 | SWXA quality bar (SpaceWeatherAdvisory) | Done | Product | S036 / EV-029; #823/#740 closed; PR #828 |
 | F29 | Parameterized lint/convert/validate rule matrices | Done | Product | S037 / EV-030; #831; shipped 2026-08-03 (#832) |
-| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; **deepen** S042 / EV-034 CD auto-rollout |
+| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; S042 / EV-034 CD; **deepen** S052 / EV-043 staging + dual CD (#886) |
 | F31 | Hybrid operator sessions (guest local + Auth long-term) | Done | Product | S038 / EV-031; amends F5/F7/F21/F22 |
 | F32 | VONA quality bar (VolcanoObservatoryNoticeForAviation) | Done | Product | S040 / EV-032; #741 closed; **deepen** S046 / EV-038 G-VONA-1/5 (#849/#850); prior S045 / EV-037; epic #846 |
 | F33 | Secure mass file/folder ingest | Implemented | Product | S050 / EV-042; #897; auth + caps + sniff/zip-bomb; multi-file + folder/zip; 11 approved |
@@ -1253,8 +1253,8 @@
 
 ### F30: Platform Independence (Auth / DO DB / DOKS) — S038 / EV-031
 
-- **Status**: **Done** (S038 / EV-031; `D-S038-13` = 1) — **deepen** S042 / EV-034 **completed**
-  (`D-S042-13` = 1; TC-F30-007 live @ `20260805115809-d3f4bb9`).
+- **Status**: **Done** (S038 / EV-031; `D-S038-13` = 1) — deepen S042 / EV-034 **completed**;
+  **deepen** S052 / EV-043 staging + dual CD ([#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886)).
 - **What it does**: Splits platform lock-in under epic [#842](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/842):
   1. **Supabase Auth only** — JWT issue/verify for optional operator login (no product PostgREST / hosted Postgres app tables).
   2. **DigitalOcean Postgres** — all product DB including F8 store/quarantine and logged-in work sessions (`DATABASE_URL`).
@@ -1263,6 +1263,10 @@
   5. **CD auto-rollout (EV-034)**: On `main` Deploy after GHCR push, pin `metar-api` /
      `metar-frontend` / `metar-worker` to the immutable `TIMESTAMP-SHA` tag via kubectl
      (`KUBE_CONFIG` Actions secret). Render hooks optional/non-blocking.
+  6. **Dual-env CD (EV-043 / #886)**: `stage` → DOKS staging (`metar-iwxxm-staging`,
+     `api|app.staging.tac-to-iwxxm.com`); `main` → prod. PR-required branches; promote
+     `stage`→`main` only after Staging smoke green (`staging-gate`). Solo-dev: PR is the
+     manual promote step (no Environment reviewers).
 - **Convert APIs**: Remain public (no JWT) for convert/lint/validate/disseminate (`D-S038-F30`).
 - **Acceptance**:
   1. Product path boots/smokes without Supabase **database** credentials (**TC-F30-001**)
@@ -1272,8 +1276,13 @@
   5. Render decommissioned after soak or residual ticket with checklist (**TC-F30-005**)
   6. Docs/CORPUS/env-contract no longer require Supabase as data plane (**TC-F30-006**)
   7. `main` CD rolls DOKS images to the pushed immutable tag without manual kubectl (**TC-F30-007**)
-- **Out of scope**: Convert/validate engine rewrites; long-lived dual production hosts after soak
-- **Source**: E31-*; E34-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712; S042 / EV-034
+  8. Staging namespace + isolated DB/secrets (**TC-F30-008**)
+  9. Staging DNS + TLS for `api|app.staging.tac-to-iwxxm.com` (**TC-F30-009**)
+  10. `stage`/`main` auto-deploy to staging/prod respectively (**TC-F30-010**)
+  11. Branch protection / rulesets: PR required on `stage` and `main` (**TC-F30-011**)
+  12. PRs to `main` require head=`stage` + Staging smoke green (**TC-F30-012**)
+- **Out of scope**: Convert/validate engine rewrites; App Platform; multi-reviewer prod approvals
+- **Source**: E31-*; E34-*; E43-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712/#886; S042 / EV-034; S052 / EV-043
 
 ### F31: Hybrid Operator Sessions — S038 / EV-031
 

--- a/docs/ops/doks-staging-dns-runbook.md
+++ b/docs/ops/doks-staging-dns-runbook.md
@@ -1,0 +1,47 @@
+# DOKS staging DNS runbook (EV-043 / #886)
+
+[Corpus: deploy] [Corpus: adr/ADR-034]
+
+Domain `tac-to-iwxxm.com` uses **Porkbun** nameservers (not DigitalOcean DNS).
+Staging Ingress + cert-manager HTTP-01 require public A records before TLS becomes Ready.
+
+## Records to create (Porkbun)
+
+| Type | Host | Answer | TTL |
+|------|------|--------|-----|
+| A | `api.staging` | `168.144.12.70` | 300 |
+| A | `app.staging` | `168.144.12.70` | 300 |
+
+(Or CNAME both to the same LB hostname if preferred.)
+
+## Verify
+
+```bash
+dig +short api.staging.tac-to-iwxxm.com
+dig +short app.staging.tac-to-iwxxm.com
+# expect 168.144.12.70
+
+curl -fsS https://api.staging.tac-to-iwxxm.com/health
+curl -fsSI https://app.staging.tac-to-iwxxm.com/ | head -5
+
+kubectl -n metar-iwxxm-staging get certificate
+# READY=True after ACME succeeds
+```
+
+Until DNS exists, Host-header probes still work:
+
+```bash
+curl -sS -H "Host: api.staging.tac-to-iwxxm.com" http://168.144.12.70/health
+```
+
+## GitHub admin (403 for non-admins)
+
+Create Environments + rulesets in the GitHub UI (or as a repo admin):
+
+1. Settings → Environments → `staging`, `production` (no required reviewers for solo-dev).
+2. Settings → Rules → New ruleset targeting `stage` and `main`:
+   - Require pull request before merging
+   - Block force pushes
+   - Required status checks: CI Test jobs; on `main` also **Staging gate**
+
+Script (admin token): `bash scripts/deploy/apply_gh_branch_rulesets.sh`

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/evolve-plan-card.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/evolve-plan-card.md
@@ -1,0 +1,30 @@
+# Evolve Plan Card
+
+> Cycle: EV-043 | Session: S052-doks-staging-prod-branch-deploys | Updated: 2026-08-08
+
+## Goal
+
+Dual DOKS envs + protected `stage`/`main` + dual CI/CD; promote to prod via PR after staging green (#886).
+
+## Features
+
+- F30 — Platform independence deepen (staging + dual CD + GH protection) — [Corpus: product §F30]
+
+## In / out of scope
+
+- In: DOKS staging ns + DNS; dual Deploy; staging-gate; rulesets; docs/skills
+- Out: App Platform; second cluster; required reviewers; product UI
+
+## Preset + routing
+
+- Preset: Standard
+- Stages: `00 → 16 → 01 → 02 → 03 → 04 → 05 → 07 → 08 → 09 → 10 → 11 → 12 → 13`
+
+## Next child stage
+
+07-build (Phase A/B docs + execution plan written; implement overlays + CI)
+
+## Risks / open decisions
+
+- DNS at Porkbun (not DO) — records may need manual UI if no API key
+- GH rulesets need admin — script + runbook if 403

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/deploy-smoke.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/deploy-smoke.md
@@ -1,0 +1,23 @@
+# 13-deploy-smoke — S052 / EV-043
+
+`env_role`: **staging** provisioned + **prod** unchanged
+
+## Staging (Host-header until DNS)
+
+| Check | Result |
+|-------|--------|
+| `kubectl -n metar-iwxxm-staging get deploy` | api/frontend/worker Running |
+| Host-header API `/health` | **200** |
+| Host-header FE `/` | **200** |
+| HTTPS staging DNS | pending Porkbun A records |
+| Certificate Ready | False until DNS |
+
+## Prod
+
+| Check | Result |
+|-------|--------|
+| `https://api.tac-to-iwxxm.com/health` | unchanged (not redeployed this cycle yet) |
+
+## CD path
+
+Land EV-043 on `stage` first → Staging smoke → PR `stage`→`main` → prod Deploy.

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/execution-plan.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/execution-plan.md
@@ -1,0 +1,17 @@
+# Execution plan — S052 / EV-043
+
+[Corpus: product §F30] [Corpus: adr/ADR-034] [Corpus: deploy]
+
+| ID | Type | Task | Spec Source | Depends On | Status |
+|----|------|------|-------------|------------|--------|
+| T1.1 | docs | F30 AC8–12 + test-plan TC-F30-008..012 + evolve-decisions + ADR-034 | feature-list; test-plan; #886 | — | completed |
+| T1.2 | rule | Cursor rule promote-from-stage / dual env_role | ADR-034 | T1.1 | completed |
+| T2.1 | iac | Kustomize overlays staging + prod | deploy/doks; ADR-034 | T1.1 | in_progress |
+| T2.2 | ci | Dual Deploy jobs + Staging smoke + staging-gate | ci-cd.yml; TC-F30-010/012 | T2.1 | pending |
+| T2.3 | ops | stage branch, ns/secrets, RBAC, DNS runbook, GH envs/rulesets | deploy.md; #886 | T2.1 | pending |
+| T2.4 | docs | deploy.md + skills 12/13/15/16 + ci-after-push | ADR-034 | T2.2 | pending |
+| T3.1 | verify | 08–13 staging smoke + prod path evidence | TC-F30-008..012 | T2.* | pending |
+
+## Milestone
+
+**M1** — Dual-env DOKS + CI/CD + protection docs/CLI

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/verify-impl.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/verify-impl.md
@@ -1,0 +1,16 @@
+# 11-verify-impl — S052 / EV-043
+
+[Corpus: product §F30] [Corpus: adr/ADR-034] [Corpus: tests]
+
+| AC / TC | Status | Evidence |
+|---------|--------|----------|
+| TC-F30-008 staging ns + DB | **MET** | `metar-iwxxm-staging`; DB `metar_iwxxm_staging`; secrets applied |
+| TC-F30-009 staging DNS + TLS | **PARTIAL** | Ingress + cert-manager issued; DNS A records pending Porkbun (Host-header `/health` 200) |
+| TC-F30-010 dual CD | **MET** (code) | `ci-cd.yml` Deploy on `stage`/`main`; Environments need admin create |
+| TC-F30-011 branch protection | **PARTIAL** | `stage` branch created; rulesets script ready (admin 403) |
+| TC-F30-012 staging-gate | **MET** (code) | `scripts/ci/staging_gate.sh` + CI job |
+
+## Notes
+
+- Solo-dev: PR is manual promote; no Environment reviewers.
+- Admin follow-ups: Porkbun DNS; `apply_gh_branch_rulesets.sh`; GH Environments UI.

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/routing-plan.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/routing-plan.md
@@ -1,0 +1,33 @@
+# Routing plan — S052 / EV-043
+
+**Preset:** Standard (**approved** via Evolve Plan Card)  
+**Route:** `00 → 16 → 01 → 02 → 03 → 04 → 05 → 07 → 08 → 09 → 10 → 11 → 12 → 13`  
+**Skip:** `06-tech-tooling`  
+**Branch:** `evolve/EV-043-doks-staging-prod`  
+**Features:** deepen **F30**  
+**Issues:** [#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886)  
+**Status:** in_progress
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | S052 open |
+| 16-evolve | yes | orchestrator | **in_progress** | Phase A→C |
+| 01-requirements | yes | delta | **in_progress** | F30 deepen AC |
+| 02-verify-plan | yes | delta | pending | Gate A |
+| 03-plan-tooling | yes | delta | pending | promote-from-stage rule |
+| 04-tech-plan | yes | delta | pending | execution-plan |
+| 05-verify-tech | yes | delta | pending | Gate B |
+| 06-tech-tooling | no | — | skipped | no new deps |
+| 07-build | yes | full | pending | overlays + CI + CLI |
+| 08-verify-build | yes | delta | pending | |
+| 09-qa | yes | delta | pending | staging smoke mapping |
+| 10-e2e | yes | delta | pending | staging H4–H5 |
+| 11-verify-impl | yes | delta | pending | |
+| 12-verify-deploy | yes | delta | pending | dual env_role |
+| 13-deploy-smoke | yes | delta | pending | staging then prod path |
+
+## Skip rationale
+
+| Skipped | Why |
+|---------|-----|
+| 06 | No new language/runtime dependency inventory change |

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/session-brief.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/session-brief.md
@@ -1,0 +1,44 @@
+---
+session_id: S052-doks-staging-prod-branch-deploys
+type: feature
+status: in_progress
+branch: evolve/EV-043-doks-staging-prod
+started_at: 2026-08-08
+intent: "DOKS staging + prod, protect stage/main, dual CI/CD; promote via PR stage→main after staging green (#886)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-043
+prior_session: S051-output-filename-download-stale
+github_issues:
+  - 886
+feature_ids:
+  - F30
+preset: Standard
+ui_preview: N/A — no product UI feature this cycle
+---
+
+# Session S052 — DOKS staging + prod branch deploys
+
+## Goal
+
+Ship dual DOKS environments with protected branches: merge to `stage` auto-deploys
+staging; promote via PR into `main` auto-deploys prod only after staging is proven green.
+
+[Corpus: product §F30] [Corpus: deploy] [Corpus: tech-spec] [Corpus: tests]
+[Corpus: adr/ADR-033] · [#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886)
+
+## In scope
+
+- DOKS staging namespace + DNS (`api|app.staging.tac-to-iwxxm.com`)
+- Protect `stage` / `main` (PR required); GH Environments `staging` / `production`
+- CI/CD: `stage`→staging, `main`→prod
+- `staging-gate` on PRs to `main` (head must be `stage` + Staging smoke green)
+- Docs / ADR amend / skill updates for dual `env_role`
+
+## Out of scope
+
+- App Platform; second DOKS cluster; multi-reviewer prod approvals; product UI features; Render reopen
+
+## Routing
+
+**Standard**: `00 → 16 → 01 → 02 → 03 → 04 → 05 → 07 → 08 → 09 → 10 → 11 → 12 → 13`  
+Skip `06` (no new runtime deps).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1677,6 +1677,58 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
   4. Missing `KUBE_CONFIG` fails Deploy; missing Render hooks do **not** fail Deploy
 - **Source**: F30 AC7; S042 / EV-034; `E34-1..4`
 
+### TC-F30-008: Staging namespace + isolated secrets (EV-043)
+
+- **Level**: Ops / T0
+- **Objective**: DOKS namespace `metar-iwxxm-staging` exists with API/FE/worker; secrets and
+  `DATABASE_URL` point at staging DB (`metar_iwxxm_staging`), not prod `defaultdb`
+- **Pass criteria**: `kubectl -n metar-iwxxm-staging get deploy` shows three workloads;
+  staging `DATABASE_URL` database name ≠ prod
+- **Source**: F30 AC8; S052 / EV-043; #886
+
+### TC-F30-009: Staging DNS + TLS
+
+- **Level**: Ops / T3
+- **Objective**: `https://api.staging.tac-to-iwxxm.com` and `https://app.staging.tac-to-iwxxm.com`
+  resolve to DOKS LB and serve valid TLS
+- **Pass criteria**: DNS A/AAAA → `168.144.12.70`; `/health` 200 on API; FE returns 200;
+  cert-manager Certificate Ready (or equivalent Ingress TLS secret)
+- **Source**: F30 AC9; D-S052-dns
+
+### TC-F30-010: Dual-branch auto CD
+
+- **Level**: Ops / CI
+- **Objective**: Push/merge to `stage` deploys staging; push/merge to `main` deploys prod
+- **Pass criteria**: Deploy jobs bound to GH Environments `staging` / `production`;
+  `DOKS_NAMESPACE` correct per branch; image tags rolled
+- **Source**: F30 AC10; #886
+
+### TC-F30-011: Branch protection on stage and main
+
+- **Level**: Ops / T0
+- **Objective**: `stage` and `main` require PR; force-push denied (rulesets or classic protection)
+- **Pass criteria**: `gh api` rulesets/protection show required PR + block force push
+- **Source**: F30 AC11; D-S052-gh
+
+### TC-F30-012: staging-gate on PRs to main
+
+- **Level**: CI
+- **Objective**: PRs targeting `main` fail unless head branch is `stage` and tip has green
+  **Staging smoke** (H0c/H1 + H4–H5 against staging DNS)
+- **Pass criteria**: `staging-gate` job fails for non-`stage` heads; passes when Staging smoke
+  succeeded for the SHA; documented in deploy.md
+- **Source**: F30 AC12; D-S052-promote
+
+### Live harness — staging (EV-043)
+
+| Env | API | Frontend |
+|-----|-----|----------|
+| staging | `https://api.staging.tac-to-iwxxm.com` | `https://app.staging.tac-to-iwxxm.com` |
+| prod | `https://api.tac-to-iwxxm.com` | `https://app.tac-to-iwxxm.com` |
+
+CI **Staging smoke** sets `LIVE_API_URL` / `LIVE_FRONTEND_URL` to staging hosts after Deploy
+staging. Prod smokes remain Makefile / 13-deploy-smoke against prod hosts.
+
 ## S043 / EV-035 — Rule-source provenance (deepen F6 / F12 / F15 / F2)
 
 **No new Fn** (G1=2). Standing provenance map under `docs/domain/rules/` (path-cite; G3=1).

--- a/scripts/ci/staging_gate.sh
+++ b/scripts/ci/staging_gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fail PRs to main unless head is stage and tip has a green Staging smoke run.
+# Traces: F30 AC12 / TC-F30-012 / ADR-034 / #886
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?}"
+EVENT_NAME="${GITHUB_EVENT_NAME:?}"
+BASE_REF="${GITHUB_BASE_REF:-}"
+HEAD_REF="${GITHUB_HEAD_REF:-}"
+SHA="${GITHUB_SHA:?}"
+# Prefer PR head SHA when present
+if [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH}" ]]; then
+  PR_SHA="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d.get("pull_request",{}).get("head",{}).get("sha",""))' "${GITHUB_EVENT_PATH}" || true)"
+  if [[ -n "${PR_SHA}" ]]; then
+    SHA="${PR_SHA}"
+  fi
+fi
+
+if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+  echo "staging-gate: skip (event=${EVENT_NAME})"
+  exit 0
+fi
+
+if [[ "${BASE_REF}" != "main" ]]; then
+  echo "staging-gate: skip (base=${BASE_REF})"
+  exit 0
+fi
+
+if [[ "${HEAD_REF}" != "stage" ]]; then
+  echo "::error::PRs to main must come from branch 'stage' (got '${HEAD_REF}'). Promote via stage→main only (ADR-034)."
+  exit 1
+fi
+
+echo "staging-gate: head=stage sha=${SHA}"
+
+# Look for a successful workflow run on stage that includes this SHA and a Staging smoke job.
+# Uses gh if available; else GitHub API via curl + GITHUB_TOKEN.
+api() {
+  local path="$1"
+  curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN:?}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${REPO}${path}"
+}
+
+# Check check-runs for this SHA for a successful "Staging smoke"
+CHECKS_JSON="$(api "/commits/${SHA}/check-runs?per_page=100")"
+python3 - <<'PY' "${CHECKS_JSON}"
+import json, sys
+data = json.loads(sys.argv[1])
+runs = data.get("check_runs") or []
+ok = [
+    r for r in runs
+    if r.get("name") == "Staging smoke"
+    and r.get("status") == "completed"
+    and r.get("conclusion") == "success"
+]
+if not ok:
+    # Also accept workflow job name variants
+    ok = [
+        r for r in runs
+        if "Staging smoke" in (r.get("name") or "")
+        and r.get("status") == "completed"
+        and r.get("conclusion") == "success"
+    ]
+if not ok:
+    print("::error::No successful 'Staging smoke' check-run for this SHA. Merge to stage, wait for Deploy + Staging smoke, then open/update the PR.")
+    sys.exit(1)
+print(f"staging-gate: found {len(ok)} successful Staging smoke check-run(s)")
+PY
+
+# Defense in depth: probe staging health (HTTPS, else Host-header via LB)
+API_URL="${STAGING_API_URL:-https://api.staging.tac-to-iwxxm.com}"
+LB_IP="${DOKS_LB_IP:-168.144.12.70}"
+code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "${API_URL}/health" || echo 000)"
+if [[ "${code}" != "200" ]]; then
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+    -H "Host: api.staging.tac-to-iwxxm.com" "http://${LB_IP}/health" || echo 000)"
+fi
+if [[ "${code}" != "200" ]]; then
+  echo "::error::Staging API /health returned ${code} (${API_URL})"
+  exit 1
+fi
+echo "staging-gate: staging /health → 200"
+echo "staging-gate: PASS"

--- a/scripts/deploy/apply_gh_branch_rulesets.sh
+++ b/scripts/deploy/apply_gh_branch_rulesets.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Apply GitHub rulesets for stage + main (requires repo admin).
+# Traces: F30 AC11 / TC-F30-011 / ADR-034 / #886
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-EMPIRIC2/TAC-to-IWXXM}"
+
+create_ruleset() {
+  local name="$1"
+  local pattern="$2"
+  local extra_checks_json="$3"
+  local body
+  body="$(python3 - <<PY
+import json
+checks = [
+    {"context": "Test (backend)", "integration_id": 0},
+    {"context": "Test (frontend)", "integration_id": 0},
+    {"context": "Alembic migrations", "integration_id": 0},
+]
+extra = json.loads('''${extra_checks_json}''')
+checks.extend(extra)
+print(json.dumps({
+  "name": "${name}",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {"ref_name": {"include": ["${pattern}"], "exclude": []}},
+  "rules": [
+    {"type": "pull_request", "parameters": {
+      "required_approving_review_count": 0,
+      "dismiss_stale_reviews_on_push": False,
+      "require_code_owner_review": False,
+      "require_last_push_approval": False,
+      "required_review_thread_resolution": False,
+    }},
+    {"type": "non_fast_forward"},
+    {"type": "required_status_checks", "parameters": {
+      "strict_required_status_checks_policy": True,
+      "do_not_enforce_on_create": True,
+      "required_status_checks": checks,
+    }},
+  ],
+}))
+PY
+)"
+  echo "Creating/updating ruleset ${name} for ${pattern}"
+  gh api --method POST "repos/${REPO}/rulesets" --input - <<<"${body}" \
+    || echo "::warning::ruleset ${name} create failed (need admin). See docs/ops/doks-staging-dns-runbook.md"
+}
+
+create_ruleset "protect-stage" "refs/heads/stage" "[]"
+create_ruleset "protect-main" "refs/heads/main" '[{"context":"Staging gate","integration_id":0}]'
+
+echo "Done. Also create Environments staging + production (no reviewers) in GitHub Settings."

--- a/scripts/deploy/staging_smoke.sh
+++ b/scripts/deploy/staging_smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Post-deploy staging connectivity smoke (H0c-style health + H4–H5 subset).
+# Traces: F30 AC9/AC12 / TC-F30-009 / ADR-034
+set -euo pipefail
+
+API_URL="${LIVE_API_URL:-https://api.staging.tac-to-iwxxm.com}"
+FE_URL="${LIVE_FRONTEND_URL:-https://app.staging.tac-to-iwxxm.com}"
+
+LB_IP="${DOKS_LB_IP:-168.144.12.70}"
+API_HOST="${API_URL#https://}"
+API_HOST="${API_HOST#http://}"
+API_HOST="${API_HOST%%/*}"
+FE_HOST="${FE_URL#https://}"
+FE_HOST="${FE_HOST#http://}"
+FE_HOST="${FE_HOST%%/*}"
+
+echo "Staging smoke: API=${API_URL} FE=${FE_URL}"
+
+api_code="$(curl -sS -o /tmp/staging-api-health.json -w '%{http_code}' --max-time 30 "${API_URL}/health" || echo 000)"
+if [[ "${api_code}" != "200" ]]; then
+  echo "::warning::HTTPS API /health → ${api_code}; trying Host-header via LB ${LB_IP}"
+  api_code="$(curl -sS -o /tmp/staging-api-health.json -w '%{http_code}' --max-time 30 \
+    -H "Host: ${API_HOST}" "http://${LB_IP}/health" || echo 000)"
+fi
+if [[ "${api_code}" != "200" ]]; then
+  echo "::error::API /health → ${api_code}"
+  cat /tmp/staging-api-health.json 2>/dev/null || true
+  exit 1
+fi
+echo "API /health → 200"
+
+fe_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "${FE_URL}/" || echo 000)"
+if [[ "${fe_code}" != "200" && "${fe_code}" != "301" && "${fe_code}" != "302" ]]; then
+  echo "::warning::HTTPS FE / → ${fe_code}; trying Host-header via LB"
+  fe_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+    -H "Host: ${FE_HOST}" "http://${LB_IP}/" || echo 000)"
+fi
+if [[ "${fe_code}" != "200" && "${fe_code}" != "301" && "${fe_code}" != "302" ]]; then
+  echo "::error::Frontend / → ${fe_code}"
+  exit 1
+fi
+echo "Frontend / → ${fe_code}"
+
+# CORS preflight (H4 subset)
+origin="${FE_URL}"
+preflight="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+  -X OPTIONS "${API_URL}/api/v1/convert" \
+  -H "Origin: ${origin}" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: content-type" || echo 000)"
+if [[ "${preflight}" != "200" && "${preflight}" != "204" ]]; then
+  echo "::warning::CORS preflight returned ${preflight} (continuing if health OK)"
+else
+  echo "CORS preflight → ${preflight}"
+fi
+
+# Optional pytest live connectivity when available
+if [[ "${STAGING_SMOKE_PYTEST:-1}" == "1" ]] && [[ -f tests/smoke/test_staging_connectivity.py ]]; then
+  export LIVE_API_URL="${API_URL}"
+  export LIVE_FRONTEND_URL="${FE_URL}"
+  if command -v uv >/dev/null 2>&1; then
+    uv run pytest tests/smoke/test_staging_connectivity.py -m live -v --tb=short || {
+      echo "::warning::pytest staging connectivity failed; curl probes already passed"
+    }
+  fi
+fi
+
+echo "Staging smoke: PASS"

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,11 +1,84 @@
-overall_status: completed
+overall_status: in_progress
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 51
-evolve_cycle_counter: 42
-active_session: null
+session_counter: 52
+evolve_cycle_counter: 43
+active_session:
+  id: S052-doks-staging-prod-branch-deploys
+  type: feature
+  intent: "Stand up DOKS staging + prod environments, protect stage/main, CI/CD for both; auto-deploy stage→staging; manual promote to main/prod (#886)"
+  status: in_progress
+  started: '2026-08-08'
+  started_at: '2026-08-08'
+  branch: evolve/EV-043-doks-staging-prod
+  branch_base: main@81701500
+  branch_base_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  branch_status: ACTIVE
+  branch_exists: false
+  branch_note: 'ACTIVE recorded @ open; branch not present locally/remotely yet — parent creates from main@81701500; tip SHA from git HEAD'
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-043
+  artifacts_dir: docs/sessions/S052-doks-staging-prod-branch-deploys/
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886
+  github_issues: [886]
+  issue_ids: [886]
+  prior_session: S051-output-filename-download-stale
+  prior_session_note: 'S051 hotfix closed D-S051-close=1; PR #905 MERGED @ a15541e5; tip closeout da2a6656; main tip now 81701500 includes later EV-039 closeout #939'
+  feature_ids:
+  - F30
+  deepen_feature_ids:
+  - F30
+  feature_note: 'Deepen F30 platform independence — DOKS staging env + protected branches + manual promote to main/prod (#886)'
+  preset: Standard
+  preset_note: Standard (pending Plan approval)
+  tip_sha: 81701500
+  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  tip_sha_pushed: true
+  tip_sha_note: 'main HEAD @ open (81701500); evolve branch tip will match once created'
+  scope_summary: >
+    Add DOKS staging + keep prod; stage→staging auto-deploy; main→prod MANUAL ONLY;
+    protect stage/main; GH Envs staging/production; product=DOKS (not App Platform).
+    Phase 0 not fully locked — Plan mode next; exact promote gate shape TBD (D-S052-cd-manual).
+  scope_decisions_locked:
+  - 'D-S052-open=1 — open session for #886'
+  - 'D-S052-scope=1 — Add DOKS staging + keep prod; stage→staging, main→prod'
+  - 'D-S052-product=1 — DOKS (not App Platform)'
+  - 'D-S052-gh=1 — Create stage branch + protect stage/main + GH Envs staging/production'
+  - 'D-S052-cd-manual — CI/CD for both staging and prod; promote to main AND prod is MANUAL ONLY (skill changes may be needed); exact gate shape TBD next AskQuestion'
+  decisions:
+    D-S052-open: '1'
+    D-S052-open_note: '1 — open session for GitHub #886 DOKS staging+prod / branch protection / CI/CD both envs / manual promote'
+    D-S052-scope: '1'
+    D-S052-scope_note: '1 — Add DOKS staging + keep prod; stage→staging, main→prod'
+    D-S052-product: '1'
+    D-S052-product_note: '1 — DOKS (not App Platform)'
+    D-S052-gh: '1'
+    D-S052-gh_note: '1 — Create stage branch + protect stage/main + GH Envs staging/production'
+    D-S052-cd-manual: pending_gate_shape
+    D-S052-cd-manual_note: 'CI/CD for both staging and prod required; promote to main AND prod MANUAL ONLY; skill changes may be needed; exact gate shape TBD next AskQuestion'
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: scoped
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    skip_rationale:
+    note: 'COMPLETE — open_session applied; decisions D-S052-open/scope/product/gh recorded; handoff 16-evolve Phase 0'
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-08-08'
+    skip_rationale:
+    note: 'IN_PROGRESS — Phase 0 handoff; scope draft from open decisions; Plan approval next; Standard pending'
+  current_stage: 16-evolve
+  current_stage_note: '00-context completed (session open); handoff 16-evolve Phase 0 — Plan mode next; promote gate shape TBD'
+  context_briefs: []
+  notes:
+  - '2026-08-08 D-S052-open=1 — OPEN S052/EV-043 for #886; session_counter=52; evolve_cycle_counter=43; branch evolve/EV-043-doks-staging-prod ACTIVE recorded (not created yet) @ main@81701500; 00-context completed → 16-evolve Phase 0; no git commit by workflow-state-manager'
 sessions:
 - id: S051-output-filename-download-stale
   type: hotfix
@@ -6455,31 +6528,32 @@ stages:
   00-context:
     status: completed
     mode: scoped
-    scoped_slug: sql-ingest-live-e2e
-    session_id: S047-sql-ingest-live-e2e
-    evolve_cycle_id: EV-039
-    started: '2026-08-06'
-    started_at: '2026-08-06'
-    completed: '2026-08-06'
-    completed_at: '2026-08-06'
-    note: 'S047/EV-039 COMPLETE — 00-context done; D-S047-open locked; handoff 16-evolve → 01-requirements'
-    prior_note: 'S046/EV-038 COMPLETE — 00-context done; D-S046-mplan M1→M2→M3→M4; handoff 01-requirements; EV-038 closed D-S046-13=1 #890 MERGED'
-    prior_session_id: S046-iwxxm-corpus-residuals
-    prior_evolve_cycle_id: EV-038
-    prior_scoped_slug: iwxxm-corpus-residuals
-    prior_completed: '2026-08-05'
-    prior_started: '2026-08-05'
-    prior_tip_sha: 619a7ac3
-    prior_tip_sha_full: 619a7ac31165ee8f66f99f1de2c431a2716d966e
-    prior_prior_note: 'S045/EV-037 COMPLETE — PR #887 MERGED @ b7302fe4; matrix dispositions #869/#870/#872 closed; deploy waived; active_session=null before S046 open'
-    prior_prior_session_id: S045-matrix-disposition-residuals
-    prior_prior_evolve_cycle_id: EV-037
-    prior_prior_scoped_slug: matrix-disposition-residuals
-    prior_mirror_session_id: S040-iwxxm-corpus-quality
-    prior_mirror_evolve_cycle_id: EV-032
-    tip_sha: 0d8ce885
-    tip_sha_full: 0d8ce8859d517ae2f83ccc4fbc4dfd6d030afedc
+    scoped_slug: doks-staging-prod-branch-deploys
+    session_id: S052-doks-staging-prod-branch-deploys
+    evolve_cycle_id: EV-043
+    started: '2026-08-08'
+    started_at: '2026-08-08'
+    completed: '2026-08-08'
+    completed_at: '2026-08-08'
+    note: 'S052/EV-043 COMPLETE — open_session for #886; D-S052-open/scope/product/gh locked; handoff 16-evolve Phase 0; Standard pending Plan approval'
+    prior_note: 'S047/EV-039 COMPLETE — 00-context done; D-S047-open locked; handoff 16-evolve → 01-requirements'
+    prior_session_id: S047-sql-ingest-live-e2e
+    prior_evolve_cycle_id: EV-039
+    prior_scoped_slug: sql-ingest-live-e2e
+    prior_completed: '2026-08-06'
+    prior_started: '2026-08-06'
+    prior_tip_sha: 0d8ce885
+    prior_tip_sha_full: 0d8ce8859d517ae2f83ccc4fbc4dfd6d030afedc
+    prior_prior_note: 'S046/EV-038 COMPLETE — 00-context done; D-S046-mplan M1→M2→M3→M4; handoff 01-requirements; EV-038 closed D-S046-13=1 #890 MERGED'
+    prior_prior_session_id: S046-iwxxm-corpus-residuals
+    prior_prior_evolve_cycle_id: EV-038
+    prior_prior_scoped_slug: iwxxm-corpus-residuals
+    tip_sha: 81701500
+    tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
     artifacts:
+    - docs/sessions/S052-doks-staging-prod-branch-deploys/
+    - docs/sessions/S051-output-filename-download-stale/
+    - docs/sessions/S050-remove-db-tools-operator-throughput/
     - docs/sessions/S047-sql-ingest-live-e2e/
     - docs/context/sql-ingest-live-e2e.md
     - docs/sessions/S046-iwxxm-corpus-residuals/
@@ -13928,41 +14002,37 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: completed
+    status: in_progress
     mode: orchestrator
-    session_id: S050-remove-db-tools-operator-throughput
-    evolve_cycle_id: EV-042
-    started_at: '2026-08-07'
-    started: '2026-08-07'
-    completed: '2026-08-07'
-    completed_at: '2026-08-07'
-    previous_session_id: S049-operator-sources-briefing
-    previous_evolve_cycle_id: EV-041
+    session_id: S052-doks-staging-prod-branch-deploys
+    evolve_cycle_id: EV-043
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed:
+    completed_at:
+    previous_session_id: S050-remove-db-tools-operator-throughput
+    previous_evolve_cycle_id: EV-042
     previous_completed_at: '2026-08-07'
-    previous_note: 'COMPLETE — D-S049-close; EV-041/S049 closed; PR #895 MERGED (merge `fa5b2140`); tip `fa5b2140`; open S050/EV-042'
+    previous_note: 'COMPLETE — D-S050-13=1; EV-042/S050 closed; PR #899 @ e3d1c7c8; CI/CD 31197264636; active_session=null'
+    prior_s051_session_id: S051-output-filename-download-stale
+    prior_s051_note: 'COMPLETE — D-S051-close=1; hotfix closed; PR #905 @ a15541e5; tip closeout da2a6656; no evolve cycle'
+    prior_s049_session_id: S049-operator-sources-briefing
+    prior_s049_evolve_cycle_id: EV-041
+    prior_s049_completed_at: '2026-08-07'
+    prior_s049_note: 'COMPLETE — D-S049-close; EV-041/S049 closed; PR #895 MERGED (merge `fa5b2140`); tip `fa5b2140`; open S050/EV-042'
     prior_s048_session_id: S048-workbench-lint-ux
     prior_s048_evolve_cycle_id: EV-040
     prior_s048_completed_at: '2026-08-06'
     prior_s048_note: 'COMPLETE — D-S048-close=1,1,1; EV-040/S048 closed; PR #893 merged (merge `4be24994`); tip was 5a9f28ef/2462a397; #894 under #840'
-    prior_s046_session_id: S046-iwxxm-corpus-residuals
-    prior_s046_evolve_cycle_id: EV-038
-    prior_s046_completed_at: '2026-08-06'
-    prior_s046_note: 'COMPLETE — D-S046-13=1; EV-038/S046 closed; #890 @ 619a7ac3; DOKS 20260806144346-619a7ac; evolve-summary.md'
-    prior_s045_session_id: S045-matrix-disposition-residuals
-    prior_s045_evolve_cycle_id: EV-037
-    prior_s045_completed_at: '2026-08-05'
-    prior_s045_note: 'COMPLETE — S045/EV-037 closed; PR #887 MERGED @ b7302fe4; tip 2d8202f3; deploy waived; CI 31049365217 SUCCESS'
-    prior_s044_session_id: S044-local-precommit-long-jobs
-    prior_s044_evolve_cycle_id: EV-036
-    prior_s044_completed_at: '2026-08-05'
-    prior_s044_note: 'COMPLETE — S044/EV-036 closed; PR #875 MERGED @ d17b8be3; tip bf020c2c; deploy waived (D-S044-12-13-waive); CI 31028291943 SUCCESS'
-    prior_mirror_session_id: S040-iwxxm-corpus-quality
-    prior_mirror_evolve_cycle_id: EV-032
-    current_child_stage:
-    current_child_stage_note: 'CLOSED — D-S050-13=1; routing complete'
-    tip_sha: e3d1c7c8
-    tip_sha_full: e3d1c7c84836751ea070cb6162df749b218d2ef2
-    note: 'COMPLETE — D-S050-13=1; EV-042/S050 closed; PR #899 @ e3d1c7c8; CI/CD 31197264636; active_session=null'
+    prior_s047_session_id: S047-sql-ingest-live-e2e
+    prior_s047_evolve_cycle_id: EV-039
+    prior_s047_completed_at: '2026-08-08'
+    prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
+    current_child_stage: phase0
+    current_child_stage_note: 'IN_PROGRESS — Phase 0 after open; Plan approval next; promote gate shape TBD (D-S052-cd-manual)'
+    tip_sha: 81701500
+    tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+    note: 'IN_PROGRESS — S052/EV-043 open for #886; 00-context completed; Phase 0 handoff; branch evolve/EV-043-doks-staging-prod ACTIVE recorded (create pending); no git commit by workflow-state-manager'
 
   15-service-health:
     status: completed
@@ -14223,6 +14293,57 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S052-open
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S052-doks-staging-prod-branch-deploys
+  evolve_cycle_id: EV-043
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: 'Open S052/EV-043 — DOKS staging+prod, GH branch protection, CI/CD both envs, manual promote (#886)'
+  summary: '1 — open session for #886; DOKS staging+prod; stage→staging; main→prod MANUAL; protect stage/main; GH Envs; Standard pending Plan'
+  decision: |
+    D-S052-open=1 — open_session for GitHub #886.
+    Session S052-doks-staging-prod-branch-deploys; evolve cycle EV-043; session_counter 52; evolve_cycle_counter 43.
+    Intent: Stand up DOKS staging + prod environments, protect stage/main, CI/CD for both;
+    auto-deploy stage→staging; manual promote to main/prod.
+    Decisions recorded at open:
+      D-S052-scope=1 — Add DOKS staging + keep prod; stage→staging, main→prod
+      D-S052-product=1 — DOKS (not App Platform)
+      D-S052-gh=1 — Create stage branch + protect stage/main + GH Envs staging/production
+      D-S052-cd-manual — CI/CD for both staging and prod; promote to main AND prod is MANUAL ONLY
+        (skill changes may be needed); exact gate shape TBD next AskQuestion
+    Feature: deepen F30 initially (platform independence).
+    Branch evolve/EV-043-doks-staging-prod status ACTIVE; base main; tip SHA from git 81701500 (8170150038e740c181cc9f236caaeaf84247ff1a).
+    Branch not present in local git at open — parent creates (exists=false recorded).
+    artifacts_dir docs/sessions/S052-doks-staging-prod-branch-deploys/ (parent writes session-brief/routing-plan; not workflow-state-manager).
+    stages.00-context in_progress→completed; active_session.current_stage=16-evolve; stages.16-evolve in_progress.
+    overall_status=in_progress. prior_session S051-output-filename-download-stale.
+    Phase 0 not fully locked — Plan mode next.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-043-doks-staging-prod
+  prior_session: S051-output-filename-download-stale
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886
+  github_issues: [886]
+  tip_sha: 81701500
+  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  deepen_feature_ids:
+  - F30
+  feature_ids:
+  - F30
+  related_decisions:
+  - D-S052-scope
+  - D-S052-product
+  - D-S052-gh
+  - D-S052-cd-manual
+  artifacts:
+  - docs/sessions/S052-doks-staging-prod-branch-deploys/
+  note: 'open_session applied; active_session=S052-doks-staging-prod-branch-deploys; EV-043 in_progress; session_counter=52; evolve_cycle_counter=43; branch ACTIVE recorded exists=false @ main@81701500'
 - id: D-S047-close
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -27061,6 +27182,14 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S052-doks-staging-prod-branch-deploys/
+  status: pending
+  stage: 00-context
+  skill_id: 00-context
+  session_id: S052-doks-staging-prod-branch-deploys
+  evolve_cycle_id: EV-043
+  kind: session_dir
+  note: 'S052 open — parent writes session-brief/routing-plan/context; dir may be created by parent'
 - path: docs/sessions/S050-remove-db-tools-operator-throughput/reports/deploy-smoke.md
   type: session-report
   kind: deploy-smoke
@@ -30396,6 +30525,90 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-043
+  session_id: S052-doks-staging-prod-branch-deploys
+  cycle_type: general
+  feature_ids:
+  - F30
+  deepen_feature_ids:
+  - F30
+  feature_note: 'Deepen F30 platform independence — staging env + manual prod promote (#886); infra/platform'
+  title: "DOKS staging + prod + protected-branch CI/CD (#886)"
+  status: in_progress
+  started: "2026-08-08"
+  started_at: "2026-08-08"
+  completed:
+  completed_at:
+  scope_summary: >
+    Add DOKS staging environment alongside existing prod; protect GitHub branches stage and main;
+    CI/CD for both staging and production; auto-deploy stage→staging; promote to main AND prod is
+    MANUAL ONLY (skill changes may be needed — exact gate shape TBD). Product platform = DOKS
+    (not App Platform). Create stage branch + GitHub Environments staging/production.
+    Phase 0 not fully locked — Plan mode next. Issue #886.
+  scope_decisions_locked:
+  - 'D-S052-open=1 — open session for #886'
+  - 'D-S052-scope=1 — Add DOKS staging + keep prod; stage→staging, main→prod'
+  - 'D-S052-product=1 — DOKS (not App Platform)'
+  - 'D-S052-gh=1 — Create stage branch + protect stage/main + GH Envs staging/production'
+  - 'D-S052-cd-manual — CI/CD both envs; promote to main/prod MANUAL ONLY; gate shape TBD'
+  github_issues: [886]
+  issue_ids: [886]
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886
+  github_issues_note: 'GitHub #886 — DOKS staging+prod + protected-branch CI/CD + manual promote'
+  routing_plan:
+    required_stages:
+    - 00-context
+    - 16-evolve
+    skipped_stages: []
+    note: Standard (pending Plan approval); full child-stage list after Phase 0 / Plan
+  current_stage: 16-evolve
+  current_stage_status: in_progress
+  current_stage_note: '00-context completed at open; Phase 0 handoff — Plan mode next; promote gate TBD'
+  stages:
+    00-context:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: COMPLETE — D-S052-open=1; session open; handoff Phase 0
+    16-evolve:
+      status: in_progress
+      started: '2026-08-08'
+      note: IN_PROGRESS — Phase 0; scope draft from open decisions; Plan approval next
+  phase0_status: in_progress
+  phase0_note: 'Draft locks from open decisions; Phase 0 not fully locked — Plan mode next'
+  branch: evolve/EV-043-doks-staging-prod
+  branch_status: ACTIVE
+  branch_exists: false
+  branch_base: main
+  branch_base_sha: 81701500
+  branch_base_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  tip_sha: 81701500
+  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  tip_sha_pushed: true
+  tip_sha_note: 'main tip at open; evolve branch create pending by parent'
+  preset: Standard
+  preset_note: Standard (pending Plan approval)
+  gates:
+    a_to_b: pending
+    b_to_c: pending
+    c_to_d: pending
+    deploy: pending
+  checkpoints:
+    phase_a: pending
+    phase_b: pending
+    phase_c: pending
+    phase_d: pending
+    deploy: pending
+  adrs: []
+  artifacts:
+  - path: docs/sessions/S052-doks-staging-prod-branch-deploys/
+    status: pending
+    stage: 00-context
+    skill_id: 00-context
+    note: parent writes session-brief/routing-plan/context
+  issues: []
+  notes:
+  - '2026-08-08 EV-043/S052-doks-staging-prod-branch-deploys OPEN — D-S052-open=1; deepen F30; #886; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false @ main@81701500; 00-context completed → 16-evolve Phase 0; Standard pending Plan; no git commit by workflow-state-manager'
 - id: EV-042
   session_id: S050-remove-db-tools-operator-throughput
   cycle_type: general
@@ -40227,15 +40440,15 @@ evolve_cycles:
   pr_merged_sha: dfecba46
 git_history:
   current_branch: main
-  ahead_of_origin: 1
-  pushed: false
+  ahead_of_origin: 0
+  pushed: true
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml after D-S051-close / close_session; no git commit by workflow-state-manager'
-  tip_sha: da2a6656
-  tip_sha_full: da2a6656257696ced3d046d4d19ea4515b9c73b5
-  tip_note: 'main @ da2a6656 S051 closeout (Phase 5 docs + Cursor rule + hotfix-log #13 + nanoid pin); PR #905 merge a15541e5; local ahead of origin by 1 pending push'
+  dirty_note: 'workflow-state.yaml after D-S052-open / open_session S052/EV-043; no git commit by workflow-state-manager'
+  tip_sha: 81701500
+  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  tip_note: 'main @ 81701500 ([EV-039] docs: close S047 after 13-deploy-smoke #939); S052/EV-043 open for #886; evolve branch create pending'
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -40244,12 +40457,13 @@ git_history:
     date: '2026-08-04'
   main_merge_sha: a15541e5
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
-  main_tip_sha: da2a6656
-  main_tip_sha_full: da2a6656257696ced3d046d4d19ea4515b9c73b5
-  recommended_branch: main
-  note: 'S051 CLOSED D-S051-close=1 — tip da2a6656; PR #905 @ a15541e5; active_session=null; no git commit by workflow-state-manager'
+  main_tip_sha: 81701500
+  main_tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+  recommended_branch: evolve/EV-043-doks-staging-prod
+  note: 'S052/EV-043 OPEN D-S052-open=1 — main tip 81701500; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false; active_session=S052-doks-staging-prod-branch-deploys; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-08 S052/EV-043 OPEN — D-S052-open=1; session_counter 52; evolve_cycle_counter 43; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false @ main@81701500; 00-context completed → 16-evolve Phase 0; #886 deepen F30; Standard pending Plan; no git commit by workflow-state-manager'
   - '2026-08-07 S051 CLOSED D-S051-close=1 — closeout da2a6656 on main (Phase 5 docs + Cursor rule + hotfix-log #13 + nanoid>=3.3.17); PR #905 MERGED @ a15541e5; 14-hotfix completed; active_session=null; recorded commits da2a6656 + a15541e5; local ahead_of_origin=1 pending push; no git commit by workflow-state-manager'
   - '2026-08-07 S050/EV-042 13-deploy-smoke STARTED — D-S050-merge=1; PR #899 MERGED @ e3d1c7c8 (e3d1c7c84836751ea070cb6162df749b218d2ef2) at 2026-08-07T16:22:36Z; tip before merge 5558c7e4 (5558c7e44107c6389b30f90189c477a183490792) signed 12; watching main CI/CD Pipeline run 31197264636 for DOKS Deploy; recorded commits 5558c7e4+e3d1c7c8; Sync DB migrations OOS accepted; 13 not completed; no git commit by workflow-state-manager'
   - '2026-08-07 S050/EV-042 12-verify-deploy COMPLETE — D-S050-12=1; tip 4fe4c37f (4fe4c37f55c596ae9eaecf0722501f594bb275b5); product CI green @18d028ed (31195470994); PR #899 MERGEABLE; Sync DB migrations CI OOS; current_stage 13-deploy-smoke pending; awaiting merge #899; recorded commit 4fe4c37f if missing; no git commit by workflow-state-manager'
@@ -40733,6 +40947,24 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-043-doks-staging-prod
+    status: ACTIVE
+    purpose: "DOKS staging + prod + protected-branch CI/CD (#886); S052/EV-043"
+    base: main
+    base_sha: 81701500
+    base_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+    created: '2026-08-08'
+    session_id: S052-doks-staging-prod-branch-deploys
+    evolve_cycle_id: EV-043
+    tip_sha: 81701500
+    tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
+    exists: false
+    pushed: false
+    tip_sha_pushed: false
+    ahead_of_origin:
+    pr_url:
+    pr_status:
+    note: 'ACTIVE recorded at D-S052-open; branch not created yet — parent creates from main@81701500; no git commit by workflow-state-manager'
   - name: fix/output-filename-download-stale
     status: merged
     base: main


### PR DESCRIPTION
## Summary
- Deepen **F30** for [#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886): DOKS staging namespace + overlays, dual CI/CD (`stage`→staging, `main`→prod), **Staging smoke** + **Staging gate** (promote-from-stage).
- ADR-034, deploy/DNS runbook, Cursor rule + skills for dual `env_role`.
- Staging cluster already provisioned (`metar-iwxxm-staging`, DB `metar_iwxxm_staging`); Host-header `/health` 200. Porkbun DNS A records + GH admin rulesets/Environments still needed (403 without admin).

## Test plan
- [ ] CI green on this PR into `stage`
- [ ] After merge: Deploy (stage) + Staging smoke
- [ ] Add Porkbun A records for `api.staging` / `app.staging` → `168.144.12.70`
- [ ] Admin: run `bash scripts/deploy/apply_gh_branch_rulesets.sh` + create GH Environments
- [ ] Later: PR `stage`→`main` after Staging smoke (Staging gate)

[Corpus: product §F30] [Corpus: adr/ADR-034] [Corpus: deploy]


Made with [Cursor](https://cursor.com)