### PR TITLE
[EV-043] fix: staging worker default replicas 0

### DIFF
--- a/deploy/doks/overlays/staging/patch-resources.yaml
+++ b/deploy/doks/overlays/staging/patch-resources.yaml
@@ -37,6 +37,7 @@ kind: Deployment
 metadata:
   name: metar-worker
 spec:
+  replicas: 0
   template:
     spec:
       containers:


### PR DESCRIPTION
Single-node DOKS capacity: keep staging worker at 0 by default.

Made with [Cursor](https://cursor.com)