### PR TITLE
[EV-043] docs: closeout + staging capacity runbook

### DIFF
--- a/docs/evolve-report-EV-043.md
+++ b/docs/evolve-report-EV-043.md
@@ -1,0 +1,30 @@
+# Evolve report — EV-043
+
+**Session**: S052-doks-staging-prod-branch-deploys  
+**Issue**: [#886](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886)  
+**Status**: implemented with residuals (DNS + GH admin + node capacity)  
+**Closed PRs**: [#940](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/940), [#942](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/942), [#943](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/943), [#941](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/941)
+
+## Delivered
+
+- DOKS staging namespace `metar-iwxxm-staging` + DB `metar_iwxxm_staging`
+- Kustomize overlays `deploy/doks/overlays/{staging,prod}`
+- Dual CI/CD: `stage`→staging Deploy + Staging smoke; `main`→prod Deploy
+- Staging gate (promote-from-stage) with poll for Staging smoke
+- ADR-034, F30 AC8–12, skills/rules for dual `env_role`
+- Branch `stage` created; promote path exercised
+
+## Residuals
+
+1. **Porkbun DNS** A records for `api.staging` / `app.staging` → `168.144.12.70` (TLS not Ready until then)
+2. **GH admin**: Environments + rulesets (`scripts/deploy/apply_gh_branch_rulesets.sh`) — 403 without admin
+3. **Node pool**: single node; staging worker kept at 0 replicas to leave headroom for prod
+
+## Evidence
+
+- Staging Deploy + Staging smoke: run `31264462312` SUCCESS  
+- Staging gate on promote PR: run `31264463945` SUCCESS (6m12s poll)  
+- Prod tip rolled to `20260808153602-018ea72` (manual assist after CD timeout OOM)  
+- Prod `/health` 200; staging Host-header `/health` 200  
+
+[Corpus: product §F30] [Corpus: adr/ADR-034] [Corpus: deploy]

--- a/docs/ops/doks-staging-dns-runbook.md
+++ b/docs/ops/doks-staging-dns-runbook.md
@@ -34,6 +34,18 @@ Until DNS exists, Host-header probes still work:
 curl -sS -H "Host: api.staging.tac-to-iwxxm.com" http://168.144.12.70/health
 ```
 
+## Single-node capacity
+
+Cluster `metar-iwxxm` currently has **one** worker node. Running full API+FE+worker in
+**both** namespaces can OOM-schedule (`Insufficient memory`). Mitigations:
+
+1. Keep staging `metar-worker` at **0** replicas until the node pool is enlarged, or
+2. Lower staging resource requests (overlay `patch-resources.yaml`), or
+3. Scale the DOKS default node pool (`doctl kubernetes cluster node-pool …`).
+
+Prod Deploy timeouts on rollout usually mean the new pod cannot schedule — free memory
+(scale staging down briefly) then re-run `doks_rollout_images.sh`.
+
 ## GitHub admin (403 for non-admins)
 
 Create Environments + rulesets in the GitHub UI (or as a repo admin):

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/deploy-smoke.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/reports/deploy-smoke.md
@@ -1,23 +1,25 @@
 # 13-deploy-smoke — S052 / EV-043
 
-`env_role`: **staging** provisioned + **prod** unchanged
+`env_role`: staging + prod (dual)
 
-## Staging (Host-header until DNS)
+## Staging
 
 | Check | Result |
 |-------|--------|
-| `kubectl -n metar-iwxxm-staging get deploy` | api/frontend/worker Running |
-| Host-header API `/health` | **200** |
-| Host-header FE `/` | **200** |
-| HTTPS staging DNS | pending Porkbun A records |
-| Certificate Ready | False until DNS |
+| Deploy (stage) + Staging smoke | PASS (runs 31264462312 / successive) |
+| Host-header API `/health` | 200 |
+| HTTPS DNS/TLS | pending Porkbun |
+| Worker replicas | 0 (single-node capacity) |
 
 ## Prod
 
 | Check | Result |
 |-------|--------|
-| `https://api.tac-to-iwxxm.com/health` | unchanged (not redeployed this cycle yet) |
+| Promote PR #941 | MERGED |
+| Image tip | `20260808153602-018ea72` |
+| `https://api.tac-to-iwxxm.com/health` | 200 |
+| CD rollout | timed out once (OOM); completed via brief staging scale-down |
 
-## CD path
+## Staging gate
 
-Land EV-043 on `stage` first → Staging smoke → PR `stage`→`main` → prod Deploy.
+PASS on promote PR (run 31264463945, ~6m poll).


### PR DESCRIPTION
Closeout for #886 / EV-043: evolve report, session smoke notes, single-node capacity guidance.

Made with [Cursor](https://cursor.com)