### PR TITLE
[EV-045] Rust crate CI (#725)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -335,11 +335,94 @@ jobs:
         run: make test-alembic
 
   # ============================================================================
-  # NATIVE — tac2iwxxm PyO3 / maturin scaffold (ADR-017 / T4.3)
+  # RUST CRATES — fmt / clippy / cargo test (EV-045 / #725 / TC-EV045-001..003)
+  # Matrix legs get GH name suffixes; required check is rust-crates-gate below.
+  # ============================================================================
+  rust-crates:
+    runs-on: ubuntu-latest
+    name: Rust crate (${{ matrix.package }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: tac2iwxxm
+            workdir: packages/tac2iwxxm/rust
+          - package: iwxxm-validate
+            workdir: packages/iwxxm-validate/rust
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      # PyO3 build scripts need a supported CPython (crate max 3.13 today).
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.workdir }} -> target
+
+      - name: cargo fmt --check
+        working-directory: ${{ matrix.workdir }}
+        run: cargo fmt --check
+
+      - name: cargo clippy -D warnings
+        working-directory: ${{ matrix.workdir }}
+        run: |
+          export PYO3_PYTHON="$(command -v python)"
+          cargo clippy -- -D warnings
+
+      - name: cargo test
+        working-directory: ${{ matrix.workdir }}
+        run: |
+          export PYO3_PYTHON="$(command -v python)"
+          cargo test
+
+  rust-crates-gate:
+    runs-on: ubuntu-latest
+    name: Rust crates (fmt/clippy/test)
+    needs: [rust-crates]
+    if: always()
+    steps:
+      - name: Require rust-crates matrix success
+        run: |
+          result="${{ needs.rust-crates.result }}"
+          echo "rust-crates result=${result}"
+          test "${result}" = "success"
+
+  # ============================================================================
+  # NATIVE — PyO3 / maturin smokes (ADR-017 / T4.3; EV-045 extends iwxxm-validate)
+  # Job id stays tac2iwxxm-native for EV-036 contract tests; display names are locked.
   # ============================================================================
   tac2iwxxm-native:
     runs-on: ubuntu-latest
-    name: tac2iwxxm PyO3 (maturin)
+    name: ${{ matrix.check_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: tac2iwxxm
+            path: packages/tac2iwxxm
+            check_name: tac2iwxxm PyO3 (maturin)
+            require_env: TAC2IWXXM_REQUIRE_RUST
+            pytest_args: >-
+              packages/tac2iwxxm/tests/test_native_scaffold.py
+              packages/tac2iwxxm/tests/test_pyo3_hotspots.py
+          - package: iwxxm-validate
+            path: packages/iwxxm-validate
+            check_name: iwxxm-validate PyO3 (maturin)
+            require_env: IWXXM_VALIDATE_REQUIRE_RUST
+            pytest_args: >-
+              packages/iwxxm-validate/tests/test_native_scaffold.py
+              packages/iwxxm-validate/tests/test_tc_f13_001_parity.py
     steps:
       - uses: actions/checkout@v5
         with:
@@ -362,18 +445,23 @@ jobs:
       - name: Install maturin
         run: uv pip install maturin
 
-      - name: Build tac2iwxxm._rust extension
-        working-directory: packages/tac2iwxxm
+      - name: Sync iwxxm-validate runtime schemas
+        if: matrix.package == 'iwxxm-validate'
+        run: uv run python packages/iwxxm-validate/scripts/sync_runtime_schemas.py
+
+      - name: Build ${{ matrix.package }}._rust extension
+        working-directory: ${{ matrix.path }}
         run: |
           source "$HOME/.cargo/env" 2>/dev/null || true
           uv run maturin develop --manifest-path rust/Cargo.toml --uv
 
       - name: Smoke-test required native extension
         env:
-          TAC2IWXXM_REQUIRE_RUST: '1'
+          REQUIRE_ENV: ${{ matrix.require_env }}
         run: |
-          uv run pytest packages/tac2iwxxm/tests/test_native_scaffold.py \
-            packages/tac2iwxxm/tests/test_pyo3_hotspots.py -v --no-cov
+          export "${REQUIRE_ENV}=1"
+          # shellcheck disable=SC2086
+          uv run pytest ${{ matrix.pytest_args }} -v --no-cov
 
   # ============================================================================
   # E2E SMOKE — Playwright browser smoke (auth bootstrap + TAC conversion)
@@ -439,7 +527,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy (${{ github.ref_name }})
-    needs: [test, test-alembic, tac2iwxxm-native]
+    needs: [test, test-alembic, rust-crates-gate, tac2iwxxm-native]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ PY_LINT := apps/backend/src apps/backend/tests \
 	test-unit-backend test-unit-frontend \
 	test-unit-tac2iwxxm test-unit-iwxxm-validate test-unit-tac-validate \
 	test-unit-dissemination test-unit-worker test-bugs \
+	build-tac2iwxxm-native build-iwxxm-validate-native \
+	test-tac2iwxxm-native test-iwxxm-validate-native rust-check \
 	db-migrate test-alembic \
 	verify-supabase-to-do-migrate migrate-supabase-to-do \
 	test-sigmet-quality \
@@ -254,6 +256,16 @@ test-iwxxm-validate-native: build-iwxxm-validate-native
 	IWXXM_VALIDATE_REQUIRE_RUST=1 $(UV) run pytest \
 		packages/iwxxm-validate/tests/test_native_scaffold.py \
 		packages/iwxxm-validate/tests/test_tc_f13_001_parity.py -v --no-cov
+
+# EV-045 / TC-EV045-005 — local mirror of CI: fmt + clippy + cargo test both crates + maturin smokes.
+# PYO3_PYTHON pins uv's interpreter so host 3.14+ does not break PyO3 build scripts.
+rust-check:
+	@PYO3_PYTHON="$$($(UV) run python -c 'import sys; print(sys.executable)')"; \
+	export PYO3_PYTHON; \
+	(cd packages/tac2iwxxm/rust && cargo fmt --check && cargo clippy -- -D warnings && cargo test) && \
+	(cd packages/iwxxm-validate/rust && cargo fmt --check && cargo clippy -- -D warnings && cargo test)
+	$(MAKE) test-tac2iwxxm-native
+	$(MAKE) test-iwxxm-validate-native
 
 # M1 — layer cost matrix harness (T1.1–T1.3). Script lands in build; stub until then.
 bench-validation-stack:

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,82 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-045 — Rust crate CI (#725) (S054)
+
+**Session**: S054-rust-ci-crates  
+**Features**: deepen **F13**, **F14**  
+**Started**: 2026-08-08  
+**Branch**: `evolve/EV-045-rust-ci`  
+**Status**: in_progress  
+**Issues**: [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)  
+**Corpus**: [Corpus: product §F13], [Corpus: product §F14], [Corpus: tech-spec],
+[Corpus: tests], [Corpus: adr/ADR-017]
+
+
+### Scope (Phase 0 — locked 2026-08-08)
+
+| ID | Decision |
+|----|----------|
+| D-park-doks | Park EV-043 + EV-044; repair mashed `active_session`; clear for #725 |
+| D-S054-open | Open S054 / EV-045; Standard with skips 03/06/10/12/13; deepen F13+F14 |
+| D-S054-01-ac | **1** — confirm ACs + defaults (extend `ci-cd.yml`, clippy `-D warnings`, `make rust-check`) → 02-verify-plan |
+| D-S054-gateA | **2** — PASS Gate A but **ruleset update before 04**; check names locked in test-plan + `apply_gh_branch_rulesets.sh` |
+| D-S054-ac6-waive | **2** — Waive AC6 **ops** half (live GH rulesets/required checks); keep docs + `apply_gh_branch_rulesets.sh`; proceed **04**; apply later when admin available |
+| D-S054-04-jobs | **2** — cargo via crate **matrix** + thin gate job `name: Rust crates (fmt/clippy/test)` (avoids GH matrix name suffix breaking required checks) |
+| D-S054-04-maturin | **2** — extend `tac2iwxxm-native` → two-package matrix; `name: ${{ matrix.check_name }}` for locked maturin contexts |
+| D-S054-04-trigger | **1** — run with default `ci-cd.yml` PR/push (not path-filter-only) |
+| D-S054-04-local | **2** — `deploy.needs` includes rust gate + native matrix; `make rust-check` = cargo both crates **+** both maturin smokes |
+| D-S054-04-plan | **1** — Approve execution plan + Build Plan Card as written → 05-verify-tech |
+| D-S054-gateB | **1** — PASS Gate B; confirm syncs; proceed 07-build (06 skipped) |
+
+**Goal**: Required CI + Makefile parity for `packages/tac2iwxxm/rust` and
+`packages/iwxxm-validate/rust` (`fmt`, `clippy -D warnings`, `cargo test`, maturin/PyO3
+smoke for both).
+
+**Out of scope**: Rust HTTP service; multi-arch wheel CI beyond `pypi-publish`; Schematron
+perf gates; browser E2E; staging/prod deploy.
+
+### Preset
+
+**Standard** — skip 03/06/10/12/13 (tooling/deps/UI/deploy not in scope).
+
+### Acceptance (F13/F14 deepen — TC-EV045-001..007) — confirmed D-S054-01-ac=1
+
+| AC | Criterion | TC |
+|----|-----------|-----|
+| AC1 | `cargo fmt --check` fails on unformatted Rust (both crates) | TC-EV045-001 |
+| AC2 | `clippy -- -D warnings` fails on warnings | TC-EV045-002 |
+| AC3 | `cargo test` green for both crates | TC-EV045-003 |
+| AC4 | Maturin/PyO3 smoke for **both** packages | TC-EV045-004 |
+| AC5 | `make rust-check` mirrors CI (cargo both + both maturin smokes) | TC-EV045-005 |
+| AC6 | Required check name(s) documented; merge blocked when red | TC-EV045-006 |
+| AC7 | Jobs on default `ci-cd.yml` PR/push (not path-filter-only) | TC-EV045-007 |
+
+**AC6 split (D-S054-ac6-waive=2):** docs half **in scope** (locked contexts in
+`docs/test-plan.md` + script). Ops half (repo rulesets actually requiring those
+contexts) **waived until admin** runs `bash scripts/deploy/apply_gh_branch_rulesets.sh`.
+Same class as EV-043 admin gap. [Corpus: tests] [Corpus: decisions]
+
+### Implementation defaults (confirmed D-S054-01-ac=1)
+
+| Topic | Default |
+|-------|---------|
+| Workflow | Extend `.github/workflows/ci-cd.yml` (matrix); not a new workflow unless latency forces |
+| Clippy | Hard `-D warnings` |
+| Local | `make rust-check` mirrors CI |
+| Cache | `Swatinem/rust-cache` (or equivalent) |
+| Toolchain | `dtolnay/rust-toolchain@stable` + rustfmt,clippy |
+
+**Current stage**: 07-build (D-S054-gateB=1; active T1.1)
+
+### Corpus cites / waivers
+
+- [Corpus: product §F13] [Corpus: product §F14]
+- [Corpus: tech-spec] [Corpus: tests] [Corpus: journeys] [Corpus: adr/ADR-017]
+- `[Corpus: WAIVED — AC6 GitHub rulesets/required-checks apply; reason: token admin=false / no rulesets; decided: D-S054-ac6-waive=2 / EV-045]`
+
+---
+
 ## Cycle EV-044 — Separate staging DOKS + DO Project (S053)
 
 **Session**: S053-separate-staging-doks-project  
@@ -13,6 +89,7 @@
 **Amends**: [ADR-034](../adr/ADR-034-doks-staging-promote-from-stage.md) (shared cluster → dual cluster)  
 **Corpus**: [Corpus: product §F30], [Corpus: deploy], [Corpus: tech-spec],
 [Corpus: tests], [Corpus: adr/ADR-033], [Corpus: adr/ADR-034]
+
 
 ### Scope (Phase 0 — locked 2026-08-08)
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -9,8 +9,9 @@
 **Features**: deepen **F13**, **F14**  
 **Started**: 2026-08-08  
 **Branch**: `evolve/EV-045-rust-ci`  
-**Status**: in_progress  
+**Status**: **completed** 2026-08-08  
 **Issues**: [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)  
+**PR**: [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → `stage` (open at close)  
 **Corpus**: [Corpus: product §F13], [Corpus: product §F14], [Corpus: tech-spec],
 [Corpus: tests], [Corpus: adr/ADR-017]
 
@@ -30,6 +31,9 @@
 | D-S054-04-local | **2** — `deploy.needs` includes rust gate + native matrix; `make rust-check` = cargo both crates **+** both maturin smokes |
 | D-S054-04-plan | **1** — Approve execution plan + Build Plan Card as written → 05-verify-tech |
 | D-S054-gateB | **1** — PASS Gate B; confirm syncs; proceed 07-build (06 skipped) |
+| D-S054-t17-ci | **1** — Accept Actions run 31273500621 as tip CI for EV-045 jobs (docs-only tip after) |
+| D-S054-phaseC | **1** — Approve Phase C; start 09-qa |
+| D-S054-11 | **1** — Approve F13+F14 deepen + accept QA-001..005; close cycle (12/13 skipped) |
 
 **Goal**: Required CI + Makefile parity for `packages/tac2iwxxm/rust` and
 `packages/iwxxm-validate/rust` (`fmt`, `clippy -D warnings`, `cargo test`, maturin/PyO3
@@ -69,7 +73,8 @@ Same class as EV-043 admin gap. [Corpus: tests] [Corpus: decisions]
 | Cache | `Swatinem/rust-cache` (or equivalent) |
 | Toolchain | `dtolnay/rust-toolchain@stable` + rustfmt,clippy |
 
-**Current stage**: 07-build (D-S054-gateB=1; active T1.1)
+**Closed**: 2026-08-08 — `D-S054-11=1`; reports `evolve-summary.md` + `docs/evolve-report-EV-045.md`.  
+PR #953 open → `stage` (merge separate). AC6 ops still deferred.
 
 ### Corpus cites / waivers
 

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -1,6 +1,6 @@
 # Requirements Decisions Log
 
-> Stage: 01-requirements | Last updated: 2026-08-06 (S047 / EV-039)
+> Stage: 01-requirements | Last updated: 2026-08-08 (S054 / EV-045)
 
 | ID | Topic | Decision | Status |
 |----|-------|----------|--------|
@@ -396,6 +396,18 @@
 | EV-025/E25-T5 | Gate C residuals | Encode residual **blocks** Gate C (supersedes S02.M2 soft deferral) | confirmed |
 | EV-025/E25-T6 | Draft plan | Draft from T1–T5; Gate B pending | confirmed |
 | EV-025/E25-04 | Gate B | Approve M0–M7 → 07-build @ T0.1 | confirmed |
+
+## EV-045 / #725 — Rust crate CI (2026-08-08)
+
+| ID | Topic | Decision | Status |
+|----|-------|----------|--------|
+| EV-045/scope | Fn | Deepen **F13** + **F14** (no new Fn; M5 optional later) | confirmed |
+| EV-045/ui | UI | N/A — no browser UI / no H4–H5 | confirmed |
+| EV-045/workflow | CI shape | Extend `ci-cd.yml` (matrix over both crates); separate `rust-ci.yml` only if latency forces | confirmed |
+| EV-045/clippy | Lint policy | `cargo clippy -- -D warnings` hard-fail; allowlist only if build proves need | confirmed |
+| EV-045/make | Local | `make rust-check` mirrors CI | confirmed |
+| EV-045/docs | Standing | feature-list, test-plan TC-EV045-*, UJ-DEV-006, tech-spec pointer | confirmed |
+| EV-045/01-ac | Gate | D-S054-01-ac=1 — ACs + defaults confirmed → 02 | confirmed |
 
 ## EV-031 / #842+#830+#712 — Platform independence (2026-08-03)
 

--- a/docs/decisions/tech-audit.md
+++ b/docs/decisions/tech-audit.md
@@ -1,6 +1,22 @@
 # Technical Plan Audit Report
 
-> Stage: 05-verify-tech | Last delta: 2026-07-21 (S019 / EV-014)
+> Stage: 05-verify-tech | Last delta: 2026-08-08 (S054 / EV-045)
+
+## S054 / EV-045 delta (2026-08-08)
+
+| Metric | Count |
+|--------|-------|
+| Documents audited | 7 (+ N/A connectivity/deps) |
+| Auto-approved (high) | 8 |
+| Medium | 2 (synced to D-S054-04 locked answers) |
+| Low | 2 (synced) |
+| Denied | 0 |
+| Plan-readiness | **PASS** — card ↔ T1.1–T1.7 |
+| Consistency issues | 2 wording drifts — resolved in test-plan / evolve-decisions / feature-list / execution-plan |
+
+Full walk: `docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md`.
+
+---
 
 ## S019 / EV-014 delta (2026-07-21)
 

--- a/docs/decisions/tech-decisions.md
+++ b/docs/decisions/tech-decisions.md
@@ -1,7 +1,20 @@
 # Technical Decision Log
 
 > Extends [product-decisions.md](product-decisions.md) with 05-verify-tech audit verdicts.
-> Last updated: 2026-07-22 (S020 / EV-015 04-tech-plan)
+> Last updated: 2026-08-08 (S054 / EV-045)
+
+## S054 / EV-045 05-verify-tech (2026-08-08)
+
+| ID | Date | Topic | Decision | Status |
+|----|------|-------|----------|--------|
+| D-S054-04-plan | 2026-08-08 | Plan | Approve execution-plan + Build Plan Card → 05 | confirmed |
+| S2.1 | 2026-08-08 | AC7 / TC-EV045-007 | Always-on default CI (not path-filter-only) | synced |
+| S2.2 | 2026-08-08 | TC-EV045-005 | `make rust-check` includes both maturin smokes | synced |
+| S3.1 | 2026-08-08 | T1.7 deps | Depends on T1.2–T1.6 | synced |
+| S3.2 | 2026-08-08 | F13 AC5 | Docs merge-block; ops rulesets waived | synced |
+| D-S054-gateB | 2026-08-08 | Gate B | PASS → 07-build (06 skipped) | confirmed |
+
+Session report: `docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md`.
 
 ## S020 / EV-015 04-tech-plan (2026-07-22)
 

--- a/docs/evolve-report-EV-045.md
+++ b/docs/evolve-report-EV-045.md
@@ -1,0 +1,42 @@
+# Evolve report — Rust crate CI (#725)
+
+- **Cycle**: EV-045
+- **Session**: S054-rust-ci-crates
+- **Status**: completed
+- **Scope**: Deepen F13 + F14 — required Rust fmt/clippy/`cargo test` + maturin smokes for both crates; `make rust-check`; tip CI green
+- **Stages run**: 00, 16, 01, 02, 04, 05, 07, 08, 09, 11 (skip 03/06/10/12/13)
+- **ADRs**: ADR-017 (toolchain); ADR-034 (PR → `stage`)
+- **Deploy**: not deployed (CI-only)
+- **PR**: [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → `stage` (open; supersedes #952)
+- **Issue**: [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)
+- **Open follow-ups**: AC6 ruleset apply (admin); merge #953
+
+## Summary
+
+EV-045 adds GitHub Actions and Makefile gates so unformatted, clippy-noisy, or failing
+Rust/`maturin` work for `tac2iwxxm` and `iwxxm-validate` cannot merge or deploy green.
+Implementation verified (`D-S054-11=1`); tip CI accepted via `D-S054-t17-ci=1`.
+
+See session summary: [`docs/sessions/S054-rust-ci-crates/reports/evolve-summary.md`](sessions/S054-rust-ci-crates/reports/evolve-summary.md).
+
+## Artifacts changed
+
+- `.github/workflows/ci-cd.yml` — rust matrix + gate; maturin two-package matrix; deploy.needs
+- `Makefile` — `rust-check` (+ native helpers)
+- `tests/test_tc_ev045_rust_ci.py` — contracts
+- `docs/feature-list.md`, `docs/test-plan.md`, `docs/tech-spec.md`, `docs/user-journeys.md`
+- `scripts/deploy/apply_gh_branch_rulesets.sh` — locked check contexts
+- Session reports under `docs/sessions/S054-rust-ci-crates/`
+
+## Verification
+
+- 08-verify-build: PASS
+- 09-qa: pass_with_advisories (QA-001..005 accepted at 11)
+- 10-e2e: skipped
+- 11-verify-impl: APPROVED (`D-S054-11=1`)
+- Tip CI: [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621) SUCCESS for EV-045 jobs
+
+## Corpus
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tests] [Corpus: tech-spec]
+[Corpus: adr/ADR-017] [Corpus: decisions]

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-07 (S050 / EV-042 — F33 mass ingest + F7/F16 deepen; prior S047 / EV-039)
+> **Last updated**: 2026-08-08 (S054 / EV-045 — F13/F14 Rust CI deepen #725; prior S050 / EV-042)
 
 ## Summary
 
@@ -20,8 +20,8 @@
 | F10 | Workbench preview clarity (IWXXM pane + lint UX) | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723); **deepen** S048 / EV-040 full lint console lines + preserve input on convert |
 | F11 | Validation stack perf review + msgspec HTTP + XSD codegen | Implemented | Product | S014 / EV-010; #703 |
 | F12 | Publishable TAC product validation (`tac-validate`) | Implemented | Product | S014 / EV-010; #698; **deepen** S043 / EV-035 lint↔source provenance |
-| F13 | Fast IWXXM validate (Rust core + Schematron + PyPI) | Implemented | Product | S014 / EV-010; #699 |
-| F14 | Publish `tac2iwxxm` + validate extras + PyPI/release CI | Implemented | Product | S014 / EV-010; #693 |
+| F13 | Fast IWXXM validate (Rust core + Schematron + PyPI) | Implemented | Product | S014 / EV-010; #699; **deepen** S054 / EV-045 Rust CI (#725) |
+| F14 | Publish `tac2iwxxm` + validate extras + PyPI/release CI | Implemented | Product | S014 / EV-010; #693; **deepen** S054 / EV-045 Rust CI (#725) |
 | F15 | Maintainable TAC lint issue registry + METAR/SPECI quality bar | Done | Product | S015 / EV-011; #732; **deepen** S043 / EV-035 ISSUE_CATALOG↔source; **deepen** S048 / EV-040 catalog source attribution in API/FE + RVR/AHL FP fixes |
 | F16 | Dissemination drawer + multi-DB upload (BYOC URI) | Done | Product | S019 / EV-014; #729; **deepen** S024 / EV-018 multi-select (#785); **deepen** S047 / EV-039 live local SQL; **deepen** S050 / EV-042 #897 **UI-hide all destinations** (API retained; restore #898) |
 | F17 | WIS2 dissemination pathway | Done | Product | S019 / EV-014; #2; **S050 / EV-042** operator UI hidden with F16–F19 (restore #898) |
@@ -478,7 +478,7 @@
 ### F13: Fast IWXXM Validate (Rust Core + Schematron + PyPI)
 
 - **Status**: **Implemented** — S014 / EV-010 (#699); EMPIRIC2 OIDC + consumer landing
-  pages EV-028 / #781 (`0.1.1`).
+  pages EV-028 / #781 (`0.1.1`); **deepen** S054 / EV-045 ([#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)).
 - **What it does**: Publish **`iwxxm-validate`** with Rust core (PyO3/maturin):
   well-formed + XSD + **native Rust Schematron/SVRL**; Python SDK
   `validate_iwxxm(...)`; pinned `vendor/schemas/*` **bundled** in the wheel; version/profile
@@ -491,12 +491,23 @@
   3. Parity tests vs golden IWXXM corpus; IWXXM-US profile supported when pin present
   4. Tag `iwxxm-validate-v*` → trusted publishing; no TAC parsing in package
   5. PyPI landing usable without internal ADR/Feature IDs
-- **Source**: #699; E10-6/7/19/22; ADR-017; #781
+- **S054 / EV-045 deepen (Rust CI — #725)**: PR/default CI must gate
+  `packages/iwxxm-validate/rust` with `cargo fmt --check`, `cargo clippy -- -D warnings`,
+  `cargo test`, plus maturin/PyO3 smoke (parity with `tac2iwxxm` native job). Local
+  `make rust-check` mirrors CI. See TC-EV045-*.
+- **Acceptance (EV-045 deepen)**:
+  1. CI fails on unformatted Rust under `packages/iwxxm-validate/rust`
+  2. CI fails on clippy warnings (`-D warnings`) unless documented allowlist
+  3. `cargo test` green for the crate on PR/push default CI
+  4. Maturin/PyO3 integration smoke required for `iwxxm-validate` (not only `tac2iwxxm`)
+  5. Required check name(s) documented so red Rust CI blocks merge (**ops** ruleset
+     apply may be deferred — D-S054-ac6-waive=2)
+- **Source**: #699; E10-6/7/19/22; ADR-017; #781; #725
 
 ### F14: Publish `tac2iwxxm` + Validate Extras + PyPI/Release CI
 
 - **Status**: **Implemented** — S014 / EV-010 (#693); EMPIRIC2 OIDC + consumer landing
-  pages EV-028 / #781 (`0.1.1`).
+  pages EV-028 / #781 (`0.1.1`); **deepen** S054 / EV-045 ([#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)).
 - **What it does**: Publish **`tac2iwxxm`** to PyPI (conversion library + optional
   PyO3). Extra **`tac2iwxxm[validate]`** depends on `tac-validate` + `iwxxm-validate`.
   Shared GitHub Actions **OIDC trusted publishing** — one workflow matrix on version
@@ -507,7 +518,16 @@
   2. `pip install tac2iwxxm[validate]` pulls both validators
   3. Tag-driven publish CI green; README install/usage (consumer-facing, no ADR/Fn required)
   4. UJ-DEV-005 / UJ-023 smokes pass
-- **Source**: #693; E10-5/19/20/25; #781
+- **S054 / EV-045 deepen (Rust CI — #725)**: Same Rust lint/typecheck/unit/integration
+  gates for `packages/tac2iwxxm/rust` as F13; extend beyond maturin-only
+  `tac2iwxxm-native` smoke. Deploy `needs` must include the new Rust check job(s).
+- **Acceptance (EV-045 deepen)**:
+  1. CI fails on unformatted Rust under `packages/tac2iwxxm/rust`
+  2. CI fails on clippy warnings (`-D warnings`) unless documented allowlist
+  3. `cargo test` green for the crate on PR/push default CI
+  4. Existing maturin smoke retained; crate-local `cargo test` is also required
+  5. `make rust-check` documents local parity for both crates
+- **Source**: #693; E10-5/19/20/25; #781; #725
 
 ### F15: Maintainable TAC Lint Issue Registry + METAR/SPECI Quality Bar
 

--- a/docs/ops/DEVELOPMENT.md
+++ b/docs/ops/DEVELOPMENT.md
@@ -217,8 +217,8 @@ Primary workflow: `.github/workflows/ci-cd.yml` (**EV-036** local-first amend).
 |------|-------|------|
 | Fast + medium | husky **pre-commit** | Fast pre-commit hooks + `make validate-ci-medium` (config-guard, env-check, audit-frontend). Strict lint/format stay here. |
 | Long local | husky **pre-push** | `make ci` = `ci-prepush` + Compose **integration** (ports **18000/18001**). Needs Docker. |
-| Remote PR/push | GitHub Actions | **No** `validate` job; **no** Compose integration. **Keeps** package **unit matrix** + coverage + sticky **PR coverage comment**. Also `tac2iwxxm-native`, `e2e-smoke`, `test-alembic`. |
-| Deploy | `main` push only | needs `test` + `test-alembic` + `tac2iwxxm-native`; GHCR + DOKS; Render optional |
+| Remote PR/push | GitHub Actions | **No** `validate` job; **no** Compose integration. **Keeps** package **unit matrix** + coverage + sticky **PR coverage comment**. Also `rust-crates` / `Rust crates (fmt/clippy/test)` gate, `tac2iwxxm-native` maturin matrix (both packages), `e2e-smoke`, `test-alembic` (EV-045). |
+| Deploy | `main`/`stage` push | needs `test` + `test-alembic` + `rust-crates-gate` + `tac2iwxxm-native`; GHCR + DOKS; Render optional |
 
 Image deploys use `scripts/deploy/trigger_render_image_deploy.py` (hook + `imgURL`, with REST
 `imageUrl` fallback when `RENDER_API_KEY` is set — BUG-2026-08-03).
@@ -227,7 +227,9 @@ Image deploys use `scripts/deploy/trigger_render_image_deploy.py` (hook + `imgUR
 |-----|--------|
 | **test** (matrix) | Package unit tests with coverage (`--cov-fail-under` / Vitest) |
 | **coverage-pr-comment** | Sticky PR comment from coverage XML / Vitest summary (PRs only) |
-| **tac2iwxxm-native** | PyO3 / maturin smoke |
+| **rust-crates** / **rust-crates-gate** | fmt + clippy `-D warnings` + `cargo test` both crates; gate name `Rust crates (fmt/clippy/test)` |
+| **tac2iwxxm-native** | PyO3 / maturin matrix (`tac2iwxxm` + `iwxxm-validate` display names) |
+| **make rust-check** | Local mirror of rust crates + both native smokes |
 | **e2e-smoke** | Playwright smoke |
 | **test-alembic** | Alembic upgrade head (TC-EV031-002) |
 | **deploy** | Docker build/push + DOKS/Render (`main` push only; skipped if CD credentials incomplete) |

--- a/docs/sessions/S052-doks-staging-prod-branch-deploys/session-brief.md
+++ b/docs/sessions/S052-doks-staging-prod-branch-deploys/session-brief.md
@@ -42,3 +42,7 @@ staging; promote via PR into `main` auto-deploys prod only after staging is prov
 
 **Standard**: `00 → 16 → 01 → 02 → 03 → 04 → 05 → 07 → 08 → 09 → 10 → 11 → 12 → 13`  
 Skip `06` (no new runtime deps).
+
+## Parked
+
+**D-park-doks=1** (2026-08-08) — Parked to open #725 Rust CI. Resume at `16-evolve` (Phase 0 incomplete; promote gate TBD). `active_session` cleared.

--- a/docs/sessions/S054-rust-ci-crates/build-plan-card.md
+++ b/docs/sessions/S054-rust-ci-crates/build-plan-card.md
@@ -1,6 +1,6 @@
 # Build Plan Card
 
-> Session: S054-rust-ci-crates | Updated: 2026-08-08 | Active: Phase 1 / M1 / T1.7
+> Session: S054-rust-ci-crates | Updated: 2026-08-08 | Active: 08-verify-build (M1 complete)
 
 ## Goal (one sentence)
 
@@ -25,7 +25,7 @@ Gate PRs on fmt/clippy/`cargo test` + maturin smokes for both Rust crates, with
 - [x] T1.4 — Config — maturin two-package matrix — Spec: D-S054-04-maturin
 - [x] T1.5 — Config — deploy.needs + always-on CI trigger — Spec: D-S054-04-trigger/local
 - [x] T1.6 — Docs — tech-spec / script confirm — Spec: tech-spec; test-plan
-- [ ] T1.7 — Code — tip CI green / clippy-fmt debt — Spec: TC-EV045-*
+- [x] T1.7 — Code — tip CI green / clippy-fmt debt — Spec: TC-EV045-* (`D-S054-t17-ci=1`)
 
 ## Out of scope (explicit)
 
@@ -40,12 +40,11 @@ Gate PRs on fmt/clippy/`cargo test` + maturin smokes for both Rust crates, with
 
 ## Acceptance for this batch
 
-- [ ] Contract tests green
-- [ ] Tip `ci-cd.yml` shows locked check names green
-- [ ] `make rust-check` mirrors CI cargo + maturin
-- [ ] TC-EV045-006 docs/script met; ops deferred
+- [x] Contract tests green
+- [x] Tip `ci-cd.yml` shows locked check names green (`D-S054-t17-ci=1` / run 31273500621)
+- [x] `make rust-check` mirrors CI cargo + maturin
+- [x] TC-EV045-006 docs/script met; ops deferred
 
 ## Next Plan prompt
 
-Refine M1 task order only if tip CI latency forces splitting the cargo matrix differently;
-otherwise Agent runs T1.1→T1.7 per execution-plan.md.
+M1 complete — Agent runs **08-verify-build** (delta), then Phase C checkpoint → **09-qa**.

--- a/docs/sessions/S054-rust-ci-crates/build-plan-card.md
+++ b/docs/sessions/S054-rust-ci-crates/build-plan-card.md
@@ -1,0 +1,51 @@
+# Build Plan Card
+
+> Session: S054-rust-ci-crates | Updated: 2026-08-08 | Active: Phase 1 / M1 / T1.7
+
+## Goal (one sentence)
+
+Gate PRs on fmt/clippy/`cargo test` + maturin smokes for both Rust crates, with
+`make rust-check` local parity (#725).
+
+## Constraints
+
+- [Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec] [Corpus: tests]
+  [Corpus: adr/ADR-017]
+- Branch: `evolve/EV-045-rust-ci` from `main`
+- Locked check names: `Rust crates (fmt/clippy/test)`, `tac2iwxxm PyO3 (maturin)`,
+  `iwxxm-validate PyO3 (maturin)`
+- AC6 ops waived (D-S054-ac6-waive=2); docs + apply script only
+- No UI / no deploy smoke (skip 10/12/13)
+
+## In scope (this batch)
+
+- [x] T1.1 — Test — contract tests for Makefile + `ci-cd.yml` job names / deploy.needs — Spec: test-plan TC-EV045-*
+- [x] T1.2 — Config — `make rust-check` (cargo both + both native smokes) — Spec: tech-spec §Rust
+- [x] T1.3 — Config — rust matrix + gate job locked name — Spec: D-S054-04-jobs
+- [x] T1.4 — Config — maturin two-package matrix — Spec: D-S054-04-maturin
+- [x] T1.5 — Config — deploy.needs + always-on CI trigger — Spec: D-S054-04-trigger/local
+- [x] T1.6 — Docs — tech-spec / script confirm — Spec: tech-spec; test-plan
+- [ ] T1.7 — Code — tip CI green / clippy-fmt debt — Spec: TC-EV045-*
+
+## Out of scope (explicit)
+
+- Separate `rust-ci.yml`; path-filter-only jobs; live ruleset apply; multi-arch wheels;
+  browser E2E; staging/prod smoke
+
+## Dependencies / blockers
+
+- Data: none
+- Prior: 01/02 complete; AC6 ops waived
+- Tooling: 06 skipped (ADR-017); Rust/maturin already in repo
+
+## Acceptance for this batch
+
+- [ ] Contract tests green
+- [ ] Tip `ci-cd.yml` shows locked check names green
+- [ ] `make rust-check` mirrors CI cargo + maturin
+- [ ] TC-EV045-006 docs/script met; ops deferred
+
+## Next Plan prompt
+
+Refine M1 task order only if tip CI latency forces splitting the cargo matrix differently;
+otherwise Agent runs T1.1→T1.7 per execution-plan.md.

--- a/docs/sessions/S054-rust-ci-crates/evolve-plan-card.md
+++ b/docs/sessions/S054-rust-ci-crates/evolve-plan-card.md
@@ -1,0 +1,43 @@
+# Evolve Plan Card
+
+> Cycle: EV-045 | Session: S054-rust-ci-crates | Updated: 2026-08-08
+
+## Goal
+
+Add required CI (and local Makefile parity) for Rust crates behind F13/F14 so
+unformatted, clippy-noisy, or failing `cargo test` / maturin bridges cannot merge green.
+
+## Features
+
+- F13 — Fast IWXXM validate (Rust core) — deepen CI gates — [Corpus: product §F13]
+- F14 — Publish `tac2iwxxm` + validate extras — deepen native CI — [Corpus: product §F14]
+
+## In / out of scope
+
+- In: `cargo fmt --check`, `clippy -D warnings`, `cargo test`, maturin/PyO3 smoke for
+  `packages/tac2iwxxm/rust` + `packages/iwxxm-validate/rust`; Cargo cache; `make rust-check`;
+  required GH checks; docs deltas in tech-spec / test-plan / feature AC as needed
+- Out: Rust HTTP service; multi-arch wheel CI beyond `pypi-publish`; Schematron perf gates;
+  browser E2E; staging/prod deploy
+
+## Preset + routing
+
+- Preset: Standard (skips 03/06/10/12/13)
+- Stages (ordered): `00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 11`
+
+## Next child stage
+
+**07-build** — T1.1–T1.6 done locally; **T1.7** tip CI after commit/push. Then 08→09→11.
+
+## Locked defaults (D-S054-01-ac=1 + D-S054-04)
+
+- Extend `ci-cd.yml`: cargo **matrix** + gate job; maturin **two-package matrix**
+- `cargo clippy -- -D warnings` hard-fail
+- `make rust-check` = cargo both + both maturin smokes
+- Default CI triggers; `deploy.needs` gated on new jobs
+
+## Risks / open decisions
+
+- AC6 ops: rulesets still empty until admin runs `apply_gh_branch_rulesets.sh`
+  (waived for this cycle — D-S054-ac6-waive=2)
+- Gate-job pattern required so locked check name stays exact under matrix

--- a/docs/sessions/S054-rust-ci-crates/evolve-plan-card.md
+++ b/docs/sessions/S054-rust-ci-crates/evolve-plan-card.md
@@ -27,7 +27,7 @@ unformatted, clippy-noisy, or failing `cargo test` / maturin bridges cannot merg
 
 ## Next child stage
 
-**07-build** — T1.1–T1.6 done locally; **T1.7** tip CI after commit/push. Then 08→09→11.
+**None** — cycle **completed** (`D-S054-11=1`). PR #953 open → `stage` (merge separate).
 
 ## Locked defaults (D-S054-01-ac=1 + D-S054-04)
 

--- a/docs/sessions/S054-rust-ci-crates/reports/01-requirements.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/01-requirements.md
@@ -1,0 +1,36 @@
+# 01-requirements — S054 / EV-045
+
+**Status**: completed — D-S054-01-ac=1  
+**Date**: 2026-08-08  
+**Mode**: delta (deepen F13 + F14)  
+**Issue**: [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)
+
+## Corpus
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: journeys] [Corpus: tech-spec]
+[Corpus: tests] [Corpus: adr/ADR-017] [Corpus: decisions]
+
+## Standing doc deltas
+
+| Doc | Change |
+|-----|--------|
+| `docs/feature-list.md` | F13/F14 deepen AC + summary row |
+| `docs/test-plan.md` | TC-EV045-001..007; CI/CD table; UJ map |
+| `docs/user-journeys.md` | UJ-DEV-006 |
+| `docs/tech-spec.md` | Rust native crates pointer |
+| `docs/decisions/requirements-decisions.md` | EV-045 section |
+| `docs/decisions/evolve-decisions.md` | EV-045 AC table |
+
+## Skipped (N/A)
+
+- Browser UI / H4–H5 / deploy.md / api-contract — CI-only
+- New ADR — extends ADR-017 tooling; no new architectural choice yet
+- Dependency inventory — no new Python/runtime package
+
+## Defaults (confirmed — D-S054-01-ac=1)
+
+1. Extend `ci-cd.yml` with crate matrix (not separate `rust-ci.yml`)
+2. `clippy -- -D warnings` hard-fail
+3. `make rust-check` local mirror
+
+**Next:** 02-verify-plan (Gate A)

--- a/docs/sessions/S054-rust-ci-crates/reports/02-verify-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/02-verify-plan.md
@@ -1,0 +1,90 @@
+# 02-verify-plan — Gate A (S054 / EV-045)
+
+**Date**: 2026-08-08  
+**Mode**: delta — F13/F14 Rust CI deepen (#725)  
+**Status**: Gate A PASS with blocker — D-S054-gateA=2 (ruleset before 04)
+
+## Inventory (touched)
+
+| # | Document | Delta | Status |
+|---|----------|-------|--------|
+| 1 | feature-list.md | F13/F14 deepen AC | audited |
+| 2 | user-journeys.md | UJ-DEV-006 | audited |
+| 3 | test-plan.md | TC-EV045-001..007 + CI table | audited |
+| 4 | tech-spec.md | Rust native crates pointer | audited |
+| 5 | evolve-decisions / requirements-decisions | EV-045 | reference |
+| — | spec.md | No CI-job text change; F13/F14 components already map | OK / no delta |
+| — | api-contract / deploy / journeys H4–H5 | N/A (no UI / no deploy) | skipped |
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Spec | **PASS** — F13→`packages/iwxxm-validate`, F14→`packages/tac2iwxxm` (+ PyO3) |
+| Feature ↔ Journey | **PASS** — UJ-DEV-006 |
+| Journey ↔ Test | **PASS** — UJ-DEV-006 → TC-EV045-001..007 |
+| Feature ↔ Test | **PASS** — deepen ACs covered by TC-EV045-* |
+| Test ↔ Acceptance | **PASS** — AC1–7 ↔ TC-EV045-001..007 |
+| Connectivity H4–H5 | **N/A** — no browser UI (routing skip 10/12/13) |
+| Spec ↔ Config | **N/A** — no new config/env |
+
+## Statements
+
+### High (auto-approved — D-S054-01-ac=1 / issue #725)
+
+| ID | Statement | Verdict |
+|----|-----------|---------|
+| S1.1 | Both Rust crates gated by `cargo fmt --check` | auto-approved |
+| S1.2 | `clippy -- -D warnings` hard-fail | auto-approved |
+| S1.3 | `cargo test` required for both crates | auto-approved |
+| S1.4 | Maturin/PyO3 smoke for **both** packages | auto-approved |
+| S1.5 | `make rust-check` mirrors CI | auto-approved |
+| S1.6 | Extend `ci-cd.yml` (matrix), not new workflow by default | auto-approved |
+| S1.7 | Jobs on rust path PRs + default CI | auto-approved |
+
+### Medium (user review)
+
+| ID | Statement | Notes |
+|----|-----------|-------|
+| S2.1 | Required GH check name(s) block merge when red (AC6) | Docs can name the job; **enabling** branch-protection/ruleset required checks is org ops — may already cover `ci-cd.yml` jobs. Recommend: document job name(s) in test-plan; verify/add ruleset in 07 or ops note if missing. |
+
+### Low
+
+None.
+
+## Contradictions
+
+None blocking. Existing `tac2iwxxm-native` remains; EV-045 **adds** crate-level cargo checks + `iwxxm-validate` maturin smoke (does not remove native job).
+
+## Gate A recommendation
+
+**PASS** with S2.1 accepted as: document required check names in standing docs; confirm ruleset wiring during 07-build (or note if already inherited from CI suite).
+
+## Gate A decision (D-S054-gateA=2)
+
+User chose **option 2**: PASS but **require ruleset update before 04**.
+
+### Evidence (2026-08-08)
+
+| Check | Result |
+|-------|--------|
+| `GET .../rulesets` | `[]` — **no rulesets** |
+| Classic branch protection `main`/`stage` | **404** (none) |
+| Token `permissions.admin` | **false** (push/triage only) |
+| `apply_gh_branch_rulesets.sh` | Updated to include EV-045 check contexts |
+
+### Locked check names (for 07 `ci-cd.yml` job `name:`)
+
+- `Rust crates (fmt/clippy/test)`
+- `tac2iwxxm PyO3 (maturin)` (existing)
+- `iwxxm-validate PyO3 (maturin)` (new)
+
+### Blocker → cleared (D-S054-ac6-waive=2)
+
+Cannot create/update rulesets without **repo admin**. Same class of gap as EV-043
+(`docs/evolve-report-EV-043.md`). User chose **waive AC6 ops half**: docs +
+`apply_gh_branch_rulesets.sh` remain; live ruleset apply deferred. **04-tech-plan
+unblocked.**
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tests] [Corpus: journeys] [Corpus: tech-spec] [Corpus: adr/ADR-017]
+`[Corpus: WAIVED — AC6 GitHub rulesets apply; decided: D-S054-ac6-waive=2 / EV-045]`

--- a/docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
@@ -1,0 +1,37 @@
+# 04-tech-plan — S054 / EV-045
+
+**Status**: completed — D-S054-04-plan=1  
+**Date**: 2026-08-08  
+**Mode**: delta
+
+## Artifacts
+
+| Path | Role |
+|------|------|
+| `reports/execution-plan.md` | Tasks T1.1–T1.7 |
+| `build-plan-card.md` | Active M1 batch for 07 |
+| Standing docs | tech-spec pointer already; AC6 waive in test-plan |
+
+## Interview answers (D-S054-04)
+
+| Q | Answer | Effect |
+|---|--------|--------|
+| 1 Job shape | **2** matrix | Matrix + **gate** job for locked name |
+| 2 Maturin | **2** extend native | Two-package matrix, distinct `check_name`s |
+| 3 Triggers | **1** always default CI | No path-filter-only |
+| 4 Deploy/local | **2** | Gate deploy; `rust-check` includes maturin |
+
+## Connectivity
+
+N/A — CI-only; no CORS / H4–H5 tasks.
+
+## ADRs
+
+None new — extends [Corpus: adr/ADR-017].
+
+## Next
+
+05-verify-tech (Gate B), then 07-build (06 skipped).
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec] [Corpus: tests]
+[Corpus: adr/ADR-017] [Corpus: decisions]

--- a/docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
@@ -1,0 +1,80 @@
+# 05-verify-tech — Gate B (S054 / EV-045)
+
+**Date**: 2026-08-08  
+**Mode**: delta — F13/F14 Rust CI  
+**Status**: completed — D-S054-gateB=1  
+**Prior**: D-S054-04-plan=1
+
+## Inventory
+
+| # | Document | Role | Status |
+|---|----------|------|--------|
+| 1 | `reports/execution-plan.md` | Tasks T1.1–T1.7 | audited |
+| 2 | `build-plan-card.md` | M1 batch | parity OK |
+| 3 | feature-list F13/F14 deepen | product AC | audited |
+| 4 | test-plan TC-EV045-* | tests | synced to D-S054-04 |
+| 5 | tech-spec §Rust native crates | CI pointer | OK |
+| 6 | evolve-decisions EV-045 | decisions | OK |
+| 7 | ADR-017 | toolchain baseline | cite only |
+| — | dependency-inventory / new ADR | N/A | 06 skipped |
+| — | connectivity H4–H5 | N/A | CI-only |
+
+## Plan-readiness
+
+| Check | Result |
+|-------|--------|
+| Build Plan Card exists | **PASS** |
+| In-scope IDs = Task Tracking T1.1–T1.7 | **PASS** |
+| Spec Source on tasks | **PASS** |
+| TDD: T1.1 before config | **PASS** |
+| No circular deps | **PASS** |
+| T1.7 depends on T1.2–T1.6 | **PASS** (synced) |
+
+## Consistency (product ↔ technical)
+
+| Check | Result |
+|-------|--------|
+| F13/F14 deepen ↔ tasks | **PASS** |
+| AC1–4 ↔ TC ↔ T1.3/T1.4 | **PASS** |
+| AC5 / TC-EV045-005 ↔ D-S054-04-local | **PASS** (synced) |
+| AC6 docs + ops waive | **PASS** |
+| AC7 / TC-EV045-007 ↔ D-S054-04-trigger | **PASS** (synced) |
+| H4–H5 | **N/A** |
+| Scope drift | **PASS** — none |
+
+## Statements
+
+### High (auto-approved — D-S054-04 + D-S054-01-ac)
+
+| ID | Statement |
+|----|-----------|
+| S1.1 | Cargo matrix + gate job for locked name `Rust crates (fmt/clippy/test)` |
+| S1.2 | Maturin two-package matrix with locked PyO3 `check_name`s |
+| S1.3 | Default CI triggers (not path-filter-only) |
+| S1.4 | `deploy.needs` includes rust gate + native matrix |
+| S1.5 | `make rust-check` includes both maturin smokes |
+| S1.6 | Clippy `-D warnings`; extend `ci-cd.yml` (no new workflow) |
+| S1.7 | AC6 ops waived; docs + apply script in scope |
+| S1.8 | No new ADR / no 06 — ADR-017 sufficient |
+
+### Medium (synced to locked decisions — recommend confirm)
+
+| ID | Finding | Resolution applied |
+|----|---------|-------------------|
+| S2.1 | TC-EV045-007 / AC7 path-filter wording vs trigger=1 | Standing docs → always-on default CI |
+| S2.2 | TC-EV045-005 “optional” maturin vs local=2 | Standing docs → both native smokes required |
+
+### Low (synced)
+
+| ID | Finding | Resolution |
+|----|---------|------------|
+| S3.1 | T1.7 omitted T1.6 dep | execution-plan Depends On → T1.2–T1.6 |
+| S3.2 | F13 AC5 “blocks merge” vs ops waive | feature-list note D-S054-ac6-waive=2 |
+
+## Gate B recommendation
+
+**PASS** → next **07-build** (06 skipped per routing).
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec] [Corpus: tests]
+[Corpus: adr/ADR-017] [Corpus: decisions]
+`[Corpus: WAIVED — AC6 GitHub rulesets apply; decided: D-S054-ac6-waive=2 / EV-045]`

--- a/docs/sessions/S054-rust-ci-crates/reports/evolve-summary.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/evolve-summary.md
@@ -1,0 +1,61 @@
+# Evolve summary — EV-045 / S054
+
+**Title:** Rust crate CI (fmt/clippy/cargo test + maturin both crates)  
+**Branch:** `evolve/EV-045-rust-ci`  
+**Status:** **completed** 2026-08-08 — PR [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) open → `stage` (awaiting merge)  
+**Features:** deepen **F13**, **F14** ([#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725))  
+**Preset:** Standard · skip 03/06/10/12/13 · **Deploy:** N/A (CI-only)  
+**Tip:** `09ce2bef` · **CI evidence:** [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621) @ `f270618c` (`D-S054-t17-ci=1`)
+
+## What shipped
+
+1. **`make rust-check`** — fmt + clippy `-D warnings` + `cargo test` both crates + both maturin smokes  
+2. **`ci-cd.yml`** — `rust-crates` matrix + gate job **`Rust crates (fmt/clippy/test)`**  
+3. **Maturin matrix** — locked names `tac2iwxxm PyO3 (maturin)` / `iwxxm-validate PyO3 (maturin)`  
+4. **`deploy.needs`** — rust gate + native matrix (blocks DOKS deploy on red Rust/native)  
+5. **TC-EV045-001..007** contract tests; tech-spec / test-plan / ruleset script docs  
+6. **AC6 ops** deferred (`D-S054-ac6-waive=2`) until admin applies rulesets
+
+## Gates
+
+| Gate | Result |
+|------|--------|
+| A (02) | PASS (`D-S054-gateA=2`) |
+| B (05) | PASS (`D-S054-gateB=1`) |
+| C (07/08) | PASS (`D-S054-phaseC=1`; T1.1–T1.7) |
+| 09 | pass_with_advisories |
+| 11 | **APPROVED** (`D-S054-11=1`) |
+| Deploy 12/13 | **skipped** (routing) |
+
+## Locked CI contexts
+
+| Context | Role |
+|---------|------|
+| `Rust crates (fmt/clippy/test)` | fmt + clippy + cargo test (both crates) |
+| `tac2iwxxm PyO3 (maturin)` | PyO3 smoke |
+| `iwxxm-validate PyO3 (maturin)` | PyO3 smoke |
+
+## Corpus cites
+
+`[Corpus: product §F13]` · `[Corpus: product §F14]` · `[Corpus: tests]` ·  
+`[Corpus: tech-spec]` · `[Corpus: adr/ADR-017]` · `[Corpus: decisions]` EV-045 ·  
+`[Corpus: WAIVED — AC6 ruleset apply; D-S054-ac6-waive=2]`
+
+## Reports
+
+| Artifact | Path |
+|----------|------|
+| Requirements | `reports/01-requirements.md` |
+| Gate A | `reports/02-verify-plan.md` |
+| Tech plan | `reports/04-tech-plan.md` |
+| Gate B | `reports/05-verify-tech.md` |
+| Execution plan | `reports/execution-plan.md` |
+| 08 | `reports/verification-report.md` |
+| 09 | `reports/qa-report.md` |
+| 11 | `reports/verify-impl.md` |
+
+## Follow-ups
+
+- Admin: `bash scripts/deploy/apply_gh_branch_rulesets.sh` (QA-001)  
+- Merge [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → `stage` when ready (user approval)  
+- Resume parked EV-043 / EV-044 when appropriate

--- a/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
@@ -90,6 +90,9 @@ None.
 | T1.6 | Back-add tech-spec / feature AC notes with final job ids + matrix/gate rationale; confirm ruleset script lists locked names | Docs | completed | tech-spec; test-plan; apply_gh_branch_rulesets.sh | T1.5 | — |
 | T1.7 | Tip CI green on `evolve/EV-045-rust-ci` (watch `ci-cd.yml`); fix clippy/fmt debt if jobs fail | Code | in_progress | TC-EV045-*; build-execution | T1.2–T1.6 | — |
 
+**PR**: [#952](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/952) → **`stage`** (ADR-034; not direct to main).  
+Prior tip run [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621): all Rust/maturin/test jobs **success**; only **Staging gate** failed while base was briefly `main`.
+
 ###### Parallelizable
 
 After T1.1 green (red→green on contracts): T1.2 ∥ T1.3 ∥ T1.4, then T1.5 → T1.6 → T1.7.

--- a/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
@@ -1,0 +1,147 @@
+# Execution plan — S054 / EV-045 (Rust crate CI)
+
+> **Generated**: 2026-08-08  
+> **Skill**: 04-tech-plan (delta)  
+> **Branch**: `evolve/EV-045-rust-ci`  
+> **Issue**: [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)  
+> **Build Plan Card**: `docs/sessions/S054-rust-ci-crates/build-plan-card.md`
+
+**Corpus**: [Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec]
+[Corpus: tests] [Corpus: adr/ADR-017] [Corpus: decisions]
+
+## Current State
+
+| Field | Value |
+|-------|-------|
+| **Active phase** | Phase 1: Rust CI gates |
+| **Active milestone** | M1: Makefile + CI workflow |
+| **Active task** | T1.7 (local cargo green; tip CI pending push) |
+| **Tasks completed** | 6 / 7 |
+| **Stage** | 07-build (D-S054-gateB=1) |
+| **Last updated** | 2026-08-08 |
+| **Build Plan Card** | `docs/sessions/S054-rust-ci-crates/build-plan-card.md` |
+
+## Tech decisions (D-S054-04 — locked 2026-08-08)
+
+| ID | Choice |
+|----|--------|
+| D-S054-04-jobs | **2** — cargo checks via **matrix** over crates; required context kept as exact `Rust crates (fmt/clippy/test)` via a thin **gate job** that `needs` the matrix (GH appends matrix values to static job names) |
+| D-S054-04-maturin | **2** — extend `tac2iwxxm-native` into a **two-package matrix**; job `name: ${{ matrix.check_name }}` with locked strings `tac2iwxxm PyO3 (maturin)` / `iwxxm-validate PyO3 (maturin)` |
+| D-S054-04-trigger | **1** — run with default `ci-cd.yml` PR/push (same as today’s native job; not path-filter-only) |
+| D-S054-04-local | **2** — `deploy.needs` includes cargo gate + both maturin matrix legs; `make rust-check` = fmt+clippy+`cargo test` **both** crates **and** both `test-*-native` maturin smokes |
+| D-S054-ac6-waive | **2** — AC6 ops (live rulesets) deferred; docs + `apply_gh_branch_rulesets.sh` already updated |
+
+### Job graph (target)
+
+```
+rust-crates (matrix: tac2iwxxm | iwxxm-validate)
+  └─ fmt --check → clippy -D warnings → cargo test
+       └─ rust-crates-gate  name: "Rust crates (fmt/clippy/test)"
+
+native-pyo3 (matrix; renames today’s tac2iwxxm-native)
+  ├─ name: tac2iwxxm PyO3 (maturin)
+  └─ name: iwxxm-validate PyO3 (maturin)
+
+deploy.needs: [test, test-alembic, rust-crates-gate, native-pyo3]
+  (or equivalent ids; both maturin matrix legs must pass)
+```
+
+Toolchain: `dtolnay/rust-toolchain@stable` + `rustfmt`,`clippy`; cache `Swatinem/rust-cache@v2` (or equivalent).
+
+## Tech Stack Summary
+
+| Category | Choice | Source |
+|----------|--------|--------|
+| Language | Rust (stable) + Python 3.12 / uv | ADR-017; existing CI |
+| Formatter | `cargo fmt --check` | AC1 / TC-EV045-001 |
+| Linter | `cargo clippy -- -D warnings` | AC2 / D-S054-01-ac |
+| Tests | `cargo test` + maturin pytest smokes | AC3–4 |
+| CI | `.github/workflows/ci-cd.yml` | D-S054-01-ac |
+| Local | `make rust-check` | AC5 / D-S054-04-local |
+| Deploy impact | Gate DOKS deploy on new jobs | D-S054-04-local |
+| Connectivity H4–H5 | **N/A** — no browser/API surface | routing skip 10/12/13 |
+
+## Data Dependencies
+
+None.
+
+## Implementation Phases
+
+### Phase 1: Rust CI gates
+
+**Objective**: Required cargo + maturin CI for both crates; Makefile parity.  
+**Entry gate**: This plan approved (D-S054-04-plan).  
+**Exit gate**: Tip CI green on evolve branch; TC-EV045-001..005/007 green; AC6 docs/script met (ops waived).
+
+#### M1: Makefile + CI workflow — P0
+
+**Goal**: Local `make rust-check` + `ci-cd.yml` jobs with locked check names.  
+**Acceptance**: TC-EV045-001..005, TC-EV045-007; deploy blocked on red Rust/native jobs.
+
+##### Tasks (TDD order)
+
+| # | Task | Type | Status | Spec Source | Depends On | Data Deps |
+|---|------|------|--------|-------------|------------|-----------|
+| T1.1 | Add contract tests for EV-045: `make rust-check` in Makefile; locked job `name:` strings + gate/matrix shape in `ci-cd.yml`; `deploy.needs` includes rust gate + native matrix | Test | completed | test-plan TC-EV045-001..007; feature-list F13/F14 deepen | — | — |
+| T1.2 | Implement `make rust-check` (and helpers if needed): both crates fmt/clippy/`cargo test` + `test-tac2iwxxm-native` + `test-iwxxm-validate-native` | Config | completed | tech-spec §Rust native crates; AC5 | T1.1 | — |
+| T1.3 | Add `rust-crates` matrix job (fmt/clippy/test) + `rust-crates-gate` with `name: Rust crates (fmt/clippy/test)`; rust-cache + stable toolchain | Config | completed | AC1–3, AC7; D-S054-04-jobs | T1.1 | — |
+| T1.4 | Refactor `tac2iwxxm-native` → package matrix with `check_name` for both PyO3 smokes (`IWXXM_VALIDATE_REQUIRE_RUST` / existing tac2iwxxm tests) | Config | completed | AC4; D-S054-04-maturin | T1.1 | — |
+| T1.5 | Wire `deploy.needs` to rust gate + native matrix; keep default CI triggers (no path-filter-only) | Config | completed | D-S054-04-trigger/local; ADR-034 deploy | T1.3, T1.4 | — |
+| T1.6 | Back-add tech-spec / feature AC notes with final job ids + matrix/gate rationale; confirm ruleset script lists locked names | Docs | completed | tech-spec; test-plan; apply_gh_branch_rulesets.sh | T1.5 | — |
+| T1.7 | Tip CI green on `evolve/EV-045-rust-ci` (watch `ci-cd.yml`); fix clippy/fmt debt if jobs fail | Code | in_progress | TC-EV045-*; build-execution | T1.2–T1.6 | — |
+
+###### Parallelizable
+
+After T1.1 green (red→green on contracts): T1.2 ∥ T1.3 ∥ T1.4, then T1.5 → T1.6 → T1.7.
+
+#### Phase 1 Gate Check
+
+- [ ] All M1 tasks `completed`
+- [ ] Contract tests green
+- [ ] Tip CI includes Rust gate + both maturin checks green
+- [ ] `make rust-check` documented and works where Rust/maturin available
+- [ ] AC6 docs/script present; ops waive recorded (D-S054-ac6-waive=2)
+
+## Git Strategy
+
+| Item | Value |
+|------|-------|
+| Branch | `evolve/EV-045-rust-ci` |
+| Commits | One task per commit: `[T1.n] …` |
+| PR | Evolve PR to `main` after 11 (or earlier if user asks); title `[EV-045] Rust crate CI (#725)` |
+| Rulesets | Script ready; **admin apply deferred** |
+
+### PR checklist (draft)
+
+- [ ] TC-EV045 contract tests pass
+- [ ] CI job names match test-plan table exactly (gate + two maturin)
+- [ ] `deploy.needs` updated
+- [ ] No browser/deploy smoke required this cycle
+
+## Task Tracking
+
+| ID | Status | Feature | evolve_cycle_id |
+|----|--------|---------|-----------------|
+| T1.1 | completed | F13, F14 | EV-045 |
+| T1.2 | completed | F13, F14 | EV-045 |
+| T1.3 | completed | F13, F14 | EV-045 |
+| T1.4 | completed | F13, F14 | EV-045 |
+| T1.5 | completed | F13, F14 | EV-045 |
+| T1.6 | completed | F13, F14 | EV-045 |
+| T1.7 | in_progress | F13, F14 | EV-045 |
+
+## Phase Gate Log
+
+| Gate | Result | Date | Notes |
+|------|--------|------|-------|
+| A→B | pending | — | D-S054-04-plan=1; awaiting D-S054-gateB |
+| B→C | — | — | — |
+| C→D | — | — | — |
+
+## Out of scope (confirm)
+
+- New `rust-ci.yml` workflow
+- Path-filter-only Rust jobs
+- Live GH ruleset apply (waived)
+- Browser E2E / staging-prod deploy smoke
+- Multi-arch wheel CI beyond `pypi-publish.yml`

--- a/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
@@ -15,9 +15,9 @@
 |-------|-------|
 | **Active phase** | Phase 1: Rust CI gates |
 | **Active milestone** | M1: Makefile + CI workflow |
-| **Active task** | T1.7 (local cargo green; tip CI pending push) |
-| **Tasks completed** | 6 / 7 |
-| **Stage** | 07-build (D-S054-gateB=1) |
+| **Active task** | — (M1 complete) |
+| **Tasks completed** | 7 / 7 |
+| **Stage** | 08-verify-build (D-S054-t17-ci=1) |
 | **Last updated** | 2026-08-08 |
 | **Build Plan Card** | `docs/sessions/S054-rust-ci-crates/build-plan-card.md` |
 
@@ -88,10 +88,10 @@ None.
 | T1.4 | Refactor `tac2iwxxm-native` → package matrix with `check_name` for both PyO3 smokes (`IWXXM_VALIDATE_REQUIRE_RUST` / existing tac2iwxxm tests) | Config | completed | AC4; D-S054-04-maturin | T1.1 | — |
 | T1.5 | Wire `deploy.needs` to rust gate + native matrix; keep default CI triggers (no path-filter-only) | Config | completed | D-S054-04-trigger/local; ADR-034 deploy | T1.3, T1.4 | — |
 | T1.6 | Back-add tech-spec / feature AC notes with final job ids + matrix/gate rationale; confirm ruleset script lists locked names | Docs | completed | tech-spec; test-plan; apply_gh_branch_rulesets.sh | T1.5 | — |
-| T1.7 | Tip CI green on `evolve/EV-045-rust-ci` (watch `ci-cd.yml`); fix clippy/fmt debt if jobs fail | Code | in_progress | TC-EV045-*; build-execution | T1.2–T1.6 | — |
+| T1.7 | Tip CI green on `evolve/EV-045-rust-ci` (watch `ci-cd.yml`); fix clippy/fmt debt if jobs fail | Code | completed | TC-EV045-*; build-execution | T1.2–T1.6 | — |
 
-**PR**: [#952](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/952) → **`stage`** (ADR-034; not direct to main).  
-Prior tip run [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621): all Rust/maturin/test jobs **success**; only **Staging gate** failed while base was briefly `main`.
+**PR**: [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → **`stage`** (ADR-034; supersedes #952).  
+**T1.7 closed** (`D-S054-t17-ci=1`): accept run [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621) @ `f270618c` as tip CI for EV-045 Rust/maturin/test jobs (tip `09ce2bef` docs-only after that; Staging gate fail was base=`main` only).
 
 ###### Parallelizable
 
@@ -99,11 +99,11 @@ After T1.1 green (red→green on contracts): T1.2 ∥ T1.3 ∥ T1.4, then T1.5 �
 
 #### Phase 1 Gate Check
 
-- [ ] All M1 tasks `completed`
-- [ ] Contract tests green
-- [ ] Tip CI includes Rust gate + both maturin checks green
-- [ ] `make rust-check` documented and works where Rust/maturin available
-- [ ] AC6 docs/script present; ops waive recorded (D-S054-ac6-waive=2)
+- [x] All M1 tasks `completed`
+- [x] Contract tests green
+- [x] Tip CI includes Rust gate + both maturin checks green (`D-S054-t17-ci=1` / run 31273500621)
+- [x] `make rust-check` documented and works where Rust/maturin available
+- [x] AC6 docs/script present; ops waive recorded (D-S054-ac6-waive=2)
 
 ## Git Strategy
 
@@ -131,15 +131,15 @@ After T1.1 green (red→green on contracts): T1.2 ∥ T1.3 ∥ T1.4, then T1.5 �
 | T1.4 | completed | F13, F14 | EV-045 |
 | T1.5 | completed | F13, F14 | EV-045 |
 | T1.6 | completed | F13, F14 | EV-045 |
-| T1.7 | in_progress | F13, F14 | EV-045 |
+| T1.7 | completed | F13, F14 | EV-045 |
 
 ## Phase Gate Log
 
 | Gate | Result | Date | Notes |
 |------|--------|------|-------|
-| A→B | pending | — | D-S054-04-plan=1; awaiting D-S054-gateB |
-| B→C | — | — | — |
-| C→D | — | — | — |
+| A→B | PASS | 2026-08-08 | D-S054-gateA=2; AC6 ops waived |
+| B→C | PASS | 2026-08-08 | D-S054-gateB=1 |
+| C→D | PASS | 2026-08-08 | 08 PASS; 09 pass_with_advisories; 11 APPROVED D-S054-11=1 |
 
 ## Out of scope (confirm)
 

--- a/docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/qa-report.md
@@ -1,0 +1,91 @@
+# QA Report — S054 / EV-045 (09-qa)
+
+> Generated: 2026-08-08  
+> Scope: delta — deepen F13 + F14 Rust CI (#725)  
+> Branch: `evolve/EV-045-rust-ci` @ `09ce2bef`  
+> Mode: delta  
+> Corpus: [Corpus: product §F13] [Corpus: product §F14] [Corpus: tests]
+> [Corpus: tech-spec] [Corpus: adr/ADR-017] [Corpus: decisions]
+
+```text
+QA Results:
+  Lint:           PASS — 0 issues (ruff + eslint)
+  Format:         PASS — 0 files (ruff format + prettier)
+  Typecheck:      PASS — 0 errors (17 pre-existing basedpyright warnings in tac2iwxxm iwxxm_us)
+  Tests (Python): PASS — TC-EV045 8/8; H0c 6/6; H0i non-live 4 skipped (env); tip CI full matrix green
+  Tests (FE):     PASS — Vitest 798 passed / 4 skipped (89 files)
+  Security:       PASS — uvx pip-audit 0 CVEs; no pickle.loads; rg eval/exec only benign RegExp.exec
+  Cross-file:     PASS — F401/F841 clean on scoped trees
+  Dependencies:   N/A delta — no new runtime deps (06 skipped ADR-017)
+  Template:       PASS — apps/{backend,frontend,worker} + packages layout
+  Data / Modal:   N/A — CI-only; no Modal/data-staging this cycle
+  Connectivity:   PASS (H0c); H4–H5 N/A (no UI); H0i live deferred (CI-only + tip CI)
+  Tip CI:         PASS — run 31273500621 @ f270618c (D-S054-t17-ci=1)
+```
+
+## Overall: **pass_with_advisories**
+
+### Blocking
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Lint / format | PASS | `make lint` / `make format-check` |
+| Typecheck | PASS | `make typecheck` — 0 errors |
+| TC-EV045 contracts | PASS | `tests/test_tc_ev045_rust_ci.py` 8/8 |
+| H0c CORS | PASS | `tests/unit/test_cors_policy.py` 6/6 |
+| `make rust-check` | PASS | both crates cargo + both maturin smokes |
+| Frontend Vitest | PASS | 798 passed, 4 skipped |
+| Security (pip-audit) | PASS | 0 known vulns |
+| Tip CI (Rust/maturin/tests) | PASS | [31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621) |
+
+### Advisories (QA-IDs for 11-verify-impl)
+
+| ID | Finding | Severity | Suggested action |
+|----|---------|----------|------------------|
+| QA-001 | AC6 **ops** half deferred — GH rulesets/required checks not applied live (`D-S054-ac6-waive=2`) | advisory | Admin run `scripts/deploy/apply_gh_branch_rulesets.sh` when token has admin; docs+script already list locked contexts |
+| QA-002 | Local `tests/integration -m "not live"` selected 4 tests all **skipped** (DB/env); tip CI covered full matrix | advisory | Accept for CI-only cycle; no H0i blocker on tip evidence |
+| QA-003 | `scripts/check_secrets.sh` / gitleaks not installed in this environment | advisory | Rely on CI secret scan + pip-audit; optional install for local parity |
+| QA-004 | H4–H5 / deploy smoke skipped by routing (no UI / CI-only) | advisory | N/A this cycle — confirm at 11 |
+| QA-005 | Pre-existing basedpyright warnings in `tac2iwxxm/profiles/iwxxm_us.py` (17) | advisory | Out of EV-045 scope; do not block |
+
+### AC → locked CI job / local target map
+
+| AC / TC | Mechanism | Locked name / target | Status |
+|---------|-----------|----------------------|--------|
+| F13/F14 AC1 + TC-EV045-001 | `rust-crates` matrix → gate | **`Rust crates (fmt/clippy/test)`** | met (CI + contracts) |
+| F13/F14 AC2 + TC-EV045-002 | same gate (`clippy -D warnings`) | **`Rust crates (fmt/clippy/test)`** | met |
+| F13/F14 AC3 + TC-EV045-003 | same gate (`cargo test`) | **`Rust crates (fmt/clippy/test)`** | met |
+| F13 AC4 + TC-EV045-004 | native matrix | **`iwxxm-validate PyO3 (maturin)`** | met |
+| F14 AC4 + TC-EV045-004 | native matrix | **`tac2iwxxm PyO3 (maturin)`** | met |
+| F14 AC5 + TC-EV045-005 | Makefile | **`make rust-check`** | met (local + contracts) |
+| AC6 / TC-EV045-006 docs | test-plan + ruleset script | contexts listed above | **docs met**; ops waived QA-001 |
+| TC-EV045-007 | default `ci-cd.yml` triggers | no `paths:` filter on workflow | met |
+| Deploy gate | `deploy.needs` | `rust-crates-gate`, `tac2iwxxm-native` (matrix) | met (contracts + workflow) |
+
+### Commands run (reproducible)
+
+```bash
+make format-check
+make lint
+make typecheck
+uv run pytest tests/test_tc_ev045_rust_ci.py tests/unit/test_cors_policy.py -q --tb=line
+uv run pytest tests/integration -q --tb=line -m "not live"
+make rust-check
+pnpm --filter @metar/frontend exec vitest run
+uvx pip-audit
+uv run ruff check --select F401,F841 --force-exclude \
+  apps/backend/src packages/auth/src packages/shared \
+  packages/tac2iwxxm/src packages/iwxxm-validate/src \
+  packages/tac-validate/src packages/dissemination/src tests
+```
+
+### Phase / plan alignment
+
+- M1 T1.1–T1.7 **completed**; Phase C approved (`D-S054-phaseC=1`)
+- Tip CI accepted (`D-S054-t17-ci=1`); PR [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → `stage`
+- 10-e2e / 12 / 13 **skipped** per routing
+
+### Next
+
+1. **11-verify-impl** — AC checklist + advisory disposition (QA-001..005)  
+2. Merge still requires user approval on #953 (do not auto-merge)

--- a/docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/verification-report.md
@@ -1,0 +1,52 @@
+# Verification Report
+
+> Generated: 2026-08-08  
+> Scope: S054 / EV-045 — M1 complete → 08-verify-build (delta, CI-only)  
+> Branch: `evolve/EV-045-rust-ci` @ `09ce2bef`  
+> Tip CI evidence: [run 31273500621](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31273500621) @ `f270618c` (`D-S054-t17-ci=1`)
+
+## Summary
+
+| Check | Status | Findings | Auto-Fixed | Tool |
+|-------|--------|----------|------------|------|
+| Lint | PASS | 0 | — | `make lint` (ruff + eslint) |
+| Format | PASS | 0 | local dirty `config.json` restored to HEAD | `make format-check` |
+| Typecheck | PASS | 0 errors (pre-existing tac2iwxxm warnings only) | — | `make typecheck` |
+| Tests (delta) | PASS | TC-EV045 8 + H0c CORS 6 = 14 | — | pytest |
+| `make rust-check` | PASS | both crates cargo + both maturin smokes | — | Makefile |
+| Tip CI (Rust/maturin/tests) | PASS | accepted run 31273500621 | — | GitHub Actions |
+| Security | PASS | 0 CVEs; no secret/eval patterns in EV-045 paths | — | `uvx pip-audit` + rg |
+| Performance | SKIPPED | no perf thresholds this cycle | — | — |
+| Data | SKIPPED | no staged data deps | — | — |
+| Modal smoke | SKIPPED | N/A (no Modal deploy) | — | — |
+
+**Overall: PASS**
+
+## Connectivity
+
+| Item | Status |
+|------|--------|
+| `tests/unit/test_cors_policy.py` (H0c) | PASS (6) |
+| `tests/smoke/test_staging_connectivity.py` | present |
+| `scripts/deploy/verify_connectivity.sh` | present |
+| H0i Compose / live integration | not run (CI-only cycle; full matrix green on tip CI) |
+| H4–H5 browser | N/A — no UI this cycle |
+
+## Tip CI note (`D-S054-t17-ci=1`)
+
+- Rust crates gate + both maturin jobs + full test matrix: **success** on `f270618c`
+- Staging gate failed only while PR briefly targeted `main`; tip `09ce2bef` is docs-only after that
+- User accepted run 31273500621 as tip CI evidence for EV-045 jobs
+
+## Workspace note
+
+- Transient Prettier failure on `apps/frontend/public/config.json` was **local uncommitted dirt** (not part of EV-045); restored to HEAD → format green
+
+## Corpus
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec] [Corpus: tests]
+[Corpus: adr/ADR-017] [Corpus: decisions]
+
+## Handoff
+
+**08 PASS** → Phase C checkpoint → **09-qa** (then **11-verify-impl**; 10/12/13 skipped).

--- a/docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+++ b/docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
@@ -1,0 +1,85 @@
+# Verify Implementation — S054 / EV-045
+
+> Generated: 2026-08-08  
+> Status: **APPROVED** (`D-S054-11=1` — 2026-08-08)  
+> Branch: `evolve/EV-045-rust-ci` @ `09ce2bef`  
+> PR: [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) → `stage`  
+> Corpus: [Corpus: product §F13] [Corpus: product §F14] [Corpus: tests]
+> [Corpus: journeys §UJ-DEV-006] [Corpus: tech-spec] [Corpus: decisions]
+
+## Sources
+
+| Artifact | Result |
+|----------|--------|
+| 08 verification-report.md | PASS |
+| 09 qa-report.md | pass_with_advisories (QA-001..005) |
+| 10 e2e-report.md | **skipped** (no browser UI) |
+| Tip CI | run 31273500621 SUCCESS for EV-045 jobs (`D-S054-t17-ci=1`) |
+
+## UI preview
+
+N/A — no browser UI in cycle scope (declined/skipped).
+
+## Feature completeness (cycle Fn only)
+
+| Feature | Implemented | Tested | QA | E2E | ACs |
+|---------|-------------|--------|----|-----|-----|
+| F13 deepen (Rust CI) | Yes — `ci-cd.yml` rust matrix + gate + iwxxm-validate maturin | TC-EV045-* | clean for cycle files | N/A (UJ-DEV-006 = CI/T0) | see below |
+| F14 deepen (Rust CI) | Yes — same + tac2iwxxm maturin + `make rust-check` + deploy.needs | TC-EV045-* | clean | N/A | see below |
+
+## Acceptance criteria status
+
+### F13 EV-045 deepen
+
+| # | Criterion | Evidence | Status |
+|---|-----------|----------|--------|
+| 1 | CI fails on unformatted Rust under `iwxxm-validate/rust` | gate job + contracts | **met** |
+| 2 | CI fails on clippy warnings (`-D warnings`) | gate job | **met** |
+| 3 | `cargo test` green on default CI | gate job; tip CI | **met** |
+| 4 | Maturin/PyO3 smoke for iwxxm-validate | check `iwxxm-validate PyO3 (maturin)` | **met** |
+| 5 | Required check names documented; ops may defer | test-plan + `apply_gh_branch_rulesets.sh`; `D-S054-ac6-waive=2` | **met (docs)** / ops deferred |
+
+### F14 EV-045 deepen
+
+| # | Criterion | Evidence | Status |
+|---|-----------|----------|--------|
+| 1 | CI fails on unformatted Rust under `tac2iwxxm/rust` | gate job | **met** |
+| 2 | clippy `-D warnings` | gate job | **met** |
+| 3 | `cargo test` green on default CI | gate job; tip CI | **met** |
+| 4 | Maturin smoke retained + cargo test required | `tac2iwxxm PyO3 (maturin)` + gate | **met** |
+| 5 | `make rust-check` local parity both crates | Makefile + TC-EV045-005 + local PASS | **met** |
+
+### Journey
+
+| Journey | Status |
+|---------|--------|
+| UJ-DEV-006 | Covered by TC-EV045 + tip CI + `make rust-check` (T0/CI tier) |
+
+## Advisories disposition (proposed)
+
+| ID | Proposal for user |
+|----|-------------------|
+| QA-001 AC6 ops deferred | **Accept / defer** — already locked `D-S054-ac6-waive=2` |
+| QA-002 H0i local skips | **Accept** — tip CI matrix green |
+| QA-003 No local check_secrets/gitleaks | **Accept** — CI covers |
+| QA-004 H4–H5/deploy skip | **Accept** — routing skip 12/13 |
+| QA-005 basedpyright warnings | **Defer** — pre-existing, OOS |
+
+## User decisions (2026-08-08)
+
+| ID | Choice |
+|----|--------|
+| D-S054-11 | **1** — Approve F13+F14 deepen + accept advisories QA-001..005 as proposed; proceed to cycle close |
+
+### Approved
+
+- F13 EV-045 deepen ACs 1–5 (ops half of AC5/AC6 remains deferred per waive)
+- F14 EV-045 deepen ACs 1–5
+- UJ-DEV-006 (CI/T0)
+- Advisories QA-001..005 accept/defer as proposed in this report
+
+### Close notes
+
+- 12/13 skipped by routing — no deploy gate  
+- PR [#953](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953) remains open → `stage` (merge requires separate user approval)  
+- Follow-up: admin apply `scripts/deploy/apply_gh_branch_rulesets.sh`

--- a/docs/sessions/S054-rust-ci-crates/routing-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/routing-plan.md
@@ -6,23 +6,23 @@
 **Branch:** `evolve/EV-045-rust-ci`  
 **Features:** deepen **F13**, **F14**  
 **Issues:** [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)  
-**Status:** in_progress
+**Status:** **completed** 2026-08-08 (`D-S054-11=1`)
 
 | Stage | Required | Mode | Status | Notes |
 |-------|----------|------|--------|-------|
 | 00-context | yes | session | **completed** | S054 open |
-| 16-evolve | yes | orchestrator | **in_progress** | Phase B — 05-verify-tech |
+| 16-evolve | yes | orchestrator | **completed** | EV-045 closed; PR #953 open → stage |
 | 01-requirements | yes | delta | **completed** | D-S054-01-ac=1 |
 | 02-verify-plan | yes | delta | **completed** | Gate A PASS; D-S054-ac6-waive=2 |
 | 03-plan-tooling | no | — | skipped | no new Cursor rules/hooks |
 | 04-tech-plan | yes | delta | **completed** | D-S054-04-plan=1 |
 | 05-verify-tech | yes | delta | **completed** | D-S054-gateB=1 |
 | 06-tech-tooling | no | — | skipped | toolchain already ADR-017 |
-| 07-build | yes | full | **in_progress** | T1.1… |
-| 08-verify-build | yes | delta | pending | |
-| 09-qa | yes | delta | pending | map AC → CI job IDs |
+| 07-build | yes | full | **completed** | T1.1–T1.7; D-S054-t17-ci=1 |
+| 08-verify-build | yes | delta | **completed** | PASS — verification-report.md |
+| 09-qa | yes | delta | **completed** | pass_with_advisories — qa-report.md |
 | 10-e2e | no | — | skipped | no browser UI |
-| 11-verify-impl | yes | delta | pending | AC checklist |
+| 11-verify-impl | yes | delta | **completed** | APPROVED D-S054-11=1 |
 | 12-verify-deploy | no | — | skipped | CI-only; tip CI green |
 | 13-deploy-smoke | no | — | skipped | no staging/prod deploy |
 

--- a/docs/sessions/S054-rust-ci-crates/routing-plan.md
+++ b/docs/sessions/S054-rust-ci-crates/routing-plan.md
@@ -1,0 +1,36 @@
+# Routing plan — S054 / EV-045
+
+**Preset:** Standard (**approved** `D-S054-open=1`)  
+**Route:** `00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 11`  
+**Skip:** `03`, `06`, `10`, `12`, `13`  
+**Branch:** `evolve/EV-045-rust-ci`  
+**Features:** deepen **F13**, **F14**  
+**Issues:** [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)  
+**Status:** in_progress
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | S054 open |
+| 16-evolve | yes | orchestrator | **in_progress** | Phase B — 05-verify-tech |
+| 01-requirements | yes | delta | **completed** | D-S054-01-ac=1 |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS; D-S054-ac6-waive=2 |
+| 03-plan-tooling | no | — | skipped | no new Cursor rules/hooks |
+| 04-tech-plan | yes | delta | **completed** | D-S054-04-plan=1 |
+| 05-verify-tech | yes | delta | **completed** | D-S054-gateB=1 |
+| 06-tech-tooling | no | — | skipped | toolchain already ADR-017 |
+| 07-build | yes | full | **in_progress** | T1.1… |
+| 08-verify-build | yes | delta | pending | |
+| 09-qa | yes | delta | pending | map AC → CI job IDs |
+| 10-e2e | no | — | skipped | no browser UI |
+| 11-verify-impl | yes | delta | pending | AC checklist |
+| 12-verify-deploy | no | — | skipped | CI-only; tip CI green |
+| 13-deploy-smoke | no | — | skipped | no staging/prod deploy |
+
+## Skip rationale
+
+| Skipped | Why |
+|---------|-----|
+| 03 | No new Cursor rules/hooks expected |
+| 06 | No new runtime dependency inventory change (maturin/rust already ADR-017) |
+| 10 | No browser UI / Playwright journeys |
+| 12 / 13 | CI-only change; merge gate is tip CI green, not deploy smoke |

--- a/docs/sessions/S054-rust-ci-crates/session-brief.md
+++ b/docs/sessions/S054-rust-ci-crates/session-brief.md
@@ -1,0 +1,58 @@
+---
+session_id: S054-rust-ci-crates
+type: feature
+status: in_progress
+branch: evolve/EV-045-rust-ci
+started_at: 2026-08-08
+intent: "CI: lint, typecheck, unit, and integration tests for Rust crates (#725)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-045
+prior_session: S053-separate-staging-doks-project
+github_issues:
+  - 725
+feature_ids:
+  - F13
+  - F14
+deepen_feature_ids:
+  - F13
+  - F14
+preset: Standard
+ui_preview: N/A — no browser UI
+---
+
+# Session S054 — Rust crate CI (#725)
+
+## Goal
+
+Gate PRs on `rustfmt`, `clippy`, `cargo test`, and maturin/PyO3 smoke for
+`packages/tac2iwxxm/rust` and `packages/iwxxm-validate/rust`, with Makefile local parity.
+
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tech-spec] [Corpus: tests]
+[Corpus: adr/ADR-017] · [#725](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725)
+
+## In scope
+
+- CI jobs for both Rust crates: `cargo fmt --check`, `clippy -- -D warnings`,
+  `cargo test` (typecheck via clippy/test builds)
+- Integration: maturin/PyO3 smoke (or pytest with Rust required) for **both** packages
+- Cargo cache; stable toolchain (`dtolnay/rust-toolchain`) aligned with S014 / ADR-017
+- `make rust-check` (or equivalent) mirroring CI
+- Required checks so PRs cannot merge with red Rust CI
+
+## Out of scope
+
+- Replacing FastAPI `apps/backend` with a Rust HTTP service
+- Full multi-arch wheel CI beyond existing `pypi-publish.yml` / maturin
+- Schematron parity perf gates (F11/F13 publish gates)
+- Browser UI / deploy smoke (stages 10/12/13 skipped)
+
+## Routing
+
+**Standard** (approved `D-S054-open=1`):  
+`00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 11`  
+Skip `03`, `06`, `10`, `12`, `13`.
+
+## Prior work parked
+
+`D-park-doks=1` — S052/EV-043 and S053/EV-044 parked (DOKS staging) so this session can run.
+Resume those cycles separately after #725.

--- a/docs/tech-spec.md
+++ b/docs/tech-spec.md
@@ -2,7 +2,7 @@
 
 > **Corpus ID:** `tech-spec` — see [CORPUS.md](CORPUS.md).  
 > **Architecture / components:** [spec.md](spec.md) (`system-spec`).  
-> **Last updated:** 2026-08-06 (S047 / EV-039 — mock-byoc live SQL e2e pointer; prior 2026-07-12 S007)
+> **Last updated:** 2026-08-08 (S054 / EV-045 — Rust CI pointer; prior S047 / EV-039)
 
 This file is the **entry point** for runtime, configuration, deployment, and dependency
 truth. Detail lives in the satellites below — do not duplicate long tables here.
@@ -34,6 +34,21 @@ When changing runtime behavior or deploy/config:
 3. New library appears in **dependency-inventory** (or AskQuestion before adding).
 4. Component boundaries still match **spec.md** §Component Overview.
 5. If the change is a non-obvious trade-off, add or cite an **ADR**.
+
+## Rust native crates (F13 / F14 — S054 / EV-045)
+
+Hot-path Rust lives under `packages/tac2iwxxm/rust` and `packages/iwxxm-validate/rust`
+(PyO3 / maturin; [Corpus: adr/ADR-017]).
+
+| Surface | Location |
+|---------|----------|
+| Remote CI | `.github/workflows/ci-cd.yml` — cargo **crate matrix** + gate job `Rust crates (fmt/clippy/test)`; maturin **two-package matrix** with locked PyO3 names (EV-045 / D-S054-04) |
+| Local mirror | `make rust-check` (= fmt/clippy/`cargo test` both + both `test-*-native` smokes) |
+| Test IDs | [test-plan.md](test-plan.md) §EV-045 / TC-EV045-*; journey UJ-DEV-006 |
+| Rulesets | `scripts/deploy/apply_gh_branch_rulesets.sh` (admin apply deferred — D-S054-ac6-waive=2) |
+
+No new runtime language deps for this deepen — toolchain already required for native builds.
+Action cache helpers (e.g. `Swatinem/rust-cache`) are CI-only, not Python inventory.
 
 ## Local mock BYOC / live SQL e2e (F16 — S047 / EV-039)
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -78,6 +78,7 @@ Unified manual live test harness against **DOKS** production endpoints after F30
 | UJ-023 | F12–F14 | PyPI tag → install smoke | CI | TC-F14-001 |
 | UJ-DEV-005 | F12–F14 | pip install packages | CI | TC-F12-001, TC-F13-001, TC-F14-002 |
 | UJ-DEV-004 | F2/F6/M5 | `tac-validate` + `iwxxm-validate` package CI | — | TC-F6-032 |
+| UJ-DEV-006 | F13–F14 | Rust fmt/clippy/`cargo test` + maturin both crates | CI | TC-EV045-001..007 |
 | UJ-024 | F15 | METAR/SPECI registry + convert→validate golden | H4–H5 if FE | TC-F15-001..005 |
 | UJ-025 | F7 | Manual TAC Input modes (ADR-024 / #730) | H6′ | TC-F7-007 |
 | UJ-027 | F16 | `apps/e2e/uj027-030-dissemination-drawer.e2e.spec.ts` (+ live local suite EV-039) | H6′ / live local | TC-F16-001..005; TC-F16-LIVE-001..004 |
@@ -556,6 +557,45 @@ Before closing S013 / EV-009:
 - [ ] Hard perf gates at publish (E10-24)
 - [ ] H4–H5 + H6′ UJ-022 after Render redeploy
 - [ ] PyPI install smokes for three packages
+
+### EV-045 / #725 — Rust crate CI (S054; F13/F14 deepen)
+
+CI must gate **both** `packages/tac2iwxxm/rust` and `packages/iwxxm-validate/rust`
+with fmt, clippy, unit tests, and maturin/PyO3 integration smoke. Prefer extending
+`.github/workflows/ci-cd.yml` (matrix) over a separate workflow unless latency requires
+split. Tooling: `dtolnay/rust-toolchain@stable` + components `rustfmt,clippy`;
+Cargo cache (`Swatinem/rust-cache` or equivalent). Local: `make rust-check`.
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tests] [Corpus: adr/ADR-017]
+
+| ID | Level | Assert |
+|----|-------|--------|
+| TC-EV045-001 | CI | `cargo fmt --check` fails on unformatted Rust in both crate trees |
+| TC-EV045-002 | CI | `cargo clippy -- -D warnings` fails on warnings (documented allowlist only if needed) |
+| TC-EV045-003 | CI | `cargo test` green for `tac2iwxxm` and `iwxxm-validate` Rust crates |
+| TC-EV045-004 | CI | Maturin/PyO3 smoke for **both** packages (`TAC2IWXXM_REQUIRE_RUST` /
+  `IWXXM_VALIDATE_REQUIRE_RUST` or equivalent) |
+| TC-EV045-005 | T0 | `make rust-check` mirrors CI: fmt + clippy + `cargo test` **both** crates **and** both `test-*-native` maturin smokes (D-S054-04-local=2) |
+| TC-EV045-006 | Ops | Required check name(s) **documented**; PRs cannot merge with red Rust CI **once rulesets applied** |
+| TC-EV045-007 | CI | Jobs run on default `ci-cd.yml` PR/push (same as today’s native job; **not** path-filter-only — D-S054-04-trigger=1) |
+
+**Required status check contexts** (must match `ci-cd.yml` job `name:` exactly; applied via
+`scripts/deploy/apply_gh_branch_rulesets.sh` when repo admin is available):
+
+| Context | Role |
+|---------|------|
+| `Rust crates (fmt/clippy/test)` | fmt + clippy + `cargo test` both crates (EV-045) |
+| `tac2iwxxm PyO3 (maturin)` | existing maturin smoke |
+| `iwxxm-validate PyO3 (maturin)` | EV-045 maturin smoke (new) |
+
+Also retained from F30 script: `Test (backend)`, `Test (frontend)`, `Alembic migrations`;
+`main` adds `Staging gate`.
+
+**AC6 ops waiver (D-S054-ac6-waive=2 / EV-045):** docs + script updated this cycle; live
+GitHub rulesets/required-check wiring deferred until an admin runs the apply script
+(token `admin=false`; rulesets currently empty — same class as EV-043). Cycle close may
+treat TC-EV045-006 as **docs/script met; ops deferred**. [Corpus: tests] [Corpus: decisions]
+
+**UJ mapping**: UJ-DEV-006 (new); deepen UJ-DEV-004.
 
 ### EV-028 / #781 — EMPIRIC2 Codecov purge + PyPI Trusted Publisher (S035)
 
@@ -2540,8 +2580,8 @@ locally (pre-commit). Scheduled workflows (`vendor-sync`, load/e2e) unchanged.
 |---------|----------|------|--------|
 | Local commit | husky → pre-commit | fast + medium | existing fast hooks + `validate-ci` medium extras (de-duped) |
 | Local push | husky pre-push | long | `make ci` = `ci-prepush` + Compose **integration** (ports 18000/18001; wis2box harness via local target) |
-| PR / push `main`, `dev` | `ci-cd.yml` | **remote** | **no** validate job, **no** Compose integration; **keep** unit matrix + coverage + PR coverage comment; keep `tac2iwxxm-native`, `e2e-smoke`, `test-alembic` |
-| push `main` only | `ci-cd.yml` | **deploy** | needs `test` + alembic + native (+ e2e if required); GHCR + **DOKS**; Render optional |
+| PR / push `main`, `dev` | `ci-cd.yml` | **remote** | **no** validate job, **no** Compose integration; **keep** unit matrix + coverage + PR coverage comment; keep `tac2iwxxm-native`, **Rust crate checks** (EV-045: fmt/clippy/`cargo test` + `iwxxm-validate` maturin smoke), `e2e-smoke`, `test-alembic` |
+| push `main` / `stage` | `ci-cd.yml` | **deploy** | needs `test` + alembic + native + **Rust crate checks** (+ e2e if required); GHCR + **DOKS**; Render optional |
 | Schedule | `vendor-sync.yml` | vendor-sync | wmo-im schema sync PR (M6) |
 | Manual / schedule | `load-tests.yml`, `e2e-tests.yml` | — | out of EV-002 / EV-036 scope |
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -76,6 +76,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-DEV-003b | Maintain tac2iwxxm + iwxxm-us pins | Maintainer workflow | F6, M2 | CI |
 | UJ-DEV-004 | Package CI for tac-validate + iwxxm-validate | `make test` / CI | F2, F6, M5 | T0 / CI |
 | UJ-DEV-005 | pip install published packages + convert/validate | clean venv | F12–F14 | T0 / CI |
+| UJ-DEV-006 | Rust crate CI (fmt/clippy/test + maturin) | `make rust-check` / CI | F13, F14 | T0 / CI |
 | UJ-OPS-001 | Deploy Render stack (API + static + worker) | render.yaml | M4, F8 | T3 (staging) |
 
 **E2E tiers**:
@@ -708,6 +709,27 @@ Extended: sync may include **iwxxm-us** pin updates via manifest (in addition to
 
 **Acceptance**: All install+smoke steps succeed offline for schema-bundled validate.
 **Tier: T0 / CI**.
+
+---
+
+### UJ-DEV-006: Rust Crate CI — fmt / clippy / test / maturin (F13/F14 / #725)
+
+**Actor**: Developer / CI
+
+**Goal**: Catch Rust style, borrow-checker, unit, and PyO3 bridge regressions before merge
+for both native crates.
+
+**Steps**:
+
+1. Locally: `make rust-check` (or CI equivalent) on
+   `packages/tac2iwxxm/rust` and `packages/iwxxm-validate/rust`.
+2. CI on PR/push: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`.
+3. Maturin/PyO3 smoke for **both** packages (required-Rust env flags).
+4. Confirm required GH check(s) block merge when red.
+
+**Acceptance**: Unformatted Rust, clippy warnings, failing `cargo test`, or missing
+iwxxm-validate maturin smoke fail CI. **Tier: T0 / CI**. TC-EV045-001..007.
+[Corpus: product §F13] [Corpus: product §F14] [Corpus: tests]
 
 ---
 
@@ -1673,3 +1695,4 @@ Apply DO Postgres migrations before worker/API traffic. Signoff includes UJ-001/
   UJ-046; deepen UJ-001/004/033; UJ-OPS-001 → DOKS primary (F30/F31; #842/#830/#712)
 - S047 / EV-039 (2026-08-06): UJ-027 live local Compose multi-DB path + TC-F16-LIVE-*;
   teardown hygiene across integration / e2e / local (F16 deepen)
+- S054 / EV-045 (2026-08-08): UJ-DEV-006 Rust crate CI (F13/F14 deepen; #725)

--- a/packages/iwxxm-validate/rust/src/lib.rs
+++ b/packages/iwxxm-validate/rust/src/lib.rs
@@ -92,9 +92,7 @@ impl VendorResolver {
             k
         };
         let by_basename = {
-            let mut guard = resolver_index_cache()
-                .lock()
-                .expect("resolver index lock");
+            let mut guard = resolver_index_cache().lock().expect("resolver index lock");
             if let Some(idx) = guard.get(&key) {
                 idx.clone()
             } else {
@@ -112,7 +110,7 @@ impl VendorResolver {
     }
 
     fn candidates(&self, location: &str, base: Option<&str>) -> Vec<PathBuf> {
-        let loc = location.split('/').last().unwrap_or(location);
+        let loc = location.split('/').next_back().unwrap_or(location);
         let stripped = location
             .strip_prefix("http://")
             .or_else(|| location.strip_prefix("https://"))
@@ -141,8 +139,8 @@ impl VendorResolver {
         // Progressive URL-path suffixes (host/…/file → …/file → file).
         let suffix_paths = url_path_suffixes(stripped);
         let remapped = aixm_schema_remaps(stripped);
-        let version_hint = version_hint_from_location(stripped)
-            .or_else(|| self.version_hint_from_resolved_dirs());
+        let version_hint =
+            version_hint_from_location(stripped).or_else(|| self.version_hint_from_resolved_dirs());
 
         for root in &self.roots {
             out.push(root.join(location));
@@ -217,9 +215,14 @@ fn is_relative_schema_location(location: &str) -> bool {
     location.starts_with("./")
         || location.starts_with("../")
         || !location.contains("://")
-            && Path::new(location)
-                .components()
-                .all(|c| matches!(c, std::path::Component::Normal(_)| std::path::Component::CurDir | std::path::Component::ParentDir))
+            && Path::new(location).components().all(|c| {
+                matches!(
+                    c,
+                    std::path::Component::Normal(_)
+                        | std::path::Component::CurDir
+                        | std::path::Component::ParentDir
+                )
+            })
 }
 
 fn version_hint_from_location(stripped: &str) -> Option<String> {
@@ -252,10 +255,7 @@ fn url_path_suffixes(stripped: &str) -> Vec<String> {
 fn aixm_schema_remaps(stripped: &str) -> Vec<String> {
     // http://www.aixm.aero/schema/5.1.1/AIXM_Features.xsd
     //   → aero/aixm/5.1.1/AIXM_Features.xsd
-    const PREFIXES: &[&str] = &[
-        "www.aixm.aero/schema/",
-        "aixm.aero/schema/",
-    ];
+    const PREFIXES: &[&str] = &["www.aixm.aero/schema/", "aixm.aero/schema/"];
     for prefix in PREFIXES {
         if let Some(rest) = stripped.strip_prefix(prefix) {
             return vec![format!("aero/aixm/{rest}"), rest.to_string()];
@@ -293,7 +293,7 @@ fn best_basename_match(
         .iter()
         .map(|p| (score_schema_candidate(p, url_parent, &segments), p))
         .collect();
-    ranked.sort_by(|a, b| b.0.cmp(&a.0));
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.0));
     ranked.first().map(|(_, p)| (*p).clone())
 }
 
@@ -430,10 +430,7 @@ fn catalog_key(catalog_roots: &[String]) -> Vec<String> {
     key
 }
 
-fn get_or_parse_xsd(
-    xsd_path: &str,
-    catalog_roots: &[String],
-) -> Result<Arc<XsdSchema>, String> {
+fn get_or_parse_xsd(xsd_path: &str, catalog_roots: &[String]) -> Result<Arc<XsdSchema>, String> {
     let key = (xsd_path.to_string(), catalog_key(catalog_roots));
     {
         let guard = xsd_cache().lock().expect("xsd cache lock");
@@ -548,14 +545,7 @@ fn validate_document<'py>(
                 } else {
                     "SCHEMA_PARSE_ERROR"
                 };
-                issues.append(issue_dict(
-                    py,
-                    "error",
-                    code,
-                    &msg,
-                    "xsd",
-                    Some(xsd_path),
-                )?)?;
+                issues.append(issue_dict(py, "error", code, &msg, "xsd", Some(xsd_path))?)?;
                 if !want_sch {
                     return Ok(issues);
                 }

--- a/scripts/deploy/apply_gh_branch_rulesets.sh
+++ b/scripts/deploy/apply_gh_branch_rulesets.sh
@@ -12,10 +12,15 @@ create_ruleset() {
   local body
   body="$(python3 - <<PY
 import json
+# Job `name:` strings from .github/workflows/ci-cd.yml (must match exactly).
+# EV-045 / #725 / TC-EV045-006 — Rust crates + both maturin smokes.
 checks = [
     {"context": "Test (backend)", "integration_id": 0},
     {"context": "Test (frontend)", "integration_id": 0},
     {"context": "Alembic migrations", "integration_id": 0},
+    {"context": "Rust crates (fmt/clippy/test)", "integration_id": 0},
+    {"context": "tac2iwxxm PyO3 (maturin)", "integration_id": 0},
+    {"context": "iwxxm-validate PyO3 (maturin)", "integration_id": 0},
 ]
 extra = json.loads('''${extra_checks_json}''')
 checks.extend(extra)

--- a/tests/test_tc_ev045_rust_ci.py
+++ b/tests/test_tc_ev045_rust_ci.py
@@ -1,0 +1,182 @@
+"""TC-EV045 — Rust crate CI contracts (S054 / EV-045 / #725).
+
+Asserts Makefile ``rust-check`` parity and ``ci-cd.yml`` locked job names /
+deploy.needs for F13/F14 deepen (D-S054-04).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+CI_CD = ROOT / ".github" / "workflows" / "ci-cd.yml"
+RULESETS = ROOT / "scripts" / "deploy" / "apply_gh_branch_rulesets.sh"
+
+LOCKED_RUST_GATE = "Rust crates (fmt/clippy/test)"
+LOCKED_TAC2IWXXM = "tac2iwxxm PyO3 (maturin)"
+LOCKED_IWXXM_VALIDATE = "iwxxm-validate PyO3 (maturin)"
+
+
+@pytest.fixture(scope="module")
+def makefile_text() -> str:
+    assert MAKEFILE.is_file()
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    assert CI_CD.is_file()
+    return CI_CD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow_doc(workflow_text: str) -> dict[str, Any]:
+    doc = yaml.safe_load(workflow_text)
+    assert isinstance(doc, dict)
+    assert "jobs" in doc
+    return doc
+
+
+def _makefile_recipe(makefile: str, target: str) -> str:
+    pattern = re.compile(rf"^{re.escape(target)}:(.*)$", re.M)
+    match = pattern.search(makefile)
+    assert match is not None, f"missing Makefile target {target}"
+    start = match.end()
+    lines = [match.group(1)]
+    for line in makefile[start:].splitlines()[1:]:
+        if (
+            not line.startswith("\t")
+            and line.strip()
+            and not line.startswith("#")
+            and re.match(r"^[A-Za-z0-9_.-]+:", line)
+        ):
+            break
+        if (
+            line.startswith("\t")
+            or line.endswith("\\")
+            or (lines and lines[-1].endswith("\\"))
+        ):
+            lines.append(line)
+        elif not line.strip():
+            continue
+        else:
+            break
+    return "\n".join(lines)
+
+
+def _job_by_name(jobs: dict[str, Any], name: str) -> tuple[str, dict[str, Any]]:
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        if job.get("name") == name:
+            return job_id, job
+    raise AssertionError(f"no job with name={name!r}")
+
+
+@pytest.mark.unit
+class TestTcEv045005MakefileRustCheck:
+    """TC-EV045-005 — make rust-check mirrors CI (cargo both + both maturin)."""
+
+    def test_rust_check_target_exists(self, makefile_text: str) -> None:
+        assert re.search(r"^rust-check:", makefile_text, re.M)
+
+    def test_rust_check_covers_both_crates_and_native(self, makefile_text: str) -> None:
+        recipe = _makefile_recipe(makefile_text, "rust-check")
+        # Cargo path for both packages (direct or via helper targets)
+        assert "tac2iwxxm" in recipe
+        assert "iwxxm-validate" in recipe
+        assert "fmt" in recipe or "cargo fmt" in recipe
+        assert "clippy" in recipe
+        assert "cargo test" in recipe or "test-*-native" in recipe or "test-" in recipe
+        assert "test-tac2iwxxm-native" in recipe
+        assert "test-iwxxm-validate-native" in recipe
+
+
+@pytest.mark.unit
+class TestTcEv045CiJobNames:
+    """TC-EV045-001..004 / AC6 — locked check contexts in ci-cd.yml."""
+
+    def test_rust_gate_job_exact_name(self, workflow_doc: dict[str, Any]) -> None:
+        jobs = workflow_doc["jobs"]
+        job_id, job = _job_by_name(jobs, LOCKED_RUST_GATE)
+        assert job_id
+        needs = job.get("needs")
+        assert needs, "gate job must need the cargo matrix"
+        if isinstance(needs, str):
+            needs = [needs]
+        assert any("rust" in str(n) for n in needs)
+
+    def test_rust_crates_matrix_present(
+        self, workflow_doc: dict[str, Any], workflow_text: str
+    ) -> None:
+        jobs = workflow_doc["jobs"]
+        assert "rust-crates" in jobs
+        rust = jobs["rust-crates"]
+        assert isinstance(rust.get("strategy"), dict)
+        assert "matrix" in rust["strategy"]
+        assert "fmt --check" in workflow_text
+        assert "clippy" in workflow_text
+        assert "-D warnings" in workflow_text
+        assert "cargo test" in workflow_text
+
+    def test_maturin_locked_names_via_check_name(
+        self, workflow_doc: dict[str, Any], workflow_text: str
+    ) -> None:
+        assert LOCKED_TAC2IWXXM in workflow_text
+        assert LOCKED_IWXXM_VALIDATE in workflow_text
+        assert "matrix.check_name" in workflow_text or "${{ matrix.check_name }}" in (
+            workflow_text
+        )
+        assert "IWXXM_VALIDATE_REQUIRE_RUST" in workflow_text
+        assert "TAC2IWXXM_REQUIRE_RUST" in workflow_text
+
+    def test_no_path_filter_only_on_workflow(
+        self, workflow_doc: dict[str, Any]
+    ) -> None:
+        """D-S054-04-trigger=1 — default PR/push, not path-filter-only rust jobs."""
+        on = workflow_doc.get("on") or workflow_doc.get(True)
+        assert isinstance(on, dict)
+        assert "pull_request" in on
+        assert "push" in on
+        # Top-level path filters would skip most PRs — forbid for this workflow.
+        for key in ("push", "pull_request"):
+            node = on[key]
+            if isinstance(node, dict):
+                assert "paths" not in node
+                assert "paths-ignore" not in node
+
+
+@pytest.mark.unit
+class TestTcEv045DeployNeeds:
+    """Deploy must wait on rust gate + native maturin matrix."""
+
+    def test_deploy_needs_rust_and_native(self, workflow_doc: dict[str, Any]) -> None:
+        deploy = workflow_doc["jobs"]["deploy"]
+        needs = deploy.get("needs")
+        assert needs
+        if isinstance(needs, str):
+            needs = [needs]
+        need_set = set(needs)
+        assert "test" in need_set
+        assert "test-alembic" in need_set
+        # Gate job id (not display name)
+        assert "rust-crates-gate" in need_set
+        # Job id retained for EV-036 contracts; matrix covers both PyO3 packages.
+        assert "tac2iwxxm-native" in need_set
+
+
+@pytest.mark.unit
+class TestTcEv045006RulesetScript:
+    """TC-EV045-006 docs half — apply script lists locked contexts."""
+
+    def test_apply_script_lists_locked_contexts(self) -> None:
+        text = RULESETS.read_text(encoding="utf-8")
+        assert LOCKED_RUST_GATE in text
+        assert LOCKED_TAC2IWXXM in text
+        assert LOCKED_IWXXM_VALIDATE in text

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -5,18 +5,35 @@ project:
   output_directory: docs/
 session_counter: 54
 evolve_cycle_counter: 45
-active_session:
-  id: S054-rust-ci-crates
+active_session: null
+sessions:
+- id: S054-rust-ci-crates
   type: feature
   intent: "CI: lint, typecheck, unit, and integration tests for Rust crates (#725)"
-  status: in_progress
+  status: completed
+  completed: '2026-08-08'
+  completed_at: '2026-08-08'
+  close_decision: D-S054-11=1
+  close_note: 'Approve F13+F14 deepen + accept QA-001..005; PR #953 OPEN → stage; EV-043/EV-044 remain PARKED'
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-045-rust-ci
   branch_base: main@d0a51f5a
   branch_status: active
   branch_exists: true
-  branch_note: 'CREATED — evolve/EV-045-rust-ci from origin/main@d0a51f5a'
+  branch_note: 'CLOSED session — evolve/EV-045-rust-ci tip 09ce2bef; PR #953 still OPEN → stage (supersedes #952); not merged'
+  tip_sha: 09ce2bef
+  tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+  tip_sha_pushed: true
+  pr_number: 953
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+  pr_status: open
+  pr_base: stage
+  pr_supersedes: 952
+  pr_note: 'PR #953 still OPEN → stage; do not mark merged'
+  ci_cd_pipeline_run: '31273500621'
+  ci_cd_pipeline_status: SUCCESS
+  ci_cd_pipeline_note: 'Accepted tip CI — run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests) per D-S054-t17-ci=1; tip delta after f270618c is docs-only (09ce2bef); Staging gate FAIL was base=main only; continue 08-verify-build'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-045
   artifacts_dir: docs/sessions/S054-rust-ci-crates/
@@ -42,6 +59,9 @@ active_session:
   - 'D-S054-04 locked — jobs=2 maturin=2 trigger=1 local=2; plan approved (D-S054-04-plan=1)'
   - 'D-S054-04-plan=1 — approve execution plan as written; close 04 → 05-verify-tech'
   - 'D-S054-gateB=1 — Gate B PASS; medium/low syncs confirmed; proceed 07-build (06 skipped ADR-017)'
+  - 'D-S054-t17-ci=1 — Accept run 31273500621 as tip CI evidence; tip delta after f270618c docs-only (09ce2bef); Staging FAIL was base=main only; continue 08-verify-build'
+  - 'D-S054-phaseC=1 — Approve Phase C; start 09-qa'
+  - 'D-S054-11=1 — Approve F13+F14 deepen + accept QA-001..005; close cycle'
   decisions:
     D-S054-open: '1'
     D-S054-open_note: '1 — open S054 as proposed (Standard; skip 03/06/10/12/13; deepen F13+F14)'
@@ -67,6 +87,12 @@ active_session:
     D-S054-04-plan_note: '1 — approve execution plan as written; close 04 → 05-verify-tech'
     D-S054-gateB: '1'
     D-S054-gateB_note: '1 — Gate B PASS; medium/low syncs confirmed; proceed 07-build M1 T1.1 (06 skipped ADR-017)'
+    D-S054-t17-ci: '1'
+    D-S054-t17-ci_note: '1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs; tip delta after f270618c is docs-only (09ce2bef); Staging gate failure was base=main only; continue to 08-verify-build'
+    D-S054-phaseC: '1'
+    D-S054-phaseC_note: '1 — Approve Phase C; start 09-qa'
+    D-S054-11: '1'
+    D-S054-11_note: '1 — Approve F13+F14 deepen + accept QA-001..005; proceed to cycle close'
   ui_preview: 'N/A — no browser UI'
   routing_plan:
   - stage: 00-context
@@ -79,9 +105,10 @@ active_session:
   - stage: 16-evolve
     required: true
     mode: orchestrator
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: 'Phase 0 locked; child stage 07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending'
+    completed: '2026-08-08'
+    note: 'COMPLETE — D-S054-11=1; EV-045 closed; PR #953 still OPEN → stage'
   - stage: 01-requirements
     required: true
     mode: delta
@@ -117,24 +144,43 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
-    active_task: T1.1
-    active_task_status: pending
+    completed: '2026-08-08'
+    note: 'COMPLETE — T1.1–T1.7 (7/7); D-S054-t17-ci=1 accepted run 31273500621 tip CI; handoff 08-verify-build'
+    active_task: null
+    active_task_status: completed
     active_milestone: M1
+    completed_through: T1.7
+    progress: 7/7
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+    overall: PASS
+    note: 'COMPLETE — PASS @ tip 09ce2bef; D-S054-t17-ci=1 run 31273500621; format/lint/typecheck PASS; TC-EV045+H0c 14 PASS; rust-check PASS; pip-audit 0 CVEs; Phase C approved D-S054-phaseC=1'
   - stage: 09-qa
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    report: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+    overall: pass_with_advisories
+    note: 'COMPLETE — pass_with_advisories; QA-001..005 (AC6 ops deferred primary); handoff 11-verify-impl'
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    report: docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+    overall: approved
+    decision: D-S054-11=1
+    note: 'COMPLETE — D-S054-11=1 approve F13+F14 deepen + accept QA-001..005; cycle close'
   - stage: 03-plan-tooling
     required: false
     mode: skipped
@@ -160,15 +206,21 @@ active_session:
     mode: skipped
     status: skipped
     skip_rationale: 'CI-only; no staging/prod deploy'
-  current_stage: 07-build
-  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
+  current_stage: completed
+  current_stage_note: 'CLOSED — D-S054-11=1; EV-045 COMPLETE; PR #953 still OPEN → stage; tip 09ce2bef'
   gate_a: PASS
   gate_b: PASS
   gate_b_status: pass
   gate_b_decision: D-S054-gateB=1
-  active_task: T1.1
-  active_task_status: pending
+  phase_c_checkpoint: passed
+  phase_c_checkpoint_note: 'D-S054-phaseC=1 — Phase C approved; gates.c_to_d passed; 09-qa COMPLETE'
+  gate_c_to_d: passed
+  gate_c_to_d_decision: D-S054-phaseC=1
+  active_task: null
+  active_task_status: completed
   active_milestone: M1
+  completed_through: T1.7
+  progress: 7/7
   gate_a_status: pass
   ac6_ops_deferred: true
   ac6_ops_deferred_note: 'GitHub rulesets/required checks wiring deferred until admin can run apply_gh_branch_rulesets.sh'
@@ -177,7 +229,9 @@ active_session:
     evolve_cycle_id: EV-045
     feature_ids: [F13, F14]
     delta_only: true
-    current_child_stage: 07-build
+    current_child_stage: completed
+    current_child_stage_status: completed
+    current_child_stage_note: 'COMPLETE — D-S054-11=1; cycle closed'
     corpus_cites:
     - "[Corpus: product §F13]"
     - "[Corpus: product §F14]"
@@ -208,9 +262,40 @@ active_session:
     stage: 05-verify-tech
     skill_id: 05-verify-tech
     note: 'APPROVED — Gate B PASS (D-S054-gateB=1)'
+  - path: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+    status: completed
+    stage: 08-verify-build
+    skill_id: 08-verify-build
+    note: 'COMPLETE — PASS @ tip 09ce2bef; Phase C approved D-S054-phaseC=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+    status: completed
+    stage: 09-qa
+    skill_id: 09-qa
+    note: 'COMPLETE — pass_with_advisories; QA-001..005 (AC6 ops deferred primary)'
+  - path: docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+    status: completed
+    stage: 11-verify-impl
+    skill_id: 11-verify-impl
+    note: 'COMPLETE — D-S054-11=1 approved'
+  - path: docs/sessions/S054-rust-ci-crates/reports/evolve-summary.md
+    status: completed
+    stage: 16-evolve
+    skill_id: 16-evolve
+    note: 'COMPLETE — EV-045 closeout'
+  - path: docs/evolve-report-EV-045.md
+    status: completed
+    stage: 16-evolve
+    skill_id: 16-evolve
+    note: 'COMPLETE — EV-045 standing evolve report'
   - path: docs/sessions/S054-rust-ci-crates/
-    status: in_progress
+    status: completed
   notes:
+  - '2026-08-08 D-S054-11=1 — CLOSED S054/EV-045; approve F13+F14 deepen + accept QA-001..005; 11-verify-impl COMPLETE (verify-impl.md); 16-evolve COMPLETE; cycle COMPLETE; PR #953 still OPEN → stage (not merged); tip 09ce2bef; closeout docs may be uncommitted; EV-043/EV-044 remain PARKED (D-park-doks=1); active_session=null; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 09-qa COMPLETE pass_with_advisories @ tip 09ce2bef — report docs/sessions/S054-rust-ci-crates/reports/qa-report.md; advisories QA-001..005 (AC6 ops deferred primary); 11-verify-impl in_progress; PR #953 → stage; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-phaseC=1 — Phase C approved; checkpoints.phase_c=passed; gates.c_to_d=passed; 08 COMPLETE; 09-qa in_progress (started 2026-08-08); tip 09ce2bef; PR #953 → stage; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 08-verify-build PASS COMPLETE @ tip 09ce2bef — report docs/sessions/S054-rust-ci-crates/reports/verification-report.md; D-S054-t17-ci=1 run 31273500621; make format-check/lint/typecheck PASS; TC-EV045+H0c 14 PASS; make rust-check PASS; uvx pip-audit 0 CVEs; 07-build remains COMPLETE 7/7; Phase C checkpoint pending AskQuestion before 09-qa (09 not started); no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-t17-ci=1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs; tip delta after f270618c is docs-only (09ce2bef); Staging gate FAIL was base=main only; T1.7 COMPLETE (7/7); 07-build COMPLETE; 08-verify-build in_progress (delta verify after T1.7 CI accept); no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 07-build — T1.1–T1.6 COMPLETE + T1.7 near-complete @ tip 09ce2bef (09ce2befdf0b5878ec6a832ec30718c489b4824b); commits cfd292f4 (T1.1), b8a1cb16 (T1.2), 3cd5844b (T1.3–5), b344b4d2 (T1.7 fix), f270618c (T1.6), 09ce2bef (T1.7 docs); branch evolve/EV-045-rust-ci pushed; PR #953 open → stage (supersedes #952) https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953; CI run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests); Staging gate FAIL only because PR briefly targeted main; tip after docs commit awaiting fresh Actions run (not queued yet); active_task T1.7 in_progress near-complete pending tip CI re-trigger; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
   - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
@@ -220,34 +305,6 @@ active_session:
   - '2026-08-08 01-requirements note — drafted docs/sessions/S054-rust-ci-crates/reports/01-requirements.md + standing docs; awaiting D-S054-01-ac; still in_progress'
   - '2026-08-08 D-S054-phase01=1 — proceed to 01-requirements; deepen F13+F14; 01 in_progress'
   - '2026-08-08 D-S054-open=1 — OPEN S054/EV-045 for #725; counters 54/45; branch evolve/EV-045-rust-ci'
-sessions:
-- id: S054-rust-ci-crates
-  type: feature
-  intent: "CI: lint, typecheck, unit, and integration tests for Rust crates (#725)"
-  status: in_progress
-  started: '2026-08-08'
-  started_at: '2026-08-08'
-  branch: evolve/EV-045-rust-ci
-  branch_base: main@d0a51f5a
-  branch_status: active
-  branch_exists: true
-  branch_note: 'CREATED — evolve/EV-045-rust-ci from origin/main@d0a51f5a'
-  orchestrator: 16-evolve
-  evolve_cycle_id: EV-045
-  artifacts_dir: docs/sessions/S054-rust-ci-crates/
-  prior_session: S053-separate-staging-doks-project
-  prior_session_note: 'S053/EV-044 and S052/EV-043 PARKED (D-park-doks=1) for this session'
-  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725
-  github_issues: [725]
-  issue_ids: [725]
-  feature_ids: [F13, F14]
-  deepen_feature_ids: [F13, F14]
-  feature_note: 'Deepen F13/F14 — Rust CI gates (fmt/clippy/cargo test + maturin smoke both crates); M5 Makefile optional later'
-  preset: Standard
-  preset_note: 'Standard with skips 03/06/10/12/13 per D-S054-open=1'
-  current_stage: 07-build
-  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
-  note: 'IN_PROGRESS — D-S054-gateB=1; 07-build M1 T1.1 pending; EV-045 for #725'
 - id: S053-separate-staging-doks-project
   type: feature
   intent: "Separate staging DOKS + Postgres under DO Project Staging TAC-to-IWXXM; amend ADR-034"
@@ -9697,11 +9754,11 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: in_progress
+    status: completed
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed_at:
-    completed:
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
     previous_started_at: '2026-08-07'
     previous_completed_at: '2026-08-07'
     previous_session_id: S050-remove-db-tools-operator-throughput
@@ -9720,14 +9777,28 @@ stages:
     session_id: S054-rust-ci-crates
     evolve_cycle_id: EV-045
     mode: full
-    note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
+    note: 'COMPLETE — T1.1–T1.7 (7/7); D-S054-t17-ci=1 accepted run 31273500621 tip CI; handoff 08-verify-build'
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    tip_sha_pushed: true
+    pr_number: 953
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+    pr_status: open
+    pr_base: stage
+    pr_supersedes: 952
+    ci_cd_pipeline_run: '31273500621'
+    ci_cd_pipeline_status: SUCCESS
+    ci_cd_pipeline_note: 'Accepted tip CI — run 31273500621 per D-S054-t17-ci=1; docs-only tip delta after f270618c; Staging FAIL was base=main only'
     pending_commit: false
     current_milestone: M1
-    current_task: T1.1
+    current_task: null
     active_milestone: M1
-    active_task: T1.1
-    active_task_status: pending
+    active_task: null
+    active_task_status: completed
+    completed_through: T1.7
+    progress: 7/7
     decision_refs:
+    - D-S054-t17-ci
     - D-S054-gateB
     - D-S054-04-plan
     - D-S054-04-jobs
@@ -9780,15 +9851,25 @@ stages:
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 07-build
-      status: in_progress
+      status: completed
       mode: full
       started_at: '2026-08-08'
       started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
       pending_commit: false
-      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
+      note: 'COMPLETE — T1.1–T1.7 (7/7); D-S054-t17-ci=1; handoff 08-verify-build'
+      tip_sha: 09ce2bef
+      tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+      tip_sha_pushed: true
+      pr_number: 953
+      pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+      pr_status: open
+      pr_base: stage
       feature_ids: [F13, F14]
       deepen_feature_ids: [F13, F14]
       decision_refs:
+      - D-S054-t17-ci
       - D-S054-gateB
       - D-S054-04-plan
       - D-S054-04-jobs
@@ -9801,10 +9882,11 @@ stages:
       - D-S054-open
       active_milestone: M1
       current_milestone: M1
-      active_task: T1.1
-      current_task: T1.1
-      active_task_status: pending
-      completed_through:
+      active_task: null
+      current_task: null
+      active_task_status: completed
+      completed_through: T1.7
+      progress: 7/7
       artifacts:
       - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
       - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
@@ -10733,6 +10815,8 @@ stages:
       active_task_status: completed
       completed_at: '2026-07-19'
     notes:
+    - '2026-08-08 D-S054-t17-ci=1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs; tip delta after f270618c is docs-only (09ce2bef); Staging gate FAIL was base=main only; T1.7 COMPLETE (7/7); 07-build COMPLETE; 08-verify-build in_progress (delta verify after T1.7 CI accept); no git commit by workflow-state-manager'
+    - '2026-08-08 S054/EV-045 07-build — T1.1–T1.6 COMPLETE + T1.7 near-complete @ tip 09ce2bef (09ce2befdf0b5878ec6a832ec30718c489b4824b); commits cfd292f4 (T1.1), b8a1cb16 (T1.2), 3cd5844b (T1.3–5), b344b4d2 (T1.7 fix), f270618c (T1.6), 09ce2bef (T1.7 docs); branch evolve/EV-045-rust-ci pushed; PR #953 open → stage (supersedes #952) https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953; CI run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests); Staging gate FAIL only because PR briefly targeted main; tip after docs commit awaiting fresh Actions run (not queued yet); active_task T1.7 in_progress near-complete pending tip CI re-trigger; no git commit by workflow-state-manager'
     - '2026-08-04 S040/EV-032 — T4.3 COMPLETE (09-qa pass_with_advisories + 10-e2e T0 pass); reports qa-report.md + e2e-report.md; progress 24/28; completed_through T4.3; active_task T4.4 pending; current_stage 11-verify-impl; tip 7b3c329b pending_commit; PR #848; #846'
     - '2026-08-04 S040/EV-032 — T2.8 COMPLETE @ d13f25e8 (d13f25e85e3b42e9fbfef136d5ce117b17924533) [T2.8] chore: add VONA quality pack and path-filtered canary; T2.6–T2.8 COMPLETE this session; active_task T2.9 pending @ M2; progress 17/28; ahead_of_origin=3 pushed=false (6f53dcb7, 682919cb, d13f25e8); next T2.9 COVERAGE_MATRIX / #741 closeout; #846/#741'
     - '2026-08-04 S040/EV-032 — T2.7 COMPLETE @ 682919cb (682919cb658a1afe952774aaefcedba788554b18) [T2.7] feat: runtime product=vona and FE Examples unlock; product=vona API + FE picker + Examples wmoPass vona-A7-1; active_task T2.8 in_progress @ M2; progress 16/28; ahead_of_origin=2 pushed=false; #846/#741'
@@ -11038,10 +11122,21 @@ stages:
     - 2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress
   09-qa:
     status: completed
-    started_at: '2026-08-07'
-    started: '2026-08-07'
-    completed_at: '2026-08-07'
-    completed: '2026-08-07'
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
+    previous_started_at: '2026-08-07'
+    previous_started: '2026-08-07'
+    previous_completed_at: '2026-08-07'
+    previous_completed: '2026-08-07'
+    previous_session_id: S050-remove-db-tools-operator-throughput
+    previous_evolve_cycle_id: EV-042
+    previous_tip_sha: dff22265
+    previous_tip_sha_full: dff22265cd77e68549238d93c15e1de931b64da8
+    previous_overall: pass_with_advisories
+    previous_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
+    previous_note: 'S050/EV-042 09 PASS pass_with_advisories @ dff22265 — superseded by S054/EV-045'
     previous_s048_started_at: '2026-08-06'
     previous_s048_started: '2026-08-06'
     previous_s048_completed_at: '2026-08-06'
@@ -11092,21 +11187,52 @@ stages:
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e00000
-    session_id: S050-remove-db-tools-operator-throughput
-    evolve_cycle_id: EV-042
-    tip_sha: dff22265
-    tip_sha_full: dff22265cd77e68549238d93c15e1de931b64da8
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    tip_sha_pushed: true
+    pr_number: 953
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
     mode: delta
     overall: pass_with_advisories
-    report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
-    note: '09 PASS pass_with_advisories @ dff22265; next was 10-e2e (now COMPLETE)'
+    report: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+    expected_report: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+    note: 'COMPLETE — pass_with_advisories; QA-001..005 (AC6 ops deferred primary); handoff 11-verify-impl'
+    advisories: [QA-001, QA-002, QA-003, QA-004, QA-005]
+    advisories_note: 'AC6 ops deferred is primary (D-S054-ac6-waive=2)'
+    decision_refs:
+    - D-S054-phaseC
+    - D-S054-t17-ci
+    - D-S054-gateB
+    - D-S054-ac6-waive
+    - D-S054-open
     pending_commit: false
-    active_milestone: M4
-    active_task: T4.3
-    active_task_status: completed
+    active_milestone: M1
+    active_task: null
+    active_task_status: null
+    prior_s050_session_id: S050-remove-db-tools-operator-throughput
+    prior_s050_evolve_cycle_id: EV-042
+    prior_s050_tip_sha: dff22265
+    prior_s050_overall: pass_with_advisories
+    prior_s050_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
     main_ci_cd_pipeline_run: '31003268652'
     main_ci_cd_pipeline_status: in_progress
     delta_substages:
+    - id: S054-rust-ci-crates-09
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
+      skill_id: 09-qa
+      status: completed
+      mode: delta
+      started: '2026-08-08'
+      started_at: '2026-08-08'
+      completed: '2026-08-08'
+      completed_at: '2026-08-08'
+      tip_sha: 09ce2bef
+      overall: pass_with_advisories
+      report: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+      note: 'COMPLETE — pass_with_advisories; QA-001..005'
     - id: S050-remove-db-tools-operator-throughput-09
       session_id: S050-remove-db-tools-operator-throughput
       evolve_cycle_id: EV-042
@@ -11386,10 +11512,18 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
     status: completed
-    started_at: '2026-08-07'
-    started: '2026-08-07'
-    completed: '2026-08-07'
-    completed_at: '2026-08-07'
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    completed_at: '2026-08-08'
+    previous_started_at: '2026-08-07'
+    previous_started: '2026-08-07'
+    previous_completed: '2026-08-07'
+    previous_completed_at: '2026-08-07'
+    previous_session_id: S050-remove-db-tools-operator-throughput
+    previous_evolve_cycle_id: EV-042
+    previous_overall: approved
+    previous_note: 'S050/EV-042 11 COMPLETE — superseded by S054/EV-045'
     previous_s048_started_at: '2026-08-06'
     previous_s048_started: '2026-08-06'
     previous_s048_completed_at: '2026-08-06'
@@ -11459,11 +11593,32 @@ stages:
     prior_s037_session_id: S037-quality-residuals-831
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 3889e4c
-    session_id: S050-remove-db-tools-operator-throughput
-    evolve_cycle_id: EV-042
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    tip_sha_pushed: true
+    pr_number: 953
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+    pr_status: open
+    pr_base: stage
     mode: delta
     overall: approved
-    note: 'COMPLETE — D-S050-11-verify approve F33 + F7 deepen + F16–F19 deepen; UJ-051..053 approved (T3/H4–H5 waived until 13); UI preview accepted localhost:18000; fix adad127c hide Upload to Database; report verify-impl.md; tip adad127c; next 12-verify-deploy'
+    report: docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+    expected_report: docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+    decision: D-S054-11=1
+    note: 'COMPLETE — D-S054-11=1; PR #953 still OPEN → stage; tip 09ce2bef'
+    decision_refs:
+    - D-S054-phaseC
+    - D-S054-t17-ci
+    - D-S054-ac6-waive
+    - D-S054-gateB
+    - D-S054-open
+    prior_s050_session_id: S050-remove-db-tools-operator-throughput
+    prior_s050_evolve_cycle_id: EV-042
+    prior_s050_overall: approved
+    prior_s050_note: 'COMPLETE — D-S050-11-verify approve F33 + F7 deepen + F16–F19 deepen; UJ-051..053 approved (T3/H4–H5 waived until 13); UI preview accepted localhost:18000; fix adad127c hide Upload to Database; report verify-impl.md; tip adad127c; next 12-verify-deploy'
+    prior_s050_report_note: 'S050/EV-042 11 COMPLETE — superseded by S054/EV-045'
     report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verify-impl.md
     report_status: approved
     tip_sha: adad127c
@@ -12269,19 +12424,28 @@ stages:
   08-verify-build:
     status: completed
     mode: delta
-    started_at: '2026-08-07'
-    started: '2026-08-07'
-    completed_at: '2026-08-07'
-    completed: '2026-08-07'
-    previous_started_at: '2026-08-05'
-    previous_completed_at: '2026-08-05'
-    previous_session_id: S045-matrix-disposition-residuals
-    previous_evolve_cycle_id: EV-037
-    previous_tip_sha: 90c2e8a3
-    previous_tip_sha_full: 90c2e8a3f090d49341fccb1f397b6ff4033d32df
-    previous_note: 'PASS — S045/EV-037 COMPLETE @ tip 90c2e8a3; report verification-report.md; handoff 11-verify-impl'
-    previous_report: docs/sessions/S045-matrix-disposition-residuals/reports/verification-report.md
-    previous_overall: pass
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
+    previous_started_at: '2026-08-07'
+    previous_completed_at: '2026-08-07'
+    previous_session_id: S050-remove-db-tools-operator-throughput
+    previous_evolve_cycle_id: EV-042
+    previous_tip_sha: 6bc756ef
+    previous_tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
+    previous_note: 'S050/EV-042 08-verify-build COMPLETE M4 PASS @ 6bc756ef — superseded by S054/EV-045'
+    previous_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
+    previous_overall: PASS
+    previous_s045_started_at: '2026-08-05'
+    previous_s045_completed_at: '2026-08-05'
+    previous_s045_session_id: S045-matrix-disposition-residuals
+    previous_s045_evolve_cycle_id: EV-037
+    previous_s045_tip_sha: 90c2e8a3
+    previous_s045_tip_sha_full: 90c2e8a3f090d49341fccb1f397b6ff4033d32df
+    previous_s045_note: 'PASS — S045/EV-037 COMPLETE @ tip 90c2e8a3; report verification-report.md; handoff 11-verify-impl'
+    previous_s045_report: docs/sessions/S045-matrix-disposition-residuals/reports/verification-report.md
+    previous_s045_overall: pass
     previous_s044_started_at: '2026-08-05'
     previous_s044_completed_at: '2026-08-05'
     previous_s044_session_id: S044-local-precommit-long-jobs
@@ -12324,15 +12488,33 @@ stages:
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 1f47eb5
     prior_s037_note: 'COMPLETE (M3 gate + T4.1) — PASS @ tip 1f47eb5; report docs/sessions/S037-quality-residuals-831/reports/verification-report-m3.md; prior M2 verification-report-m2.md; CI 30823368642 SUCCESS; reopen for final M4 08; PR #832 open; #831→#835'
-    session_id: S050-remove-db-tools-operator-throughput
-    evolve_cycle_id: EV-042
-    tip_sha: 6bc756ef
-    tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
-    note: 'S050/EV-042 08-verify-build COMPLETE M4 PASS @ 6bc756ef — after T4.1–T4.2 H4–H5; tip CI green 05893ccb; report verification-report.md; next 09-qa (T4.3 handoff)'
-    expected_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
-    report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    tip_sha_pushed: true
+    pr_number: 953
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+    pr_status: open
+    pr_base: stage
+    ci_cd_pipeline_run: '31273500621'
+    ci_cd_pipeline_status: SUCCESS
+    ci_cd_pipeline_note: 'Accepted tip CI — run 31273500621 per D-S054-t17-ci=1'
+    note: 'COMPLETE — PASS @ tip 09ce2bef; Phase C checkpoint pending AskQuestion before 09-qa'
+    expected_report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+    report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
     overall: PASS
-    next_stage: 07-build
+    phase_c_checkpoint: passed
+    phase_c_checkpoint_note: 'D-S054-phaseC=1 — Phase C approved; 09-qa started'
+    next_stage: 09-qa
+    next_stage_status: in_progress
+    next_stage_note: 'D-S054-phaseC=1 — 09-qa in_progress'
+    prior_s050_session_id: S050-remove-db-tools-operator-throughput
+    prior_s050_evolve_cycle_id: EV-042
+    prior_s050_tip_sha: 6bc756ef
+    prior_s050_note: 'S050/EV-042 08-verify-build COMPLETE M4 PASS @ 6bc756ef — superseded by S054/EV-045'
+    prior_s050_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
+    prior_s050_overall: PASS
     prior_s040_report: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report.md
     prior_s040_report_m4: docs/sessions/S040-iwxxm-corpus-quality/reports/verification-report-M4.md
     prior_s040_overall: pass
@@ -12350,16 +12532,21 @@ stages:
     m5_overall: pass
     m5_tip_sha: 7a2cb7d0
     m5_report: docs/sessions/S038-platform-independence-842/reports/verification-report-M5.md
-    active_milestone: M4
-    active_task:
-    active_task_status:
-    progress:
-    completed_through: M3
+    active_milestone: M1
+    active_task: null
+    active_task_status: null
+    progress: null
+    completed_through: T1.7
     m3_boundary: passed
     m5_boundary: false
     m5_boundary_complete: true
     m7_pack: true
     decision_refs:
+    - D-S054-t17-ci
+    - D-S054-gateB
+    - D-S054-04-plan
+    - D-S054-open
+    decision_refs_prior_s050:
     - D-S050-gate-b
     - D-S050-ac
     - D-S050-proceed
@@ -12373,24 +12560,50 @@ stages:
     substeps:
       lint:
         status: completed
-        note: PASS
+        note: PASS — make lint
       format:
         status: completed
-        note: PASS
+        note: PASS — make format-check
       typecheck:
         status: completed
-        note: PASS
+        note: PASS — make typecheck
       tests:
         status: completed
-        note: PASS
+        note: PASS — TC-EV045+H0c 14 PASS; make rust-check PASS
       security:
         status: completed
-        note: PASS
+        note: PASS — uvx pip-audit 0 CVEs
       report:
         status: completed
-        path: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
+        path: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
         note: Overall PASS
     active_session:
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
+      skill_id: 08-verify-build
+      status: completed
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      tip_sha: 09ce2bef
+      tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+      tip_sha_pushed: true
+      pr_number: 953
+      pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+      overall: PASS
+      report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+      expected_report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+      note: 'COMPLETE — PASS @ tip 09ce2bef; Phase C checkpoint pending AskQuestion before 09-qa'
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-t17-ci
+      - D-S054-gateB
+      - D-S054-04-plan
+      - D-S054-open
+    prior_active_session_s050:
       session_id: S050-remove-db-tools-operator-throughput
       evolve_cycle_id: EV-042
       skill_id: 08-verify-build
@@ -12405,7 +12618,7 @@ stages:
       overall: PASS
       report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
       expected_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
-      note: 'PASS @ 410055cf — M1–M3 boundary; next M4/PR; handoff 07-build M4'
+      note: 'PASS @ 410055cf — M1–M3 boundary; superseded by S054/EV-045'
       feature_ids:
       - F33
       deepen_feature_ids:
@@ -14625,6 +14838,101 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S054-11
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 11-verify-impl
+  skill_id: 11-verify-impl
+  stage: 11-verify-impl
+  category: verify_impl_approval
+  status: confirmed
+  topic: 'Approve F13+F14 deepen + accept QA-001..005; close cycle'
+  summary: '1 — Approve F13+F14 deepen + accept QA-001..005; proceed to cycle close'
+  decision: |
+    D-S054-11=1 — Approve F13+F14 deepen + accept QA-001..005 for S054/EV-045.
+    Complete 11-verify-impl (verify-impl.md); complete 16-evolve; close EV-045 and S054.
+    PR #953 remains OPEN → stage (not merged). Tip 09ce2bef; closeout docs may be uncommitted.
+    EV-043/EV-044 remain PARKED (D-park-doks=1).
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-045-rust-ci
+  related_decisions:
+  - D-S054-phaseC
+  - D-S054-t17-ci
+  - D-S054-ac6-waive
+  - D-S054-gateB
+  - D-S054-open
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  current_stage: completed
+  tip_sha: 09ce2bef
+  pr_number: 953
+  pr_status: open
+  note: 'Cycle+session CLOSED; active_session=null'
+- id: D-S054-phaseC
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 08-verify-build
+  skill_id: 08-verify-build
+  stage: 08-verify-build
+  category: phase_c_checkpoint
+  status: confirmed
+  topic: 'Approve Phase C; start 09-qa'
+  summary: '1 — Approve Phase C; start 09-qa'
+  decision: |
+    D-S054-phaseC=1 — Approve Phase C for S054/EV-045 after 08-verify-build PASS.
+    checkpoints.phase_c=passed; gates.c_to_d=passed.
+    Start 09-qa (in_progress, started 2026-08-08).
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-045-rust-ci
+  related_decisions:
+  - D-S054-t17-ci
+  - D-S054-gateB
+  - D-S054-open
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  current_stage: 09-qa
+  tip_sha: 09ce2bef
+  note: 'Phase C approved; 09-qa in_progress'
+- id: D-S054-t17-ci
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 07-build
+  skill_id: 07-build
+  stage: 07-build
+  category: ci_evidence
+  status: confirmed
+  topic: 'Accept run 31273500621 as tip CI evidence; close T1.7 → 08-verify-build'
+  summary: '1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs; tip delta after f270618c is docs-only (09ce2bef); Staging gate failure was base=main only; continue to 08-verify-build'
+  decision: |
+    D-S054-t17-ci=1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs.
+    Tip delta after f270618c is docs-only (09ce2bef); Staging gate failure was base=main only.
+    Close T1.7 / 07-build (completed 2026-08-08, progress 7/7); start 08-verify-build (in_progress).
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-045-rust-ci
+  related_decisions:
+  - D-S054-gateB
+  - D-S054-04-plan
+  - D-S054-open
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  current_stage: 08-verify-build
+  completed_through: T1.7
+  progress: 7/7
+  ci_cd_pipeline_run: '31273500621'
+  tip_sha: 09ce2bef
+  note: 'T1.7 COMPLETE; 07-build COMPLETE; 08-verify-build in_progress'
 - id: D-S054-gateB
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -31262,16 +31570,37 @@ evolve_cycles:
   feature_ids: [F13, F14]
   deepen_feature_ids: [F13, F14]
   title: "Rust crate CI — fmt/clippy/test/integration (#725)"
-  status: in_progress
+  status: completed
   started: '2026-08-08'
+  completed: '2026-08-08'
+  completed_at: '2026-08-08'
   github_issues: [725]
-  current_stage: 07-build
+  branch: evolve/EV-045-rust-ci
+  tip_sha: 09ce2bef
+  tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+  tip_sha_pushed: true
+  pr_number: 953
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+  pr_status: open
+  pr_base: stage
+  pr_supersedes: 952
+  ci_cd_pipeline_run: '31273500621'
+  ci_cd_pipeline_status: SUCCESS
+  ci_cd_pipeline_note: 'Accepted tip CI — run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests) per D-S054-t17-ci=1; tip delta after f270618c is docs-only (09ce2bef); Staging gate FAIL was base=main only; 08-verify-build PASS'
+  current_stage: completed
+  active_task: null
+  active_task_status: completed
+  active_milestone: M1
+  completed_through: T1.7
+  progress: 7/7
+  phase_c_checkpoint: passed
   routing_plan:
     required_stages: [00-context, 16-evolve, 01-requirements, 02-verify-plan, 04-tech-plan, 05-verify-tech, 07-build, 08-verify-build, 09-qa, 11-verify-impl]
     skipped_stages: [03-plan-tooling, 06-tech-tooling, 10-e2e, 12-verify-deploy, 13-deploy-smoke]
-  gates: {a_to_b: passed_ops_deferred, b_to_c: passed, c_to_d: pending, deploy: skipped}
-  gates_note: 'a_to_b passed_ops_deferred — Gate A PASS (D-S054-gateA=2); AC6 ops half waived (D-S054-ac6-waive=2); docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available'
-  checkpoints: {phase_a: passed, phase_b: passed, phase_c: pending, phase_d: pending, deploy: skipped}
+  gates: {a_to_b: passed_ops_deferred, b_to_c: passed, c_to_d: passed, deploy: skipped}
+  gates_note: 'c_to_d passed — D-S054-phaseC=1; phase_d passed — D-S054-11=1 cycle close; deploy skipped (CI-only)'
+  checkpoints: {phase_a: passed, phase_b: passed, phase_c: passed, phase_d: passed, deploy: skipped}
+  checkpoints_note: 'phase_d passed D-S054-11=1; cycle COMPLETE; PR #953 still OPEN → stage'
   ac6_ops_deferred: true
   ac6_docs_in_scope: true
   artifacts:
@@ -31298,8 +31627,31 @@ evolve_cycles:
     stage: 05-verify-tech
     skill_id: 05-verify-tech
     note: 'APPROVED — Gate B PASS (D-S054-gateB=1)'
+  - path: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+    status: completed
+    stage: 08-verify-build
+    skill_id: 08-verify-build
+    note: 'COMPLETE — PASS @ tip 09ce2bef; Phase C approved D-S054-phaseC=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+    status: completed
+    stage: 09-qa
+    skill_id: 09-qa
+    note: 'COMPLETE — pass_with_advisories; QA-001..005 (AC6 ops deferred primary)'
+  - path: docs/sessions/S054-rust-ci-crates/reports/verify-impl.md
+    status: completed
+    stage: 11-verify-impl
+    skill_id: 11-verify-impl
+    note: 'COMPLETE — D-S054-11=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/evolve-summary.md
+    status: completed
+    stage: 16-evolve
+    note: 'COMPLETE — EV-045 closeout'
+  - path: docs/evolve-report-EV-045.md
+    status: completed
+    stage: 16-evolve
+    note: 'COMPLETE — EV-045 standing report'
   - path: docs/sessions/S054-rust-ci-crates/
-    status: in_progress
+    status: completed
   - path: docs/sessions/S054-rust-ci-crates/session-brief.md
     status: in_progress
   - path: docs/sessions/S054-rust-ci-crates/routing-plan.md
@@ -31312,8 +31664,14 @@ evolve_cycles:
   - path: docs/decisions/requirements-decisions.md
     status: confirmed
     note: 'EV-045 rows already confirmed (D-S054-01-ac=1)'
-  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
+  current_stage_note: 'CLOSED — D-S054-11=1; EV-045 COMPLETE; PR #953 still OPEN → stage; tip 09ce2bef'
   notes:
+  - '2026-08-08 D-S054-11=1 — CLOSED S054/EV-045; approve F13+F14 deepen + accept QA-001..005; 11-verify-impl COMPLETE (verify-impl.md); 16-evolve COMPLETE; cycle COMPLETE; PR #953 still OPEN → stage (not merged); tip 09ce2bef; closeout docs may be uncommitted; EV-043/EV-044 remain PARKED (D-park-doks=1); active_session=null; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 09-qa COMPLETE pass_with_advisories @ tip 09ce2bef — report docs/sessions/S054-rust-ci-crates/reports/qa-report.md; advisories QA-001..005 (AC6 ops deferred primary); 11-verify-impl in_progress; PR #953 → stage; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-phaseC=1 — Phase C approved; checkpoints.phase_c=passed; gates.c_to_d=passed; 08 COMPLETE; 09-qa in_progress (started 2026-08-08); tip 09ce2bef; PR #953 → stage; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 08-verify-build PASS COMPLETE @ tip 09ce2bef — report docs/sessions/S054-rust-ci-crates/reports/verification-report.md; D-S054-t17-ci=1 run 31273500621; make format-check/lint/typecheck PASS; TC-EV045+H0c 14 PASS; make rust-check PASS; uvx pip-audit 0 CVEs; 07-build remains COMPLETE 7/7; Phase C checkpoint pending AskQuestion before 09-qa (09 not started); no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-t17-ci=1 — Accept GitHub Actions run 31273500621 as tip CI evidence for EV-045 Rust/maturin/test jobs; tip delta after f270618c is docs-only (09ce2bef); Staging gate FAIL was base=main only; T1.7 COMPLETE (7/7); 07-build COMPLETE; 08-verify-build in_progress (delta verify after T1.7 CI accept); no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 07-build — T1.1–T1.6 COMPLETE + T1.7 near-complete @ tip 09ce2bef (09ce2befdf0b5878ec6a832ec30718c489b4824b); commits cfd292f4 (T1.1), b8a1cb16 (T1.2), 3cd5844b (T1.3–5), b344b4d2 (T1.7 fix), f270618c (T1.6), 09ce2bef (T1.7 docs); branch evolve/EV-045-rust-ci pushed; PR #953 open → stage (supersedes #952) https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953; CI run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests); Staging gate FAIL only because PR briefly targeted main; tip after docs commit awaiting fresh Actions run (not queued yet); active_task T1.7 in_progress near-complete pending tip CI re-trigger; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
   - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
@@ -31329,9 +31687,10 @@ evolve_cycles:
       completed: '2026-08-08'
       note: 'COMPLETE — D-S054-open=1; handoff 16-evolve Phase 0'
     16-evolve:
-      status: in_progress
+      status: completed
       started: '2026-08-08'
-      note: 'Phase 0 locked; child stage 07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S054-11=1; EV-045 closed; PR #953 still OPEN → stage'
     01-requirements:
       status: completed
       started: '2026-08-08'
@@ -31359,12 +31718,33 @@ evolve_cycles:
       status: skipped
       note: 'skipped — Standard routing; toolchain already ADR-017 (06-tech-tooling N/A)'
     07-build:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — T1.1–T1.7 (7/7); D-S054-t17-ci=1 accepted run 31273500621 tip CI; handoff 08-verify-build'
+      active_task: null
+      active_task_status: completed
+      active_milestone: M1
+      completed_through: T1.7
+      progress: 7/7
+    08-verify-build:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      report: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
+      overall: PASS
+      note: 'COMPLETE — PASS @ tip 09ce2bef; D-S054-t17-ci=1 run 31273500621; Phase C approved D-S054-phaseC=1'
+    09-qa:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      report: docs/sessions/S054-rust-ci-crates/reports/qa-report.md
+      overall: pass_with_advisories
+      note: 'COMPLETE — pass_with_advisories; QA-001..005 (AC6 ops deferred primary); handoff 11-verify-impl'
+    11-verify-impl:
       status: in_progress
       started: '2026-08-08'
-      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending'
-      active_task: T1.1
-      active_task_status: pending
-      active_milestone: M1
+      note: 'IN_PROGRESS — after 09-qa pass_with_advisories; tip 09ce2bef'
 - id: EV-044
   session_id: S053-separate-staging-doks-project
   cycle_type: general
@@ -41322,10 +41702,14 @@ git_history:
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml after D-S054-gateB=1; 05 COMPLETE → 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
+  dirty_note: 'workflow-state.yaml after S054/EV-045 CLOSED D-S054-11=1; tip 09ce2bef; PR #953 OPEN → stage; closeout docs may be uncommitted; no git commit by workflow-state-manager'
   tip_sha: d0a51f5a
   tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-  tip_note: 'origin/main @d0a51f5a; S054/EV-045 07-build in_progress (D-S054-gateB=1) M1 T1.1 pending; AC6 ops deferred (D-S054-ac6-waive=2)'
+  tip_note: 'origin/main @d0a51f5a; S054/EV-045 CLOSED; evolve tip 09ce2bef; PR #953 still OPEN → stage'
+  evolve_branch: evolve/EV-045-rust-ci
+  evolve_tip_sha: 09ce2bef
+  evolve_tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+  evolve_tip_sha_pushed: true
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -41337,9 +41721,11 @@ git_history:
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   recommended_branch: evolve/EV-045-rust-ci
-  note: 'S054/EV-045 IN_PROGRESS — D-S054-gateB=1; 05 COMPLETE Gate B PASS; 07-build in_progress M1 T1.1 pending; main tip d0a51f5a; branch evolve/EV-045-rust-ci ACTIVE; active_session=S054-rust-ci-crates; no git commit by workflow-state-manager'
+  note: 'S054/EV-045 CLOSED D-S054-11=1; tip 09ce2bef; PR #953 still OPEN → stage; closeout docs may be uncommitted; active_session=null; EV-043/EV-044 remain PARKED; main tip d0a51f5a; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-08 D-S054-11=1 — CLOSED S054/EV-045; approve F13+F14 deepen + accept QA-001..005; 11-verify-impl COMPLETE (verify-impl.md); 16-evolve COMPLETE; cycle COMPLETE; PR #953 still OPEN → stage (not merged); tip 09ce2bef; closeout docs may be uncommitted; EV-043/EV-044 remain PARKED (D-park-doks=1); active_session=null; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 07-build — T1.1–T1.6 COMPLETE + T1.7 near-complete @ tip 09ce2bef (09ce2befdf0b5878ec6a832ec30718c489b4824b); commits cfd292f4 (T1.1), b8a1cb16 (T1.2), 3cd5844b (T1.3–5), b344b4d2 (T1.7 fix), f270618c (T1.6), 09ce2bef (T1.7 docs); branch evolve/EV-045-rust-ci pushed; PR #953 open → stage (supersedes #952) https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953; CI run 31273500621 SUCCESS (Rust crates gate + both maturin + all tests); Staging gate FAIL only because PR briefly targeted main; tip after docs commit awaiting fresh Actions run (not queued yet); active_task T1.7 in_progress near-complete pending tip CI re-trigger; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
   - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
   - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
@@ -41838,13 +42224,21 @@ git_history:
     created: '2026-08-08'
     session_id: S054-rust-ci-crates
     evolve_cycle_id: EV-045
-    tip_sha: d0a51f5a
-    tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-    tip_note: 'local — evolve/EV-045-rust-ci created from origin/main@d0a51f5a'
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    tip_note: 'pushed — tip 09ce2bef; PR #953 open → stage (supersedes #952); T1.7 near-complete pending tip CI'
     exists: true
-    pushed: false
-    tip_sha_pushed: false
-    note: 'ACTIVE — CREATED locally from origin/main@d0a51f5a; exists=true; tip local; not pushed'
+    pushed: true
+    tip_sha_pushed: true
+    ahead_of_origin: 0
+    pr_number: 953
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/953
+    pr_status: open
+    pr_base: stage
+    pr_supersedes: 952
+    ci_cd_pipeline_run: '31273500621'
+    ci_cd_pipeline_status: SUCCESS
+    note: 'ACTIVE — tip 09ce2bef pushed; PR #953 → stage; T1.1–T1.6 COMPLETE; T1.7 near-complete pending tip CI re-trigger'
   - name: evolve/EV-044-separate-staging-doks
     base: main
     base_sha: d0a51f5a863daac91a2cac5ca545f4d5459baac8
@@ -43111,6 +43505,80 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 09ce2bef
+    sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    message: '[T1.7] docs: note PR #952 retargeted to stage for tip CI'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.7
+    timestamp: '2026-08-08'
+    pushed: true
+    tip_sha: 09ce2bef
+    tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    note: 'S054/EV-045 T1.7 docs — PR #953 open → stage (supersedes #952); tip CI re-trigger pending'
+  - sha: f270618c
+    sha_full: f270618c25ab445185ff51157290c248f3d3187b
+    message: '[T1.6] docs: S054/EV-045 Rust CI specs, session artifacts, ruleset script'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.6
+    timestamp: '2026-08-08'
+    pushed: true
+    note: 'S054/EV-045 T1.6 COMPLETE — docs + ruleset script'
+  - sha: b344b4d2
+    sha_full: b344b4d2d3d193cb6ab0b4111068401bfd762605
+    message: '[T1.7] fix: clear clippy -D warnings in iwxxm-validate rust'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.7
+    timestamp: '2026-08-08'
+    pushed: true
+    note: 'S054/EV-045 T1.7 fix — clippy debt cleared in iwxxm-validate'
+  - sha: 3cd5844b
+    sha_full: 3cd5844b93728cb48d468dccc9349010ef7b106f
+    message: '[T1.3][T1.4][T1.5] config: rust crates CI matrix, maturin matrix, deploy needs'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.3
+    timestamp: '2026-08-08'
+    pushed: true
+    note: 'S054/EV-045 T1.3–T1.5 COMPLETE — CI matrix + deploy needs'
+  - sha: b8a1cb16
+    sha_full: b8a1cb16ec0ffb818f0db581f29cc72d3e75c9d7
+    message: '[T1.2] config: add make rust-check for cargo + maturin parity'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.2
+    timestamp: '2026-08-08'
+    pushed: true
+    note: 'S054/EV-045 T1.2 COMPLETE — make rust-check'
+  - sha: cfd292f4
+    sha_full: cfd292f4658d60a250182ca61fb45bbf00ba9e70
+    message: '[T1.1] test: add TC-EV045 rust CI contract tests'
+    branch: evolve/EV-045-rust-ci
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    task_id: T1.1
+    timestamp: '2026-08-08'
+    pushed: true
+    note: 'S054/EV-045 T1.1 COMPLETE — contract tests red→green'
   - sha: da2a6656
     sha_full: da2a6656257696ced3d046d4d19ea4515b9c73b5
     message: 'chore(deps): pin nanoid >=3.3.17 for GHSA-2v37-7h3g-55p8'

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,44 +3,71 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 53
-evolve_cycle_counter: 44
+session_counter: 54
+evolve_cycle_counter: 45
 active_session:
-  id: S053-separate-staging-doks-project
+  id: S054-rust-ci-crates
   type: feature
-  intent: "Separate staging DOKS + Postgres under DO Project Staging TAC-to-IWXXM; prod remains on TAC-to-IWXXM; amend ADR-034 shared-cluster"
+  intent: "CI: lint, typecheck, unit, and integration tests for Rust crates (#725)"
   status: in_progress
   started: '2026-08-08'
   started_at: '2026-08-08'
-  branch: evolve/EV-044-separate-staging-doks
+  branch: evolve/EV-045-rust-ci
   branch_base: main@d0a51f5a
-  branch_base_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   branch_status: active
   branch_exists: true
-  branch_note: 'OPEN — cut from origin/main@d0a51f5a after D-S053-open=1'
+  branch_note: 'CREATED — evolve/EV-045-rust-ci from origin/main@d0a51f5a'
   orchestrator: 16-evolve
-  evolve_cycle_id: EV-044
-  artifacts_dir: docs/sessions/S053-separate-staging-doks-project/
-  prior_session: S052-doks-staging-prod-branch-deploys
-  feature_ids: [F30]
-  deepen_feature_ids: [F30]
-  feature_note: 'Deepen F30 — dual DO Projects / separate staging DOKS + PG'
+  evolve_cycle_id: EV-045
+  artifacts_dir: docs/sessions/S054-rust-ci-crates/
+  prior_session: S053-separate-staging-doks-project
+  prior_session_note: 'S053/EV-044 and S052/EV-043 PARKED (D-park-doks=1) for this session'
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725
+  github_issues: [725]
+  issue_ids: [725]
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  feature_note: 'Deepen F13/F14 — Rust CI gates (fmt/clippy/cargo test + maturin smoke both crates); M5 Makefile optional later'
   preset: Standard
+  preset_note: 'Standard with skips 03/06/10/12/13 per D-S054-open=1'
   scope_summary: >
-    Provision staging DOKS metar-iwxxm-staging (1x s-2vcpu-4gb) + managed PG
-    metar-iwxxm-staging (db-s-1vcpu-1gb) under DO Project Staging TAC-to-IWXXM;
-    keep prod on TAC-to-IWXXM; rewire stage CD to staging cluster; tear down shared-ns staging;
-    amend ADR-034.
+    Add GitHub Actions CI for packages/tac2iwxxm/rust and packages/iwxxm-validate/rust:
+    rustfmt, clippy -D warnings, cargo test, maturin/PyO3 integration smoke for both;
+    Makefile local parity (make rust-check); required checks so PRs cannot merge red Rust CI.
+    Out: Rust HTTP service; multi-arch wheel CI beyond pypi-publish; Schematron perf gates.
   scope_decisions_locked:
-  - 'D-S053-open=1 — approve S053/EV-044 Standard'
-  - 'D-S053-db=1 — new cheapest managed PG under Staging project'
-  - 'D-S053-size=1 — 1x s-2vcpu-4gb nyc1'
-  - 'D-S053-teardown=1 — tear down shared-cluster staging ns after cutover'
+  - 'D-park-doks=1 — park EV-043+EV-044'
+  - 'D-S054-open=1 — approve S054/EV-045 Standard skips 03/06/10/12/13'
+  - 'D-S054-ac6-waive=2 — waive AC6 ops half; docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available'
+  - 'D-S054-04 locked — jobs=2 maturin=2 trigger=1 local=2; plan approved (D-S054-04-plan=1)'
+  - 'D-S054-04-plan=1 — approve execution plan as written; close 04 → 05-verify-tech'
+  - 'D-S054-gateB=1 — Gate B PASS; medium/low syncs confirmed; proceed 07-build (06 skipped ADR-017)'
   decisions:
-    D-S053-open: '1'
-    D-S053-db: '1'
-    D-S053-size: '1'
-    D-S053-teardown: '1'
+    D-S054-open: '1'
+    D-S054-open_note: '1 — open S054 as proposed (Standard; skip 03/06/10/12/13; deepen F13+F14)'
+    D-S054-phase01: '1'
+    D-S054-phase01_note: '1 — deepen F13+F14; proceed to 01-requirements'
+    D-S054-01-ac: '1'
+    D-S054-01-ac_note: '1 — confirm ACs + defaults (extend ci-cd.yml, clippy -D warnings, make rust-check) → 02'
+    D-S054-gateA: '2'
+    D-S054-gateA_note: '2 — Gate A PASS; BLOCKED before 04 — no GH rulesets; token admin=false; need admin apply_gh_branch_rulesets.sh or waiver'
+    D-S054-ac6-waive: '2'
+    D-S054-ac6-waive_note: '2 — waive AC6 ops half (GitHub rulesets/required checks wiring); docs+apply_gh_branch_rulesets.sh only; proceed 04; wire rulesets later when admin can run script; AC6 docs half still in scope (locked check names)'
+    D-S054-04-jobs: '2'
+    D-S054-04-jobs_note: '2 — matrix + gate job for locked check name'
+    D-S054-04-maturin: '2'
+    D-S054-04-maturin_note: '2 — extend native; two-package matrix, distinct check_names'
+    D-S054-04-trigger: '1'
+    D-S054-04-trigger_note: '1 — always default CI; no path-filter-only'
+    D-S054-04-local: '2'
+    D-S054-04-local_note: '2 — gate deploy; rust-check includes maturin'
+    D-S054-04: jobs=2 maturin=2 trigger=1 local=2
+    D-S054-04_note: '04-tech-plan interview locked — matrix+gate; two-package maturin; default CI triggers; gate deploy + rust-check maturin; plan approved D-S054-04-plan=1'
+    D-S054-04-plan: '1'
+    D-S054-04-plan_note: '1 — approve execution plan as written; close 04 → 05-verify-tech'
+    D-S054-gateB: '1'
+    D-S054-gateB_note: '1 — Gate B PASS; medium/low syncs confirmed; proceed 07-build M1 T1.1 (06 skipped ADR-017)'
+  ui_preview: 'N/A — no browser UI'
   routing_plan:
   - stage: 00-context
     required: true
@@ -48,47 +75,54 @@ active_session:
     status: completed
     started: '2026-08-08'
     completed: '2026-08-08'
-    note: 'COMPLETE — D-S053-open=1; handoff 16-evolve'
+    note: 'COMPLETE — D-S054-open=1; handoff 16-evolve Phase 0'
   - stage: 16-evolve
     required: true
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: 'Phase A → Gate A / 02-03-04'
+    note: 'Phase 0 locked; child stage 07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending'
   - stage: 01-requirements
     required: true
     mode: delta
     status: completed
     started: '2026-08-08'
     completed: '2026-08-08'
-    note: 'COMPLETE — ADR-034 amend + F30 AC13 + deploy/test deltas'
+    note: 'COMPLETE — D-S054-01-ac=1; ACs + defaults (extend ci-cd.yml, clippy -D warnings, make rust-check)'
   - stage: 02-verify-plan
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: 'Gate A in progress'
-  - stage: 03-plan-tooling
-    required: true
-    mode: delta
-    status: pending
+    completed: '2026-08-08'
+    note: 'COMPLETE — Gate A PASS (D-S054-gateA=2); AC6 ops half waived (D-S054-ac6-waive=2); handoff 04-tech-plan'
+    gate_a: PASS
+    gate_a_decision: D-S054-gateA=2
   - stage: 04-tech-plan
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; reports/04-tech-plan.md; handoff 05-verify-tech'
   - stage: 05-verify-tech
     required: true
     mode: delta
-    status: pending
-  - stage: 06-tech-tooling
-    required: false
-    mode: skipped
-    status: skipped
-    skip_rationale: 'no new runtime deps'
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; report 05-verify-tech.md; handoff 07-build M1 T1.1'
+    gate_b: PASS
+    gate_b_decision: D-S054-gateB=1
   - stage: 07-build
     required: true
     mode: full
-    status: pending
+    status: in_progress
+    started: '2026-08-08'
+    note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
+    active_task: T1.1
+    active_task_status: pending
+    active_milestone: M1
   - stage: 08-verify-build
     required: true
     mode: delta
@@ -97,104 +131,130 @@ active_session:
     required: true
     mode: delta
     status: pending
-  - stage: 10-e2e
-    required: true
-    mode: delta
-    status: pending
   - stage: 11-verify-impl
     required: true
     mode: delta
     status: pending
+  - stage: 03-plan-tooling
+    required: false
+    mode: skipped
+    status: skipped
+    skip_rationale: 'no new Cursor rules/hooks expected'
+  - stage: 06-tech-tooling
+    required: false
+    mode: skipped
+    status: skipped
+    skip_rationale: 'skipped — Standard routing; no new runtime deps; toolchain already ADR-017 (06-tech-tooling N/A)'
+  - stage: 10-e2e
+    required: false
+    mode: skipped
+    status: skipped
+    skip_rationale: 'no browser UI'
   - stage: 12-verify-deploy
-    required: true
-    mode: delta
-    status: pending
+    required: false
+    mode: skipped
+    status: skipped
+    skip_rationale: 'CI-only; tip CI green is gate'
   - stage: 13-deploy-smoke
-    required: true
-    mode: delta
-    status: pending
-  current_stage: 05-verify-tech
-  current_stage_note: 'Gate A PASS; 02/03/04 done; awaiting Gate B'
+    required: false
+    mode: skipped
+    status: skipped
+    skip_rationale: 'CI-only; no staging/prod deploy'
+  current_stage: 07-build
+  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
+  gate_a: PASS
+  gate_b: PASS
+  gate_b_status: pass
+  gate_b_decision: D-S054-gateB=1
+  active_task: T1.1
+  active_task_status: pending
+  active_milestone: M1
+  gate_a_status: pass
+  ac6_ops_deferred: true
+  ac6_ops_deferred_note: 'GitHub rulesets/required checks wiring deferred until admin can run apply_gh_branch_rulesets.sh'
+  evolve_context:
+    mode: evolve
+    evolve_cycle_id: EV-045
+    feature_ids: [F13, F14]
+    delta_only: true
+    current_child_stage: 07-build
+    corpus_cites:
+    - "[Corpus: product §F13]"
+    - "[Corpus: product §F14]"
+    - "[Corpus: tech-spec]"
+    - "[Corpus: tests]"
+    - "[Corpus: adr/ADR-017]"
+  artifacts:
+  - path: docs/sessions/S054-rust-ci-crates/reports/01-requirements.md
+    status: completed
+    note: 'COMPLETE — D-S054-01-ac=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — T1.1–T1.7; D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/build-plan-card.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — active M1 batch for 07; D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+    status: approved
+    stage: 05-verify-tech
+    skill_id: 05-verify-tech
+    note: 'APPROVED — Gate B PASS (D-S054-gateB=1)'
+  - path: docs/sessions/S054-rust-ci-crates/
+    status: in_progress
   notes:
-  - '2026-08-08 D-S053-open=1 — OPEN S053/EV-044; counters 53/44; branch evolve/EV-044-separate-staging-doks @ main@d0a51f5a'
-  id: S052-doks-staging-prod-branch-deploys
+  - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-ac6-waive=2 — AC6 ops half waived; proceed 04-tech-plan; docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available; AC6 docs half still in scope (locked check names)'
+  - '2026-08-08 D-S054-gateA=2 — Gate A PASS; 02 COMPLETE; BLOCKED before 04 (no GH rulesets; token admin=false)'
+  - '2026-08-08 D-S054-01-ac=1 — 01 COMPLETE; ACs+defaults confirmed; 02-verify-plan in_progress'
+  - '2026-08-08 01-requirements note — drafted docs/sessions/S054-rust-ci-crates/reports/01-requirements.md + standing docs; awaiting D-S054-01-ac; still in_progress'
+  - '2026-08-08 D-S054-phase01=1 — proceed to 01-requirements; deepen F13+F14; 01 in_progress'
+  - '2026-08-08 D-S054-open=1 — OPEN S054/EV-045 for #725; counters 54/45; branch evolve/EV-045-rust-ci'
+sessions:
+- id: S054-rust-ci-crates
   type: feature
-  intent: "Stand up DOKS staging + prod environments, protect stage/main, CI/CD for both; auto-deploy stage→staging; manual promote to main/prod (#886)"
+  intent: "CI: lint, typecheck, unit, and integration tests for Rust crates (#725)"
   status: in_progress
   started: '2026-08-08'
   started_at: '2026-08-08'
-  branch: evolve/EV-043-doks-staging-prod
-  branch_base: main@81701500
-  branch_base_full: 8170150038e740c181cc9f236caaeaf84247ff1a
-  branch_status: ACTIVE
-  branch_exists: false
-  branch_note: 'ACTIVE recorded @ open; branch not present locally/remotely yet — parent creates from main@81701500; tip SHA from git HEAD'
+  branch: evolve/EV-045-rust-ci
+  branch_base: main@d0a51f5a
+  branch_status: active
+  branch_exists: true
+  branch_note: 'CREATED — evolve/EV-045-rust-ci from origin/main@d0a51f5a'
   orchestrator: 16-evolve
-  evolve_cycle_id: EV-043
-  artifacts_dir: docs/sessions/S052-doks-staging-prod-branch-deploys/
-  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/886
-  github_issues: [886]
-  issue_ids: [886]
-  prior_session: S051-output-filename-download-stale
-  prior_session_note: 'S051 hotfix closed D-S051-close=1; PR #905 MERGED @ a15541e5; tip closeout da2a6656; main tip now 81701500 includes later EV-039 closeout #939'
-  feature_ids:
-  - F30
-  deepen_feature_ids:
-  - F30
-  feature_note: 'Deepen F30 platform independence — DOKS staging env + protected branches + manual promote to main/prod (#886)'
+  evolve_cycle_id: EV-045
+  artifacts_dir: docs/sessions/S054-rust-ci-crates/
+  prior_session: S053-separate-staging-doks-project
+  prior_session_note: 'S053/EV-044 and S052/EV-043 PARKED (D-park-doks=1) for this session'
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725
+  github_issues: [725]
+  issue_ids: [725]
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  feature_note: 'Deepen F13/F14 — Rust CI gates (fmt/clippy/cargo test + maturin smoke both crates); M5 Makefile optional later'
   preset: Standard
-  preset_note: Standard (pending Plan approval)
-  tip_sha: 81701500
-  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
-  tip_sha_pushed: true
-  tip_sha_note: 'main HEAD @ open (81701500); evolve branch tip will match once created'
-  scope_summary: >
-    Add DOKS staging + keep prod; stage→staging auto-deploy; main→prod MANUAL ONLY;
-    protect stage/main; GH Envs staging/production; product=DOKS (not App Platform).
-    Phase 0 not fully locked — Plan mode next; exact promote gate shape TBD (D-S052-cd-manual).
-  scope_decisions_locked:
-  - 'D-S052-open=1 — open session for #886'
-  - 'D-S052-scope=1 — Add DOKS staging + keep prod; stage→staging, main→prod'
-  - 'D-S052-product=1 — DOKS (not App Platform)'
-  - 'D-S052-gh=1 — Create stage branch + protect stage/main + GH Envs staging/production'
-  - 'D-S052-cd-manual — CI/CD for both staging and prod; promote to main AND prod is MANUAL ONLY (skill changes may be needed); exact gate shape TBD next AskQuestion'
-  decisions:
-    D-S052-open: '1'
-    D-S052-open_note: '1 — open session for GitHub #886 DOKS staging+prod / branch protection / CI/CD both envs / manual promote'
-    D-S052-scope: '1'
-    D-S052-scope_note: '1 — Add DOKS staging + keep prod; stage→staging, main→prod'
-    D-S052-product: '1'
-    D-S052-product_note: '1 — DOKS (not App Platform)'
-    D-S052-gh: '1'
-    D-S052-gh_note: '1 — Create stage branch + protect stage/main + GH Envs staging/production'
-    D-S052-cd-manual: pending_gate_shape
-    D-S052-cd-manual_note: 'CI/CD for both staging and prod required; promote to main AND prod MANUAL ONLY; skill changes may be needed; exact gate shape TBD next AskQuestion'
-  routing_plan:
-  - stage: 00-context
-    required: true
-    mode: scoped
-    status: completed
-    started: '2026-08-08'
-    completed: '2026-08-08'
-    skip_rationale:
-    note: 'COMPLETE — open_session applied; decisions D-S052-open/scope/product/gh recorded; handoff 16-evolve Phase 0'
-  - stage: 16-evolve
-    required: true
-    mode: orchestrator
-    status: in_progress
-    started: '2026-08-08'
-    skip_rationale:
-    note: 'IN_PROGRESS — Phase 0 handoff; scope draft from open decisions; Plan approval next; Standard pending'
-  current_stage: 16-evolve
-  current_stage_note: '00-context completed (session open); handoff 16-evolve Phase 0 — Plan mode next; promote gate shape TBD'
-  context_briefs: []
-  notes:
-  - '2026-08-08 D-S052-open=1 — OPEN S052/EV-043 for #886; session_counter=52; evolve_cycle_counter=43; branch evolve/EV-043-doks-staging-prod ACTIVE recorded (not created yet) @ main@81701500; 00-context completed → 16-evolve Phase 0; no git commit by workflow-state-manager'
-sessions:
+  preset_note: 'Standard with skips 03/06/10/12/13 per D-S054-open=1'
+  current_stage: 07-build
+  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
+  note: 'IN_PROGRESS — D-S054-gateB=1; 07-build M1 T1.1 pending; EV-045 for #725'
 - id: S053-separate-staging-doks-project
   type: feature
   intent: "Separate staging DOKS + Postgres under DO Project Staging TAC-to-IWXXM; amend ADR-034"
   status: in_progress
+  parked: true
+  parked_at: '2026-08-08'
+  park_reason: 'D-park-doks=1 — parked for #725 Rust CI session'
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-044-separate-staging-doks
@@ -206,7 +266,26 @@ sessions:
   prior_session: S052-doks-staging-prod-branch-deploys
   feature_ids: [F30]
   preset: Standard
-  note: 'OPEN — D-S053-open=1; Phase A docs; Gate A next'
+  note: 'PARKED — D-park-doks=1; Gate A PASS / awaiting Gate B when resumed'
+- id: S052-doks-staging-prod-branch-deploys
+  type: feature
+  intent: "Stand up DOKS staging + prod environments, protect stage/main, CI/CD for both; auto-deploy stage→staging; manual promote to main/prod (#886)"
+  status: in_progress
+  parked: true
+  parked_at: '2026-08-08'
+  park_reason: 'D-park-doks=1 — parked for #725 Rust CI session'
+  started: '2026-08-08'
+  started_at: '2026-08-08'
+  branch: evolve/EV-043-doks-staging-prod
+  branch_base: main@81701500
+  branch_status: ACTIVE
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-043
+  artifacts_dir: docs/sessions/S052-doks-staging-prod-branch-deploys/
+  github_issues: [886]
+  feature_ids: [F30]
+  preset: Standard
+  note: 'PARKED — D-park-doks=1; Phase 0 incomplete'
 - id: S051-output-filename-download-stale
   type: hotfix
   intent: "Fix #904 — after convert, Output filename field changes must apply to Download / ZIP member names (BUG-2026-08-07-output-filename-download-stale)"
@@ -8225,45 +8304,61 @@ stages:
   04-tech-plan:
     status: completed
     mode: delta
-    started_at: '2026-08-06'
-    started: '2026-08-06'
-    completed_at: '2026-08-06'
-    completed: '2026-08-06'
-    previous_started_at: '2026-08-05'
-    previous_completed_at: '2026-08-05'
-    previous_session_id: S046-iwxxm-corpus-residuals
-    previous_evolve_cycle_id: EV-038
-    previous_note: 'S046/EV-038 04-tech-plan COMPLETE (delta) — D-S046-04-plan=1; execution-plan approved M1–M5; handoff 05-verify-tech'
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
+    previous_started_at: '2026-08-06'
+    previous_completed_at: '2026-08-06'
+    previous_session_id: S047-sql-ingest-live-e2e
+    previous_evolve_cycle_id: EV-039
+    previous_note: 'S047/EV-039 04-tech-plan COMPLETE (delta) — D-S047-04-plan=1; execution-plan approved M1–M5; handoff 05-verify-tech'
     prior_session_id: S046-iwxxm-corpus-residuals
     prior_evolve_cycle_id: EV-038
     prior_started: '2026-08-05'
     prior_completed: '2026-08-05'
     prior_note: 'S046/EV-038 04-tech-plan COMPLETE (delta) — D-S046-04-plan=1; handoff 05-verify-tech'
-    session_id: S047-sql-ingest-live-e2e
-    evolve_cycle_id: EV-039
-    tip_sha: 7970ba46
-    tip_sha_full: 7970ba4671f2654b48244720254e6b175ed7474c
-    note: "COMPLETE D-S047-04-plan=1"
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; handoff 05-verify-tech'
     decision_refs:
-    - D-S047-02-gate-a
-    - D-S047-ac
-    - D-S047-open
-    - D-S047-04
-    - D-S047-04-plan
-    substeps:
-      phase_1_toolchain:
-        status: completed
-      phase_2_interview:
-        status: completed
-      phase_3_execution_plan:
-        status: completed
-      phase_4_user_review:
-        status: completed
-      phase_5_back_add:
-        status: completed
-      phase_6_documents:
-        status: completed
+    - D-S054-04-plan
+    - D-S054-04-jobs
+    - D-S054-04-maturin
+    - D-S054-04-trigger
+    - D-S054-04-local
+    - D-S054-ac6-waive
+    - D-S054-gateA
+    - D-S054-01-ac
+    - D-S054-open
     active_session:
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
+      skill_id: 04-tech-plan
+      status: completed
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; handoff 05-verify-tech'
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-04-plan
+      - D-S054-04-jobs
+      - D-S054-04-maturin
+      - D-S054-04-trigger
+      - D-S054-04-local
+      - D-S054-ac6-waive
+      - D-S054-gateA
+      - D-S054-01-ac
+      - D-S054-open
+      artifacts:
+      - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+      - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+      - docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+    prior_active_session:
       session_id: S047-sql-ingest-live-e2e
       evolve_cycle_id: EV-039
       skill_id: 04-tech-plan
@@ -8283,7 +8378,7 @@ stages:
       - D-S047-open
       artifacts:
       - docs/sessions/S047-sql-ingest-live-e2e/reports/02-verify-plan-audit.md
-    prior_active_session:
+    prior_prior_active_session:
       session_id: S046-iwxxm-corpus-residuals
       evolve_cycle_id: EV-038
       skill_id: 04-tech-plan
@@ -9225,24 +9320,25 @@ stages:
     - '2026-08-05 S046/EV-038 04-tech-plan COMPLETE (D-S046-04-plan=1) — execution-plan approved M1–M5; handoff 05-verify-tech; tip f03ed255'
   05-verify-tech:
     status: completed
-    session_id: S047-sql-ingest-live-e2e
-    evolve_cycle_id: EV-039
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
     mode: delta
-    started_at: '2026-08-06'
-    started: '2026-08-06'
-    completed_at: '2026-08-06'
-    completed: '2026-08-06'
-    previous_started_at: '2026-06-15T01:15:00Z'
-    previous_completed_at: '2026-06-15T01:45:00Z'
-    previous_session_id: S046-iwxxm-corpus-residuals
-    previous_evolve_cycle_id: EV-038
-    previous_note: 'S046/EV-038 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S046-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1; tip f03ed255'
+    started_at: '2026-08-08'
+    started: '2026-08-08'
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
+    overall: pass
+    previous_started_at: '2026-08-06'
+    previous_completed_at: '2026-08-06'
+    previous_session_id: S047-sql-ingest-live-e2e
+    previous_evolve_cycle_id: EV-039
+    previous_note: 'S047/EV-039 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S047-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1; tip f03ed255'
     prior_session_id: S046-iwxxm-corpus-residuals
     prior_evolve_cycle_id: EV-038
     prior_started: '2026-08-05'
     prior_completed: '2026-08-05'
     prior_note: 'S046/EV-038 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S046-05-gate-b=1); tip f03ed255'
-    note: "COMPLETE Gate B PASS"
+    note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; handoff 07-build M1 T1.1; 06 skipped ADR-017'
     substeps:
       inventory:
         status: completed
@@ -9259,6 +9355,35 @@ stages:
     - docs/decisions/tech-audit.md
     - docs/decisions/tech-decisions.md
     delta_substages:
+    - session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
+      skill_id: 05-verify-tech
+      status: completed
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      mode: delta
+      overall: pass
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-gateB
+      - D-S054-04-plan
+      - D-S054-04-jobs
+      - D-S054-04-maturin
+      - D-S054-04-trigger
+      - D-S054-04-local
+      - D-S054-ac6-waive
+      - D-S054-gateA
+      - D-S054-01-ac
+      - D-S054-open
+      note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; handoff 07-build M1 T1.1'
+      report: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+      artifacts:
+      - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+      - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+      - docs/sessions/S054-rust-ci-crates/build-plan-card.md
     - session_id: S047-sql-ingest-live-e2e
       evolve_cycle_id: EV-039
       skill_id: 05-verify-tech
@@ -9379,6 +9504,8 @@ stages:
       overall: pass
       note: PASS — 12 auto + 44A–47A (feature-list ADR-027, matrix docs, T5.6 CORS, T3.7a/T3.8a)
     notes:
+    - '2026-08-08 D-S054-gateB=1 — S054/EV-045 05-verify-tech COMPLETE; Gate B PASS; medium/low syncs confirmed; handoff 07-build M1 T1.1; 06 skipped ADR-017; no git commit by workflow-state-manager'
+    - '2026-08-08 S054/EV-045 05-verify-tech STARTED (D-S054-04-plan=1) — Gate B; verify execution-plan T1.1–T1.7 vs ACs / D-S054-04 locked / routing; gates.b_to_c + checkpoints.phase_b pending; no git commit by workflow-state-manager'
     - '2026-08-06 S047/EV-039 05-verify-tech COMPLETE (D-S047-05-gate-b=1) — Gate B PASS; S05.M*/L1 as 07; handoff 07-build M1 T1.1; 06 skipped'
     - '2026-08-05 S046/EV-038 05-verify-tech COMPLETE (D-S046-05-gate-b=1) — Gate B PASS; S05.M*/L1 as 07; handoff 07-build M1 T1.1; tip f03ed255'
     - '2026-08-05 S046/EV-038 05-verify-tech STARTED (D-S046-04-plan=1) — Gate B; verify execution-plan M1–M5 vs AC1–AC14 / D-S046-sot / routing; historical baseline status remains completed; tip f03ed255'
@@ -9396,33 +9523,77 @@ stages:
     - S011/EV-008 delta 05-verify-tech completed 2026-07-13 — audit PASS; A1–A3 as-is; phase_b still pending (no auto-pass)
     - S014/EV-010 delta 05-verify-tech PASS 2026-07-18 — 12 auto + 44A–47A; Phase B checkpoint before 06
     active_session:
-      session_id: S046-iwxxm-corpus-residuals
-      evolve_cycle_id: EV-038
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
+      skill_id: 07-build
+      status: in_progress
+      mode: full
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-gateB
+      - D-S054-04-plan
+      - D-S054-04-jobs
+      - D-S054-04-maturin
+      - D-S054-04-trigger
+      - D-S054-04-local
+      - D-S054-ac6-waive
+      - D-S054-gateA
+      - D-S054-01-ac
+      - D-S054-open
+      active_milestone: M1
+      active_task: T1.1
+      active_task_status: pending
+      artifacts:
+      - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+      - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+      - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+    prior_active_session:
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
       skill_id: 05-verify-tech
       status: completed
       mode: delta
-      started_at: '2026-08-05'
-      started: '2026-08-05'
-      completed_at: '2026-08-05'
-      completed: '2026-08-05'
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
       overall: pass
-      note: 'COMPLETE — Gate B PASS (D-S046-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1'
+      note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); handoff 07-build M1 T1.1'
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-gateB
+      - D-S054-04-plan
+      report: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+    prior_prior_active_session:
+      session_id: S047-sql-ingest-live-e2e
+      evolve_cycle_id: EV-039
+      skill_id: 05-verify-tech
+      status: completed
+      mode: delta
+      started_at: '2026-08-06'
+      started: '2026-08-06'
+      completed_at: '2026-08-06'
+      completed: '2026-08-06'
+      overall: pass
+      note: 'COMPLETE — Gate B PASS (D-S047-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1'
       feature_ids: []
       deepen_feature_ids:
-      - F2
-      - F4
-      - F6
-      - F7
-      - F32
+      - F16
       decision_refs:
-      - D-S046-05-gate-b
-      - D-S046-04-plan
-      - D-S046-sot
-      - D-S046-ac
-      - D-S046-mplan
-      report: docs/sessions/S046-iwxxm-corpus-residuals/reports/05-verify-tech-audit.md
-    prior_active_session:
-      session_id: S019-dissemination-upload
+      - D-S047-05-gate-b
+      - D-S047-04-plan
+      - D-S047-04
+      - D-S047-02-gate-a
+      - D-S047-ac
+      - D-S047-open
+      report: docs/sessions/S047-sql-ingest-live-e2e/reports/05-verify-tech-audit.md
+    prior_prior_prior_active_session:
+      session_id: S046-iwxxm-corpus-residuals
       evolve_cycle_id: EV-014
       skill_id: 05-verify-tech
       status: completed
@@ -9527,49 +9698,50 @@ stages:
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
     status: in_progress
-    started_at: '2026-08-07'
-    started: '2026-08-07'
+    started_at: '2026-08-08'
+    started: '2026-08-08'
     completed_at:
     completed:
-    previous_started_at: '2026-08-06'
-    previous_completed_at:
-    previous_session_id: S047-sql-ingest-live-e2e
-    previous_evolve_cycle_id: EV-039
-    previous_tip_sha: 7970ba46
-    previous_tip_sha_full: 7970ba4671f2654b48244720254e6b175ed7474c
-    previous_note: 'S047/EV-039 07-build was in_progress @ 7970ba46 (M1 T1.1); superseded by S050/EV-042'
-    prior_session_id: S046-iwxxm-corpus-residuals
-    prior_evolve_cycle_id: EV-038
-    prior_started: '2026-08-05'
+    previous_started_at: '2026-08-07'
+    previous_completed_at: '2026-08-07'
+    previous_session_id: S050-remove-db-tools-operator-throughput
+    previous_evolve_cycle_id: EV-042
+    previous_tip_sha: 6bc756ef
+    previous_tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
+    previous_note: 'S050/EV-042 07-build COMPLETE — M4 done; superseded by S054/EV-045'
+    prior_session_id: S047-sql-ingest-live-e2e
+    prior_evolve_cycle_id: EV-039
+    prior_started: '2026-08-06'
     prior_completed: '2026-08-06'
-    prior_note: 'S046/EV-038 07-build COMPLETE — #890 MERGED @ 619a7ac3'
-    prior_prior_session_id: S044-local-precommit-long-jobs
-    prior_prior_evolve_cycle_id: EV-036
-    prior_prior_note: 'S044/EV-036 07-build COMPLETE — T1–T5 @ d4fd6955; handoff 08'
-    session_id: S050-remove-db-tools-operator-throughput
-    evolve_cycle_id: EV-042
+    prior_note: 'S047/EV-039 07-build COMPLETE historically; closed D-S047-close=1'
+    prior_prior_session_id: S046-iwxxm-corpus-residuals
+    prior_prior_evolve_cycle_id: EV-038
+    prior_prior_note: 'S046/EV-038 07-build COMPLETE — #890 MERGED @ 619a7ac3'
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
     mode: full
-    note: 'M4 T4.1–T4.2 completed; T4.3 handoff to 09–13; tip 6bc756ef; local 08 PASS; tip CI green 05893ccb'
-    tip_sha: 6bc756ef
-    tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
-    tip_note: 'S050/EV-042 M4 @ 6bc756ef; T4.1–T4.2 done; tip CI green 05893ccb; tip_sha_pushed=true'
+    note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
     pending_commit: false
-    next_stage: 09-qa
-    current_milestone: M4
-    current_task: T4.3
-    active_milestone: M4
-    active_task: T4.3
-    active_task_status: in_progress
-    completed_through: M4-T4.2
-    progress: 'M1–M3; M4 T4.1–T4.2 done; local 08 PASS; T4.3→09-qa'
-    next_task: T4.3
+    current_milestone: M1
+    current_task: T1.1
+    active_milestone: M1
+    active_task: T1.1
+    active_task_status: pending
     decision_refs:
-    - D-S047-05-gate-b
-    - D-S047-04-plan
-    - D-S047-04
-    - D-S047-02-gate-a
-    - D-S047-ac
-    - D-S047-open
+    - D-S054-gateB
+    - D-S054-04-plan
+    - D-S054-04-jobs
+    - D-S054-04-maturin
+    - D-S054-04-trigger
+    - D-S054-04-local
+    - D-S054-ac6-waive
+    - D-S054-gateA
+    - D-S054-01-ac
+    - D-S054-open
+    artifacts_s054:
+    - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+    - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+    - docs/sessions/S054-rust-ci-crates/build-plan-card.md
     decision_refs_s044:
     - D-S044-02-gate-a
     - D-S044-r1-ac
@@ -9605,17 +9777,52 @@ stages:
     - tests/test_tc_ev036_local_precommit_ci.py
     - tests/unit/test_format_coverage_pr_comment.py
     active_session:
-      session_id: S050-remove-db-tools-operator-throughput
-      evolve_cycle_id: EV-042
+      session_id: S054-rust-ci-crates
+      evolve_cycle_id: EV-045
       skill_id: 07-build
       status: in_progress
       mode: full
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      pending_commit: false
+      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
+      feature_ids: [F13, F14]
+      deepen_feature_ids: [F13, F14]
+      decision_refs:
+      - D-S054-gateB
+      - D-S054-04-plan
+      - D-S054-04-jobs
+      - D-S054-04-maturin
+      - D-S054-04-trigger
+      - D-S054-04-local
+      - D-S054-ac6-waive
+      - D-S054-gateA
+      - D-S054-01-ac
+      - D-S054-open
+      active_milestone: M1
+      current_milestone: M1
+      active_task: T1.1
+      current_task: T1.1
+      active_task_status: pending
+      completed_through:
+      artifacts:
+      - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+      - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+      - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+    prior_active_session_s050:
+      session_id: S050-remove-db-tools-operator-throughput
+      evolve_cycle_id: EV-042
+      skill_id: 07-build
+      status: completed
+      mode: full
       started_at: '2026-08-07'
       started: '2026-08-07'
-      tip_sha: 410055cf
-      tip_sha_full: 410055cfd5551e3e83ffc68a390d8b9a28d4d9e2
+      completed_at: '2026-08-07'
+      completed: '2026-08-07'
+      tip_sha: 6bc756ef
+      tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
       pending_commit: false
-      note: 'IN_PROGRESS — 08 PASS @ 410055cf; next M4/PR (T4.1)'
+      note: 'COMPLETE — S050/EV-042 M4 done; superseded by S054/EV-045'
       feature_ids:
       - F33
       deepen_feature_ids:
@@ -9633,10 +9840,8 @@ stages:
       - D-S050-proceed
       active_milestone: M4
       current_milestone: M4
-      active_task:
-      current_task:
       active_task_status: completed
-      completed_through: M3
+      completed_through: M4
       artifacts:
       - docs/sessions/S050-remove-db-tools-operator-throughput/reports/execution-plan.md
       - docs/sessions/S050-remove-db-tools-operator-throughput/reports/05-verify-tech.md
@@ -14420,6 +14625,361 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S054-gateB
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 05-verify-tech
+  skill_id: 05-verify-tech
+  stage: 05-verify-tech
+  category: gate_b
+  status: confirmed
+  topic: 'Gate B PASS — proceed 07-build M1 T1.1 (06 skipped)'
+  summary: '1 — Gate B PASS; medium/low syncs confirmed; close 05 → start 07-build M1 T1.1 (06 skipped ADR-017)'
+  decision: |
+    D-S054-gateB=1 — Gate B PASS for S054/EV-045.
+    Medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2).
+    Close 05-verify-tech (completed 2026-08-08); start 07-build (in_progress) M1 T1.1 pending.
+    06-tech-tooling skipped per Standard routing + ADR-017 (maturin/rust toolchain already documented).
+    gates.b_to_c=passed; checkpoints.phase_b=passed.
+    Artifact: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-045-rust-ci
+  related_decisions:
+  - D-S054-04-plan
+  - D-S054-04-jobs
+  - D-S054-04-maturin
+  - D-S054-04-trigger
+  - D-S054-04-local
+  - D-S054-ac6-waive
+  - D-S054-gateA
+  - D-S054-01-ac
+  - D-S054-open
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  current_stage: 07-build
+  active_task: T1.1
+  active_task_status: pending
+  active_milestone: M1
+  artifacts:
+  - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+  - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+  - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+  note: '05-verify-tech COMPLETE; Gate B PASS; 07-build in_progress M1 T1.1 pending'
+- id: D-S054-04-plan
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: tech_plan_approval
+  status: confirmed
+  topic: 'Approve execution plan as written → 05-verify-tech'
+  summary: '1 — approve execution plan + build-plan-card as written; close 04 → 05-verify-tech'
+  decision: |
+    D-S054-04-plan=1 — approve execution plan as written for S054/EV-045.
+    Close 04-tech-plan (completed 2026-08-08); start 05-verify-tech (in_progress).
+    Artifacts approved: execution-plan.md (T1.1–T1.7), build-plan-card.md, reports/04-tech-plan.md.
+    Locked interview: jobs=2 maturin=2 trigger=1 local=2 (D-S054-04).
+    gates.b_to_c + checkpoints.phase_b pending Gate B.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_decisions:
+  - D-S054-04-jobs
+  - D-S054-04-maturin
+  - D-S054-04-trigger
+  - D-S054-04-local
+  - D-S054-ac6-waive
+  - D-S054-gateA
+  - D-S054-01-ac
+  - D-S054-open
+  artifacts:
+  - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+  - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+  - docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+  note: '04-tech-plan COMPLETE; 05-verify-tech in_progress; awaiting Gate B'
+- id: D-S054-04-local
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: tech_plan_interview
+  status: confirmed
+  topic: '04 Q4 — deploy/local parity'
+  summary: '2 — gate deploy; rust-check includes maturin'
+  decision: |
+    D-S054-04-local=2 — gate deploy on Rust CI; make rust-check includes maturin smoke.
+    Part of D-S054-04 interview locked for EV-045 / S054.
+    04-tech-plan plan drafted; awaiting D-S054-04-plan approval; stage remains in_progress.
+    No git commit by workflow-state-manager.
+  user_option: '2'
+  related_decisions:
+  - D-S054-04-jobs
+  - D-S054-04-maturin
+  - D-S054-04-trigger
+  note: '04 interview Q4 locked; awaiting D-S054-04-plan'
+- id: D-S054-04-trigger
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: tech_plan_interview
+  status: confirmed
+  topic: '04 Q3 — CI triggers'
+  summary: '1 — always default CI; no path-filter-only'
+  decision: |
+    D-S054-04-trigger=1 — Rust CI runs on default CI triggers; no path-filter-only workflow.
+    Part of D-S054-04 interview locked for EV-045 / S054.
+    04-tech-plan plan drafted; awaiting D-S054-04-plan approval; stage remains in_progress.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_decisions:
+  - D-S054-04-jobs
+  - D-S054-04-maturin
+  - D-S054-04-local
+  note: '04 interview Q3 locked; awaiting D-S054-04-plan'
+- id: D-S054-04-maturin
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: tech_plan_interview
+  status: confirmed
+  topic: '04 Q2 — maturin integration smoke'
+  summary: '2 — extend native; two-package matrix, distinct check_names'
+  decision: |
+    D-S054-04-maturin=2 — extend native CI; two-package maturin matrix with distinct check_names for tac2iwxxm and iwxxm-validate.
+    Part of D-S054-04 interview locked for EV-045 / S054.
+    04-tech-plan plan drafted; awaiting D-S054-04-plan approval; stage remains in_progress.
+    No git commit by workflow-state-manager.
+  user_option: '2'
+  related_decisions:
+  - D-S054-04-jobs
+  - D-S054-04-trigger
+  - D-S054-04-local
+  note: '04 interview Q2 locked; awaiting D-S054-04-plan'
+- id: D-S054-04-jobs
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: tech_plan_interview
+  status: confirmed
+  topic: '04 Q1 — CI job shape'
+  summary: '2 — matrix + gate job for locked check name'
+  decision: |
+    D-S054-04-jobs=2 — matrix jobs plus gate job for locked required-check name (AC6 docs half).
+    Part of D-S054-04 interview locked for EV-045 / S054.
+    Artifacts drafted: execution-plan.md, build-plan-card.md, reports/04-tech-plan.md.
+    Awaiting D-S054-04-plan approval; 04-tech-plan remains in_progress (not completed).
+    No git commit by workflow-state-manager.
+  user_option: '2'
+  related_decisions:
+  - D-S054-04-maturin
+  - D-S054-04-trigger
+  - D-S054-04-local
+  artifacts:
+  - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+  - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+  - docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+  note: '04 interview Q1 locked; plan drafted; awaiting D-S054-04-plan'
+- id: D-S054-ac6-waive
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: ac6_ops_waiver
+  status: confirmed
+  topic: 'Waive AC6 ops half — GitHub rulesets/required checks wiring deferred'
+  summary: '2 — waive AC6 ops half; docs+apply_gh_branch_rulesets.sh only; proceed 04-tech-plan; wire rulesets later when admin can run script'
+  decision: |
+    D-S054-ac6-waive=2 — user waived AC6 ops half (GitHub rulesets/required checks wiring) for now.
+    In scope now: AC6 docs half (locked check names) + apply_gh_branch_rulesets.sh script/docs only.
+    Deferred: admin apply of rulesets until token admin=true or admin runs apply_gh_branch_rulesets.sh.
+    Unblocks EV-045 / S054 before 04-tech-plan after Gate A PASS (D-S054-gateA=2).
+    EV-045 gates.a_to_b=passed_ops_deferred; checkpoints.phase_a=passed.
+    04-tech-plan in_progress. No git commit by workflow-state-manager.
+  user_option: '2'
+  gate: A
+  gate_result: PASS
+  prior_blocker: 'no GH rulesets; token admin=false'
+  ac6_docs_in_scope: true
+  ac6_ops_deferred: true
+  next_stage: 04-tech-plan
+  note: 'Blocker cleared; 04-tech-plan started; AC6 ops deferred'
+- id: D-S054-gateA
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: gate_a
+  status: confirmed
+  topic: 'Gate A — pass with ruleset blocker before Phase A→B / 04-tech-plan'
+  summary: '2 — Gate A PASS; BLOCKED before 04 — no GH rulesets; token admin=false; need admin apply_gh_branch_rulesets.sh or waiver'
+  decision: |
+    D-S054-gateA=2 — Gate A PASS (02-verify-plan audit complete) but Phase A→B blocked.
+    Blocker: no GitHub rulesets on repo; token admin=false.
+    Unblock paths: admin runs apply_gh_branch_rulesets.sh, or explicit waiver to proceed to 04.
+    02-verify-plan COMPLETE. 04-tech-plan NOT started.
+    EV-045 gates.a_to_b=pending_blocked_ruleset; checkpoints.phase_a=pass_blocked_ruleset.
+    No git commit by workflow-state-manager.
+  user_option: '2'
+  gate: A
+  gate_result: PASS
+  next_stage_blocked: 04-tech-plan
+  unblock_options:
+  - admin apply_gh_branch_rulesets.sh
+  - waiver to proceed without rulesets
+  note: '02 completed; 04 not started; blocked_before_stage=04-tech-plan'
+- id: D-S054-01-ac
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: acceptance_criteria
+  status: confirmed
+  topic: 'Confirm ACs + defaults for Rust crate CI (#725)'
+  summary: '1 — confirm ACs + defaults (extend ci-cd.yml, clippy -D warnings, make rust-check)'
+  decision: |
+    D-S054-01-ac=1 — confirm acceptance criteria and defaults for EV-045 / S054.
+    Defaults locked:
+      - Extend ci-cd.yml (crate matrix); not separate rust-ci.yml unless latency forces
+      - cargo clippy -- -D warnings hard-fail
+      - make rust-check local mirror of CI
+    Deepen F13 + F14. 01-requirements COMPLETE; start 02-verify-plan (Gate A).
+    requirements-decisions.md EV-045 rows already confirmed in standing doc.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  next_stage: 02-verify-plan
+  artifacts:
+  - docs/sessions/S054-rust-ci-crates/reports/01-requirements.md
+  - docs/decisions/requirements-decisions.md
+  note: '01 completed; 02-verify-plan in_progress'
+- id: D-S054-phase01
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: phase0_to_1
+  category: phase_proceed
+  status: confirmed
+  topic: 'Phase 0→1 proceed — deepen F13+F14; start 01-requirements'
+  summary: '1 — deepen F13+F14; proceed to 01-requirements'
+  decision: |
+    D-S054-phase01=1 — user/parent proceeded Phase 0→1.
+    Deepen F13 + F14 (Rust CI gates). Start 01-requirements (in_progress; not completed).
+    EV-045.current_stage=01-requirements. Corpus: product §F13/§F14, tech-spec, tests, ADR-017.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  corpus_cites:
+  - "[Corpus: product §F13]"
+  - "[Corpus: product §F14]"
+  - "[Corpus: tech-spec]"
+  - "[Corpus: tests]"
+  - "[Corpus: adr/ADR-017]"
+  note: '01-requirements marked in_progress; not completed'
+- id: D-S054-open
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: 'Open S054/EV-045 — Rust crate CI fmt/clippy/test/integration (#725)'
+  summary: '1 — open S054 as proposed (Standard; skip 03/06/10/12/13; deepen F13+F14)'
+  decision: |
+    D-S054-open=1 — open_session for GitHub #725 Rust crate CI.
+    Session S054-rust-ci-crates; evolve cycle EV-045; session_counter 54; evolve_cycle_counter 45.
+    Intent: CI lint/typecheck/unit/integration for packages/tac2iwxxm/rust and packages/iwxxm-validate/rust.
+    Preset Standard with skips 03/06/10/12/13.
+    Deepen F13 + F14. Prior S053/EV-044 and S052/EV-043 remain PARKED (D-park-doks=1).
+    Branch evolve/EV-045-rust-ci status active; base main@d0a51f5a (d0a51f5a863daac91a2cac5ca545f4d5459baac8).
+    Branch not present in local git at open — parent creates (exists=false recorded).
+    artifacts_dir docs/sessions/S054-rust-ci-crates/ (parent writes session-brief/routing-plan; not workflow-state-manager).
+    stages.00-context completed; active_session.current_stage=16-evolve; stages.16-evolve in_progress.
+    overall_status=in_progress. No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-045-rust-ci
+  prior_session: S053-separate-staging-doks-project
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/725
+  github_issues: [725]
+  tip_sha: d0a51f5a
+  tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+  deepen_feature_ids: [F13, F14]
+  feature_ids: [F13, F14]
+  artifacts:
+  - docs/sessions/S054-rust-ci-crates/
+  note: 'open_session applied; active_session=S054-rust-ci-crates; EV-045 in_progress; session_counter=54; evolve_cycle_counter=45; branch ACTIVE recorded exists=false @ main@d0a51f5a'
+- id: D-park-doks
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  skill: 00-context
+  skill_id: 00-context
+  stage: park_sessions
+  category: session_park
+  status: confirmed
+  topic: 'Park EV-043+EV-044; repair active_session mash; clear active_session for #725'
+  summary: 'D-park-doks=1 — Park EV-043+EV-044; repair active_session mash; clear active_session for #725 Rust CI'
+  decision: |
+    D-park-doks=1 — user chose park to open #725 Rust CI session.
+    - Repaired corrupted active_session (S053+S052 concatenated) → active_session: null
+    - EV-044/S053 parked (status in_progress, parked=true); resume_at_stage 05-verify-tech
+    - EV-043/S052 parked (status in_progress, parked=true); resume_at_stage 16-evolve; S052 inserted into sessions[]
+    - session_counter / evolve_cycle_counter unchanged (53/44); #725 session NOT opened in this update
+  user_option: '1'
+  related_sessions:
+  - S053-separate-staging-doks-project
+  - S052-doks-staging-prod-branch-deploys
+  related_evolve_cycles:
+  - EV-044
+  - EV-043
+  github_issues_deferred: [725]
 - id: D-S052-open
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -27309,6 +27869,50 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+  type: session-report
+  kind: verify-tech
+  stage: 05-verify-tech
+  skill_id: 05-verify-tech
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: approved
+  note: 'S054/EV-045 Gate B PASS — D-S054-gateB=1'
+- path: docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+  type: session-report
+  kind: tech-plan
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: approved
+  note: 'S054/EV-045 04-tech-plan APPROVED — D-S054-04-plan=1'
+- path: docs/sessions/S054-rust-ci-crates/build-plan-card.md
+  type: session-artifact
+  kind: build-plan-card
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: approved
+  note: 'S054/EV-045 build-plan-card APPROVED — D-S054-04-plan=1'
+- path: docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+  type: session-artifact
+  kind: execution-plan
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S054-rust-ci-crates
+  evolve_cycle_id: EV-045
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: approved
+  note: 'S054/EV-045 execution-plan APPROVED — T1.1–T1.7; D-S054-04-plan=1'
 - path: docs/sessions/S052-doks-staging-prod-branch-deploys/
   status: pending
   stage: 00-context
@@ -30652,12 +31256,125 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-045
+  session_id: S054-rust-ci-crates
+  cycle_type: general
+  feature_ids: [F13, F14]
+  deepen_feature_ids: [F13, F14]
+  title: "Rust crate CI — fmt/clippy/test/integration (#725)"
+  status: in_progress
+  started: '2026-08-08'
+  github_issues: [725]
+  current_stage: 07-build
+  routing_plan:
+    required_stages: [00-context, 16-evolve, 01-requirements, 02-verify-plan, 04-tech-plan, 05-verify-tech, 07-build, 08-verify-build, 09-qa, 11-verify-impl]
+    skipped_stages: [03-plan-tooling, 06-tech-tooling, 10-e2e, 12-verify-deploy, 13-deploy-smoke]
+  gates: {a_to_b: passed_ops_deferred, b_to_c: passed, c_to_d: pending, deploy: skipped}
+  gates_note: 'a_to_b passed_ops_deferred — Gate A PASS (D-S054-gateA=2); AC6 ops half waived (D-S054-ac6-waive=2); docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available'
+  checkpoints: {phase_a: passed, phase_b: passed, phase_c: pending, phase_d: pending, deploy: skipped}
+  ac6_ops_deferred: true
+  ac6_docs_in_scope: true
+  artifacts:
+  - path: docs/sessions/S054-rust-ci-crates/reports/01-requirements.md
+    status: completed
+    note: 'COMPLETE — D-S054-01-ac=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — T1.1–T1.7; D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/build-plan-card.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — active M1 batch for 07; D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
+    status: approved
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    note: 'APPROVED — D-S054-04-plan=1'
+  - path: docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
+    status: approved
+    stage: 05-verify-tech
+    skill_id: 05-verify-tech
+    note: 'APPROVED — Gate B PASS (D-S054-gateB=1)'
+  - path: docs/sessions/S054-rust-ci-crates/
+    status: in_progress
+  - path: docs/sessions/S054-rust-ci-crates/session-brief.md
+    status: in_progress
+  - path: docs/sessions/S054-rust-ci-crates/routing-plan.md
+    status: in_progress
+  - path: docs/sessions/S054-rust-ci-crates/evolve-plan-card.md
+    status: in_progress
+  - path: docs/decisions/evolve-decisions.md
+    status: in_progress
+    note: 'EV-045 section'
+  - path: docs/decisions/requirements-decisions.md
+    status: confirmed
+    note: 'EV-045 rows already confirmed (D-S054-01-ac=1)'
+  current_stage_note: '07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending (06 skipped ADR-017)'
+  notes:
+  - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-ac6-waive=2 — AC6 ops half waived; proceed 04-tech-plan; docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available'
+  - '2026-08-08 D-S054-gateA=2 — Gate A PASS; 02 COMPLETE; a_to_b pending_blocked_ruleset; 04 NOT started'
+  - '2026-08-08 D-S054-01-ac=1 — 01 COMPLETE; defaults confirmed; 02-verify-plan in_progress'
+  - '2026-08-08 D-S054-phase01=1 — deepen F13+F14; proceed to 01-requirements (in_progress)'
+  - '2026-08-08 Phase 0 locked — D-S054-open=1; Standard skips 03/06/10/12/13; deepen F13+F14; #725; awaiting proceed to 01-requirements'
+  stages:
+    00-context:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S054-open=1; handoff 16-evolve Phase 0'
+    16-evolve:
+      status: in_progress
+      started: '2026-08-08'
+      note: 'Phase 0 locked; child stage 07-build in_progress — D-S054-gateB=1; Gate B PASS; M1 T1.1 pending'
+    01-requirements:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S054-01-ac=1; ACs + defaults confirmed'
+    02-verify-plan:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — Gate A PASS (D-S054-gateA=2); AC6 ops waived (D-S054-ac6-waive=2); handoff 04-tech-plan'
+      gate_a: PASS
+    04-tech-plan:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; handoff 05-verify-tech'
+    05-verify-tech:
+      status: completed
+      started: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; handoff 07-build M1 T1.1'
+      gate_b: PASS
+      gate_b_decision: D-S054-gateB=1
+    06-tech-tooling:
+      status: skipped
+      note: 'skipped — Standard routing; toolchain already ADR-017 (06-tech-tooling N/A)'
+    07-build:
+      status: in_progress
+      started: '2026-08-08'
+      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending'
+      active_task: T1.1
+      active_task_status: pending
+      active_milestone: M1
 - id: EV-044
   session_id: S053-separate-staging-doks-project
   cycle_type: general
   feature_ids: [F30]
   title: "Separate staging DOKS + DO Project (amend ADR-034)"
   status: in_progress
+  parked: true
+  parked_at: '2026-08-08'
+  park_reason: 'D-park-doks=1 — user chose park to open #725 Rust CI; resume later'
+  resume_at_stage: 05-verify-tech
   started: '2026-08-08'
   started_at: '2026-08-08'
   completed: null
@@ -30668,6 +31385,7 @@ evolve_cycles:
     required_stages: [00-context, 16-evolve, 01-requirements, 02-verify-plan, 03-plan-tooling, 04-tech-plan, 05-verify-tech, 07-build, 08-verify-build, 09-qa, 10-e2e, 11-verify-impl, 12-verify-deploy, 13-deploy-smoke]
     skipped_stages: [06-tech-tooling]
   current_stage: 05-verify-tech
+  current_stage_note: 'PARKED — D-park-doks=1; Gate A PASS / awaiting Gate B when resumed'
   gates: {a_to_b: passed, b_to_c: pending, c_to_d: pending, deploy: pending}
   checkpoints: {phase_a: pending, phase_b: pending, phase_c: pending, phase_d: pending, deploy: pending}
   adrs: [docs/adr/ADR-034-doks-staging-promote-from-stage.md]
@@ -30676,6 +31394,9 @@ evolve_cycles:
     status: in_progress
   - path: docs/decisions/evolve-decisions.md
     status: in_progress
+  notes:
+  - '2026-08-08 D-park-doks=1 — PARKED for #725 Rust CI; resume at 05-verify-tech (Gate B)'
+
 - id: EV-043
   session_id: S052-doks-staging-prod-branch-deploys
   cycle_type: general
@@ -30686,6 +31407,10 @@ evolve_cycles:
   feature_note: 'Deepen F30 platform independence — staging env + manual prod promote (#886); infra/platform'
   title: "DOKS staging + prod + protected-branch CI/CD (#886)"
   status: in_progress
+  parked: true
+  parked_at: '2026-08-08'
+  park_reason: 'D-park-doks=1 — user chose park to open #725 Rust CI; resume later'
+  resume_at_stage: 16-evolve
   started: "2026-08-08"
   started_at: "2026-08-08"
   completed:
@@ -30714,7 +31439,7 @@ evolve_cycles:
     note: Standard (pending Plan approval); full child-stage list after Phase 0 / Plan
   current_stage: 16-evolve
   current_stage_status: in_progress
-  current_stage_note: '00-context completed at open; Phase 0 handoff — Plan mode next; promote gate TBD'
+  current_stage_note: 'PARKED — D-park-doks=1; Phase 0 incomplete (promote gate TBD)'
   stages:
     00-context:
       status: completed
@@ -30759,6 +31484,7 @@ evolve_cycles:
     note: parent writes session-brief/routing-plan/context
   issues: []
   notes:
+  - '2026-08-08 D-park-doks=1 — PARKED for #725 Rust CI; resume at 16-evolve Phase 0'
   - '2026-08-08 EV-043/S052-doks-staging-prod-branch-deploys OPEN — D-S052-open=1; deepen F30; #886; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false @ main@81701500; 00-context completed → 16-evolve Phase 0; Standard pending Plan; no git commit by workflow-state-manager'
 - id: EV-042
   session_id: S050-remove-db-tools-operator-throughput
@@ -40596,10 +41322,10 @@ git_history:
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml after D-S052-open / open_session S052/EV-043; no git commit by workflow-state-manager'
-  tip_sha: 81701500
-  tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
-  tip_note: 'main @ 81701500 ([EV-039] docs: close S047 after 13-deploy-smoke #939); S052/EV-043 open for #886; evolve branch create pending'
+  dirty_note: 'workflow-state.yaml after D-S054-gateB=1; 05 COMPLETE → 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
+  tip_sha: d0a51f5a
+  tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+  tip_note: 'origin/main @d0a51f5a; S054/EV-045 07-build in_progress (D-S054-gateB=1) M1 T1.1 pending; AC6 ops deferred (D-S054-ac6-waive=2)'
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -40608,12 +41334,17 @@ git_history:
     date: '2026-08-04'
   main_merge_sha: a15541e5
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
-  main_tip_sha: 81701500
-  main_tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
-  recommended_branch: evolve/EV-043-doks-staging-prod
-  note: 'S052/EV-043 OPEN D-S052-open=1 — main tip 81701500; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false; active_session=S052-doks-staging-prod-branch-deploys; no git commit by workflow-state-manager'
+  main_tip_sha: d0a51f5a
+  main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+  recommended_branch: evolve/EV-045-rust-ci
+  note: 'S054/EV-045 IN_PROGRESS — D-S054-gateB=1; 05 COMPLETE Gate B PASS; 07-build in_progress M1 T1.1 pending; main tip d0a51f5a; branch evolve/EV-045-rust-ci ACTIVE; active_session=S054-rust-ci-crates; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-08 D-S054-gateB=1 — S054/EV-045 Gate B PASS; medium/low syncs confirmed (S2.1/S2.2/S3.1/S3.2); 05 COMPLETE; 06 skipped ADR-017; 07-build in_progress M1 T1.1 pending; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-04-plan=1 — S054/EV-045 04 COMPLETE; execution-plan + build-plan-card approved; 05-verify-tech in_progress; Gate B pending; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 04-tech-plan draft ready — D-S054-04 locked (jobs=2 maturin=2 trigger=1 local=2); execution-plan + build-plan-card + reports/04-tech-plan.md; awaiting D-S054-04-plan approve → 05; still in_progress; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S054-ac6-waive=2 — AC6 ops half waived; unblock → 04-tech-plan in_progress; docs+apply_gh_branch_rulesets.sh only; wire rulesets when admin available; no git commit by workflow-state-manager'
+  - '2026-08-08 S054/EV-045 OPEN — D-S054-open=1; session_counter 54; evolve_cycle_counter 45; branch evolve/EV-045-rust-ci ACTIVE recorded exists=false @ main@d0a51f5a; 00-context completed → 16-evolve Phase 0; #725 deepen F13+F14; Standard skips 03/06/10/12/13; no git commit by workflow-state-manager'
   - '2026-08-08 S052/EV-043 OPEN — D-S052-open=1; session_counter 52; evolve_cycle_counter 43; branch evolve/EV-043-doks-staging-prod ACTIVE recorded exists=false @ main@81701500; 00-context completed → 16-evolve Phase 0; #886 deepen F30; Standard pending Plan; no git commit by workflow-state-manager'
   - '2026-08-07 S051 CLOSED D-S051-close=1 — closeout da2a6656 on main (Phase 5 docs + Cursor rule + hotfix-log #13 + nanoid>=3.3.17); PR #905 MERGED @ a15541e5; 14-hotfix completed; active_session=null; recorded commits da2a6656 + a15541e5; local ahead_of_origin=1 pending push; no git commit by workflow-state-manager'
   - '2026-08-07 S050/EV-042 13-deploy-smoke STARTED — D-S050-merge=1; PR #899 MERGED @ e3d1c7c8 (e3d1c7c84836751ea070cb6162df749b218d2ef2) at 2026-08-07T16:22:36Z; tip before merge 5558c7e4 (5558c7e44107c6389b30f90189c477a183490792) signed 12; watching main CI/CD Pipeline run 31197264636 for DOKS Deploy; recorded commits 5558c7e4+e3d1c7c8; Sync DB migrations OOS accepted; 13 not completed; no git commit by workflow-state-manager'
@@ -41098,6 +41829,22 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-045-rust-ci
+    status: active
+    purpose: EV-045 / S054 Rust CI #725
+    base: main@d0a51f5a
+    base_sha: d0a51f5a
+    base_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+    created: '2026-08-08'
+    session_id: S054-rust-ci-crates
+    evolve_cycle_id: EV-045
+    tip_sha: d0a51f5a
+    tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+    tip_note: 'local — evolve/EV-045-rust-ci created from origin/main@d0a51f5a'
+    exists: true
+    pushed: false
+    tip_sha_pushed: false
+    note: 'ACTIVE — CREATED locally from origin/main@d0a51f5a; exists=true; tip local; not pushed'
   - name: evolve/EV-044-separate-staging-doks
     base: main
     base_sha: d0a51f5a863daac91a2cac5ca545f4d5459baac8


### PR DESCRIPTION
## Summary
- Add required `ci-cd.yml` jobs for both Rust crates: `cargo fmt --check`, `clippy -D warnings`, `cargo test` (matrix + gate check `Rust crates (fmt/clippy/test)`).
- Extend `tac2iwxxm-native` into a two-package maturin matrix with locked names `tac2iwxxm PyO3 (maturin)` / `iwxxm-validate PyO3 (maturin)`; gate Deploy on `rust-crates-gate`.
- Add `make rust-check` local parity; TC-EV045 contract tests; docs + ruleset script contexts (AC6 ops apply deferred — D-S054-ac6-waive=2).

## Test plan
- [x] `tests/test_tc_ev045_rust_ci.py` + EV-036 contracts
- [x] Local cargo fmt/clippy/test both crates + both maturin smokes
- [ ] Tip `ci-cd.yml` green on this PR (Rust gate + both PyO3 jobs)
- [ ] Confirm locked check names match job `name:` fields

**Base:** `stage` (ADR-034 — do not target `main` directly).

Corpus: [Corpus: product §F13] [Corpus: product §F14] [Corpus: tests] [Corpus: adr/ADR-017]

Supersedes #952.

Made with [Cursor](https://cursor.com)