### PR TITLE
[EV-048] Strip internal doc refs from UI + OpenAPI (#951)

### DIFF
--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -1469,7 +1469,10 @@ async def convert(
     bulletin_id: str = Form(default="", description="Optional bulletin identifier"),
     issuing_center: str = Form(default="", description="Optional issuing centre ICAO code"),
     lint: bool = Form(default=True, description="Run tac-validate before convert (Q14=C; default on)"),
-    product: str = Form(default="METAR", description="TAC product (required for F6; default METAR for legacy)"),
+    product: str = Form(
+        default="METAR",
+        description="TAC product type (default METAR for legacy clients)",
+    ),
     profile: str = Form(default="annex3", description="Schema profile: annex3 or iwxxm_us"),
     preview: bool = Form(
         default=False,

--- a/apps/backend/src/api.py
+++ b/apps/backend/src/api.py
@@ -909,7 +909,7 @@ def get_schema_status():
 async def lint_issue_catalog(
     product: Optional[str] = None,
 ) -> Response:
-    """Export the tac-validate issue registry for FE tooltips / catalog panel (E11-31 / EV-040)."""
+    """Export the tac-validate issue registry for FE tooltips / catalog panel."""
     from tac_validate.catalog_attribution import attribution_for
 
     entries = tac_catalog_entries(product=product)
@@ -998,7 +998,7 @@ async def decode_tac_endpoint(
     manual_text: str = Form(default="", description="TAC text to decode"),
     files: Optional[List[UploadFile]] = File(None),
 ) -> Response:
-    """Thin wrapper over ``tac2iwxxm.decode_tac`` (S011 / #702 / TC-F7-002)."""
+    """Decode TAC into annotated segments and a plain-language summary."""
     content_type = (request.headers.get("content-type") or "").lower()
     if "multipart/form-data" not in content_type:
         raise HTTPException(
@@ -1053,10 +1053,10 @@ async def convert_bulletin(
     iwxxm_version: str = Form(default="2025-2", description="Target IWXXM version"),
     lint: bool = Form(default=True, description="Run tac-validate before each report convert"),
 ) -> Response:
-    """Split a WMO AHL bulletin and convert each TAC report (F6.bulletin / TC-F6-030).
+    """Split a WMO AHL bulletin and convert each TAC report.
 
-    Partial success is allowed: HTTP 200 when split succeeds even if some reports fail
-    (Q6=A). Per-report ``issues`` / ``fixes`` follow lint-style identity (Q7=C).
+    Partial success is allowed: HTTP 200 when split succeeds even if some reports fail.
+    Per-report ``issues`` / ``fixes`` follow lint-style identity.
     """
     content_type = (request.headers.get("content-type") or "").lower()
     if "multipart/form-data" not in content_type:
@@ -1186,7 +1186,7 @@ async def ingest_collect(
     profile: str = Form(default="annex3"),
     iwxxm_version: str = Form(default="2025-2"),
 ) -> dict[str, Any]:
-    """Placeholder for IWXXM COLLECT / FTBP ingest (ADR-024).
+    """Placeholder for IWXXM COLLECT / FTBP ingest.
 
     Accepts uploads (including ``.gz`` via ``read_upload_files_text``) so the operator UI
     can exercise the path; returns HTTP 501 until member extraction + validate is shipped.
@@ -1269,7 +1269,7 @@ async def validate_comprehensive(
     6. **Layer 6 (GML_REFERENCES)**: Validates GML internal references
     7. **Layer 7 (WMO_CODELISTS)**: Validates against official WMO RDF codelists
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031
+    **Authentication**: Public (no login required)
 
     **Request Parameters**:
     - **manual_text** (required): METAR TAC text to validate
@@ -1473,11 +1473,11 @@ async def convert(
     profile: str = Form(default="annex3", description="Schema profile: annex3 or iwxxm_us"),
     preview: bool = Form(
         default=False,
-        description="Soft-preview mode (ADR-022): best-effort IWXXM + failed_spans on partial failure",
+        description="Soft-preview: best-effort IWXXM with failure spans on partial convert",
     ),
     include_nil_reasons: bool = Form(
         default=True,
-        description="When false, prefer omitting nilReason attributes (engine may still emit NIL report shells; ADR-024)",
+        description=("When false, prefer omitting nilReason attributes (engine may still emit NIL report shells)"),
     ),
     emit_translation_centre: bool = Form(
         default=False,
@@ -1566,7 +1566,7 @@ async def convert(
     - Input validation (ICAO code and TAC syntax)
     - Optional output validation (full 7-layer IWXXM validation)
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031
+    **Authentication**: Public (no login required)
 
     **Request Parameters**:
     - **files** (array): Optional uploaded text files containing METAR TAC
@@ -2789,7 +2789,7 @@ async def convert_zip(
     Similar to `/api/v1/convert` but returns results as a ZIP archive instead of JSON.
     Useful for batch processing or downloading multiple converted files.
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031
+    **Authentication**: Public (no login required)
 
     **Request Parameters**:
     - **files** (array): Optional uploaded text files containing METAR TAC

--- a/apps/backend/src/routers/icao_opmet.py
+++ b/apps/backend/src/routers/icao_opmet.py
@@ -71,7 +71,7 @@ async def get_translation_statistics(
     Retrieves translation centre statistics for a specified time period with optional filters.
     Implements ICAO OPMET Data Exchange Guidelines Section 7 reporting requirements.
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031.
+    **Authentication**: Public (no login required).
 
     **Request Parameters**:
     - **start_date** (required): Statistics period start (ISO 8601)
@@ -146,7 +146,7 @@ async def get_recent_statistics(
 
     Convenience endpoint for querying recent activity without specifying exact dates.
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031.
+    **Authentication**: Public (no login required).
 
     **Query Parameters**:
     - **hours**: Number of hours to look back (1-168, default: 24)
@@ -195,7 +195,7 @@ async def get_statistics_by_region(
     Returns translation activity summary for all ICAO regions.
     Useful for identifying regional distribution and capacity planning.
 
-    **Authentication**: Public (no JWT) — F21 / ADR-031.
+    **Authentication**: Public (no login required).
 
     **Query Parameters**:
     - **start_date**: Statistics period start (ISO 8601)

--- a/apps/backend/src/schemas/conversion.py
+++ b/apps/backend/src/schemas/conversion.py
@@ -61,7 +61,7 @@ class ConversionIssue(BaseModel):
 
 
 class FailedSpan(BaseModel):
-    """Character span marking a soft-preview failure (ADR-022 / F7)."""
+    """Character span marking a soft-preview failure."""
 
     start: int = Field(..., ge=0, description="Inclusive character offset into source TAC")
     end: int = Field(..., ge=0, description="Exclusive character offset into source TAC")
@@ -152,11 +152,11 @@ class ConversionResponse(BaseModel):
     )
     ok: Optional[bool] = Field(
         default=None,
-        description="Soft-preview envelope flag (ADR-022); set when preview=true",
+        description="Soft-preview envelope flag; set when preview=true",
     )
     failed_spans: List[FailedSpan] = Field(
         default_factory=list,
-        description="Soft-preview failed character spans (ADR-022); empty when preview omitted/false",
+        description="Soft-preview failed character spans; empty when preview omitted/false",
     )
 
 
@@ -223,7 +223,7 @@ class ConversionRequest(BaseModel):
     )
     preview: bool = Field(
         default=False,
-        description="Soft-preview mode (ADR-022): best-effort IWXXM + failed_spans on partial failure",
+        description="Soft-preview: best-effort IWXXM with failure spans on partial convert",
     )
     product: Optional[str] = Field(
         default=None,

--- a/apps/backend/src/schemas/validation.py
+++ b/apps/backend/src/schemas/validation.py
@@ -336,7 +336,7 @@ class PackageIssueModel(BaseModel):
 
 
 class ValidateIssueModel(BaseModel):
-    """HTTP DTO for a legacy F2 orchestrator finding on /validate."""
+    """HTTP DTO for a validation orchestrator finding on /validate."""
 
     layer: str
     level: str
@@ -357,7 +357,7 @@ class ValidateLayerIssueModel(BaseModel):
 
 
 class ValidateResponse(BaseModel):
-    """Response for POST /api/v1/validate (F2 layers + package_* extras)."""
+    """Response for POST /api/v1/validate (validation layers + package_* extras)."""
 
     is_valid: bool
     version: str

--- a/apps/backend/src/schemas/validation.py
+++ b/apps/backend/src/schemas/validation.py
@@ -276,7 +276,7 @@ class LintTacResponse(BaseModel):
 
 
 class LintIssueCatalogEntryModel(BaseModel):
-    """One registry row exported by GET /api/v1/lint-issue-catalog (E11-31 / EV-040)."""
+    """One registry row exported by GET /api/v1/lint-issue-catalog."""
 
     code: str
     severity: str
@@ -295,7 +295,7 @@ class LintIssueCatalogResponse(BaseModel):
 
 
 class DecodeSegmentModel(BaseModel):
-    """HTTP DTO for one TAC decode/annotate segment (S011 / #702)."""
+    """HTTP DTO for one TAC decode/annotate segment."""
 
     start: int
     end: int
@@ -319,7 +319,7 @@ class DecodeTacResponse(BaseModel):
     residuals: List[DecodeResidualModel] = Field(default_factory=list)
     summary: str = Field(
         default="",
-        description="Deterministic plain-language paragraph of the report (F9 / ADR-025)",
+        description="Deterministic plain-language paragraph of the report",
     )
 
 

--- a/apps/backend/src/schemas/work_session.py
+++ b/apps/backend/src/schemas/work_session.py
@@ -18,7 +18,7 @@ class WorkSessionStatus(str, Enum):
 
 
 class WorkSessionProduct(str, Enum):
-    """F6 product ids stored on ``tac_work_sessions.product`` (lowercase)."""
+    """Product ids stored on ``tac_work_sessions.product`` (lowercase)."""
 
     AIRMET = "airmet"
     METAR = "metar"

--- a/apps/backend/tests/unit/test_tc_ev048_openapi_internal_doc_refs.py
+++ b/apps/backend/tests/unit/test_tc_ev048_openapi_internal_doc_refs.py
@@ -1,0 +1,123 @@
+"""TC-EV048-002/005 — OpenAPI free of internal planning vocabulary (EV-048 / #951).
+
+T1.1: red clean-scan until M2 strip; synthetic inject always green.
+[Corpus: tests] [Corpus: api] [Corpus: product §F21]
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import pytest
+
+from src import api as api_module
+
+# Locked patterns (D-S057-guard-s0=1, D-S057-04-guard-ext=1).
+# `#NNN` uses (?<!\\w) because ``\\b#`` does not match after spaces/slashes (e.g. ``#702``).
+INTERNAL_DOC_REF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("Corpus", re.compile(r"\[Corpus:")),
+    ("docs/sessions", re.compile(r"docs/sessions/")),
+    ("docs/feature-list", re.compile(r"docs/feature-list")),
+    ("ADR", re.compile(r"\bADR-\d+\b")),
+    ("EV", re.compile(r"\bEV-\d+\b")),
+    ("S0", re.compile(r"\bS0\d+\b")),
+    ("TC", re.compile(r"\bTC-[A-Z0-9-]+\b")),
+    ("E##", re.compile(r"\bE\d{2}-\d+\b")),
+    ("#NNN", re.compile(r"(?<!\w)#\d{3,}\b")),
+)
+
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def find_internal_doc_refs(text: str) -> list[tuple[str, str]]:
+    """Return ``(pattern_name, match)`` pairs for planning vocabulary in ``text``."""
+    hits: list[tuple[str, str]] = []
+    for name, pattern in INTERNAL_DOC_REF_PATTERNS:
+        for match in pattern.finditer(text):
+            token = match.group(0)
+            if token in ALLOWLIST:
+                continue
+            hits.append((name, token))
+    return hits
+
+
+def walk_string_values(obj: Any, path: str = "$") -> Iterator[tuple[str, str]]:
+    """Yield ``(json_path, value)`` for every string in a JSON-like structure."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            yield from walk_string_values(value, f"{path}.{key}")
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            yield from walk_string_values(value, f"{path}[{index}]")
+    elif isinstance(obj, str):
+        yield path, obj
+
+
+def collect_openapi_ref_hits(schema: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """Scan an OpenAPI document for internal doc refs."""
+    found: list[tuple[str, str, str]] = []
+    for path, value in walk_string_values(schema):
+        for name, token in find_internal_doc_refs(value):
+            found.append((path, name, token))
+    return found
+
+
+def format_hits(hits: Iterable[tuple[str, str, str]]) -> str:
+    """Format OpenAPI hits for assertion messages."""
+    lines = [f"  {path}: {name}={token!r}" for path, name, token in hits]
+    return "\n".join(lines) if lines else "(none)"
+
+
+def test_tc_ev048_005_synthetic_inject_detected() -> None:
+    """Guard must fail when a synthetic planning cite is injected into a string."""
+    poisoned = "Soft-preview mode (ADR-022): best-effort; see #702 and TC-F7-002 / E11-31 / EV-040 / S011"
+    hits = find_internal_doc_refs(poisoned)
+    names = {name for name, _ in hits}
+    assert "ADR" in names
+    assert "#NNN" in names
+    assert "TC" in names
+    assert "E##" in names
+    assert "EV" in names
+    assert "S0" in names
+
+
+def test_tc_ev048_005_clean_operator_copy_passes() -> None:
+    """Operator-friendly replacements must not trip the guard."""
+    clean = (
+        "Soft-preview: best-effort IWXXM with failure spans on partial convert. "
+        "Public (no login required). Deterministic plain-language paragraph of the report."
+    )
+    assert find_internal_doc_refs(clean) == []
+
+
+def test_tc_ev048_002_openapi_export_has_no_internal_doc_refs() -> None:
+    """TC-EV048-002: walk all OpenAPI string values; fail on planning vocabulary."""
+    schema = api_module.app.openapi()
+    hits = collect_openapi_ref_hits(schema)
+    assert hits == [], f"OpenAPI still contains internal planning vocabulary ({len(hits)} hits):\n{format_hits(hits)}"
+
+
+def test_tc_ev048_005_injected_openapi_description_detected() -> None:
+    """Regression: mutating a description in a copied schema is detected."""
+    schema = copy.deepcopy(api_module.app.openapi())
+    paths = schema.get("paths") or {}
+    injected = False
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        for method_body in path_item.values():
+            if isinstance(method_body, dict) and "description" in method_body:
+                method_body["description"] = f"{method_body.get('description', '')} [Corpus: product] ADR-999"
+                injected = True
+                break
+        if injected:
+            break
+    if not injected:
+        schema.setdefault("info", {})["description"] = "leak ADR-999 [Corpus: tests]"
+
+    hits = collect_openapi_ref_hits(schema)
+    names = {name for _, name, _ in hits}
+    assert "ADR" in names or "Corpus" in names

--- a/apps/backend/tests/unit/test_tc_ev048_openapi_internal_doc_refs.py
+++ b/apps/backend/tests/unit/test_tc_ev048_openapi_internal_doc_refs.py
@@ -27,6 +27,8 @@ INTERNAL_DOC_REF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("TC", re.compile(r"\bTC-[A-Z0-9-]+\b")),
     ("E##", re.compile(r"\bE\d{2}-\d+\b")),
     ("#NNN", re.compile(r"(?<!\w)#\d{3,}\b")),
+    # Product feature ids (D-S057-qa003=2).
+    ("Fn", re.compile(r"\bF\d+\b")),
 )
 
 ALLOWLIST: frozenset[str] = frozenset()
@@ -73,7 +75,7 @@ def format_hits(hits: Iterable[tuple[str, str, str]]) -> str:
 
 def test_tc_ev048_005_synthetic_inject_detected() -> None:
     """Guard must fail when a synthetic planning cite is injected into a string."""
-    poisoned = "Soft-preview mode (ADR-022): best-effort; see #702 and TC-F7-002 / E11-31 / EV-040 / S011"
+    poisoned = "Soft-preview mode (ADR-022): best-effort; see #702 and TC-F7-002 / E11-31 / EV-040 / S011 / F31"
     hits = find_internal_doc_refs(poisoned)
     names = {name for name, _ in hits}
     assert "ADR" in names
@@ -82,6 +84,7 @@ def test_tc_ev048_005_synthetic_inject_detected() -> None:
     assert "E##" in names
     assert "EV" in names
     assert "S0" in names
+    assert "Fn" in names
 
 
 def test_tc_ev048_005_clean_operator_copy_passes() -> None:

--- a/apps/frontend/src/app/components/SoftPreviewControl.tsx
+++ b/apps/frontend/src/app/components/SoftPreviewControl.tsx
@@ -2,6 +2,13 @@
  * Soft-preview checkbox for convert ``preview=true`` (UJ-016 / ADR-022).
  */
 
+/** Operator-visible label (scanned by TC-EV048-003). */
+export const SOFT_PREVIEW_LABEL = 'Soft-preview';
+
+/** Operator-visible help under the soft-preview toggle (scanned by TC-EV048-003). */
+export const SOFT_PREVIEW_HELP =
+  'Return best-effort IWXXM and failed spans when TAC is partial (not for publish).';
+
 export interface SoftPreviewControlProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
@@ -30,10 +37,9 @@ export function SoftPreviewControl({
         onChange={(e) => onChange(e.target.checked)}
       />
       <span>
-        <span className="font-medium">Soft-preview</span>
+        <span className="font-medium">{SOFT_PREVIEW_LABEL}</span>
         <span className="block text-xs text-gray-500 dark:text-gray-400">
-          Return best-effort IWXXM and failed spans when TAC is partial (not for
-          publish).
+          {SOFT_PREVIEW_HELP}
         </span>
       </span>
     </label>

--- a/apps/frontend/src/utils/internalDocRefGuard.test.ts
+++ b/apps/frontend/src/utils/internalDocRefGuard.test.ts
@@ -12,7 +12,7 @@ import { collectOperatorVisibleCopy } from './operatorVisibleCopy';
 describe('TC-EV048 internal doc ref guard (FE)', () => {
   it('TC-EV048-005: detects synthetic planning cites', () => {
     const poisoned =
-      'Soft-preview (ADR-022); see #702 and TC-F7-002 / E11-31 / EV-040 / S011 [Corpus: product]';
+      'Soft-preview (ADR-022); see #702 and TC-F7-002 / E11-31 / EV-040 / S011 / F31 [Corpus: product]';
     const hits = findInternalDocRefs(poisoned);
     const names = new Set(hits.map((h) => h.name));
     expect(names.has('ADR')).toBe(true);
@@ -22,6 +22,7 @@ describe('TC-EV048 internal doc ref guard (FE)', () => {
     expect(names.has('EV')).toBe(true);
     expect(names.has('S0')).toBe(true);
     expect(names.has('Corpus')).toBe(true);
+    expect(names.has('Fn')).toBe(true);
   });
 
   it('TC-EV048-005: clean operator copy passes', () => {

--- a/apps/frontend/src/utils/internalDocRefGuard.test.ts
+++ b/apps/frontend/src/utils/internalDocRefGuard.test.ts
@@ -1,0 +1,45 @@
+/**
+ * TC-EV048-003/005 — FE operator string catalogs free of internal planning vocabulary.
+ *
+ * [Corpus: tests] [Corpus: product §F7]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { findInternalDocRefs } from './internalDocRefGuard';
+import { collectOperatorVisibleCopy } from './operatorVisibleCopy';
+
+describe('TC-EV048 internal doc ref guard (FE)', () => {
+  it('TC-EV048-005: detects synthetic planning cites', () => {
+    const poisoned =
+      'Soft-preview (ADR-022); see #702 and TC-F7-002 / E11-31 / EV-040 / S011 [Corpus: product]';
+    const hits = findInternalDocRefs(poisoned);
+    const names = new Set(hits.map((h) => h.name));
+    expect(names.has('ADR')).toBe(true);
+    expect(names.has('#NNN')).toBe(true);
+    expect(names.has('TC')).toBe(true);
+    expect(names.has('E##')).toBe(true);
+    expect(names.has('EV')).toBe(true);
+    expect(names.has('S0')).toBe(true);
+    expect(names.has('Corpus')).toBe(true);
+  });
+
+  it('TC-EV048-005: clean operator copy passes', () => {
+    expect(
+      findInternalDocRefs(
+        'Soft-preview: best-effort IWXXM with failure spans on partial convert.',
+      ),
+    ).toEqual([]);
+  });
+
+  it('TC-EV048-003: operator-visible catalogs pass guard', () => {
+    const leaks: string[] = [];
+    for (const { id, text } of collectOperatorVisibleCopy()) {
+      const hits = findInternalDocRefs(text);
+      if (hits.length > 0) {
+        leaks.push(`${id}: ${hits.map((h) => `${h.name}=${h.token}`).join(', ')}`);
+      }
+    }
+    expect(leaks, leaks.join('\n')).toEqual([]);
+  });
+});

--- a/apps/frontend/src/utils/internalDocRefGuard.ts
+++ b/apps/frontend/src/utils/internalDocRefGuard.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal planning-vocabulary guard for operator-visible FE strings (EV-048 / #951).
+ *
+ * [Corpus: tests] TC-EV048-003/005 · [Corpus: product §F7] · D-S057-04-guard-ext=1
+ */
+
+/** Locked patterns (D-S057-guard-s0=1, D-S057-04-guard-ext=1). */
+export const INTERNAL_DOC_REF_PATTERNS: ReadonlyArray<{
+  name: string;
+  pattern: RegExp;
+}> = [
+  { name: 'Corpus', pattern: /\[Corpus:/g },
+  { name: 'docs/sessions', pattern: /docs\/sessions\//g },
+  { name: 'docs/feature-list', pattern: /docs\/feature-list/g },
+  { name: 'ADR', pattern: /\bADR-\d+\b/g },
+  { name: 'EV', pattern: /\bEV-\d+\b/g },
+  { name: 'S0', pattern: /\bS0\d+\b/g },
+  { name: 'TC', pattern: /\bTC-[A-Z0-9-]+\b/g },
+  { name: 'E##', pattern: /\bE\d{2}-\d+\b/g },
+  // `(?<!\w)#` — `\b#` misses `#702` after spaces/slashes.
+  { name: '#NNN', pattern: /(?<!\w)#\d{3,}\b/g },
+];
+
+/** Empty unless a proven domain false positive is documented. */
+export const INTERNAL_DOC_REF_ALLOWLIST = new Set<string>();
+
+export type InternalDocRefHit = { name: string; token: string };
+
+/**
+ * Find planning-vocabulary tokens in a user-visible string.
+ *
+ * @param text - Operator-visible copy
+ * @returns Matching pattern name + token pairs
+ */
+export function findInternalDocRefs(text: string): InternalDocRefHit[] {
+  const hits: InternalDocRefHit[] = [];
+  for (const { name, pattern } of INTERNAL_DOC_REF_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const token = match[0];
+      if (INTERNAL_DOC_REF_ALLOWLIST.has(token)) {
+        continue;
+      }
+      hits.push({ name, token });
+    }
+  }
+  return hits;
+}

--- a/apps/frontend/src/utils/internalDocRefGuard.ts
+++ b/apps/frontend/src/utils/internalDocRefGuard.ts
@@ -19,6 +19,8 @@ export const INTERNAL_DOC_REF_PATTERNS: ReadonlyArray<{
   { name: 'E##', pattern: /\bE\d{2}-\d+\b/g },
   // `(?<!\w)#` — `\b#` misses `#702` after spaces/slashes.
   { name: '#NNN', pattern: /(?<!\w)#\d{3,}\b/g },
+  // Product feature ids (D-S057-qa003=2 — privacy / OpenAPI operator surfaces).
+  { name: 'Fn', pattern: /\bF\d+\b/g },
 ];
 
 /** Empty unless a proven domain false positive is documented. */

--- a/apps/frontend/src/utils/operatorVisibleCopy.ts
+++ b/apps/frontend/src/utils/operatorVisibleCopy.ts
@@ -1,0 +1,51 @@
+/**
+ * Catalog of operator-visible string exports for EV-048 guard scans (TC-EV048-003).
+ *
+ * Source comments / test files are out of scope — only these runtime strings.
+ * [Corpus: product §F7] [Corpus: tests]
+ */
+
+import { EXAMPLES } from '@/fixtures/examples/examplesCatalog';
+import {
+  SOFT_PREVIEW_HELP,
+  SOFT_PREVIEW_LABEL,
+} from '@/app/components/SoftPreviewControl';
+import { GUEST_LOSS_OF_PROGRESS_MESSAGE } from '@/utils/guestLossNotice';
+import { OPERATOR_HANDBOOK_URL, OPERATOR_ONE_PAGER_URL } from '@/utils/operatorHelp';
+import { STORAGE_INVENTORY } from '@/utils/privacyPreferences';
+
+export type OperatorVisibleCopyEntry = {
+  id: string;
+  text: string;
+};
+
+/**
+ * Collect agreed FE string catalogs for the internal-doc-ref guard.
+ *
+ * @returns Flat list of `{ id, text }` entries
+ */
+export function collectOperatorVisibleCopy(): OperatorVisibleCopyEntry[] {
+  const entries: OperatorVisibleCopyEntry[] = [
+    { id: 'soft-preview.label', text: SOFT_PREVIEW_LABEL },
+    { id: 'soft-preview.help', text: SOFT_PREVIEW_HELP },
+    { id: 'guest.loss-of-progress', text: GUEST_LOSS_OF_PROGRESS_MESSAGE },
+    { id: 'help.one-pager-url', text: OPERATOR_ONE_PAGER_URL },
+    { id: 'help.handbook-url', text: OPERATOR_HANDBOOK_URL },
+  ];
+
+  for (const item of STORAGE_INVENTORY) {
+    entries.push({
+      id: `privacy.inventory.${item.kind}`,
+      text: item.purpose,
+    });
+  }
+
+  for (const example of EXAMPLES) {
+    entries.push({
+      id: `examples.${example.id}.label`,
+      text: example.label,
+    });
+  }
+
+  return entries;
+}

--- a/apps/frontend/src/utils/privacyPreferences.ts
+++ b/apps/frontend/src/utils/privacyPreferences.ts
@@ -50,7 +50,7 @@ export interface StorageInventoryItem {
 export const STORAGE_INVENTORY: readonly StorageInventoryItem[] = [
   {
     kind: 'indexedDB',
-    purpose: 'Guest work history and converter sessions (F5 / F7.h / F31)',
+    purpose: 'Guest work history and converter sessions',
     necessary: false,
   },
   {
@@ -60,7 +60,7 @@ export const STORAGE_INVENTORY: readonly StorageInventoryItem[] = [
   },
   {
     kind: 'cookie',
-    purpose: 'Supabase Auth session cookies when signed in (F31 / UJ-047)',
+    purpose: 'Supabase Auth session cookies when signed in',
     necessary: false,
   },
 ] as const;

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -539,6 +539,17 @@ Convert responses may also carry `errors` / `issues` / `failed_spans` with optio
 `start` / `end` (see Conversion). HTTP status codes: 400 / 422 / 5xx as documented for F6; soft-preview
 uses **200** with structured partial failure when `preview=true`.
 
+### Operator-facing OpenAPI and error copy (EV-048 / #951)
+
+Public OpenAPI (path/operation summaries, parameter and schema `description` fields that
+feed `/docs` / Redoc) and client-facing `detail` / error messages MUST describe controls and
+failures in plain operator language. They MUST NOT cite internal engineering documents or
+planning IDs — including `[Corpus:…]`, `ADR-NNN`, `EV-NNN`, `S0NN`, `docs/sessions/`,
+`docs/feature-list`, or UJ/TC/GitHub issue numbers used as planning vocabulary.
+
+Developer source comments, test names/docstrings, and standing `docs/` remain free to cite
+corpus/ADRs. Automated guard: TC-EV048-002/004/005. [Corpus: api] [Corpus: product §F21]
+
 ## Frontend Integration
 
 Runtime config via `GET /config.json` (copied from `config/prod.json` at deploy; publishable

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -32,6 +32,11 @@
 | D-S057-gateB | **1** — Gate B PASS; S5.M1–S5.M3 defaults; proceed 07-build M1 |
 | D-S057-phaseC | **1** — Continue 09-qa + 10-e2e (delta/light) → 11-verify-impl |
 | D-S057-ui-preview-verify | **2** — No non-deployed UI preview before Verify (FE catalogs clean) |
+| D-S057-uj055 | **1** — Approve UJ-055 |
+| D-S057-f7 | **1** — Approve F7 deepen (copy hygiene) |
+| D-S057-f21 | **1** — Approve F21 deepen (OpenAPI/errors) |
+| D-S057-qa003 | **2** — Expand guard with `\bF\d+\b`; strip Fn IDs from privacy + OpenAPI |
+| D-S057-11-next | **1** — Push branch + open PR to `stage` (12/13 stay skipped) |
 
 ### Acceptance (confirmed `D-S057-01-ac=1`)
 

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,47 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-048 — Strip internal doc refs from UI + public API (#951) (S057)
+
+**Session**: S057-strip-internal-doc-refs  
+**Features**: deepen **F7 / F21** (no new Fn)  
+**Started**: 2026-08-08  
+**Branch**: `evolve/EV-048-strip-internal-doc-refs` (base `stage@d7652d5d`)  
+**Status**: **in_progress**  
+
+**Issues**: [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)  
+**Corpus**: [Corpus: product §F7], [Corpus: product §F21], [Corpus: api],
+[Corpus: journeys], [Corpus: tests], [Corpus: decisions]
+
+### Scope (Phase 0 — locked 2026-08-08)
+
+| ID | Decision |
+|----|----------|
+| D-S057-open | **1** — Open S057 → EV-048 for #951 |
+| D-S057-scope | **1** — Full #951: UI + OpenAPI + client errors + automated guard |
+| D-S057-preset | **1** — Standard (amended from initial Lean) |
+| D-S057-preset-reconfirm | **1** — `00→16→01→02→04→05→07→08→09→10→11`; skip 03/06/12/13 |
+| D-S057-ui-preview | **1** — Non-deployed local UI at http://localhost:5173/ |
+| D-S057-01-ac | **1** — Approve AC1–AC6 + UJ-055 as drafted |
+| D-S057-guard-s0 | **1** — Include `\bS0\d+\b` in guard patterns |
+| D-S057-gateA | **1** — Gate A PASS; S2.1–S2.4 as 04/07 defaults |
+| D-S057-04-plan | **1** — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05 then 07 |
+| D-S057-04-guard-ext | **1** — Extend guard with `\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `\b#\d{3,}\b` on scanned surfaces |
+| D-S057-gateB | **1** — Gate B PASS; S5.M1–S5.M3 defaults; proceed 07-build M1 |
+
+### Acceptance (confirmed `D-S057-01-ac=1`)
+
+| AC | Criterion | TC |
+|----|-----------|-----|
+| AC1 | Audit findings listed in PR | TC-EV048-001 |
+| AC2 | OpenAPI descriptions pass guard | TC-EV048-002 |
+| AC3 | Operator UI string catalogs pass guard | TC-EV048-003 |
+| AC4 | Client-facing API errors pass guard | TC-EV048-004 |
+| AC5 | Automated guard fails on synthetic regression | TC-EV048-005 |
+| AC6 | Soft-preview etc. operator-friendly; tests updated | TC-EV048-002/003 |
+
+---
+
 ## Cycle EV-047 — M0 stabilize + operator trust (#833/#834/#956/#957) (S056)
 
 **Session**: S056-m0-stabilize-operator-trust  

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -30,6 +30,8 @@
 | D-S057-04-plan | **1** — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05 then 07 |
 | D-S057-04-guard-ext | **1** — Extend guard with `\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `\b#\d{3,}\b` on scanned surfaces |
 | D-S057-gateB | **1** — Gate B PASS; S5.M1–S5.M3 defaults; proceed 07-build M1 |
+| D-S057-phaseC | **1** — Continue 09-qa + 10-e2e (delta/light) → 11-verify-impl |
+| D-S057-ui-preview-verify | **2** — No non-deployed UI preview before Verify (FE catalogs clean) |
 
 ### Acceptance (confirmed `D-S057-01-ac=1`)
 

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -1,6 +1,17 @@
 # Requirements Decisions Log
 
-> Stage: 01-requirements | Last updated: 2026-08-08 (S056 / EV-047)
+> Stage: 01-requirements | Last updated: 2026-08-08 (S057 / EV-048)
+
+## EV-048 / S057 — Strip internal doc refs (#951) (`D-S057-01-ac=1`)
+
+| Prefix | Topic | Decision | Status |
+|--------|-------|----------|--------|
+| EV-048 / F7 | Operator UI copy | No Corpus/ADR/EV/S0/`docs/` cites in operator-visible strings | confirmed |
+| EV-048 / F21 | Public OpenAPI + errors | Operator language only in descriptions/`detail` | confirmed |
+| EV-048 / guard | Patterns | `\[Corpus:`, `docs/sessions/`, `docs/feature-list`, `ADR-\d+`, `EV-\d+`, `S0\d+` (`D-S057-guard-s0=1`) + `TC-*`, `E##-##`, `#NNN` (`D-S057-04-guard-ext=1`) | confirmed |
+| EV-048 / UJ | UJ-055 | New journey; T0/T2; T3 if UI audit finds hits | confirmed |
+| EV-048 / UI | 01 preview | Non-deployed local Vite (`D-S057-ui-preview=1`) | confirmed |
+| EV-048 / route | Standard | 04/05/07–11 required; 12/13 waived | confirmed |
 
 ## EV-047 / S056 — M0 husky + converter perf + operator docs (`D-S056-01-ac=1`)
 

--- a/docs/decisions/tech-decisions.md
+++ b/docs/decisions/tech-decisions.md
@@ -1,7 +1,20 @@
 # Technical Decision Log
 
 > Extends [product-decisions.md](product-decisions.md) with 05-verify-tech audit verdicts.
-> Last updated: 2026-08-08 (S054 / EV-045)
+> Last updated: 2026-08-08 (S057 / EV-048)
+
+## S057 / EV-048 05-verify-tech (2026-08-08)
+
+| ID | Date | Topic | Decision | Status |
+|----|------|-------|----------|--------|
+| D-S057-04-plan | 2026-08-08 | Plan | Approve M1–M3 / T1.1–T3.3 → 05 then 07 | confirmed |
+| D-S057-04-guard-ext | 2026-08-08 | Guard | Also fail on `TC-*`, `E##-##`, `#NNN` in scanned surfaces | confirmed |
+| S5.M1 | 2026-08-08 | Patterns | Duplicate BE pytest + FE Vitest lists (no shared pkg) | confirmed |
+| S5.M2 | 2026-08-08 | `#NNN` | Allowlist path if domain false positive | confirmed |
+| S5.M3 | 2026-08-08 | ADR in exceptions | OK if never HTTP `detail` (T2.3 spot-check) | confirmed |
+| D-S057-gateB | 2026-08-08 | Gate B | PASS → 07-build M1 | confirmed |
+
+Session report: `docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md`.
 
 ## S054 / EV-045 05-verify-tech (2026-08-08)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-08 (S055 / EV-046 — #889 codes.wmo.int Lean; S054 / EV-045 Rust CI on stage)
+> **Last updated**: 2026-08-08 (S057 / EV-048 — #951 strip internal doc refs from UI/API; prior EV-046/047)
 
 ## Summary
 
@@ -14,7 +14,7 @@
 | F4 | IWXXM version handling | Implemented | Product | docs/domain/iwxxm/IWXXM_VERSION_SWITCHING.md; **deepen** S046 / EV-038 release-line SoT/UX (#851–#855) |
 | F5 | User METAR work history | Implemented | Product | S038 / EV-031 / F31 hybrid: guest IndexedDB + logged-in DO Postgres |
 | F6 | General TAC→IWXXM (`tac2iwxxm`) | Implemented | Product | S008, ADR-013/014/019; bulletin split; **deepen** S055 / EV-046 #889 codes.wmo.int coverage across products; prior S046 / EV-038 |
-| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S046 / EV-038 picker Latest/Previous (#854); **deepen** S048 / EV-040 New TAC + official AHL/Collect examples + slim prefs; **deepen** S050 / EV-042 #897 queue/keyboard + batch churn UX |
+| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S046 / EV-038 picker Latest/Previous (#854); **deepen** S048 / EV-040 New TAC + official AHL/Collect examples + slim prefs; **deepen** S050 / EV-042 #897 queue/keyboard + batch churn UX; **deepen** S057 / EV-048 #951 no internal-doc cites in operator UI |
 | F8 | Near-realtime TAC ingest → IWXXM gate | Implemented | Product | S008 ADR-018; **F30** writers → DO Postgres (not Supabase DB) |
 | F9 | Value-aware live decode + plain-language summary | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723) |
 | F10 | Workbench preview clarity (IWXXM pane + lint UX) | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723); **deepen** S048 / EV-040 full lint console lines + preserve input on convert |
@@ -28,7 +28,7 @@
 | F18 | EDIS → RTH Washington dissemination | Done | Product | S019 / EV-014; #6; **S050 / EV-042** operator UI hidden (restore #898) |
 | F19 | AMHS / SWIM / AFS adapters | Done | Product | S019 / EV-014; **S050 / EV-042** operator UI hidden (restore #898) |
 | F20 | TAF + SPECI quality bar (F15 sequel) | Done | Product | S020 / EV-015; #735/#734; #778; **deepen** S055 / EV-046 #889 |
-| F21 | Public convert + optional Auth for long-term storage | Amended | Product | S023 #783; **S038 / EV-031 / F31** amend |
+| F21 | Public convert + optional Auth for long-term storage | Amended | Product | S023 #783; **S038 / EV-031 / F31** amend; **deepen** S057 / EV-048 #951 OpenAPI/error copy hygiene |
 | F22 | Privacy preference center (Solution A + GPC) | Implemented | Product | S023 / EV-017; #783; **deepen** F31 storage gates |
 | F23 | SIGMET family quality bar (general + VA) | Done | Product | S025 / EV-019; #733/#739; PR #792; **deepen** S055 / EV-046 #889 |
 | F24 | AIRMET quality bar | Done | Product | S026 / EV-020; #731; PR #793; **deepen** S055 / EV-046 #889 |
@@ -359,6 +359,16 @@
      from one-pager for depth).
   4. No internal engineering citations in user-facing handbook/one-pager text.
   5. UJ-054 / TC-EV047-009..011 green (Vitest/Playwright for Help entry as applicable).
+- **S057 / EV-048 deepen (#951 — strip internal doc refs from operator UI)**: Operator-visible
+  UI copy (labels, helpers, tooltips, banners, empty states, console/catalog copy, example
+  tier labels, privacy/auth copy) must not cite internal engineering vocabulary
+  (`[Corpus:…]`, ADR/session/EV IDs, `docs/` paths, UJ/TC/issue numbers). Source comments,
+  tests, and repo docs remain allowed. Does **not** flip F7 → Implemented.
+- **Acceptance (EV-048 / #951 — F7 UI slice)** — **approved** (`D-S057-01-ac=1`):
+  1. Audit findings for UI string catalogs listed in the PR.
+  2. No operator-visible UI string matches guard patterns (see test-plan TC-EV048).
+  3. Automated guard covers FE string catalogs; comments/tests excluded.
+  4. UJ-055 / TC-EV048-003 green.
 - **Resolved gaps (S011 Feature List Batch 2)**:
   | ID | Decision |
   |----|----------|
@@ -828,7 +838,18 @@
   5. Env/docs: Supabase **Auth** credentials for login path; product **DB** = DO `DATABASE_URL`
   6. E2E: public convert UJs plus login / guest-notice / privacy UJs (F31)
 - **Out of scope**: Forced login for convert; CMP; selling personal data
-- **Source**: #783; E17-*; **S038 / EV-031**; [Context: platform-independence-842](context/platform-independence-842.md)
+- **S057 / EV-048 deepen (#951 — public OpenAPI / client error copy)**: Public OpenAPI
+  path/operation summaries, parameter/schema `description` fields, runtime `/docs` / Redoc
+  text, and client-facing `detail`/error messages must use operator-friendly language —
+  no `[Corpus:…]`, ADR/session/EV IDs, `docs/` paths, TC/E## planning IDs, or GitHub
+  issue `#NNN` citations. Developer comments and test docstrings remain allowed.
+- **Acceptance (EV-048 / #951 — F21 API slice)** — **approved** (`D-S057-01-ac=1`):
+  1. Audit findings for OpenAPI + client-facing errors listed in the PR.
+  2. OpenAPI export and error surfaces pass automated guard (TC-EV048-002/004/005).
+  3. Soft-preview and related field descriptions preserve intent without ADR citations.
+  4. Backend unit/OpenAPI snapshot tests updated.
+- **Source**: #783; E17-*; **S038 / EV-031**; [Context: platform-independence-842](context/platform-independence-842.md);
+  [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951) (S057 / EV-048)
 
 ### F22: Privacy Preference Center — S023 / EV-017
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -362,8 +362,8 @@
 - **S057 / EV-048 deepen (#951 — strip internal doc refs from operator UI)**: Operator-visible
   UI copy (labels, helpers, tooltips, banners, empty states, console/catalog copy, example
   tier labels, privacy/auth copy) must not cite internal engineering vocabulary
-  (`[Corpus:…]`, ADR/session/EV IDs, `docs/` paths, UJ/TC/issue numbers). Source comments,
-  tests, and repo docs remain allowed. Does **not** flip F7 → Implemented.
+  (`[Corpus:…]`, ADR/session/EV IDs, product `FNN` ids, `docs/` paths, UJ/TC/issue numbers).
+  Source comments, tests, and repo docs remain allowed. Does **not** flip F7 → Implemented.
 - **Acceptance (EV-048 / #951 — F7 UI slice)** — **approved** (`D-S057-01-ac=1`):
   1. Audit findings for UI string catalogs listed in the PR.
   2. No operator-visible UI string matches guard patterns (see test-plan TC-EV048).
@@ -841,8 +841,8 @@
 - **S057 / EV-048 deepen (#951 — public OpenAPI / client error copy)**: Public OpenAPI
   path/operation summaries, parameter/schema `description` fields, runtime `/docs` / Redoc
   text, and client-facing `detail`/error messages must use operator-friendly language —
-  no `[Corpus:…]`, ADR/session/EV IDs, `docs/` paths, TC/E## planning IDs, or GitHub
-  issue `#NNN` citations. Developer comments and test docstrings remain allowed.
+  no `[Corpus:…]`, ADR/session/EV IDs, product `FNN` ids, `docs/` paths, TC/E## planning
+  IDs, or GitHub issue `#NNN` citations. Developer comments and test docstrings remain allowed.
 - **Acceptance (EV-048 / #951 — F21 API slice)** — **approved** (`D-S057-01-ac=1`):
   1. Audit findings for OpenAPI + client-facing errors listed in the PR.
   2. OpenAPI export and error surfaces pass automated guard (TC-EV048-002/004/005).

--- a/docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
@@ -1,0 +1,32 @@
+# Build Plan Card — S057 / EV-048
+
+> Updated: 2026-08-08
+
+## Goal
+
+Strip internal planning citations from operator UI and public OpenAPI/error surfaces;
+add automated OpenAPI + FE string-catalog guards. [#951]
+
+## Out of scope
+
+Source comments; test names/docstrings; standing `docs/` / ADRs; commit/PR corpus rules;
+staging/prod deploy (12/13 waived).
+
+## Milestones
+
+1. **M1** — Red guards + audit report (T1.1–T1.3)
+2. **M2** — Strip OpenAPI Field/Form + route docstrings (T2.1–T2.3)
+3. **M3** — FE catalog scanner + optional UJ-055 e2e (T3.1–T3.3)
+
+## First batch (07)
+
+T1.1 → T1.2 → T1.3 → T2.* → T3.* (TDD: red guards before strip).
+
+## Guard (locked)
+
+Base + `TC-*` + `E##-##` + `#NNN` (`D-S057-04-guard-ext=1`). Duplicate pattern
+lists in BE pytest + FE Vitest OK (S5.M1 default).
+
+## Corpus
+
+[Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: tests]

--- a/docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
@@ -26,10 +26,11 @@ API/OpenAPI surfaces, with an automated regression guard. [#951]
 
 ## Next child stage
 
-**08-verify-build** — M1–M3 implementation done; tip CI / local verify
+**11-verify-impl** — 09+10 PASS (delta); tip `3a43da37` not pushed yet
 
 ## Risks / open decisions
 
-- UI preview: http://localhost:5173/
+- UI preview before Verify: declined (`D-S057-ui-preview-verify=2`)
 - OpenAPI stripped; BE+FE guards green; T3.3 Playwright skipped (no FE hits)
 - `#NNN` pattern uses `(?<!\w)#\d{3,}\b` (lookbehind; `\b#` missed `#702`)
+- Push + PR to `stage` after 11 approval (QA-001)

--- a/docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
@@ -1,0 +1,35 @@
+# Evolve Plan Card
+
+> Cycle: EV-048 | Session: S057-strip-internal-doc-refs | Updated: 2026-08-08
+
+## Goal
+
+Strip internal engineering document references from operator UI copy and public
+API/OpenAPI surfaces, with an automated regression guard. [#951]
+
+## Features
+
+- F7 — Multi-product operator UI (deepen copy hygiene) — [Corpus: product §F7]
+- F21 — Public unauthenticated operator app (deepen OpenAPI/error copy) — [Corpus: product §F21]
+- [Corpus: api] · [Corpus: tests]
+
+## In / out of scope
+
+- In: UI strings; OpenAPI descriptions; client-facing errors; automated guard; unit/OpenAPI tests
+- Out: source comments; test names/docstrings; docs/ADRs/sessions; commit/PR citation rules
+
+## Preset + routing
+
+- Preset: **Standard** (`D-S057-preset-reconfirm=1`)
+- Stages: `00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 10 → 11`
+- Skip: `03`, `06`, `12`, `13`
+
+## Next child stage
+
+**08-verify-build** — M1–M3 implementation done; tip CI / local verify
+
+## Risks / open decisions
+
+- UI preview: http://localhost:5173/
+- OpenAPI stripped; BE+FE guards green; T3.3 Playwright skipped (no FE hits)
+- `#NNN` pattern uses `(?<!\w)#\d{3,}\b` (lookbehind; `\b#` missed `#702`)

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
@@ -1,0 +1,51 @@
+# 01-requirements — S057 / EV-048
+
+**Status**: completed — `D-S057-01-ac=1` (`D-S057-guard-s0=1`; UI preview `D-S057-ui-preview=1`)  
+**Date**: 2026-08-08  
+**Mode**: delta (deepen F7 + F21)  
+**Issues**: [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)
+
+## Corpus
+
+[Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: journeys]
+[Corpus: tests] [Corpus: decisions]
+
+## Standing doc deltas
+
+| Doc | Change |
+|-----|--------|
+| `docs/feature-list.md` | F7 + F21 EV-048 deepen + AC tables |
+| `docs/api-contract.md` | Operator-facing OpenAPI/error copy policy |
+| `docs/user-journeys.md` | UJ-055 |
+| `docs/test-plan.md` | TC-EV048-001..005 + UJ map |
+| `docs/decisions/evolve-decisions.md` | Cycle EV-048 scope + AC table |
+| `docs/decisions/requirements-decisions.md` | EV-048 section |
+
+## Skipped (N/A this cycle)
+
+- New ADR (hygiene deepen; no architecture change)
+- `deploy.md` / dependency inventory — no new env or runtime deps
+- H4–H5 live deploy — waived with 12/13 unless 11 requires
+
+## Acceptance criteria (confirmed)
+
+| AC | Criterion | TC |
+|----|-----------|-----|
+| AC1 | Audit findings listed in PR | TC-EV048-001 |
+| AC2 | OpenAPI descriptions pass guard | TC-EV048-002 |
+| AC3 | Operator UI string catalogs pass guard | TC-EV048-003 |
+| AC4 | Client-facing API errors pass guard | TC-EV048-004 |
+| AC5 | Automated guard fails on synthetic regression | TC-EV048-005 |
+| AC6 | Soft-preview etc. operator-friendly; tests updated | TC-EV048-002/003 |
+
+## Guard patterns (locked)
+
+`\[Corpus:`, `docs/sessions/`, `docs/feature-list`, `\bADR-\d+\b`, `\bEV-\d+\b`, `\bS0\d+\b`
+
+## UI preview
+
+Non-deployed local: http://localhost:5173/
+
+## Next
+
+**02-verify-plan** (Gate A).

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
@@ -1,0 +1,82 @@
+# 02-verify-plan — Gate A (S057 / EV-048)
+
+**Date**: 2026-08-08  
+**Mode**: delta — F7 UI + F21 OpenAPI/error copy hygiene (#951)  
+**Status**: Gate A PASS — `D-S057-gateA=1`  
+**01**: completed (`D-S057-01-ac=1`; `D-S057-guard-s0=1`; UI preview `D-S057-ui-preview=1`)
+
+## Inventory (touched)
+
+| # | Document | Delta | Status |
+|---|----------|-------|--------|
+| 1 | feature-list.md | F7 / F21 EV-048 AC | audited |
+| 2 | api-contract.md | Operator-facing OpenAPI/error copy policy | audited |
+| 3 | user-journeys.md | UJ-055 | audited |
+| 4 | test-plan.md | TC-EV048-001..005 | audited |
+| 5 | evolve-decisions / requirements-decisions | EV-048 locks | reference |
+| — | spec.md | No new component — `apps/frontend` + `apps/backend` already map | OK |
+| — | deploy.md | N/A — no new env | OK |
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Spec | **PASS** — F7 frontend; F21 public API/OpenAPI |
+| Feature ↔ Journey | **PASS** — UJ-055 |
+| Journey ↔ Test | **PASS** — → TC-EV048-001..005 |
+| Feature ↔ Test | **PASS** — AC1–6 ↔ TC-EV048-* |
+| Feature ↔ API | **PASS** — api-contract policy section |
+| Test ↔ Acceptance | **PASS** |
+| Connectivity H4–H5 | **ADVISORY** — UJ-055 may be T0/T2 only; **10-e2e** on route; **12/13 waived** |
+
+## Statements
+
+### High (auto-approved — D-S057-01-ac=1 / Phase 0 locks)
+
+| ID | Statement | Verdict |
+|----|-----------|---------|
+| S1.1 | No `[Corpus:]` / ADR / EV / S0 / `docs/` cites in operator UI strings | auto-approved |
+| S1.2 | Same for public OpenAPI descriptions + client-facing errors | auto-approved |
+| S1.3 | Guard patterns include `\bS0\d+\b` (`D-S057-guard-s0=1`) | auto-approved |
+| S1.4 | Comments, tests, standing docs remain allowed | auto-approved |
+| S1.5 | UJ-055 + TC-EV048-001..005 define verification | auto-approved |
+| S1.6 | Standard route; 12/13 waived unless 11 requires deploy | auto-approved |
+
+### Medium (user review → 04 deliverables)
+
+| ID | Statement | Notes |
+|----|-----------|-------|
+| S2.1 | FE “string catalogs” = explicit module list (e.g. `operatorHelp`, SoftPreview, privacy, examples) scanned by Vitest | Inventory in 04 — recommend accept |
+| S2.2 | OpenAPI scan via FastAPI `app.openapi()` (or equivalent export) in backend unit test | Recommend accept |
+| S2.3 | T3 Playwright for UJ-055 only if UI audit finds visible hits; else T0/T2 unit guard sufficient | Recommend accept (matches AC) |
+| S2.4 | Allowlist empty at start; add only on proven domain false positives | Recommend accept |
+
+### Low
+
+| ID | Statement | Notes |
+|----|-----------|-------|
+| S3.1 | Lint-issue catalog `source` attribution may mention external WMO URLs — not ADR/Corpus; out of guard unless it embeds planning IDs | Advisory — keep out of scope unless leak found |
+
+## Contradictions
+
+None blocking. Soft-preview UI copy already clean; OpenAPI `description=` still leaks ADRs (in scope for 07).
+
+## Gate A recommendation
+
+**PASS** — accept S2.1–S2.4 as 04/07 work; S3.1 advisory.
+
+## Gate A decision (`D-S057-gateA=1`)
+
+User chose **option 1**: PASS; S2.1–S2.4 as 04/07 defaults; proceed **04-tech-plan**.
+
+| Item | Locked for 04/07 |
+|------|------------------|
+| S2.1 | FE string catalog inventory in 04 |
+| S2.2 | OpenAPI scan via `app.openapi()` |
+| S2.3 | T3 only if UI audit finds visible hits |
+| S2.4 | Allowlist empty until proven false positive |
+| S3.1 | Lint catalog external URLs OOS unless planning IDs leak |
+
+## Next
+
+**04-tech-plan**.

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
@@ -1,0 +1,19 @@
+# 04-tech-plan — S057 / EV-048
+
+**Status**: **completed** (`D-S057-04-plan=1`, `D-S057-04-guard-ext=1`)  
+**Date**: 2026-08-08  
+**Artifacts**: `reports/execution-plan.md`, `build-plan-card.md`
+
+## Pre-build OpenAPI audit
+
+16 planning-vocabulary hits in `app.openapi()` (ADR/EV/S0 + extras TC-/E##-/#).  
+FE operator-visible literals look clean; comments/tests retain citations (allowed).
+
+## Locked decisions
+
+M1–M3 / T1.1–T3.3 as drafted. Guard includes base patterns plus `TC-*`, `E##-##`, `#NNN`
+(`D-S057-04-guard-ext=1`). See execution-plan §Tech decisions.
+
+## Next
+
+05-verify-tech (Gate B) → 07-build.

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
@@ -1,0 +1,71 @@
+# 05-verify-tech — Gate B (S057 / EV-048)
+
+**Date**: 2026-08-08  
+**Status**: **PASS** (`D-S057-gateB=1`)  
+**Mode**: delta / Standard  
+**Corpus**: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api]
+[Corpus: tests] [Corpus: journeys] [Corpus: decisions]
+
+## Plan-readiness
+
+| Check | Result |
+|-------|--------|
+| Execution plan exists | PASS |
+| Build Plan Card exists | PASS |
+| Card task IDs ∈ plan | PASS (M1–M3 / T1.1–T3.3) |
+| Spec sources on tasks | PASS (TC-EV048 / AC / UJ-055) |
+| TDD order | PASS — red guards (M1) before strip (M2/M3) |
+| Connectivity | 10-e2e only if T3.3; 12/13 waived per routing |
+
+## Consistency vs product ACs
+
+| AC / TC | Tech plan coverage |
+|---------|-------------------|
+| AC1 / TC-EV048-001 | T1.3 audit markdown |
+| AC2 / TC-EV048-002 | T1.1 + T2.1–T2.2 |
+| AC3 / TC-EV048-003 | T1.2 + T3.1–T3.2 |
+| AC4 / TC-EV048-004 | T2.3 |
+| AC5 / TC-EV048-005 | T1.1 + T1.2 synthetic inject |
+| AC6 soft-preview copy | T2.1 replacements |
+| Guard-ext TC/E##/# | D-S057-04-guard-ext=1 → T1.1/T1.2 patterns |
+
+## Auto-approved (high confidence — user interview)
+
+| ID | Statement |
+|----|-----------|
+| S5.1 | M1→M2→M3 TDD order is correct |
+| S5.2 | OpenAPI scan = walk all strings in `app.openapi()` |
+| S5.3 | Guard includes base + `TC-*` + `E##-##` + `#NNN` |
+| S5.4 | FE catalogs listed in D-S057-04-fe-catalogs |
+| S5.5 | T3.3 Playwright only if visible FE hits |
+| S5.6 | Allowlist empty until a proven domain false positive |
+| S5.7 | No new runtime deps (06 skipped) |
+| S5.8 | Comments/tests/`docs/` remain unscanned |
+
+## Medium (defaults for Gate B — confirm or modify)
+
+| ID | Statement | Default |
+|----|-----------|---------|
+| S5.M1 | Pattern lists may be **duplicated** in BE pytest + FE Vitest (no shared package) | Accept |
+| S5.M2 | `\b#\d{3,}\b` may need allowlist if a true domain `#NNN` appears in operator copy | Accept + allowlist path |
+| S5.M3 | `NotImplementedError` / developer-path ADR cites are OK if never returned as HTTP `detail` — spot-check in T2.3 | Accept |
+
+## Internal technical consistency
+
+| Check | Result |
+|-------|--------|
+| Dependency graph | PASS — M2/M3 depend on M1 red guards |
+| Circular deps | none |
+| Scope drift | none — deepen F7/F21 only |
+| Template | N/A (copy hygiene; no new deployable) |
+
+## Gate B criteria
+
+- [x] Execution plan audited
+- [x] Build Plan Card ↔ Task Tracking parity
+- [x] Product ↔ technical AC coverage
+- [x] User Gate B approval (`D-S057-gateB=1`; S5.M1–S5.M3 defaults)
+
+## Next
+
+**07-build** M1 (T1.1 → T1.2 → T1.3).

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
@@ -1,0 +1,30 @@
+# 08-verify-build — S057 / EV-048
+
+**Date**: 2026-08-08  
+**Tip**: `71779d46` on `evolve/EV-048-strip-internal-doc-refs`  
+**Status**: **PASS**  
+**Corpus**: [Corpus: tests] [Corpus: api] [Corpus: product §F7] [Corpus: product §F21]
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| `make validate-fast` | PASS |
+| BE `test_tc_ev048_*` + soft-preview + decode summary | 27 passed |
+| FE `internalDocRefGuard` + SoftPreviewControl | 5 passed |
+| OpenAPI clean scan (TC-EV048-002) | PASS (post-M2) |
+| Connectivity H0c/H0i | N/A delta (no CORS/route shape change) |
+
+## Auto-corrections
+
+None required (format/lint already clean).
+
+## Notes
+
+- T3.3 Playwright skipped (no operator-visible FE hits).
+- `#NNN` guard uses `(?<!\w)#\d{3,}\b`.
+- Source comments retain ADR/EV cites (out of scope).
+
+## Next
+
+Phase C checkpoint → **09-qa** + **10-e2e** (delta; 10 likely light) → **11-verify-impl**.

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/audit-internal-doc-refs.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/audit-internal-doc-refs.md
@@ -33,8 +33,8 @@ Operator-visible catalog strings are **clean** under the locked guard (Soft-prev
 plain language; exported `SOFT_PREVIEW_*` for scanning). ADRs/EV/S0/UJ remain in **comments**
 and **tests** (allowed). **T3.3 Playwright skipped** (D-S057-04-t3 — no visible hits).
 
-Note: privacy inventory purposes still mention product Fn IDs (`F5` / `F31`) — **not** in
-the locked regex set; left as-is unless a follow-on cycle expands the guard.
+**QA-003 fix (`D-S057-qa003=2`)**: Guard now includes `\bF\d+\b`. Privacy inventory
+purposes and OpenAPI F2/F6 planning cites rewritten to operator language.
 
 ## Client-facing errors
 

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/audit-internal-doc-refs.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/audit-internal-doc-refs.md
@@ -1,0 +1,48 @@
+# Audit — internal doc refs in operator / public surfaces (EV-048 / #951)
+
+**Date**: 2026-08-08  
+**Session**: S057-strip-internal-doc-refs  
+**TC**: TC-EV048-001  
+**Corpus**: [Corpus: api] [Corpus: product §F7] [Corpus: product §F21] [Corpus: tests]
+
+## Scope scanned
+
+| Surface | Method |
+|---------|--------|
+| OpenAPI | `app.openapi()` — all string values |
+| FE catalogs | Soft-preview label/help, guest loss notice, Help URLs, privacy `STORAGE_INVENTORY` purposes, example `label`s |
+| Client `detail` | Spot-check (T2.3); no common `HTTPException(detail=…ADR…)` found pre-build |
+
+## OpenAPI hits (pre-M2 strip; **cleared in M2**) — 19 pattern matches / ~16 string surfaces
+
+| Pattern | Location (summary) |
+|---------|-------------------|
+| ADR-031 | `/translation/statistics*` + `/validate` route descriptions |
+| EV-040 / E11-31 | `/lint-issue-catalog` + `LintIssueCatalogEntryModel` |
+| S011 / #702 / TC-F7-002 | `/decode-tac` + `DecodeSegmentModel` |
+| TC-F6-030 | `/convert-bulletin` |
+| ADR-024 | `/ingest-collect` + `include_nil_reasons` Form |
+| ADR-022 | convert `preview` Form; `ConversionResponse.ok` / `failed_spans`; `FailedSpan` |
+| ADR-025 | `DecodeTacResponse.summary` |
+
+Comments-only ADR cites in `api.py` / utilities remain **out of scope**.
+
+## Frontend
+
+Operator-visible catalog strings are **clean** under the locked guard (Soft-preview already
+plain language; exported `SOFT_PREVIEW_*` for scanning). ADRs/EV/S0/UJ remain in **comments**
+and **tests** (allowed). **T3.3 Playwright skipped** (D-S057-04-t3 — no visible hits).
+
+Note: privacy inventory purposes still mention product Fn IDs (`F5` / `F31`) — **not** in
+the locked regex set; left as-is unless a follow-on cycle expands the guard.
+
+## Client-facing errors
+
+No hits in `detail=` paths containing ADR/EV/S0/TC/E##/#/Corpus (T2.3 spot-check).
+Developer-path `NotImplementedError` ADR cites remain (not HTTP `detail`).
+
+## Guard
+
+Automated: `apps/backend/tests/unit/test_tc_ev048_openapi_internal_doc_refs.py` +
+`apps/frontend/src/utils/internalDocRefGuard.test.ts` + `operatorVisibleCopy.ts`
+(synthetic inject + catalog/OpenAPI scan). Post-M2 OpenAPI scan **green**.

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
@@ -1,0 +1,50 @@
+# E2E Behavior Report — S057 / EV-048 (10-e2e)
+
+> Generated: 2026-08-08  
+> Mechanism: T0 unit/API guards (delta/light) — no Playwright (T3.3 skipped)  
+> Journeys in cycle: **UJ-055** (primary)  
+> Branch: `evolve/EV-048-strip-internal-doc-refs` @ `3a43da37`  
+> Corpus: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: journeys] [Corpus: tests]  
+> UI preview before Verify: **declined** (`D-S057-ui-preview-verify=2`)
+
+## Summary
+
+| # | Journey | Mechanism | Steps | Passed | Failed | Status |
+|---|---------|-----------|-------|--------|--------|--------|
+| 1 | UJ-055 Operator UI + API free of internal planning vocabulary | T0 OpenAPI walk + FE catalog Vitest | 3 | 3 | 0 | **PASS** |
+
+| Tier | Status | Evidence |
+|------|--------|----------|
+| T0 Local | PASS | `test_tc_ev048_*` 4/4; FE guard + SoftPreview 5/5; audit report |
+| T1 Integration | N/A delta | No route/CORS shape change; H0c 6/6 for connectivity baseline |
+| T2 Connectivity / browser | **waived / not claimed** | No FE visible hits → T3.3 Playwright skipped (`D-S057-04-t3`) |
+| T2 CI Playwright smoke | N/A this cycle | Tip not pushed yet (QA-001) |
+| T3 Live staging | N/A | 12/13 waived (`D-S057-preset-reconfirm=1`) |
+
+## Journey Details
+
+### UJ-055: Operator Surfaces Without Internal Doc References
+
+- **Feature**: F7 + F21 deepen (EV-048 / #951) — [Corpus: product §F7] [Corpus: product §F21]
+- **Mechanism**: Automated string guards (T0); browser T3 not required (audit clean)
+- **Steps** (mapped to acceptance):
+  1. Soft-preview / operator-visible copy free of ADR/Corpus/session IDs — **PASS** (FE catalog + SoftPreviewControl)
+  2. Public OpenAPI field/operation strings operator-only — **PASS** (OpenAPI export walk)
+  3. Privacy/auth helper catalogs under guard — **PASS** (Vitest catalogs; Fn IDs outside regex = QA-003)
+- **T3 Playwright**: **SKIPPED** — FE audit found no visible hits; Gate B / execution-plan default
+
+### Connectivity columns
+
+| Column | Result |
+|--------|--------|
+| T0 | PASS — in-process pytest + Vitest |
+| T2 connectivity (H4–H5 staging) | **waived** — 12/13 skipped; not claimed as staging CORS proof |
+| T3 browser live | N/A this cycle |
+
+**Note:** T0 ≠ production browser CORS. Staging H4–H5 remain waived unless 11 requires deploy.
+
+## Overall: **PASS** (T3/H4–H5 waiver per routing + D-S057-04-t3)
+
+## Handoff
+
+**10 PASS** → **11-verify-impl** (AC checklist + UJ-055 signoff + advisory disposition).

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
@@ -1,0 +1,125 @@
+# Execution plan — S057 / EV-048 (#951 strip internal doc refs)
+
+> **Generated**: 2026-08-08  
+> **Skill**: 04-tech-plan (delta)  
+> **Branch**: `evolve/EV-048-strip-internal-doc-refs`  
+> **Issues**: [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)  
+> **Build Plan Card**: `docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md`
+
+**Corpus**: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api]
+[Corpus: tests] [Corpus: journeys] [Corpus: decisions]
+
+## Current State
+
+| Field | Value |
+|-------|-------|
+| **Active phase** | Phase 1: Copy hygiene |
+| **Active milestone** | M3 complete — awaiting 08-verify-build |
+| **Active task** | — |
+| **Tasks completed** | 7 / 8 (T3.3 skipped — no UI hits) |
+| **Stage** | 07-build |
+| **Last updated** | 2026-08-08 |
+
+## Tech decisions (**locked** `D-S057-04-plan=1`, `D-S057-04-guard-ext=1`)
+
+| ID | Choice |
+|----|--------|
+| D-S057-04-openapi | Scan via FastAPI `app.openapi()`; walk all string values in export |
+| D-S057-04-guard | Shared pattern set (BE pytest + FE Vitest): `\[Corpus:`, `docs/sessions/`, `docs/feature-list`, `\bADR-\d+\b`, `\bEV-\d+\b`, `\bS0\d+\b` |
+| D-S057-04-guard-ext | **Locked**: also fail (and strip in M2) `\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `\b#\d{3,}\b` |
+| D-S057-04-fe-catalogs | Scan exported operator string modules: SoftPreviewControl, operatorHelp, guestLossNotice, privacy preference copy, examplesCatalog `label`s, FileConverter user-visible literals via catalog helper if needed |
+| D-S057-04-t3 | Playwright UJ-055 only if FE audit finds visible hits; else T0/T2 unit guards |
+| D-S057-04-allowlist | Empty initially; document in test module if a domain false positive appears |
+
+## Audit snapshot (pre-build, 2026-08-08)
+
+### OpenAPI (`app.openapi()`) — 16 hits (locked patterns + planning extras)
+
+| Surface | Leak |
+|---------|------|
+| convert `preview` / `include_nil_reasons` Form | ADR-022, ADR-024 |
+| ConversionResponse `ok` / `failed_spans` | ADR-022 |
+| FailedSpan schema description | ADR-022 / F7 |
+| DecodeTacResponse `summary` | F9 / ADR-025 |
+| DecodeSegmentModel description | S011 / #702 |
+| lint-issue-catalog / LintIssueCatalogEntryModel | E11-31 / EV-040 |
+| decode-tac route docstring | S011 / #702 / TC-F7-002 |
+| convert-bulletin route docstring | TC-F6-030 |
+| ingest-collect route docstring | ADR-024 |
+| validate + ICAO translation stats docstrings | F21 / ADR-031 |
+| (comments-only) | out of scope |
+
+### Frontend
+
+Operator-visible string literals appear **clean** so far (SoftPreview already plain language). ADRs/EV/S0 appear in **comments** and **tests** (keep). Guard still required for regression.
+
+### Client errors
+
+No common `HTTPException(detail=…ADR…)` found; `NotImplementedError` ADR-033 is developer-path — confirm not returned as public `detail`.
+
+## Tech Stack Summary
+
+| Category | Choice | Source |
+|----------|--------|--------|
+| OpenAPI | FastAPI export | TC-EV048-002 |
+| BE test | pytest unit | TC-EV048-002/004/005 |
+| FE test | Vitest | TC-EV048-003/005 |
+| Connectivity | 10-e2e if UI hits; 12/13 waived | routing |
+
+## Data Dependencies
+
+None.
+
+## Implementation Phases
+
+### Phase 1: Copy hygiene
+
+**Entry**: `D-S057-04-plan=1` approved.  
+**Exit**: AC1–AC6 green; tip tests green; PR lists audit findings.
+
+#### M1: Red guards + audit report — P0
+
+**Goal**: Failing tests encode guard; PR audit list drafted.  
+**Acceptance**: TC-EV048-001/005 red then green after M2/M3.
+
+| # | Task | Type | Status | Spec Source | Depends On | Data Deps |
+|---|------|------|--------|-------------|------------|-----------|
+| T1.1 | Backend unit: walk `app.openapi()` strings; assert no guard patterns; include synthetic inject regression | Test | completed | TC-EV048-002/005 | — | — |
+| T1.2 | Frontend Vitest: scan agreed string catalogs; synthetic inject regression | Test | completed | TC-EV048-003/005 | — | — |
+| T1.3 | Write audit findings markdown for PR (`reports/audit-internal-doc-refs.md`) | Docs | completed | TC-EV048-001 | — | — |
+
+#### M2: Strip OpenAPI + client-facing copy — P0
+
+**Goal**: OpenAPI export clean; operator-friendly replacements.  
+**Acceptance**: TC-EV048-002/004 green.
+
+| # | Task | Type | Status | Spec Source | Depends On | Data Deps |
+|---|------|------|--------|-------------|------------|-----------|
+| T2.1 | Rewrite Field/`Form` descriptions in `schemas/conversion.py`, `schemas/validation.py`, `api.py` Form params | Code | completed | AC2/AC6; #951 examples | T1.1 | — |
+| T2.2 | Rewrite route docstrings that feed OpenAPI (`api.py`, `icao_opmet.py`, related) — keep Auth note without ADR/F21 planning IDs | Code | completed | AC2 | T1.1 | — |
+| T2.3 | Spot-check client `detail` paths; fix any leaks; keep comments citing corpus | Code | completed | AC4 | T1.1 | — |
+
+#### M3: FE catalog guard + any UI fixes — P0
+
+**Goal**: FE guard green; fix any visible hits if audit finds them.  
+**Acceptance**: TC-EV048-003 green; T3 only if needed.
+
+| # | Task | Type | Status | Spec Source | Depends On | Data Deps |
+|---|------|------|--------|-------------|------------|-----------|
+| T3.1 | Implement FE string catalog scanner module + Vitest | Code | completed | TC-EV048-003/005 | T1.2 | — |
+| T3.2 | Fix any operator-visible FE leaks found; else document clean | Code | completed | AC3 | T1.2, T1.3 | — |
+| T3.3 | Optional Playwright UJ-055 if T3.2 found visible hits | Test | skipped | UJ-055; D-S057-04-t3 — no FE hits | T3.2 | — |
+
+## PR Plan
+
+| PR | Base | When |
+|----|------|------|
+| EV-048 strip internal doc refs | `stage` | After 08–11 |
+
+## Replacement examples (locked intent)
+
+| Bad | Good |
+|-----|------|
+| Soft-preview mode (ADR-022): … | Soft-preview: best-effort IWXXM with failure spans on partial convert |
+| F9 / ADR-025 | Deterministic plain-language paragraph of the report |
+| Public (no JWT) — F21 / ADR-031 | Public (no login required) |

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
@@ -1,0 +1,74 @@
+# QA Report — S057 / EV-048 (09-qa)
+
+> Generated: 2026-08-08  
+> Scope: delta — deepen F7 (operator UI copy) + F21 (OpenAPI/error surfaces) — #951  
+> Branch: `evolve/EV-048-strip-internal-doc-refs` @ `3a43da37`  
+> Mode: delta  
+> Corpus: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: tests]
+
+```text
+QA Results:
+  Lint:           PASS — 0 issues (ruff + eslint)
+  Format:         PASS — 0 files (ruff format + prettier)
+  Typecheck:      PASS — 0 errors (pre-existing basedpyright warnings only)
+  Tests (Python): PASS — TC-EV048 4/4; H0c CORS 6/6; 08 validate-fast green
+  Tests (FE):     PASS — internalDocRefGuard + SoftPreviewControl 5/5
+  Security:       PASS — uvx pip-audit 0 CVEs; gitleaks pre-commit Passed
+  Cross-file:     PASS — lint clean; dangerous-pattern rg only benign RegExp.exec
+  Dependencies:   N/A delta — no new runtime deps (06 skipped)
+  Template:       PASS — apps/{backend,frontend,worker} + packages layout
+  Data / Modal:   N/A — no Modal/data-staging this cycle
+  Connectivity:   PASS (H0c); H4–H5 staging waived (12/13 skipped)
+  Tip CI:         PENDING push — branch has no upstream yet
+```
+
+## Overall: **pass_with_advisories**
+
+### Blocking
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Lint / format / typecheck | PASS | `make validate-fast` |
+| H0c CORS | PASS | `tests/unit/test_cors_policy.py` 6/6 |
+| TC-EV048 OpenAPI guard | PASS | `test_tc_ev048_*` 4/4 (`--no-cov`) |
+| FE string catalog guard | PASS | Vitest 5/5 |
+| Secrets (tree) | PASS | `pre-commit run gitleaks --all-files` |
+| pip-audit | PASS | 0 known vulnerabilities |
+
+### Advisories (QA-IDs for 11-verify-impl)
+
+| ID | Finding | Severity | Suggested action |
+|----|---------|----------|------------------|
+| QA-001 | Tip not pushed — no remote CI run for `3a43da37` | advisory | Push branch before PR to `stage`; watch `ci.yml` |
+| QA-002 | H4–H5 / 12/13 deploy smoke waived by routing | advisory | Merge gate = tip CI → `stage` (no live deploy required) |
+| QA-003 | Privacy inventory still mentions product Fn IDs (`F5`/`F31`) — outside locked guard regex | advisory | Accept for #951; optional follow-on if Fn IDs should be stripped |
+| QA-004 | T3.3 Playwright UJ-055 skipped (no FE visible hits) | advisory | Accept T0/T2 unit guards per D-S057-04-t3 / Gate B |
+
+### AC → evidence map
+
+| AC | TC | Status |
+|----|-----|--------|
+| AC1 audit findings | TC-EV048-001 | met — `reports/audit-internal-doc-refs.md` |
+| AC2 OpenAPI clean | TC-EV048-002 | met — pytest OpenAPI walk green |
+| AC3 FE catalogs clean | TC-EV048-003 | met — Vitest catalog scan green |
+| AC4 client errors | TC-EV048-004 | met — audit T2.3 + no detail leaks |
+| AC5 synthetic inject | TC-EV048-005 | met — BE+FE inject tests |
+| AC6 soft-preview copy | TC-EV048-002/003 | met — SoftPreviewControl + OpenAPI rewrite |
+
+### Commands run (reproducible)
+
+```bash
+make validate-fast
+cd apps/backend && uv run pytest tests/unit/test_tc_ev048_openapi_internal_doc_refs.py -q --tb=line --no-cov
+uv run pytest tests/unit/test_cors_policy.py -q --tb=line --no-cov
+cd apps/frontend && pnpm exec vitest run \
+  src/utils/internalDocRefGuard.test.ts \
+  src/app/components/SoftPreviewControl.test.tsx
+uvx pip-audit
+```
+
+### Next
+
+1. **10-e2e** (parallel) — UJ-055 light / T0  
+2. **11-verify-impl** — AC + journey sign-off + advisory disposition  
+3. Push + PR to `stage` after 11 approval (do not auto-merge)

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
@@ -41,7 +41,7 @@ QA Results:
 |----|---------|----------|------------------|
 | QA-001 | Tip not pushed — no remote CI run for `3a43da37` | advisory | Push branch before PR to `stage`; watch `ci.yml` |
 | QA-002 | H4–H5 / 12/13 deploy smoke waived by routing | advisory | Merge gate = tip CI → `stage` (no live deploy required) |
-| QA-003 | Privacy inventory still mentions product Fn IDs (`F5`/`F31`) — outside locked guard regex | advisory | Accept for #951; optional follow-on if Fn IDs should be stripped |
+| QA-003 | Privacy inventory / OpenAPI had product Fn IDs | **fixed** (`D-S057-qa003=2`) | Guard += `\bF\d+\b`; privacy + OpenAPI rewritten |
 | QA-004 | T3.3 Playwright UJ-055 skipped (no FE visible hits) | advisory | Accept T0/T2 unit guards per D-S057-04-t3 / Gate B |
 
 ### AC → evidence map

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
@@ -1,7 +1,8 @@
 # Implementation Verification — S057 / EV-048 (11-verify-impl)
 
-> Generated: 2026-08-08 (draft — awaiting user sign-off)  
-> Tip: `3a43da37` on `evolve/EV-048-strip-internal-doc-refs`  
+> Generated: 2026-08-08  
+> Tip: post–QA-003 fix on `evolve/EV-048-strip-internal-doc-refs`  
+> Status: **PASS** (user sign-off)  
 > Corpus: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: tests] [Corpus: journeys]
 
 ## Inputs
@@ -9,49 +10,44 @@
 | Source | Result |
 |--------|--------|
 | 08-verify-build | PASS |
-| 09-qa | **pass_with_advisories** — `reports/qa-report.md` |
-| 10-e2e | **PASS** (T0; T3 waived) — `reports/e2e-report.md` |
-| UI preview (11) | Declined earlier (`D-S057-ui-preview-verify=2`); not re-offered unless user asks |
+| 09-qa | pass_with_advisories → QA-003 fixed in place |
+| 10-e2e | PASS (T0; T3 waived) |
+| UI preview (11) | Declined (`D-S057-ui-preview-verify=2`) |
 
 ## Acceptance criteria
 
 | AC | Criterion | Evidence | Status |
 |----|-----------|----------|--------|
 | AC1 | Audit findings listed | `reports/audit-internal-doc-refs.md` | met |
-| AC2 | OpenAPI pass guard | TC-EV048-002 pytest | met |
-| AC3 | FE catalogs pass guard | TC-EV048-003 Vitest | met |
+| AC2 | OpenAPI pass guard | TC-EV048-002 (+ `\bF\d+\b`) | met |
+| AC3 | FE catalogs pass guard | TC-EV048-003 (+ privacy Fn strip) | met |
 | AC4 | Client-facing errors pass guard | audit T2.3 + TC-EV048-004 | met |
-| AC5 | Synthetic inject fails guard | TC-EV048-005 BE+FE | met |
+| AC5 | Synthetic inject fails guard | TC-EV048-005 incl. Fn | met |
 | AC6 | Soft-preview operator-friendly | SoftPreview + OpenAPI rewrite | met |
 
-## Feature completeness (cycle scope)
+## Sign-off
 
-| Feature | Implemented | Tested | QA | E2E | AC |
-|---------|-------------|--------|----|-----|-----|
-| F7 deepen (copy hygiene) | yes | yes | clean | UJ-055 T0 | AC1/3/5/6 |
-| F21 deepen (OpenAPI/errors) | yes | yes | clean | UJ-055 T0 | AC1/2/4/5 |
+| Item | Decision |
+|------|----------|
+| UJ-055 | **Approve** (`D-S057-uj055=1`) |
+| F7 deepen | **Approve** (`D-S057-f7=1`) |
+| F21 deepen | **Approve** (`D-S057-f21=1`) |
+| Advisories | QA-003 fixed (`D-S057-qa003=2`); QA-001/002/004 accepted |
+| Next | Push + PR to `stage` (`D-S057-11-next=1`) |
 
-## Journey (UJ-055)
+## Feature completeness
 
-| Check | Status |
-|-------|--------|
-| T0 exists + passed | PASS |
-| T3 / Playwright | SKIPPED — no FE hits (D-S057-04-t3) |
-| H4–H5 staging | waived (12/13) |
+| Feature | Implemented | Tested | QA | E2E | AC | User |
+|---------|-------------|--------|----|-----|-----|------|
+| F7 deepen | yes | yes | clean | UJ-055 T0 | met | approved |
+| F21 deepen | yes | yes | clean | UJ-055 T0 | met | approved |
 
-## Advisories pending disposition
+## Scope
 
-| ID | Finding | Recommended |
-|----|---------|-------------|
-| QA-001 | Tip not pushed / no remote CI | Push before/with PR |
-| QA-002 | 12/13 waived | Accept — merge gate tip CI → stage |
-| QA-003 | Privacy Fn IDs outside regex | Accept for #951 |
-| QA-004 | T3 Playwright skipped | Accept per Gate B |
+- Creep: none  
+- Gaps: none (T3 Playwright intentionally skipped — no FE hits)
 
-## Sign-off (pending AskQuestion)
+## Deploy gate (partial)
 
-- UJ-055: _pending_
-- F7 deepen: _pending_
-- F21 deepen: _pending_
-- Advisories: _pending_
-- Next after approve: push → PR to `stage` (12/13 remain skipped)
+- ✓ QA / E2E / implementation verified  
+- ○ 12/13 skipped by routing — merge gate = tip CI → `stage`

--- a/docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
@@ -1,0 +1,57 @@
+# Implementation Verification — S057 / EV-048 (11-verify-impl)
+
+> Generated: 2026-08-08 (draft — awaiting user sign-off)  
+> Tip: `3a43da37` on `evolve/EV-048-strip-internal-doc-refs`  
+> Corpus: [Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: tests] [Corpus: journeys]
+
+## Inputs
+
+| Source | Result |
+|--------|--------|
+| 08-verify-build | PASS |
+| 09-qa | **pass_with_advisories** — `reports/qa-report.md` |
+| 10-e2e | **PASS** (T0; T3 waived) — `reports/e2e-report.md` |
+| UI preview (11) | Declined earlier (`D-S057-ui-preview-verify=2`); not re-offered unless user asks |
+
+## Acceptance criteria
+
+| AC | Criterion | Evidence | Status |
+|----|-----------|----------|--------|
+| AC1 | Audit findings listed | `reports/audit-internal-doc-refs.md` | met |
+| AC2 | OpenAPI pass guard | TC-EV048-002 pytest | met |
+| AC3 | FE catalogs pass guard | TC-EV048-003 Vitest | met |
+| AC4 | Client-facing errors pass guard | audit T2.3 + TC-EV048-004 | met |
+| AC5 | Synthetic inject fails guard | TC-EV048-005 BE+FE | met |
+| AC6 | Soft-preview operator-friendly | SoftPreview + OpenAPI rewrite | met |
+
+## Feature completeness (cycle scope)
+
+| Feature | Implemented | Tested | QA | E2E | AC |
+|---------|-------------|--------|----|-----|-----|
+| F7 deepen (copy hygiene) | yes | yes | clean | UJ-055 T0 | AC1/3/5/6 |
+| F21 deepen (OpenAPI/errors) | yes | yes | clean | UJ-055 T0 | AC1/2/4/5 |
+
+## Journey (UJ-055)
+
+| Check | Status |
+|-------|--------|
+| T0 exists + passed | PASS |
+| T3 / Playwright | SKIPPED — no FE hits (D-S057-04-t3) |
+| H4–H5 staging | waived (12/13) |
+
+## Advisories pending disposition
+
+| ID | Finding | Recommended |
+|----|---------|-------------|
+| QA-001 | Tip not pushed / no remote CI | Push before/with PR |
+| QA-002 | 12/13 waived | Accept — merge gate tip CI → stage |
+| QA-003 | Privacy Fn IDs outside regex | Accept for #951 |
+| QA-004 | T3 Playwright skipped | Accept per Gate B |
+
+## Sign-off (pending AskQuestion)
+
+- UJ-055: _pending_
+- F7 deepen: _pending_
+- F21 deepen: _pending_
+- Advisories: _pending_
+- Next after approve: push → PR to `stage` (12/13 remain skipped)

--- a/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
@@ -22,7 +22,7 @@
 | 08-verify-build | yes | delta | **completed** | PASS; report 08-verify-build.md |
 | 09-qa | yes | delta | **completed** | pass_with_advisories; qa-report.md |
 | 10-e2e | yes | delta | **completed** | UJ-055 T0 PASS; T3 skipped; e2e-report.md |
-| 11-verify-impl | yes | delta | **in_progress** | AC + UJ signoff |
+| 11-verify-impl | yes | delta | **completed** | PASS; D-S057-uj055/f7/f21=1; qa003=2 |
 | 12-verify-deploy | no | — | skipped | waive unless deploy |
 | 13-deploy-smoke | no | — | skipped | waive unless deploy |
 

--- a/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
@@ -18,8 +18,8 @@
 | 04-tech-plan | yes | delta | **completed** | D-S057-04-plan=1; guard-ext=1 |
 | 05-verify-tech | yes | delta | **completed** | Gate B PASS D-S057-gateB=1 |
 | 06-tech-tooling | no | — | skipped | no new runtime deps |
-| 07-build | yes | full | **completed** | M1–M3; T3.3 skipped |
-| 08-verify-build | yes | delta | pending | |
+| 07-build | yes | full | **completed** | M1–M3; T3.3 skipped @ 71779d46 |
+| 08-verify-build | yes | delta | **completed** | PASS; report 08-verify-build.md |
 | 09-qa | yes | delta | pending | |
 | 10-e2e | yes | delta | pending | operator-visible copy if UI hits |
 | 11-verify-impl | yes | delta | pending | |

--- a/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
@@ -1,0 +1,39 @@
+# Routing plan — S057 / EV-048
+
+**Preset:** Standard (**approved** `D-S057-preset-reconfirm=1`)  
+**Route:** `00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 10 → 11`  
+**Skip:** `03`, `06`, `12`, `13`  
+**Branch:** `evolve/EV-048-strip-internal-doc-refs` (base `stage@d7652d5d`)  
+**Features:** deepen **F7**, **F21** (no new Fn)  
+**Issues:** [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)  
+**Status:** **in_progress** — 16-evolve → 08-verify-build
+
+| Stage | Required | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | S057 open; Standard amend |
+| 16-evolve | yes | orchestrator | **in_progress** | Orchestrating; child 08 |
+| 01-requirements | yes | delta | **completed** | D-S057-01-ac=1; guard-s0=1 |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS D-S057-gateA=1 |
+| 03-plan-tooling | no | — | skipped | unless new Cursor rules for guard |
+| 04-tech-plan | yes | delta | **completed** | D-S057-04-plan=1; guard-ext=1 |
+| 05-verify-tech | yes | delta | **completed** | Gate B PASS D-S057-gateB=1 |
+| 06-tech-tooling | no | — | skipped | no new runtime deps |
+| 07-build | yes | full | **completed** | M1–M3; T3.3 skipped |
+| 08-verify-build | yes | delta | pending | |
+| 09-qa | yes | delta | pending | |
+| 10-e2e | yes | delta | pending | operator-visible copy if UI hits |
+| 11-verify-impl | yes | delta | pending | |
+| 12-verify-deploy | no | — | skipped | waive unless deploy |
+| 13-deploy-smoke | no | — | skipped | waive unless deploy |
+
+## Skip rationale
+
+| Skipped | Why |
+|---------|-----|
+| 03 | No new Cursor rules expected beyond optional CI test for guard |
+| 06 | No new runtime dependency inventory change |
+| 12 / 13 | Merge gate is tip CI green → `stage`; no live deploy required for copy hygiene |
+
+## Corpus cites
+
+[Corpus: api] [Corpus: product §F7] [Corpus: product §F21] [Corpus: tests]

--- a/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
@@ -6,12 +6,12 @@
 **Branch:** `evolve/EV-048-strip-internal-doc-refs` (base `stage@d7652d5d`)  
 **Features:** deepen **F7**, **F21** (no new Fn)  
 **Issues:** [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)  
-**Status:** **in_progress** — 16-evolve → 08-verify-build
+**Status:** **in_progress** — 16-evolve → 11-verify-impl (09+10 done)
 
 | Stage | Required | Mode | Status | Notes |
 |-------|----------|------|--------|-------|
 | 00-context | yes | session | **completed** | S057 open; Standard amend |
-| 16-evolve | yes | orchestrator | **in_progress** | Orchestrating; child 08 |
+| 16-evolve | yes | orchestrator | **in_progress** | Phase D; D-S057-phaseC=1 |
 | 01-requirements | yes | delta | **completed** | D-S057-01-ac=1; guard-s0=1 |
 | 02-verify-plan | yes | delta | **completed** | Gate A PASS D-S057-gateA=1 |
 | 03-plan-tooling | no | — | skipped | unless new Cursor rules for guard |
@@ -20,9 +20,9 @@
 | 06-tech-tooling | no | — | skipped | no new runtime deps |
 | 07-build | yes | full | **completed** | M1–M3; T3.3 skipped @ 71779d46 |
 | 08-verify-build | yes | delta | **completed** | PASS; report 08-verify-build.md |
-| 09-qa | yes | delta | pending | |
-| 10-e2e | yes | delta | pending | operator-visible copy if UI hits |
-| 11-verify-impl | yes | delta | pending | |
+| 09-qa | yes | delta | **completed** | pass_with_advisories; qa-report.md |
+| 10-e2e | yes | delta | **completed** | UJ-055 T0 PASS; T3 skipped; e2e-report.md |
+| 11-verify-impl | yes | delta | **in_progress** | AC + UJ signoff |
 | 12-verify-deploy | no | — | skipped | waive unless deploy |
 | 13-deploy-smoke | no | — | skipped | waive unless deploy |
 

--- a/docs/sessions/S057-strip-internal-doc-refs/session-brief.md
+++ b/docs/sessions/S057-strip-internal-doc-refs/session-brief.md
@@ -1,0 +1,78 @@
+---
+session_id: S057-strip-internal-doc-refs
+type: feature
+status: in_progress
+branch: evolve/EV-048-strip-internal-doc-refs
+started_at: 2026-08-08
+intent: "Strip internal document references from user-facing UI and API surfaces (#951)"
+orchestrator: 16-evolve
+evolve_cycle_id: EV-048
+prior_session: S056-m0-stabilize-operator-trust
+github_issues:
+  - 951
+milestone: "M0 — Stabilize + operator trust + narrative"
+feature_ids: []
+deepen_feature_ids:
+  - F7
+  - F21
+feature_note: "Deepen F7 operator UI copy + F21 public OpenAPI/error surfaces; no new product Fn — hygiene for #951"
+preset: Standard
+ui_preview: "http://localhost:5173/ (non-deployed local Vite)"
+decisions:
+  D-S057-open: "1 — open S057/EV-048 for #951"
+  D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
+  D-S057-preset: "1 — Standard (amended from Lean)"
+  D-S057-preset-reconfirm: "1 — Standard 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13"
+  D-S057-ui-preview: "1 — yes non-deployed local UI"
+---
+
+# Session S057 — Strip internal doc refs (#951)
+
+## Goal
+
+Remove internal engineering citations (Corpus tags, ADR/session IDs, `docs/` paths,
+UJ/TC/issue numbers) from **operator-visible UI copy** and **public API** surfaces
+(OpenAPI descriptions, client-facing errors), and add an automated guard so they
+do not regress.
+
+[Corpus: api] [Corpus: product §F7] [Corpus: product §F21] [Corpus: tests]
+
+## Issues
+
+| # | Title | Map |
+|---|--------|-----|
+| [#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951) | Strip internal document references from user-facing UI and API | Deepen **F7** UI + **F21** public API |
+
+## In scope
+
+1. Operator UI: labels, helpers, tooltips, banners, empty states, console/catalog copy, example tier labels, privacy/auth copy
+2. Public OpenAPI: path/operation summaries, parameter/schema `description` fields that cite ADR/Corpus/session docs
+3. API error/detail messages returned to clients that mention internal doc paths or corpus tags
+4. Runtime `/docs` / Redoc text that leaks internal planning vocabulary
+5. Automated guard (lint or test) on user-facing string catalogs / OpenAPI export
+6. Frontend + backend unit/OpenAPI snapshot tests updated
+
+## Out of scope
+
+- Source comments, module/file docstrings for developers
+- Unit/integration test names and test docstrings
+- Repo docs under `docs/`, ADRs, session reports, workflow-state
+- CI / agent rules that require corpus citations in commits/PRs
+- Staging/prod deploy unless later decided (`12`/`13`)
+
+## Routing
+
+**Standard (`D-S057-preset-reconfirm=1`):**  
+`00 → 16 → 01 → 02 → 04 → 05 → 07 → 08 → 09 → 10 → 11`  
+Skip `03`, `06`, `12`, `13`.
+
+## Branch
+
+`evolve/EV-048-strip-internal-doc-refs` from `stage@d7652d5d`.  
+PR target: **`stage`** (not `main`).
+
+## Status
+
+- **00-context:** completed
+- **16-evolve:** in_progress → 01-requirements
+- **UI preview:** non-deployed local at http://localhost:5173/

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-08 (S055 / EV-046 — #889 codes.wmo.int present/cite/cover Lean)
+> **Last updated**: 2026-08-08 (S057 / EV-048 — #951 strip internal doc refs; prior EV-046/047)
 
 ## Scope
 
@@ -109,6 +109,7 @@ Unified manual live test harness against **DOKS** production endpoints after F30
 | UJ-052 | F7 deepen (EV-042) | Queue + keyboard/batch convert·validate | **H4–H5 required** | TC-EV042-003..004 |
 | UJ-053 | F16–F19 deepen (EV-042) | Operator UI has no dissemination destinations | **H4–H5 required** | TC-EV042-001..002 |
 | UJ-054 | F7 deepen (EV-047) | Operator Help → one-pager / handbook (#956/#957) | T0/T2; H4–H5 when FE deploy | TC-EV047-009..011 |
+| UJ-055 | F7+F21 deepen (EV-048) | Operator UI + OpenAPI free of internal planning vocabulary (#951) | T0/T2; T3 if UI hits | TC-EV048-001..005 |
 | UJ-DEV-007 | M5 deepen (EV-047) | Slim husky lint commit + fast-unit push (#833) | — | TC-EV047-001..004 |
 | UJ-DEV-008 | F6 deepen (EV-047) | Converter perf regression blocks PR (#834) | CI | TC-EV047-005..008 |
 
@@ -2693,6 +2694,23 @@ Remote Playwright **e2e-smoke** stays on Actions (browser install cost; not ever
 | TC-EV047-009 | T0 | `docs/guides/operator-one-pager.md` exists; one-page content checklist (convert→validate→download; version; soft preview); no internal citations |
 | TC-EV047-010 | T0 | `docs/guides/operator-handbook.md` has required sections + ingest pointer; no internal citations; one-pager links here |
 | TC-EV047-011 | T0/T2 | README Quick start links both docs; in-app Help entry reaches one-pager (UJ-054) |
+
+### TC-EV048 (F7 / F21 / S057) — strip internal doc refs from UI + public API (#951)
+
+**Guard patterns** (fail when found in scanned user-facing surfaces): `\[Corpus:`,
+`docs/sessions/`, `docs/feature-list`, `\bADR-\d+\b`, `\bEV-\d+\b`, `\bS0\d+\b`,
+`\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `(?<!\w)#\d{3,}\b` (`D-S057-guard-s0=1`,
+`D-S057-04-guard-ext=1`; `#NNN` uses lookbehind because `\b#` misses `#702` after
+spaces/slashes). Allowlist only for true domain false positives. Do **not** scan
+`docs/` standing text, source comments-only, or `*.test.*` / pytest modules.
+
+| ID | Tier | Criterion |
+|----|------|-----------|
+| TC-EV048-001 | T0 | PR (or session report) lists audit findings for UI strings + OpenAPI descriptions + client-facing errors |
+| TC-EV048-002 | T0 | OpenAPI export / schema `description` + operation summaries pass guard (no internal-doc patterns) |
+| TC-EV048-003 | T0/T2 | Operator-visible FE string catalogs (labels/helpers/tooltips/banners/empty states/console/catalog/example tiers/privacy-auth) pass guard |
+| TC-EV048-004 | T0 | Client-facing API `detail` / error messages pass guard |
+| TC-EV048-005 | T0/CI | Automated unit/CI test fails if a synthetic internal cite is injected into scanned OpenAPI or FE catalogs; comments/tests remain allowed |
 
 ### Removed workflows (EV-002)
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2699,10 +2699,11 @@ Remote Playwright **e2e-smoke** stays on Actions (browser install cost; not ever
 
 **Guard patterns** (fail when found in scanned user-facing surfaces): `\[Corpus:`,
 `docs/sessions/`, `docs/feature-list`, `\bADR-\d+\b`, `\bEV-\d+\b`, `\bS0\d+\b`,
-`\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `(?<!\w)#\d{3,}\b` (`D-S057-guard-s0=1`,
-`D-S057-04-guard-ext=1`; `#NNN` uses lookbehind because `\b#` misses `#702` after
-spaces/slashes). Allowlist only for true domain false positives. Do **not** scan
-`docs/` standing text, source comments-only, or `*.test.*` / pytest modules.
+`\bTC-[A-Z0-9-]+\b`, `\bE\d{2}-\d+\b`, `(?<!\w)#\d{3,}\b`, `\bF\d+\b`
+(`D-S057-guard-s0=1`, `D-S057-04-guard-ext=1`, `D-S057-qa003=2`; `#NNN` uses
+lookbehind because `\b#` misses `#702` after spaces/slashes). Allowlist only for
+true domain false positives. Do **not** scan `docs/` standing text, source
+comments-only, or `*.test.*` / pytest modules.
 
 | ID | Tier | Criterion |
 |----|------|-----------|

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -7,7 +7,7 @@
 > S019 / EV-014 dissemination epic F16–F19; S020 / EV-015 F20 TAF+SPECI quality (#735/#734);
 > S023 / EV-017 public app + privacy (#783); S038 / EV-031 platform independence F30/F31;
 > S040 / EV-032 F32 VONA + #846 corpus
-> **Last updated**: 2026-08-08 (S056 / EV-047 UJ-054 Help/docs + UJ-DEV-007/008 husky/perf; prior UJ-051..053)
+> **Last updated**: 2026-08-08 (S057 / EV-048 UJ-055 strip internal doc refs; prior UJ-054 / EV-047)
 
 Product-facing journeys (UJ-*) describe end-user flows. Developer journeys (UJ-DEV-*)
 describe monorepo workflows introduced by migration features M1–M6 and F6.
@@ -71,6 +71,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-052 | Operator queue + keyboard/batch convert·validate churn | apps/frontend | F7 deepen (EV-042) | T2 / **T3** / H4–H5 |
 | UJ-053 | Operator UI has no dissemination destinations | apps/frontend | F16–F19 deepen (EV-042) | T2 / **T3** / H4–H5 |
 | UJ-054 | Operator Help → one-pager / handbook | apps/frontend | F7 deepen (EV-047 / #956/#957) | T0 / T2 / **T3** |
+| UJ-055 | Operator UI + API docs free of internal planning vocabulary | apps/frontend / OpenAPI | F7+F21 deepen (EV-048 / #951) | T0 / T2 / **T3** |
 | UJ-DEV-001 | Clone and run monorepo | `git clone` + `make dev` | M1, M5 | T0 |
 | UJ-DEV-002 | Sync vendor schemas | Scheduled Action / manual | M2, M6, F6 | CI |
 | UJ-DEV-003 | ~~Merge GIFTs upstream~~ | — | M3 | **Deprecated** (ADR-014) |
@@ -788,6 +789,27 @@ merge-strength gates.
 **Acceptance**: User-facing text has **no** internal corpus/ADR/session citations.
 TC-EV047-009..011. **Tier: T0 / T2 / T3**.
 [Corpus: product §F7] [Corpus: journeys]
+
+---
+
+### UJ-055: Operator Surfaces Without Internal Doc References (F7+F21 / #951)
+
+**Actor**: Meteorological operator / API consumer
+
+**Goal**: Use convert soft-preview, public OpenAPI `/docs` field descriptions, and
+representative privacy/auth empty-state copy without seeing internal planning vocabulary.
+
+**Steps**:
+
+1. Open the operator app (non-deployed or deployed). Confirm soft-preview helper text
+   describes best-effort IWXXM / failed spans in plain language (no ADR/Corpus/session IDs).
+2. Open public API `/docs` (or Redoc). Spot-check convert `preview` / nilReason / plain-language
+   field descriptions — operator meaning only.
+3. Spot-check privacy/auth empty-state or helper copy for the same constraint.
+
+**Acceptance**: No `[Corpus:…]`, `ADR-NNN`, `EV-NNN`, `S0NN`, or `docs/…` path citations in
+those surfaces. TC-EV048-001..005. **Tier: T0 / T2**; **T3** if UI audit finds visible hits.
+[Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: journeys]
 
 ---
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -807,8 +807,9 @@ representative privacy/auth empty-state copy without seeing internal planning vo
    field descriptions — operator meaning only.
 3. Spot-check privacy/auth empty-state or helper copy for the same constraint.
 
-**Acceptance**: No `[Corpus:…]`, `ADR-NNN`, `EV-NNN`, `S0NN`, or `docs/…` path citations in
-those surfaces. TC-EV048-001..005. **Tier: T0 / T2**; **T3** if UI audit finds visible hits.
+**Acceptance**: No `[Corpus:…]`, `ADR-NNN`, `EV-NNN`, `S0NN`, `FNN` product ids, or
+`docs/…` path citations in those surfaces. TC-EV048-001..005. **Tier: T0 / T2**;
+**T3** if UI audit finds visible hits.
 [Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: journeys]
 
 ---

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,10 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: d7652d5d
-  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  tip_sha: 71779d46
+  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
   tip_sha_pushed: false
-  branch_note: "ACTIVE — branch created @ stage@d7652d5d; tip d7652d5d; Plan mode switch rejected by user; continuing Agent orchestration"
+  branch_note: "ACTIVE — tip 71779d46 after 07-build M1–M3; T3.3 skipped; 08-verify-build in_progress"
   github_issues:
   - 951
   issue_ids:
@@ -41,8 +41,8 @@ active_session:
   ui_preview_url: http://localhost:5173/
   prior_session: S056-m0-stabilize-operator-trust
   artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
-  current_stage: 07-build
-  current_stage_note: "IN_PROGRESS — Gate B PASS D-S057-gateB=1; M1 T1.1 next; 05-verify-tech COMPLETE"
+  current_stage: 08-verify-build
+  current_stage_note: "IN_PROGRESS — after 07-build M1–M3 COMPLETE @ 71779d46; T3.3 skipped"
   decisions:
     D-S057-open: "1 — open S057/EV-048 for #951"
     D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
@@ -68,7 +68,7 @@ active_session:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; child stage 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE"
+    note: "IN_PROGRESS — Standard orchestrator; child stage 08-verify-build in_progress; 07-build COMPLETE @ 71779d46"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -118,14 +118,16 @@ active_session:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1"
+    completed: '2026-08-08'
+    note: "COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46"
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — verify EV-048 tip after 07"
   - stage: 09-qa
     required: true
     mode: delta
@@ -275,8 +277,9 @@ active_session:
     evolve_cycle_id: EV-048
     created_at: '2026-08-08'
     note: "Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults"
-  note: "05-verify-tech COMPLETE D-S057-gateB=1 Gate B PASS; 07-build IN_PROGRESS M1 T1.1; 16-evolve orchestrator; ui_preview http://localhost:5173/"
+  note: "07-build COMPLETE @ 71779d46; 08-verify-build IN_PROGRESS; 16-evolve orchestrator; ui_preview http://localhost:5173/"
   notes:
+  - "2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-gateB=1 — Gate B PASS; S5.M1–S5.M3 defaults accepted; 05 COMPLETE; 07-build IN_PROGRESS M1; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-04-plan=1 + D-S057-04-guard-ext=1 — execution plan approved; guard extended TC/E##/#; 04 COMPLETE; 05-verify-tech IN_PROGRESS; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-open=1 — OPEN S057/EV-048 for #951; active_session set; session_counter 57; evolve_cycle_counter 48; branch_base stage@d7652d5d; Lean + pending D-S057-preset-reconfirm; no git commit by workflow-state-manager"
@@ -10608,9 +10611,11 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: in_progress
+    status: completed
     started_at: '2026-08-08'
     started: '2026-08-08'
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
     previous_session_id: S056-m0-stabilize-operator-trust
@@ -10632,9 +10637,9 @@ stages:
     evolve_cycle_id: EV-048
     skill_id: 07-build
     mode: full
-    note: 'IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS'
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    note: 'COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46'
+    tip_sha: 71779d46
+    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
     tip_sha_pushed: false
     pr_number:
     pr_url:
@@ -10643,15 +10648,16 @@ stages:
     pr_supersedes:
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: 'S056 prior tip CI archived under previous_*; S057 tip tracked on evolve/EV-048'
+    ci_cd_pipeline_note: 'S056 prior tip CI archived under previous_*; S057 tip 71779d46 on evolve/EV-048'
     pending_commit: false
-    current_milestone: M1
-    current_task: T1.1
-    active_milestone: M1
-    active_task: T1.1
-    active_task_status: pending
-    completed_through:
-    progress: 0/9
+    current_milestone: M3
+    current_task:
+    active_milestone: M3
+    active_task:
+    active_task_status: completed
+    completed_through: T3.2
+    progress: 8/9
+    skipped_tasks: [T3.3]
     deepen_feature_ids: [F7, F21]
     feature_ids: []
     decision_refs:
@@ -10724,14 +10730,16 @@ stages:
       session_id: S057-strip-internal-doc-refs
       evolve_cycle_id: EV-048
       skill_id: 07-build
-      status: in_progress
+      status: completed
       mode: full
       started_at: '2026-08-08'
       started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
       pending_commit: false
-      note: 'IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1'
-      tip_sha: d7652d5d
-      tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+      note: 'COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46'
+      tip_sha: 71779d46
+      tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
       tip_sha_pushed: false
       feature_ids: []
       deepen_feature_ids: [F7, F21]
@@ -10743,13 +10751,14 @@ stages:
       - D-S057-01-ac
       - D-S057-guard-s0
       - D-S057-open
-      active_milestone: M1
-      current_milestone: M1
-      active_task: T1.1
-      current_task: T1.1
-      active_task_status: pending
-      completed_through:
-      progress: 0/9
+      active_milestone: M3
+      current_milestone: M3
+      active_task:
+      current_task:
+      active_task_status: completed
+      completed_through: T3.2
+      progress: 8/9
+      skipped_tasks: [T3.3]
       artifacts:
       - docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
       - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
@@ -13325,19 +13334,26 @@ stages:
     - D-S039-tls
     - D-S039-route
   08-verify-build:
-    status: completed
+    status: in_progress
     mode: delta
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
-    previous_started_at: '2026-08-07'
-    previous_completed_at: '2026-08-07'
-    previous_session_id: S050-remove-db-tools-operator-throughput
-    previous_evolve_cycle_id: EV-042
-    previous_tip_sha: 6bc756ef
-    previous_tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
-    previous_note: 'S050/EV-042 08-verify-build COMPLETE M4 PASS @ 6bc756ef — superseded by S054/EV-045'
+    completed_at:
+    completed:
+    previous_started_at: '2026-08-08'
+    previous_completed_at: '2026-08-08'
+    previous_session_id: S056-m0-stabilize-operator-trust
+    previous_evolve_cycle_id: EV-047
+    previous_tip_sha: 3ca4f438
+    previous_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_note: 'COMPLETE — PASS @ tip 3ca4f438; superseded by S057/EV-048'
+    previous_s050_started_at: '2026-08-07'
+    previous_s050_completed_at: '2026-08-07'
+    previous_s050_session_id: S050-remove-db-tools-operator-throughput
+    previous_s050_evolve_cycle_id: EV-042
+    previous_s050_tip_sha: 6bc756ef
+    previous_s050_tip_sha_full: 6bc756efe902f77373fa4de8d4c15b50219dd333
+    previous_s050_note: 'S050/EV-042 08-verify-build COMPLETE M4 PASS @ 6bc756ef — superseded by S054/EV-045'
     previous_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verification-report.md
     previous_overall: PASS
     previous_s045_started_at: '2026-08-05'
@@ -13391,23 +13407,30 @@ stages:
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 1f47eb5
     prior_s037_note: 'COMPLETE (M3 gate + T4.1) — PASS @ tip 1f47eb5; report docs/sessions/S037-quality-residuals-831/reports/verification-report-m3.md; prior M2 verification-report-m2.md; CI 30823368642 SUCCESS; reopen for final M4 08; PR #832 open; #831→#835'
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
-    tip_sha: 3ca4f438
-    tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    tip_sha_pushed: true
-    ci_cd_pipeline_run: '31286442836'
-    ci_cd_pipeline_status: SUCCESS
-    ci_cd_pipeline_note: 'Tip CI green — run 31286442836 @ 3ca4f438'
-    note: 'COMPLETE — PASS @ tip 3ca4f438; report docs/sessions/S056-m0-stabilize-operator-trust/reports/verification-report.md; Phase C done; handoff 09-qa'
-    expected_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verification-report.md
-    report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verification-report.md
-    overall: pass
-    phase_c_checkpoint: passed
-    phase_c_checkpoint_note: 'Phase C done — 08/09/10 PASS @ 3ca4f438; entering Phase D / 11-verify-impl'
-    next_stage: 11-verify-impl
-    next_stage_status: in_progress
-    next_stage_note: '11-verify-impl in_progress — awaiting AC sign-off'
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    tip_sha: 71779d46
+    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    tip_sha_pushed: false
+    ci_cd_pipeline_run:
+    ci_cd_pipeline_status:
+    ci_cd_pipeline_note: 'awaiting tip CI after 07 @ 71779d46'
+    note: 'IN_PROGRESS — verify EV-048 tip after 07'
+    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verification-report.md
+    report:
+    overall:
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_note: 'COMPLETE — PASS @ tip 3ca4f438; report docs/sessions/S056-m0-stabilize-operator-trust/reports/verification-report.md; Phase C done; handoff 09-qa'
+    previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verification-report.md
+    previous_s056_overall: pass
+    previous_s056_phase_c_checkpoint: passed
+    skill_id: 08-verify-build
+    next_stage: 09-qa
+    next_stage_status: pending
+    next_stage_note: 'pending after 08-verify-build'
     prior_s050_session_id: S050-remove-db-tools-operator-throughput
     prior_s050_evolve_cycle_id: EV-042
     prior_s050_tip_sha: 6bc756ef
@@ -13477,6 +13500,31 @@ stages:
         path: docs/sessions/S054-rust-ci-crates/reports/verification-report.md
         note: Overall PASS
     active_session:
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 08-verify-build
+      status: in_progress
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      tip_sha: 71779d46
+      tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+      tip_sha_pushed: false
+      overall:
+      report:
+      expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verification-report.md
+      note: 'IN_PROGRESS — verify EV-048 tip after 07'
+      feature_ids: []
+      deepen_feature_ids: [F7, F21]
+      decision_refs:
+      - D-S057-gateB
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      - D-S057-open
+    prior_active_session_s054:
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 08-verify-build
@@ -15478,12 +15526,12 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: 07-build
-    current_child_stage_note: '07-build in_progress M1 T1.1; Gate B PASS D-S057-gateB=1; 05 COMPLETE'
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    current_child_stage: 08-verify-build
+    current_child_stage_note: '08-verify-build in_progress after 07 COMPLETE @ 71779d46; T3.3 skipped'
+    tip_sha: 71779d46
+    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
     tip_sha_pushed: false
-    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; child 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; child 08-verify-build in_progress; 07-build COMPLETE @ 71779d46; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -15748,6 +15796,26 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-07-complete
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 07-build
+  skill_id: 07-build
+  stage: 07-build
+  category: progress
+  status: recorded
+  topic: 'S057/EV-048 07-build COMPLETE → 08-verify-build'
+  summary: '2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator'
+  decision: |
+    2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator
+    Tip 71779d46 (71779d46e5a6f53da5d4244b0f465e1e5c420773).
+    No git commit by workflow-state-manager.
+  tip_sha: 71779d46
+  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+  current_stage: 08-verify-build
+  note: '07-build COMPLETE; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator'
 - id: D-S057-gateB
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -33522,8 +33590,8 @@ evolve_cycles:
   - 951
   milestone: "M0 — Stabilize + operator trust + narrative"
   phase: 1
-  current_stage: 07-build
-  current_stage_note: "IN_PROGRESS — Gate B PASS D-S057-gateB=1; M1 T1.1 next; 05-verify-tech COMPLETE"
+  current_stage: 08-verify-build
+  current_stage_note: "IN_PROGRESS — after 07-build M1–M3 COMPLETE @ 71779d46; T3.3 skipped"
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -33531,8 +33599,8 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: d7652d5d
-  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  tip_sha: 71779d46
+  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
   tip_sha_pushed: false
   interrupted_by_hotfix: false
   parked: false
@@ -33569,7 +33637,7 @@ evolve_cycles:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; child stage 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE"
+    note: "IN_PROGRESS — Standard orchestrator; child stage 08-verify-build in_progress; 07-build COMPLETE @ 71779d46"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -33619,14 +33687,16 @@ evolve_cycles:
   - stage: 07-build
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1"
+    completed: '2026-08-08'
+    note: "COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46"
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — verify EV-048 tip after 07"
   - stage: 09-qa
     required: true
     mode: delta
@@ -33652,7 +33722,7 @@ evolve_cycles:
     mode: skip
     status: skipped
     note: "waive unless deploy (Standard)"
-  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage 07-build; Gate B PASS D-S057-gateB=1; 05 COMPLETE; 16-evolve orchestrator in_progress; ui_preview http://localhost:5173/"
+  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage 08-verify-build; 07-build COMPLETE @ 71779d46; T3.3 skipped; 16-evolve orchestrator in_progress; ui_preview http://localhost:5173/"
   artifacts:
   - docs/sessions/S057-strip-internal-doc-refs/
   - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
@@ -44052,18 +44122,18 @@ evolve_cycles:
   pr_merged_sha: dfecba46
 git_history:
   current_branch: evolve/EV-048-strip-internal-doc-refs
-  ahead_of_origin: 0
+  ahead_of_origin: 1
   pushed: false
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml S057/EV-048 open + branch create; session artifacts written; no git commit by workflow-state-manager'
-  tip_sha: d7652d5d
-  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
-  tip_note: 'S057/EV-048 ACTIVE on evolve/EV-048-strip-internal-doc-refs @ tip d7652d5d (= stage tip)'
+  dirty_note: 'workflow-state.yaml S057/EV-048 stage bookkeeping; tip 71779d46; no git commit by workflow-state-manager'
+  tip_sha: 71779d46
+  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+  tip_note: 'S057/EV-048 ACTIVE on evolve/EV-048-strip-internal-doc-refs @ tip 71779d46 (07-build COMPLETE)'
   evolve_branch: evolve/EV-048-strip-internal-doc-refs
-  evolve_tip_sha: d7652d5d
-  evolve_tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  evolve_tip_sha: 71779d46
+  evolve_tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
   evolve_tip_sha_pushed: false
   stage_merge_sha: 2a1fb22d
   stage_merge_sha_full: 2a1fb22d9697dc8fedf979f49ac621c045f96956
@@ -44080,9 +44150,10 @@ git_history:
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   recommended_branch: evolve/EV-048-strip-internal-doc-refs
-  note: 'S057/EV-048 ACTIVE — Standard after D-S057-preset-reconfirm=1; current_stage 16-evolve; 00-context completed; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+  note: 'S057/EV-048 ACTIVE — Standard; current_stage 08-verify-build; 07-build COMPLETE @ 71779d46; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator'
   - '2026-08-08 02-verify-plan COMPLETE / 04-tech-plan IN_PROGRESS — D-S057-gateA=1 PASS; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; evolve-decisions note; 16-evolve remains orchestrator; no git commit by workflow-state-manager'
   - '2026-08-08 01-requirements COMPLETE / 02-verify-plan IN_PROGRESS — D-S057-01-ac=1 + D-S057-guard-s0=1; standing doc deltas recorded; 16-evolve remains orchestrator; no git commit by workflow-state-manager'
   - '2026-08-08 01-requirements IN_PROGRESS — S057/EV-048 evolve delta; deepen F7/F21; 16-evolve remains in_progress; D-S057-preset-reconfirm=1 already recorded; no git commit by workflow-state-manager'
@@ -44599,10 +44670,10 @@ git_history:
     purpose: "EV-048 / S057 strip internal doc refs from UI/API (#951)"
     session_id: S057-strip-internal-doc-refs
     evolve_cycle_id: EV-048
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    tip_sha: 71779d46
+    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
     tip_sha_pushed: false
-    note: "ACTIVE — branch created @ tip d7652d5d; session-brief + routing-plan written; Plan mode rejected — Agent orchestration; pending D-S057-preset-reconfirm"
+    note: "ACTIVE — tip 71779d46 after 07-build M1–M3; T3.3 skipped; 08-verify-build in_progress"
   - name: evolve/EV-047-m0-stabilize-operator-trust
     base: stage
     base_sha: adcf3b1f
@@ -45929,6 +46000,20 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: 71779d46
+    sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    message: '[EV-048] fix: strip internal doc refs from OpenAPI and add guards'
+    branch: evolve/EV-048-strip-internal-doc-refs
+    stage: 07-build
+    skill_id: 07-build
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    files_changed: 27
+    timestamp: '2026-08-08T22:30:00-04:00'
+    pushed: false
+    tip_sha: 71779d46
+    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    note: 'S057/EV-048 07-build COMPLETE — M1–M3; T3.3 skipped; handoff 08-verify-build'
   - sha: 2a1fb22d
     sha_full: 2a1fb22d9697dc8fedf979f49ac621c045f96956
     message: 'Merge pull request #961 from EMPIRIC2/evolve/EV-047-m0-stabilize-operator-trust'

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -23,7 +23,7 @@ active_session:
   tip_sha: 71779d46
   tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
   tip_sha_pushed: false
-  branch_note: "ACTIVE — tip 71779d46 after 07-build M1–M3; T3.3 skipped; 08-verify-build in_progress"
+  branch_note: "ACTIVE — tip 71779d46 after 07-build M1–M3; 08-verify-build COMPLETE PASS; Phase C checkpoint pending"
   github_issues:
   - 951
   issue_ids:
@@ -41,8 +41,8 @@ active_session:
   ui_preview_url: http://localhost:5173/
   prior_session: S056-m0-stabilize-operator-trust
   artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
-  current_stage: 08-verify-build
-  current_stage_note: "IN_PROGRESS — after 07-build M1–M3 COMPLETE @ 71779d46; T3.3 skipped"
+  current_stage: 16-evolve
+  current_stage_note: "IN_PROGRESS — Phase C done (07+08 PASS); await D-S057-phaseC checkpoint before 09+10"
   decisions:
     D-S057-open: "1 — open S057/EV-048 for #951"
     D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
@@ -68,7 +68,7 @@ active_session:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; child stage 08-verify-build in_progress; 07-build COMPLETE @ 71779d46"
+    note: "IN_PROGRESS — Standard orchestrator; Phase C done (07+08 PASS); await D-S057-phaseC before 09+10"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -125,9 +125,11 @@ active_session:
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — verify EV-048 tip after 07"
+    completed: '2026-08-08'
+    note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
   - stage: 09-qa
     required: true
     mode: delta
@@ -277,8 +279,18 @@ active_session:
     evolve_cycle_id: EV-048
     created_at: '2026-08-08'
     note: "Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults"
-  note: "07-build COMPLETE @ 71779d46; 08-verify-build IN_PROGRESS; 16-evolve orchestrator; ui_preview http://localhost:5173/"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+    type: report
+    status: completed
+    stage: 08-verify-build
+    skill_id: 08-verify-build
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
+  note: "08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator; ui_preview http://localhost:5173/"
   notes:
+  - "2026-08-08 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator"
   - "2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-gateB=1 — Gate B PASS; S5.M1–S5.M3 defaults accepted; 05 COMPLETE; 07-build IN_PROGRESS M1; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-04-plan=1 + D-S057-04-guard-ext=1 — execution plan approved; guard extended TC/E##/#; 04 COMPLETE; 05-verify-tech IN_PROGRESS; 16-evolve remains orchestrator"
@@ -13334,12 +13346,12 @@ stages:
     - D-S039-tls
     - D-S039-route
   08-verify-build:
-    status: in_progress
+    status: completed
     mode: delta
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed_at:
-    completed:
+    completed_at: '2026-08-08'
+    completed: '2026-08-08'
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
     previous_session_id: S056-m0-stabilize-operator-trust
@@ -13414,11 +13426,11 @@ stages:
     tip_sha_pushed: false
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: 'awaiting tip CI after 07 @ 71779d46'
-    note: 'IN_PROGRESS — verify EV-048 tip after 07'
+    ci_cd_pipeline_note: '08 PASS locally; tip CI optional before PR'
+    note: 'COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md'
     expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verification-report.md
-    report:
-    overall:
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+    overall: PASS
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
     previous_s056_tip_sha: 3ca4f438
@@ -13428,9 +13440,9 @@ stages:
     previous_s056_overall: pass
     previous_s056_phase_c_checkpoint: passed
     skill_id: 08-verify-build
-    next_stage: 09-qa
+    next_stage: phase-c-checkpoint
     next_stage_status: pending
-    next_stage_note: 'pending after 08-verify-build'
+    next_stage_note: 'await D-S057-phaseC before 09+10'
     prior_s050_session_id: S050-remove-db-tools-operator-throughput
     prior_s050_evolve_cycle_id: EV-042
     prior_s050_tip_sha: 6bc756ef
@@ -13503,17 +13515,19 @@ stages:
       session_id: S057-strip-internal-doc-refs
       evolve_cycle_id: EV-048
       skill_id: 08-verify-build
-      status: in_progress
+      status: completed
       mode: delta
       started_at: '2026-08-08'
       started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
       tip_sha: 71779d46
       tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
       tip_sha_pushed: false
-      overall:
-      report:
+      overall: PASS
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
       expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verification-report.md
-      note: 'IN_PROGRESS — verify EV-048 tip after 07'
+      note: 'COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md'
       feature_ids: []
       deepen_feature_ids: [F7, F21]
       decision_refs:
@@ -15526,12 +15540,12 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: 08-verify-build
-    current_child_stage_note: '08-verify-build in_progress after 07 COMPLETE @ 71779d46; T3.3 skipped'
+    current_child_stage: phase-c-checkpoint
+    current_child_stage_note: '08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC'
     tip_sha: 71779d46
     tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
     tip_sha_pushed: false
-    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; child 08-verify-build in_progress; 07-build COMPLETE @ 71779d46; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; tip 71779d46; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -15796,6 +15810,27 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-08-complete
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 08-verify-build
+  skill_id: 08-verify-build
+  stage: 08-verify-build
+  category: progress
+  status: recorded
+  topic: 'S057/EV-048 08-verify-build COMPLETE PASS → phase-c-checkpoint'
+  summary: '2026-08-08 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator'
+  decision: |
+    2026-08-08 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator
+    Report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md.
+    Tip 71779d46. No git commit by workflow-state-manager.
+  report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+  tip_sha: 71779d46
+  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+  current_stage: phase-c-checkpoint
+  note: '08 COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve remains orchestrator'
 - id: D-S057-07-complete
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -29999,6 +30034,17 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+  type: report
+  kind: verify-build
+  stage: 08-verify-build
+  skill_id: 08-verify-build
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: completed
+  note: 'S057/EV-048 08 COMPLETE PASS — COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md'
 - path: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
   type: session-report
   kind: tech-plan
@@ -33590,8 +33636,8 @@ evolve_cycles:
   - 951
   milestone: "M0 — Stabilize + operator trust + narrative"
   phase: 1
-  current_stage: 08-verify-build
-  current_stage_note: "IN_PROGRESS — after 07-build M1–M3 COMPLETE @ 71779d46; T3.3 skipped"
+  current_stage: phase-c-checkpoint
+  current_stage_note: "IN_PROGRESS — Phase C done (07+08 PASS); await D-S057-phaseC checkpoint before 09+10"
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -33637,7 +33683,7 @@ evolve_cycles:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; child stage 08-verify-build in_progress; 07-build COMPLETE @ 71779d46"
+    note: "IN_PROGRESS — Standard orchestrator; Phase C done (07+08 PASS); await D-S057-phaseC before 09+10"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -33694,9 +33740,11 @@ evolve_cycles:
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — verify EV-048 tip after 07"
+    completed: '2026-08-08'
+    note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
   - stage: 09-qa
     required: true
     mode: delta
@@ -33722,7 +33770,7 @@ evolve_cycles:
     mode: skip
     status: skipped
     note: "waive unless deploy (Standard)"
-  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage 08-verify-build; 07-build COMPLETE @ 71779d46; T3.3 skipped; 16-evolve orchestrator in_progress; ui_preview http://localhost:5173/"
+  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage phase-c-checkpoint; 08 COMPLETE PASS; await D-S057-phaseC; tip 71779d46; 16-evolve orchestrator; ui_preview http://localhost:5173/"
   artifacts:
   - docs/sessions/S057-strip-internal-doc-refs/
   - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
@@ -33809,6 +33857,13 @@ evolve_cycles:
     stage: 02-verify-plan
     session_id: S057-strip-internal-doc-refs
     note: "D-S057-gateA=1 Gate A PASS"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+    type: report
+    status: completed
+    stage: 08-verify-build
+    skill_id: 08-verify-build
+    session_id: S057-strip-internal-doc-refs
+    note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
 - id: EV-047
   session_id: S056-m0-stabilize-operator-trust
   status: completed

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,10 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: 923c7170
-  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha: c52521c7
+  tip_sha_full: c52521c772a950d9e43ca088933dd5163ad59a12
   tip_sha_pushed: true
-  branch_note: "ACTIVE — tip 748cbb84 pushed; PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval"
+  branch_note: "ACTIVE — tip c52521c7 pushed (PR tip was 748cbb84); PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval"
   pr_number: 963
   pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
   pr_status: open
@@ -15678,8 +15678,8 @@ stages:
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
     current_child_stage: 11-verify-impl
     current_child_stage_note: 'PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval'
-    tip_sha: 923c7170
-    tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+    tip_sha: c52521c7
+    tip_sha_full: c52521c772a950d9e43ca088933dd5163ad59a12
     tip_sha_pushed: true
     pr_number: 963
     pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
@@ -15964,7 +15964,7 @@ decisions_log:
   decision: |
     D-S057-11-next=1 — PR opened after 11-verify-impl PASS.
     PR #963 OPEN → base stage.
-    Tip 748cbb84 (923c717070975f3c6201432f95b2890e024ae5cf) tip_sha_pushed=true.
+    Tip 748cbb84 (c52521c772a950d9e43ca088933dd5163ad59a12) tip_sha_pushed=true.
     CI/CD Pipeline run 31290962521 SUCCESS — https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31290962521
     Awaiting merge approval.
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -15974,8 +15974,8 @@ decisions_log:
   pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
   pr_status: open
   pr_base: stage
-  tip_sha: 923c7170
-  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha: c52521c7
+  tip_sha_full: c52521c772a950d9e43ca088933dd5163ad59a12
   tip_sha_pushed: true
   ci_cd_pipeline_run: '31290962521'
   ci_cd_pipeline_status: SUCCESS
@@ -33874,8 +33874,8 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: 923c7170
-  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha: c52521c7
+  tip_sha_full: c52521c772a950d9e43ca088933dd5163ad59a12
   tip_sha_pushed: true
   pr_number: 963
   pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,9 +3,288 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 56
-evolve_cycle_counter: 47
-active_session: null
+session_counter: 57
+evolve_cycle_counter: 48
+active_session:
+  id: S057-strip-internal-doc-refs
+  type: feature
+  intent: "Strip internal document references from user-facing UI and API surfaces (#951)"
+  status: in_progress
+  started: '2026-08-08'
+  started_at: '2026-08-08'
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-048
+  branch: evolve/EV-048-strip-internal-doc-refs
+  branch_base: stage@d7652d5d
+  branch_base_sha: d7652d5d
+  branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  branch_status: active
+  branch_exists: true
+  tip_sha: d7652d5d
+  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  tip_sha_pushed: false
+  branch_note: "ACTIVE — branch created @ stage@d7652d5d; tip d7652d5d; Plan mode switch rejected by user; continuing Agent orchestration"
+  github_issues:
+  - 951
+  issue_ids:
+  - 951
+  milestone: "M0 — Stabilize + operator trust + narrative"
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  - F21
+  feature_note: "Deepen F7 operator UI copy + F21 public OpenAPI/error surfaces; no new product Fn — hygiene for #951"
+  preset: Standard
+  preset_note: "D-S057-preset-reconfirm=1 — amended Lean→Standard; 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13"
+  ui_preview: requested
+  ui_preview_note: "D-S057-ui-preview=1 — non-deployed local UI; local http://localhost:5173/ started"
+  ui_preview_url: http://localhost:5173/
+  prior_session: S056-m0-stabilize-operator-trust
+  artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
+  current_stage: 07-build
+  current_stage_note: "IN_PROGRESS — Gate B PASS D-S057-gateB=1; M1 T1.1 next; 05-verify-tech COMPLETE"
+  decisions:
+    D-S057-open: "1 — open S057/EV-048 for #951"
+    D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
+    D-S057-preset: "1 — Standard amend (was Lean 2; reconfirm)"
+    D-S057-preset-reconfirm: "1 — Standard 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13"
+    D-S057-ui-preview: "1 — yes non-deployed local UI"
+    D-S057-01-ac: "1 — Approve AC1–AC6 + UJ-055"
+    D-S057-guard-s0: "1 — Include S0\d+ in guard"
+    D-S057-gateA: "1 — PASS; S2.1–S2.4 as 04/07 defaults; proceed 04"
+    D-S057-04-plan: "1 — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05 then 07"
+    D-S057-04-guard-ext: "1 — Extend guard with TC-*, E##-##, #NNN (3+ digits) on scanned surfaces"
+    D-S057-gateB: "1 — PASS; accept S5.M1–S5.M3 defaults; proceed 07-build M1"
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — Standard orchestrator; child stage 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; report reports/01-requirements.md; handoff 02-verify-plan"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; report reports/02-verify-plan.md; handoff 04-tech-plan"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+    gate_a: PASS
+    gate_a_decision: D-S057-gateA=1
+  - stage: 03-plan-tooling
+    required: false
+    mode: skip
+    status: skipped
+    note: "Standard skip"
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-04-plan=1 + D-S057-04-guard-ext=1; execution-plan + build-plan-card; handoff 05-verify-tech"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+  - stage: 05-verify-tech
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults; report reports/05-verify-tech.md; handoff 07-build M1"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    gate_b: PASS
+    gate_b_decision: D-S057-gateB=1
+  - stage: 06-tech-tooling
+    required: false
+    mode: skip
+    status: skipped
+    note: "Standard skip"
+  - stage: 07-build
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1"
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 09-qa
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 10-e2e
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 11-verify-impl
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 12-verify-deploy
+    required: false
+    mode: skip
+    status: skipped
+    note: "waive unless deploy (Standard)"
+  - stage: 13-deploy-smoke
+    required: false
+    mode: skip
+    status: skipped
+    note: "waive unless deploy (Standard)"
+  artifacts:
+  - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
+    status: written
+    stage: 00-context
+    skill_id: 00-context
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+  - path: docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+    status: written
+    stage: 00-context
+    skill_id: 00-context
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+  - path: docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+    status: written
+    stage: 16-evolve
+    skill_id: 16-evolve
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+    status: completed
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+  - path: docs/feature-list.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "F7 + F21 EV-048 deepen + AC tables"
+  - path: docs/api-contract.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "Operator-facing OpenAPI/error copy policy"
+  - path: docs/user-journeys.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "UJ-055"
+  - path: docs/test-plan.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "TC-EV048-001..005 + UJ map"
+  - path: docs/decisions/evolve-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "Cycle EV-048 scope + AC table"
+  - path: docs/decisions/requirements-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "EV-048 section"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+    status: completed
+    stage: 02-verify-plan
+    skill_id: 02-verify-plan
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "Gate A PASS D-S057-gateA=1"
+  - path: docs/decisions/evolve-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 02-verify-plan
+    skill_id: 02-verify-plan
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    note: "D-S057-gateA=1 Gate A PASS note appended"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+    status: completed
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "D-S057-04-plan=1 + D-S057-04-guard-ext=1"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+    status: written
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "M1–M3 / T1.1–T3.3 approved"
+  - path: docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+    status: written
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    status: completed
+    stage: 05-verify-tech
+    skill_id: 05-verify-tech
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults"
+  note: "05-verify-tech COMPLETE D-S057-gateB=1 Gate B PASS; 07-build IN_PROGRESS M1 T1.1; 16-evolve orchestrator; ui_preview http://localhost:5173/"
+  notes:
+  - "2026-08-08 D-S057-gateB=1 — Gate B PASS; S5.M1–S5.M3 defaults accepted; 05 COMPLETE; 07-build IN_PROGRESS M1; 16-evolve remains orchestrator"
+  - "2026-08-08 D-S057-04-plan=1 + D-S057-04-guard-ext=1 — execution plan approved; guard extended TC/E##/#; 04 COMPLETE; 05-verify-tech IN_PROGRESS; 16-evolve remains orchestrator"
+  - "2026-08-08 D-S057-open=1 — OPEN S057/EV-048 for #951; active_session set; session_counter 57; evolve_cycle_counter 48; branch_base stage@d7652d5d; Lean + pending D-S057-preset-reconfirm; no git commit by workflow-state-manager"
+  - "2026-08-08 branch evolve/EV-048-strip-internal-doc-refs ACTIVE @ tip d7652d5d; session-brief.md + routing-plan.md written; Plan mode switch rejected by user — continuing Agent orchestration; pending D-S057-preset-reconfirm; no git commit by workflow-state-manager"
+  - "2026-08-08 D-S057-preset-reconfirm=1 — amend Lean→Standard; 00-context completed; current_stage 16-evolve; evolve-plan-card.md recorded; ui_preview http://localhost:5173/ started; no git commit by workflow-state-manager"
+  - "2026-08-08 01-requirements IN_PROGRESS — evolve delta deepen F7/F21; corpus api/product§F7/F21/tests; 16-evolve remains orchestrator; D-S057-preset-reconfirm=1 already recorded; no git commit by workflow-state-manager"
+  - "2026-08-08 01-requirements COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; report 01-requirements.md; standing doc deltas recorded; 02-verify-plan IN_PROGRESS; 16-evolve remains orchestrator; no git commit by workflow-state-manager"
+  - "2026-08-08 02-verify-plan COMPLETE — D-S057-gateA=1 PASS; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; evolve-decisions note; 04-tech-plan IN_PROGRESS; 16-evolve remains orchestrator; no git commit by workflow-state-manager"
 sessions:
 - id: S056-m0-stabilize-operator-trust
   type: feature
@@ -7171,29 +7450,34 @@ stages:
   00-context:
     status: completed
     mode: session
-    scoped_slug: wmo-aviation-registers
-    session_id: S055-wmo-aviation-registers
-    evolve_cycle_id: EV-046
+    scoped_slug: strip-internal-doc-refs
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
     started: '2026-08-08'
     started_at: '2026-08-08'
     completed: '2026-08-08'
     completed_at: '2026-08-08'
-    note: 'S055/EV-046 COMPLETE — open_session D-S055-open=2 Lean for #889; handoff 16-evolve Phase 0; EV-043/EV-044 remain PARKED'
-    prior_note: 'S052/EV-043 COMPLETE — open_session for #886; D-S052-open/scope/product/gh locked; handoff 16-evolve Phase 0; Standard pending Plan approval'
-    prior_session_id: S052-doks-staging-prod-branch-deploys
-    prior_evolve_cycle_id: EV-043
-    prior_scoped_slug: doks-staging-prod-branch-deploys
+    note: 'S057/EV-048 COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve; session-brief + routing-plan written'
+    prior_note: 'S055/EV-046 COMPLETE — open_session D-S055-open=2 Lean for #889; handoff 16-evolve Phase 0; EV-043/EV-044 remain PARKED'
+    prior_session_id: S055-wmo-aviation-registers
+    prior_evolve_cycle_id: EV-046
+    prior_scoped_slug: wmo-aviation-registers
     prior_completed: '2026-08-08'
     prior_started: '2026-08-08'
-    prior_tip_sha: 81701500
-    prior_tip_sha_full: 8170150038e740c181cc9f236caaeaf84247ff1a
-    prior_prior_note: 'S047/EV-039 COMPLETE — 00-context done; D-S047-open locked; handoff 16-evolve → 01-requirements'
-    prior_prior_session_id: S047-sql-ingest-live-e2e
-    prior_prior_evolve_cycle_id: EV-039
-    prior_prior_scoped_slug: sql-ingest-live-e2e
-    tip_sha: d0a51f5a
-    tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+    prior_tip_sha: d0a51f5a
+    prior_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
+    prior_prior_note: 'S052/EV-043 COMPLETE — open_session for #886; D-S052-open/scope/product/gh locked; handoff 16-evolve Phase 0; Standard pending Plan approval'
+    prior_prior_session_id: S052-doks-staging-prod-branch-deploys
+    prior_prior_evolve_cycle_id: EV-043
+    prior_prior_scoped_slug: doks-staging-prod-branch-deploys
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
     artifacts:
+    - docs/sessions/S057-strip-internal-doc-refs/
+    - docs/sessions/S057-strip-internal-doc-refs/session-brief.md
+    - docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+    - docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+    - docs/sessions/S056-m0-stabilize-operator-trust/
     - docs/sessions/S055-wmo-aviation-registers/
     - docs/sessions/S052-doks-staging-prod-branch-deploys/
     - docs/sessions/S051-output-filename-download-stale/
@@ -7223,20 +7507,33 @@ stages:
     started: '2026-08-08'
     completed_at: '2026-08-08'
     completed: '2026-08-08'
-    session_id: S055-wmo-aviation-registers
-    evolve_cycle_id: EV-046
-    tip_sha: d0a51f5a
-    tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-    note: 'S055/EV-046 COMPLETE — D-S055-01-ac=1; AC1–AC6 confirmed; handoff 02-verify-plan'
-    prior_session_id: S047-sql-ingest-live-e2e
-    prior_evolve_cycle_id: EV-039
-    prior_started: '2026-08-06'
-    prior_completed: '2026-08-06'
-    prior_note: 'S047/EV-039 01-requirements COMPLETE (delta) — D-S047-ac=1 AC1–AC7 + manifest; reports/01-requirements-summary.md; tip a4f4d3a6; handoff 02-verify-plan'
-    prior_prior_session_id: S046-iwxxm-corpus-residuals
-    prior_prior_evolve_cycle_id: EV-038
-    prior_prior_note: 'S046/EV-038 01-requirements COMPLETE (delta) — D-S046-ac AC=1 approve AC1–AC14; handoff 02-verify-plan'
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    skill_id: 01-requirements
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    deepen_feature_ids: [F7, F21]
+    feature_ids: []
+    delta_only: true
+    corpus_cites:
+    - '[Corpus: api]'
+    - '[Corpus: product §F7]'
+    - '[Corpus: product §F21]'
+    - '[Corpus: tests]'
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
     decision_refs:
+    - D-S057-01-ac
+    - D-S057-guard-s0
+    note: 'S057/EV-048 COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; AC1–AC6 + UJ-055; report 01-requirements.md; handoff 02-verify-plan'
+    prior_session_id: S055-wmo-aviation-registers
+    prior_evolve_cycle_id: EV-046
+    prior_started: '2026-08-08'
+    prior_completed: '2026-08-08'
+    prior_note: 'S055/EV-046 COMPLETE — D-S055-01-ac=1; AC1–AC6 confirmed; handoff 02-verify-plan'
+    prior_prior_session_id: S047-sql-ingest-live-e2e
+    prior_prior_evolve_cycle_id: EV-039
+    prior_prior_note: 'S047/EV-039 01-requirements COMPLETE (delta) — D-S047-ac=1 AC1–AC7 + manifest; reports/01-requirements-summary.md; tip a4f4d3a6; handoff 02-verify-plan'
+    prior_decision_refs:
     - D-S055-01-ac
     - D-S055-phase01
     - D-S055-open
@@ -7977,27 +8274,39 @@ stages:
     started: '2026-08-08'
     completed_at: '2026-08-08'
     completed: '2026-08-08'
-    session_id: S055-wmo-aviation-registers
-    evolve_cycle_id: EV-046
-    tip_sha: d0a51f5a
-    tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-    note: 'S055/EV-046 COMPLETE — Gate A PASS (D-S055-gateA=1); accept M1/M2/L1; handoff lean-docs-execution'
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    skill_id: 02-verify-plan
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    deepen_feature_ids: [F7, F21]
+    feature_ids: []
+    delta_only: true
     gate_a: PASS
     gate_a_status: pass
-    gate_a_decision: D-S055-gateA=1
+    gate_a_decision: D-S057-gateA=1
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
     decision_refs:
+    - D-S057-gateA
+    - D-S057-01-ac
+    - D-S057-guard-s0
+    note: 'S057/EV-048 COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; handoff 04-tech-plan'
+    prior_session_id: S055-wmo-aviation-registers
+    prior_evolve_cycle_id: EV-046
+    prior_started: '2026-08-08'
+    prior_completed: '2026-08-08'
+    prior_note: 'S055/EV-046 COMPLETE — Gate A PASS (D-S055-gateA=1); accept M1/M2/L1; handoff lean-docs-execution'
+    prior_gate_a: PASS
+    prior_gate_a_status: pass
+    prior_gate_a_decision: D-S055-gateA=1
+    prior_decision_refs:
     - D-S055-gateA
     - D-S055-01-ac
     - D-S055-phase01
     - D-S055-open
-    prior_session_id: S047-sql-ingest-live-e2e
-    prior_evolve_cycle_id: EV-039
-    prior_started: '2026-08-06'
-    prior_completed: '2026-08-06'
-    prior_note: 'S047/EV-039 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S047-02-gate-a=2); S02.M3 via spec.md; tip 7970ba46; handoff 04-tech-plan'
-    prior_prior_session_id: S046-iwxxm-corpus-residuals
-    prior_prior_evolve_cycle_id: EV-038
-    prior_prior_note: 'S046/EV-038 02-verify-plan COMPLETE — Gate A PASS; handoff 04-tech-plan'
+    prior_prior_session_id: S047-sql-ingest-live-e2e
+    prior_prior_evolve_cycle_id: EV-039
+    prior_prior_note: 'S047/EV-039 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S047-02-gate-a=2); S02.M3 via spec.md; tip 7970ba46; handoff 04-tech-plan'
     substeps:
       inventory:
         status: completed
@@ -8012,6 +8321,36 @@ stages:
     current_document:
     current_statement:
     active_session:
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 02-verify-plan
+      status: completed
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; handoff 04-tech-plan'
+      gate_a: PASS
+      gate_a_decision: D-S057-gateA=1
+      feature_ids: []
+      deepen_feature_ids:
+      - F7
+      - F21
+      decision_refs:
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      artifacts:
+      - docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+      - docs/feature-list.md
+      - docs/api-contract.md
+      - docs/user-journeys.md
+      - docs/test-plan.md
+      - docs/decisions/evolve-decisions.md
+      - docs/decisions/requirements-decisions.md
+    prior_active_session:
       session_id: S055-wmo-aviation-registers
       evolve_cycle_id: EV-046
       skill_id: 02-verify-plan
@@ -8055,7 +8394,7 @@ stages:
       - docs/sessions/S055-wmo-aviation-registers/reports/02-verify-plan.md
       - docs/sessions/S055-wmo-aviation-registers/reports/01-requirements.md
       - docs/sessions/S055-wmo-aviation-registers/
-    prior_active_session:
+    prior_prior_active_session_s047:
       session_id: S047-sql-ingest-live-e2e
       evolve_cycle_id: EV-039
       skill_id: 02-verify-plan
@@ -8805,20 +9144,33 @@ stages:
     started: '2026-08-08'
     completed_at: '2026-08-08'
     completed: '2026-08-08'
-    previous_started_at: '2026-08-06'
-    previous_completed_at: '2026-08-06'
-    previous_session_id: S047-sql-ingest-live-e2e
-    previous_evolve_cycle_id: EV-039
-    previous_note: 'S047/EV-039 04-tech-plan COMPLETE (delta) — D-S047-04-plan=1; execution-plan approved M1–M5; handoff 05-verify-tech'
-    prior_session_id: S046-iwxxm-corpus-residuals
-    prior_evolve_cycle_id: EV-038
-    prior_started: '2026-08-05'
-    prior_completed: '2026-08-05'
-    prior_note: 'S046/EV-038 04-tech-plan COMPLETE (delta) — D-S046-04-plan=1; handoff 05-verify-tech'
-    session_id: S054-rust-ci-crates
-    evolve_cycle_id: EV-045
-    note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; handoff 05-verify-tech'
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    skill_id: 04-tech-plan
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    deepen_feature_ids: [F7, F21]
+    feature_ids: []
+    delta_only: true
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
     decision_refs:
+    - D-S057-04-plan
+    - D-S057-04-guard-ext
+    - D-S057-gateA
+    - D-S057-01-ac
+    - D-S057-guard-s0
+    note: 'S057/EV-048 COMPLETE — D-S057-04-plan=1 + D-S057-04-guard-ext=1; execution-plan + build-plan-card; handoff 05-verify-tech'
+    previous_started_at: '2026-08-08'
+    previous_completed_at: '2026-08-08'
+    previous_session_id: S054-rust-ci-crates
+    previous_evolve_cycle_id: EV-045
+    previous_note: 'COMPLETE — D-S054-04-plan=1; execution-plan + build-plan-card approved; handoff 05-verify-tech'
+    prior_session_id: S047-sql-ingest-live-e2e
+    prior_evolve_cycle_id: EV-039
+    prior_started: '2026-08-06'
+    prior_completed: '2026-08-06'
+    prior_note: 'S047/EV-039 04-tech-plan COMPLETE (delta) — D-S047-04-plan=1; execution-plan approved M1–M5; handoff 05-verify-tech'
+    prior_decision_refs:
     - D-S054-04-plan
     - D-S054-04-jobs
     - D-S054-04-maturin
@@ -8829,6 +9181,33 @@ stages:
     - D-S054-01-ac
     - D-S054-open
     active_session:
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 04-tech-plan
+      status: completed
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      note: 'COMPLETE — D-S057-04-plan=1 + D-S057-04-guard-ext=1; execution-plan + build-plan-card; handoff 05-verify-tech'
+      feature_ids: []
+      deepen_feature_ids:
+      - F7
+      - F21
+      decision_refs:
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      artifacts:
+      - docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+    prior_active_session:
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 04-tech-plan
@@ -8855,7 +9234,7 @@ stages:
       - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
       - docs/sessions/S054-rust-ci-crates/build-plan-card.md
       - docs/sessions/S054-rust-ci-crates/reports/04-tech-plan.md
-    prior_active_session:
+    prior_prior_active_session_s047:
       session_id: S047-sql-ingest-live-e2e
       evolve_cycle_id: EV-039
       skill_id: 04-tech-plan
@@ -9797,25 +10176,35 @@ stages:
     - '2026-08-05 S046/EV-038 04-tech-plan COMPLETE (D-S046-04-plan=1) — execution-plan approved M1–M5; handoff 05-verify-tech; tip f03ed255'
   05-verify-tech:
     status: completed
-    session_id: S054-rust-ci-crates
-    evolve_cycle_id: EV-045
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    skill_id: 05-verify-tech
     mode: delta
     started_at: '2026-08-08'
     started: '2026-08-08'
     completed_at: '2026-08-08'
     completed: '2026-08-08'
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    deepen_feature_ids: [F7, F21]
+    feature_ids: []
+    delta_only: true
+    gate_b: PASS
+    gate_b_decision: D-S057-gateB=1
     overall: pass
-    previous_started_at: '2026-08-06'
-    previous_completed_at: '2026-08-06'
-    previous_session_id: S047-sql-ingest-live-e2e
-    previous_evolve_cycle_id: EV-039
-    previous_note: 'S047/EV-039 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S047-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1; tip f03ed255'
-    prior_session_id: S046-iwxxm-corpus-residuals
-    prior_evolve_cycle_id: EV-038
-    prior_started: '2026-08-05'
-    prior_completed: '2026-08-05'
-    prior_note: 'S046/EV-038 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S046-05-gate-b=1); tip f03ed255'
-    note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; handoff 07-build M1 T1.1; 06 skipped ADR-017'
+    previous_started_at: '2026-08-08'
+    previous_completed_at: '2026-08-08'
+    previous_session_id: S054-rust-ci-crates
+    previous_evolve_cycle_id: EV-045
+    previous_overall: pass
+    previous_note: 'COMPLETE — Gate B PASS (D-S054-gateB=1); medium/low syncs confirmed; handoff 07-build M1 T1.1; 06 skipped ADR-017'
+    prior_session_id: S047-sql-ingest-live-e2e
+    prior_evolve_cycle_id: EV-039
+    prior_started: '2026-08-06'
+    prior_completed: '2026-08-06'
+    prior_note: 'S047/EV-039 05-verify-tech COMPLETE (delta) — Gate B PASS (D-S047-05-gate-b=1); S05.M*/L1 as 07; handoff 07-build M1 T1.1; tip f03ed255'
+    note: 'COMPLETE — D-S057-gateB=1 PASS; S5.M1–S5.M3 defaults; report 05-verify-tech.md'
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
     substeps:
       inventory:
         status: completed
@@ -9832,6 +10221,34 @@ stages:
     - docs/decisions/tech-audit.md
     - docs/decisions/tech-decisions.md
     delta_substages:
+    - session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 05-verify-tech
+      status: completed
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      mode: delta
+      overall: pass
+      feature_ids: []
+      deepen_feature_ids: [F7, F21]
+      decision_refs:
+      - D-S057-gateB
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      note: 'COMPLETE — Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults; handoff 07-build M1'
+      gate_b: PASS
+      gate_b_decision: D-S057-gateB=1
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+      artifacts:
+      - docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
     - session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 05-verify-tech
@@ -9981,6 +10398,7 @@ stages:
       overall: pass
       note: PASS — 12 auto + 44A–47A (feature-list ADR-027, matrix docs, T5.6 CORS, T3.7a/T3.8a)
     notes:
+    - '2026-08-08 D-S057-gateB=1 — S057/EV-048 05-verify-tech COMPLETE; Gate B PASS; S5.M1–S5.M3 defaults accepted; handoff 07-build M1 T1.1; 06 skipped Standard; no git commit by workflow-state-manager'
     - '2026-08-08 D-S054-gateB=1 — S054/EV-045 05-verify-tech COMPLETE; Gate B PASS; medium/low syncs confirmed; handoff 07-build M1 T1.1; 06 skipped ADR-017; no git commit by workflow-state-manager'
     - '2026-08-08 S054/EV-045 05-verify-tech STARTED (D-S054-04-plan=1) — Gate B; verify execution-plan T1.1–T1.7 vs ACs / D-S054-04 locked / routing; gates.b_to_c + checkpoints.phase_b pending; no git commit by workflow-state-manager'
     - '2026-08-06 S047/EV-039 05-verify-tech COMPLETE (D-S047-05-gate-b=1) — Gate B PASS; S05.M*/L1 as 07; handoff 07-build M1 T1.1; 06 skipped'
@@ -10000,35 +10418,51 @@ stages:
     - S011/EV-008 delta 05-verify-tech completed 2026-07-13 — audit PASS; A1–A3 as-is; phase_b still pending (no auto-pass)
     - S014/EV-010 delta 05-verify-tech PASS 2026-07-18 — 12 auto + 44A–47A; Phase B checkpoint before 06
     active_session:
-      session_id: S054-rust-ci-crates
-      evolve_cycle_id: EV-045
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
       skill_id: 07-build
       status: in_progress
       mode: full
       started_at: '2026-08-08'
       started: '2026-08-08'
-      note: 'IN_PROGRESS — D-S054-gateB=1; M1 T1.1 pending (06 skipped ADR-017)'
-      feature_ids: [F13, F14]
-      deepen_feature_ids: [F13, F14]
+      note: 'IN_PROGRESS — D-S057-gateB=1; M1 red guards T1.1–T1.3; 06 skipped Standard'
+      feature_ids: []
+      deepen_feature_ids: [F7, F21]
       decision_refs:
-      - D-S054-gateB
-      - D-S054-04-plan
-      - D-S054-04-jobs
-      - D-S054-04-maturin
-      - D-S054-04-trigger
-      - D-S054-04-local
-      - D-S054-ac6-waive
-      - D-S054-gateA
-      - D-S054-01-ac
-      - D-S054-open
+      - D-S057-gateB
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      - D-S057-open
       active_milestone: M1
       active_task: T1.1
       active_task_status: pending
       artifacts:
-      - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
-      - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
-      - docs/sessions/S054-rust-ci-crates/build-plan-card.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
     prior_active_session:
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 05-verify-tech
+      status: completed
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      overall: pass
+      note: 'COMPLETE — Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults; handoff 07-build M1'
+      feature_ids: []
+      deepen_feature_ids: [F7, F21]
+      decision_refs:
+      - D-S057-gateB
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    prior_prior_active_session_s054:
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 05-verify-tech
@@ -10174,33 +10608,34 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: completed
+    status: in_progress
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
-    previous_session_id: S054-rust-ci-crates
-    previous_evolve_cycle_id: EV-045
-    previous_tip_sha: 09ce2bef
-    previous_tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
-    previous_note: 'S054/EV-045 07-build COMPLETE — T1.1–T1.7; superseded by S056/EV-047'
-    prior_session_id: S050-remove-db-tools-operator-throughput
-    prior_evolve_cycle_id: EV-042
-    prior_started: '2026-08-07'
-    prior_completed: '2026-08-07'
-    prior_note: 'S050/EV-042 07-build COMPLETE — M4 done; superseded by S054/EV-045'
-    prior_prior_session_id: S047-sql-ingest-live-e2e
-    prior_prior_evolve_cycle_id: EV-039
-    prior_prior_note: 'S047/EV-039 07-build COMPLETE historically; closed D-S047-close=1'
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
+    previous_session_id: S056-m0-stabilize-operator-trust
+    previous_evolve_cycle_id: EV-047
+    previous_tip_sha: 3ca4f438
+    previous_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_note: 'COMPLETE — M1–M3+M2.5 done @ 3ca4f438; T1.5 deferred (D-S056-t15-admin); superseded by S057/EV-048'
+    prior_session_id: S054-rust-ci-crates
+    prior_evolve_cycle_id: EV-045
+    prior_started: '2026-08-08'
+    prior_completed: '2026-08-08'
+    prior_tip_sha: 09ce2bef
+    prior_tip_sha_full: 09ce2befdf0b5878ec6a832ec30718c489b4824b
+    prior_note: 'S054/EV-045 07-build COMPLETE — T1.1–T1.7; superseded by S056/EV-047'
+    prior_prior_session_id: S050-remove-db-tools-operator-throughput
+    prior_prior_evolve_cycle_id: EV-042
+    prior_prior_note: 'S050/EV-042 07-build COMPLETE — M4 done; superseded by S054/EV-045'
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    skill_id: 07-build
     mode: full
-    note: 'COMPLETE — M1–M3+M2.5 done @ 3ca4f438; T1.5 deferred (D-S056-t15-admin); handoff M4 verify 08→09+10→11'
-    tip_sha: 3ca4f438
-    tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    tip_sha_pushed: true
+    note: 'IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS'
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    tip_sha_pushed: false
     pr_number:
     pr_url:
     pr_status:
@@ -10208,20 +10643,30 @@ stages:
     pr_supersedes:
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: 'S054 prior tip CI 31273500621 archived under previous_*; S056 tip CI tracked on evolve/EV-047'
+    ci_cd_pipeline_note: 'S056 prior tip CI archived under previous_*; S057 tip tracked on evolve/EV-048'
     pending_commit: false
-    current_milestone: M3
-    current_task: T3.1
-    active_milestone: M3
-    active_task: T3.1
+    current_milestone: M1
+    current_task: T1.1
+    active_milestone: M1
+    active_task: T1.1
     active_task_status: pending
-    completed_through: T2.5.4
-    progress: 14/20
+    completed_through:
+    progress: 0/9
+    deepen_feature_ids: [F7, F21]
+    feature_ids: []
+    decision_refs:
+    - D-S057-gateB
+    - D-S057-04-plan
+    - D-S057-04-guard-ext
+    - D-S057-gateA
+    - D-S057-01-ac
+    - D-S057-guard-s0
+    - D-S057-open
     decision_refs_s056:
     - D-S056-next-m3
     - D-S056-t15-admin
     - D-S056-04-plan
-    decision_refs:
+    decision_refs_s054:
     - D-S054-t17-ci
     - D-S054-gateB
     - D-S054-04-plan
@@ -10233,6 +10678,10 @@ stages:
     - D-S054-gateA
     - D-S054-01-ac
     - D-S054-open
+    artifacts_s057:
+    - docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+    - docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
     artifacts_s054:
     - docs/sessions/S054-rust-ci-crates/reports/05-verify-tech.md
     - docs/sessions/S054-rust-ci-crates/reports/execution-plan.md
@@ -10272,6 +10721,64 @@ stages:
     - tests/test_tc_ev036_local_precommit_ci.py
     - tests/unit/test_format_coverage_pr_comment.py
     active_session:
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 07-build
+      status: in_progress
+      mode: full
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      pending_commit: false
+      note: 'IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1'
+      tip_sha: d7652d5d
+      tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+      tip_sha_pushed: false
+      feature_ids: []
+      deepen_feature_ids: [F7, F21]
+      decision_refs:
+      - D-S057-gateB
+      - D-S057-04-plan
+      - D-S057-04-guard-ext
+      - D-S057-gateA
+      - D-S057-01-ac
+      - D-S057-guard-s0
+      - D-S057-open
+      active_milestone: M1
+      current_milestone: M1
+      active_task: T1.1
+      current_task: T1.1
+      active_task_status: pending
+      completed_through:
+      progress: 0/9
+      artifacts:
+      - docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+      - docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+      - docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+    prior_active_session_s056:
+      session_id: S056-m0-stabilize-operator-trust
+      evolve_cycle_id: EV-047
+      skill_id: 07-build
+      status: completed
+      mode: full
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      completed_at: '2026-08-08'
+      completed: '2026-08-08'
+      pending_commit: false
+      note: 'COMPLETE — M1–M3+M2.5 done @ 3ca4f438; T1.5 deferred; superseded by S057/EV-048'
+      tip_sha: 3ca4f438
+      tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+      tip_sha_pushed: true
+      deepen_feature_ids: [M5, F6, F7]
+      decision_refs:
+      - D-S056-next-m3
+      - D-S056-t15-admin
+      - D-S056-04-plan
+      active_milestone: M3
+      current_milestone: M3
+      completed_through: T2.5.4
+      progress: 14/20
+    prior_active_session_s054:
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
       skill_id: 07-build
@@ -14939,14 +15446,16 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: completed
+    status: in_progress
     mode: orchestrator
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed: '2026-08-08'
-    completed_at: '2026-08-08'
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_completed: '2026-08-08'
+    previous_s056_note: 'COMPLETE — D-S056-close=1; EV-047 closed; PR #961 MERGED → stage @ 2a1fb22d'
     previous_s055_session_id: S055-wmo-aviation-registers
     previous_s055_evolve_cycle_id: EV-046
     previous_s055_completed: '2026-08-08'
@@ -14969,13 +15478,13 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: completed
-    current_child_stage_note: 'D-S056-close=1 — EV-047 COMPLETE; PR #961 MERGED → stage @ 2a1fb22d'
-    tip_sha: 269475cc
-    tip_sha_full: 269475ccde9befbfd826e59dcfd8cc1fb6b2a9bc
-    tip_sha_pushed: true
-    note: 'COMPLETE — D-S056-close=1; EV-047 closed; PR #961 MERGED → stage @ 2a1fb22d; active_session=null; T1.5 deferred; no git commit by workflow-state-manager'
-    close_decision: D-S056-close=1
+    current_child_stage: 07-build
+    current_child_stage_note: '07-build in_progress M1 T1.1; Gate B PASS D-S057-gateB=1; 05 COMPLETE'
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    tip_sha_pushed: false
+    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; child 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+    prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
     prior_s054_evolve_cycle_id: EV-045
@@ -15239,6 +15748,250 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-gateB
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 05-verify-tech
+  skill_id: 05-verify-tech
+  stage: 05-verify-tech
+  category: gate_b
+  status: confirmed
+  topic: 'S057 Gate B — PASS; proceed 07-build M1'
+  summary: 'D-S057-gateB=1 — PASS; accept S5.M1–S5.M3 defaults; proceed 07-build M1'
+  decision: |
+    D-S057-gateB=1 — Gate B PASS for S057/EV-048.
+    Accept S5.M1–S5.M3 defaults; close 05-verify-tech; start 07-build M1 (T1.1–T1.3 red guards).
+    06-tech-tooling skipped per Standard routing.
+    Report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md.
+    16-evolve remains orchestrator. No git commit by workflow-state-manager.
+  user_option: '1'
+  gate_b: PASS
+  related_issues: ['951']
+  related_decisions: ['D-S057-04-plan', 'D-S057-04-guard-ext', 'D-S057-gateA']
+  report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+  current_stage: 07-build
+  active_milestone: M1
+  active_task: T1.1
+  active_task_status: pending
+  note: '05-verify-tech COMPLETE; Gate B PASS; 07-build IN_PROGRESS M1; 16-evolve remains orchestrator'
+- id: D-S057-04-plan
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: plan_approval
+  status: confirmed
+  topic: 'S057 execution plan approve — M1–M3 / T1.1–T3.3'
+  summary: 'D-S057-04-plan=1 — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05 then 07'
+  decision: |
+    D-S057-04-plan=1 — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05-verify-tech then 07-build.
+    Artifacts: reports/execution-plan.md, build-plan-card.md, reports/04-tech-plan.md.
+    Paired with D-S057-04-guard-ext=1. 16-evolve remains orchestrator.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-04-guard-ext', 'D-S057-gateA']
+  report: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+- id: D-S057-04-guard-ext
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 04-tech-plan
+  skill_id: 04-tech-plan
+  stage: 04-tech-plan
+  category: scope
+  status: confirmed
+  topic: 'S057 guard extend — TC-*, E##-##, #NNN (3+ digits)'
+  summary: 'D-S057-04-guard-ext=1 — Extend guard with TC-*, E##-##, #NNN (3+ digits) on scanned surfaces'
+  decision: |
+    D-S057-04-guard-ext=1 — Extend guard with TC-*, E##-##, #NNN (3+ digits) on scanned surfaces.
+    Extends D-S057-guard-s0=1 (S0\d+). Locked for 05 Gate B / 07 build.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-04-plan', 'D-S057-guard-s0']
+- id: D-S057-gateA
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: gate
+  status: confirmed
+  topic: 'S057 Gate A — PASS; proceed 04'
+  summary: 'D-S057-gateA=1 — PASS; S2.1–S2.4 as 04/07 defaults; proceed 04'
+  decision: |
+    D-S057-gateA=1 — PASS Gate A.
+    S2.1–S2.4 as 04/07 defaults; proceed 04-tech-plan.
+    Report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md.
+    Note appended to docs/decisions/evolve-decisions.md.
+    16-evolve remains orchestrator. No git commit by workflow-state-manager.
+  user_option: '1'
+  gate_a: PASS
+  related_issues: ['951']
+  related_decisions: ['D-S057-01-ac', 'D-S057-guard-s0']
+  report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+  evolve_decisions_note: 'Appended D-S057-gateA=1 Gate A PASS to docs/decisions/evolve-decisions.md'
+- id: D-S057-01-ac
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: acceptance
+  status: confirmed
+  topic: 'S057 AC approve — AC1–AC6 + UJ-055'
+  summary: 'D-S057-01-ac=1 — Approve AC1–AC6 + UJ-055'
+  decision: |
+    D-S057-01-ac=1 — Approve AC1–AC6 + UJ-055.
+    Report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md.
+    Handoff 02-verify-plan (Gate A). 16-evolve remains orchestrator.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-guard-s0', 'D-S057-open']
+  report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+- id: D-S057-guard-s0
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: scope
+  status: confirmed
+  topic: 'S057 guard — include S0\d+ pattern'
+  summary: 'D-S057-guard-s0=1 — Include S0\d+ in guard'
+  decision: 'D-S057-guard-s0=1 — Include S0\d+ in guard patterns with Corpus/docs/sessions/ADR/EV.'
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-01-ac']
+- id: D-S057-open
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: 'Open S057/EV-048 for #951 — strip internal doc refs from UI/API'
+  summary: 'D-S057-open=1 — open S057/EV-048 for #951'
+  decision: |
+    D-S057-open=1 — open S057/EV-048 for #951.
+    Session S057-strip-internal-doc-refs; evolve cycle EV-048; session_counter 57; evolve_cycle_counter 48.
+    Intent: Strip internal document references from user-facing UI and API surfaces (#951).
+    Deepen F7 + F21; no new product Fn. Branch evolve/EV-048-strip-internal-doc-refs @ stage@d7652d5d.
+    Preset Lean (D-S057-preset=2) with pending reconfirm — AC needs 04/07.
+    Scope full UI+OpenAPI+guard (D-S057-scope=1). UI preview non-deployed local (D-S057-ui-preview=1).
+    Prior session S056 remains completed in sessions[]. active_session set.
+    stages.00-context in_progress. No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-048-strip-internal-doc-refs
+  prior_session: S056-m0-stabilize-operator-trust
+  github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951
+  github_issues:
+  - 951
+  tip_sha: d7652d5d
+  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  note: 'D-S057-open=1 S057/EV-048 for #951; Lean + preset reconfirm pending'
+- id: D-S057-scope
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: scope
+  status: confirmed
+  topic: 'S057 scope — full #951 UI+OpenAPI+guard'
+  summary: 'D-S057-scope=1 — full #951 UI+OpenAPI+guard'
+  decision: 'D-S057-scope=1 — full #951 UI+OpenAPI+guard'
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-open']
+- id: D-S057-preset-reconfirm
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: routing
+  status: confirmed
+  topic: 'S057 preset reconfirm — amend Lean→Standard'
+  summary: 'D-S057-preset-reconfirm=1 — Standard 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13'
+  decision: |
+    D-S057-preset-reconfirm=1 — Amend to Standard.
+    Routing: 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13 (waive 12/13 unless deploy).
+    Amends prior D-S057-preset=2 Lean. Exit 00-context → 16-evolve in_progress.
+    ui_preview local http://localhost:5173/ started. evolve-plan-card.md recorded.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-open', 'D-S057-preset']
+  note: 'Standard amend; 00 completed; 16-evolve in_progress'
+- id: D-S057-preset
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: routing
+  status: superseded_amended
+  topic: 'S057 routing preset — amended to Standard via reconfirm'
+  summary: 'D-S057-preset=1 — Standard amend (was Lean 2; reconfirm)'
+  decision: |
+    Originally D-S057-preset=2 Lean (user 3b).
+    Amended by D-S057-preset-reconfirm=1 → Standard (effective D-S057-preset=1).
+  user_option: '1'
+  prior_user_option: '2'
+  related_issues: ['951']
+  related_decisions: ['D-S057-open', 'D-S057-preset-reconfirm']
+  note: 'amended by D-S057-preset-reconfirm=1'
+- id: D-S057-ui-preview
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 00-context
+  skill_id: 00-context
+  stage: open_session
+  category: ui_preview
+  status: confirmed
+  topic: 'S057 UI preview — non-deployed local'
+  summary: 'D-S057-ui-preview=1 — yes non-deployed local UI'
+  decision: 'D-S057-ui-preview=1 — yes non-deployed local UI (user 4a)'
+  user_option: '1'
+  related_issues: ['951']
+  related_decisions: ['D-S057-open']
 - id: D-S056-cov95-scope
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -29178,6 +29931,149 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+  type: session-report
+  kind: tech-plan
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: completed
+  note: 'S057/EV-048 04 COMPLETE — D-S057-04-plan=1 + D-S057-04-guard-ext=1'
+- path: docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+  type: session-artifact
+  kind: execution-plan
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: written
+  note: 'M1–M3 / T1.1–T3.3 approved'
+- path: docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+  type: session-artifact
+  kind: build-plan-card
+  stage: 04-tech-plan
+  skill_id: 04-tech-plan
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: written
+- path: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+  type: session-report
+  kind: verify-plan
+  stage: 02-verify-plan
+  skill_id: 02-verify-plan
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: completed
+  note: 'S057/EV-048 Gate A PASS — D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults'
+- path: docs/decisions/evolve-decisions.md
+  type: standing-doc-delta
+  stage: 02-verify-plan
+  skill_id: 02-verify-plan
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'D-S057-gateA=1 Gate A PASS note'
+- path: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+  type: session-report
+  kind: requirements
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: completed
+  note: 'S057/EV-048 01 COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1'
+- path: docs/feature-list.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'F7 + F21 EV-048 deepen + AC tables'
+- path: docs/api-contract.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'Operator-facing OpenAPI/error copy policy'
+- path: docs/user-journeys.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'UJ-055'
+- path: docs/test-plan.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'TC-EV048-001..005 + UJ map'
+- path: docs/decisions/evolve-decisions.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'Cycle EV-048 scope + AC table'
+- path: docs/decisions/requirements-decisions.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  status: written
+  note: 'EV-048 section'
+- path: docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+  type: session-artifact
+  kind: evolve-plan-card
+  stage: 16-evolve
+  skill_id: 16-evolve
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: written
+  note: 'S057/EV-048 evolve-plan-card after D-S057-preset-reconfirm=1 Standard'
+- path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
+  type: session-artifact
+  kind: session-brief
+  stage: 00-context
+  skill_id: 00-context
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: written
+  note: 'S057/EV-048 session brief written; pending D-S057-preset-reconfirm'
+- path: docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+  type: session-artifact
+  kind: routing-plan
+  stage: 00-context
+  skill_id: 00-context
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  created_at: '2026-08-08'
+  updated_at: '2026-08-08'
+  status: written
+  note: 'S057/EV-048 Lean routing-plan written; 04/07 conflict noted; pending preset reconfirm'
 - path: docs/sessions/S055-wmo-aviation-registers/reports/codes-wmo-int-coverage.md
   type: session-report
   kind: coverage-report
@@ -32609,6 +33505,240 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-048
+  session_id: S057-strip-internal-doc-refs
+  status: in_progress
+  cycle_type: feature
+  preset: Standard
+  preset_note: "D-S057-preset-reconfirm=1 — Lean→Standard; 00→16→01→02→04→05→07→08→09→10→11; skip 03/06/12/13"
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  - F21
+  feature_note: "Deepen F7 operator UI copy + F21 public OpenAPI/error surfaces; no new product Fn — hygiene for #951"
+  title: "Strip internal doc refs from UI/API (#951)"
+  slug: strip-internal-doc-refs
+  github_issues:
+  - 951
+  milestone: "M0 — Stabilize + operator trust + narrative"
+  phase: 1
+  current_stage: 07-build
+  current_stage_note: "IN_PROGRESS — Gate B PASS D-S057-gateB=1; M1 T1.1 next; 05-verify-tech COMPLETE"
+  started: '2026-08-08'
+  started_at: '2026-08-08'
+  branch: evolve/EV-048-strip-internal-doc-refs
+  branch_base: stage@d7652d5d
+  branch_base_sha: d7652d5d
+  branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  branch_status: active
+  tip_sha: d7652d5d
+  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  tip_sha_pushed: false
+  interrupted_by_hotfix: false
+  parked: false
+  ui_preview: requested
+  ui_preview_note: "D-S057-ui-preview=1 — non-deployed local; local http://localhost:5173/ started"
+  ui_preview_url: http://localhost:5173/
+  scope_note: "Full #951 UI+OpenAPI+guard (D-S057-scope=1); strip internal document references from user-facing surfaces"
+  decisions_locked:
+  - D-S057-open=1
+  - D-S057-scope=1
+  - D-S057-preset=1
+  - D-S057-preset-reconfirm=1
+  - D-S057-ui-preview=1
+  - D-S057-01-ac=1
+  - D-S057-guard-s0=1
+  - D-S057-gateA=1
+  - D-S057-04-plan=1
+  - D-S057-04-guard-ext=1
+  - D-S057-gateB=1
+  gate_a: PASS
+  gate_a_decision: D-S057-gateA=1
+  gate_b: PASS
+  gate_b_decision: D-S057-gateB=1
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — Standard orchestrator; child stage 07-build in_progress; Gate B PASS D-S057-gateB=1; 05 COMPLETE"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; report reports/01-requirements.md; handoff 02-verify-plan"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; report reports/02-verify-plan.md; handoff 04-tech-plan"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+    gate_a: PASS
+    gate_a_decision: D-S057-gateA=1
+  - stage: 03-plan-tooling
+    required: false
+    mode: skip
+    status: skipped
+    note: "Standard skip"
+  - stage: 04-tech-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — D-S057-04-plan=1 + D-S057-04-guard-ext=1; execution-plan + build-plan-card; handoff 05-verify-tech"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+  - stage: 05-verify-tech
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    note: "COMPLETE — Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults; report reports/05-verify-tech.md; handoff 07-build M1"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    gate_b: PASS
+    gate_b_decision: D-S057-gateB=1
+  - stage: 06-tech-tooling
+    required: false
+    mode: skip
+    status: skipped
+    note: "Standard skip"
+  - stage: 07-build
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — M1 red guards T1.1–T1.3 after Gate B PASS D-S057-gateB=1"
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 09-qa
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 10-e2e
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 11-verify-impl
+    required: true
+    mode: delta
+    status: pending
+    note: "pending required (Standard)"
+  - stage: 12-verify-deploy
+    required: false
+    mode: skip
+    status: skipped
+    note: "waive unless deploy (Standard)"
+  - stage: 13-deploy-smoke
+    required: false
+    mode: skip
+    status: skipped
+    note: "waive unless deploy (Standard)"
+  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage 07-build; Gate B PASS D-S057-gateB=1; 05 COMPLETE; 16-evolve orchestrator in_progress; ui_preview http://localhost:5173/"
+  artifacts:
+  - docs/sessions/S057-strip-internal-doc-refs/
+  - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
+    status: written
+    stage: 00-context
+    skill_id: 00-context
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
+    status: written
+    stage: 00-context
+    skill_id: 00-context
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/evolve-plan-card.md
+    status: written
+    stage: 16-evolve
+    skill_id: 16-evolve
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+    status: completed
+    stage: 01-requirements
+    skill_id: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/feature-list.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/api-contract.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/user-journeys.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/test-plan.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/decisions/evolve-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/decisions/requirements-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 01-requirements
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+    status: completed
+    stage: 02-verify-plan
+    skill_id: 02-verify-plan
+    session_id: S057-strip-internal-doc-refs
+    note: "Gate A PASS D-S057-gateA=1"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/04-tech-plan.md
+    status: completed
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+    note: "D-S057-04-plan=1 + D-S057-04-guard-ext=1"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/execution-plan.md
+    status: written
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/build-plan-card.md
+    status: written
+    stage: 04-tech-plan
+    skill_id: 04-tech-plan
+    session_id: S057-strip-internal-doc-refs
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/05-verify-tech.md
+    status: completed
+    stage: 05-verify-tech
+    skill_id: 05-verify-tech
+    session_id: S057-strip-internal-doc-refs
+    note: "Gate B PASS D-S057-gateB=1; S5.M1–S5.M3 defaults"
+  - path: docs/decisions/evolve-decisions.md
+    status: written
+    kind: standing-doc-delta
+    stage: 02-verify-plan
+    session_id: S057-strip-internal-doc-refs
+    note: "D-S057-gateA=1 Gate A PASS"
 - id: EV-047
   session_id: S056-m0-stabilize-operator-trust
   status: completed
@@ -42921,24 +44051,24 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: stage
+  current_branch: evolve/EV-048-strip-internal-doc-refs
   ahead_of_origin: 0
-  pushed: true
+  pushed: false
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml close_session for S056/EV-047 PR #961 merge; no git commit by workflow-state-manager'
-  tip_sha: 269475cc
-  tip_sha_full: 269475ccde9befbfd826e59dcfd8cc1fb6b2a9bc
-  tip_note: 'S056/EV-047 PR #961 MERGED → stage @ 2a1fb22d; evolve tip 269475cc'
-  evolve_branch: evolve/EV-047-m0-stabilize-operator-trust
-  evolve_tip_sha: 269475cc
-  evolve_tip_sha_full: 269475ccde9befbfd826e59dcfd8cc1fb6b2a9bc
-  evolve_tip_sha_pushed: true
+  dirty_note: 'workflow-state.yaml S057/EV-048 open + branch create; session artifacts written; no git commit by workflow-state-manager'
+  tip_sha: d7652d5d
+  tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  tip_note: 'S057/EV-048 ACTIVE on evolve/EV-048-strip-internal-doc-refs @ tip d7652d5d (= stage tip)'
+  evolve_branch: evolve/EV-048-strip-internal-doc-refs
+  evolve_tip_sha: d7652d5d
+  evolve_tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+  evolve_tip_sha_pushed: false
   stage_merge_sha: 2a1fb22d
   stage_merge_sha_full: 2a1fb22d9697dc8fedf979f49ac621c045f96956
-  stage_tip_sha: 2a1fb22d
-  stage_tip_sha_full: 2a1fb22d9697dc8fedf979f49ac621c045f96956
+  stage_tip_sha: d7652d5d
+  stage_tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -42949,10 +44079,15 @@ git_history:
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-  recommended_branch: stage
-  note: 'S056/EV-047 CLOSED — PR #961 MERGED → stage @ 2a1fb22d; evolve tip 269475cc; active_session=null; no git commit by workflow-state-manager'
+  recommended_branch: evolve/EV-048-strip-internal-doc-refs
+  note: 'S057/EV-048 ACTIVE — Standard after D-S057-preset-reconfirm=1; current_stage 16-evolve; 00-context completed; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-08 02-verify-plan COMPLETE / 04-tech-plan IN_PROGRESS — D-S057-gateA=1 PASS; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; evolve-decisions note; 16-evolve remains orchestrator; no git commit by workflow-state-manager'
+  - '2026-08-08 01-requirements COMPLETE / 02-verify-plan IN_PROGRESS — D-S057-01-ac=1 + D-S057-guard-s0=1; standing doc deltas recorded; 16-evolve remains orchestrator; no git commit by workflow-state-manager'
+  - '2026-08-08 01-requirements IN_PROGRESS — S057/EV-048 evolve delta; deepen F7/F21; 16-evolve remains in_progress; D-S057-preset-reconfirm=1 already recorded; no git commit by workflow-state-manager'
+  - '2026-08-08 D-S057-preset-reconfirm=1 — Lean→Standard; 00-context COMPLETE; current_stage 16-evolve; evolve-plan-card.md; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+  - '2026-08-08 S057/EV-048 update — branch ACTIVE exists tip d7652d5d; session-brief.md + routing-plan.md written; Plan mode switch rejected by user — continuing Agent orchestration; pending D-S057-preset-reconfirm; no git commit by workflow-state-manager'
   - '2026-08-08 D-S056-close=1 — CLOSED S056/EV-047; PR #961 MERGED → stage @ merge 2a1fb22d tip 269475cc; active_session=null; T1.5 deferred; no git commit by workflow-state-manager'
   - '2026-08-08 S056/EV-047 M2.5 COMPLETE — recorded commits b45d3162 ([T2.5.2] checker), 2b50b983 ([T2.5.1][T2.5.4] auth+worker), 2408e2bb ([T2.5.3] package gaps), da31bf1f ([T2.5.2] CI/Makefile enforce); tip da31bf1f (da31bf1f73263b4037d9d00ec6ecb7e040c824ab); ahead_of_origin=0 pushed=true; next M3 T3.1; T1.5 still admin-blocked; dirty workflow-state uncommitted; no git commit by workflow-state-manager'
   - '2026-08-08 D-S056-cov95=2 + D-S056-m3-order=2 — package+per-file ≥95% this cycle (all Python packages in CI); resolve coverage (M2.5) before M3 docs/Help; T2.5.1 in_progress; T1.5 still admin-blocked; no git commit by workflow-state-manager'
@@ -43454,6 +44589,20 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-048-strip-internal-doc-refs
+    base: stage
+    base_sha: d7652d5d
+    base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    status: active
+    created: '2026-08-08'
+    exists: true
+    purpose: "EV-048 / S057 strip internal doc refs from UI/API (#951)"
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    tip_sha: d7652d5d
+    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    tip_sha_pushed: false
+    note: "ACTIVE — branch created @ tip d7652d5d; session-brief + routing-plan written; Plan mode rejected — Agent orchestration; pending D-S057-preset-reconfirm"
   - name: evolve/EV-047-m0-stabilize-operator-trust
     base: stage
     base_sha: adcf3b1f

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,10 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: 71779d46
-  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+  tip_sha: 3a43da37
+  tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
   tip_sha_pushed: false
-  branch_note: "ACTIVE — tip 71779d46 after 07-build M1–M3; 08-verify-build COMPLETE PASS; Phase C checkpoint pending"
+  branch_note: "ACTIVE — tip 3a43da37; Phase D 11-verify-impl awaiting sign-off; 09+10 complete"
   github_issues:
   - 951
   issue_ids:
@@ -42,7 +42,7 @@ active_session:
   prior_session: S056-m0-stabilize-operator-trust
   artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
   current_stage: 16-evolve
-  current_stage_note: "IN_PROGRESS — Phase C done (07+08 PASS); await D-S057-phaseC checkpoint before 09+10"
+  current_stage_note: "IN_PROGRESS — Phase D 11-verify-impl awaiting user sign-off; 09+10 complete"
   decisions:
     D-S057-open: "1 — open S057/EV-048 for #951"
     D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
@@ -55,6 +55,8 @@ active_session:
     D-S057-04-plan: "1 — Approve M1–M3 / T1.1–T3.3 as drafted; proceed 05 then 07"
     D-S057-04-guard-ext: "1 — Extend guard with TC-*, E##-##, #NNN (3+ digits) on scanned surfaces"
     D-S057-gateB: "1 — PASS; accept S5.M1–S5.M3 defaults; proceed 07-build M1"
+    D-S057-phaseC: "1 — Continue 09-qa + 10-e2e delta → 11-verify-impl"
+    D-S057-ui-preview-verify: "2 — No non-deployed UI preview before Verify (FE catalogs clean)"
   routing_plan:
   - stage: 00-context
     required: true
@@ -68,7 +70,7 @@ active_session:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; Phase C done (07+08 PASS); await D-S057-phaseC before 09+10"
+    note: "IN_PROGRESS — Phase D in progress after D-S057-phaseC=1"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -133,18 +135,28 @@ active_session:
   - stage: 09-qa
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    overall: pass_with_advisories
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    note: "COMPLETE — pass_with_advisories; report qa-report.md; handoff 11-verify-impl"
   - stage: 10-e2e
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    overall: PASS
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+    note: "COMPLETE — PASS; report e2e-report.md; delta/light UJ-055 T0/T2; T3 skipped"
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
   - stage: 12-verify-deploy
     required: false
     mode: skip
@@ -288,8 +300,37 @@ active_session:
     evolve_cycle_id: EV-048
     created_at: '2026-08-08'
     note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
-  note: "08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator; ui_preview http://localhost:5173/"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    type: report
+    status: completed
+    stage: 09-qa
+    skill_id: 09-qa
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "COMPLETE — pass_with_advisories; report qa-report.md"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+    type: report
+    status: completed
+    stage: 10-e2e
+    skill_id: 10-e2e
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "COMPLETE — PASS; report e2e-report.md"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    type: report
+    status: draft
+    stage: 11-verify-impl
+    skill_id: 11-verify-impl
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    created_at: '2026-08-08'
+    note: "DRAFT — awaiting UJ-055 + F7/F21 signoff"
+  note: "Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; 16-evolve orchestrator"
   notes:
+  - "2026-08-08 09-qa COMPLETE pass_with_advisories + 10-e2e COMPLETE PASS; 11-verify-impl IN_PROGRESS awaiting UJ-055 + F7/F21 signoff; tip 3a43da37; 16-evolve orchestrator"
+  - "2026-08-08 D-S057-phaseC=1 + D-S057-ui-preview-verify=2 — Phase D started; 09-qa + 10-e2e in_progress; tip 3a43da37; 16-evolve orchestrator"
   - "2026-08-08 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator"
   - "2026-08-08 07-build COMPLETE @ 71779d46 — M1–M3 done; T3.3 skipped; 08-verify-build IN_PROGRESS; 16-evolve remains orchestrator"
   - "2026-08-08 D-S057-gateB=1 — Gate B PASS; S5.M1–S5.M3 defaults accepted; 05 COMPLETE; 07-build IN_PROGRESS M1; 16-evolve remains orchestrator"
@@ -12125,26 +12166,33 @@ stages:
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e00000
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
-    tip_sha: 3ca4f438
-    tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    tip_sha_pushed: true
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    tip_sha: 3a43da37
+    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    tip_sha_pushed: false
     mode: delta
     overall: pass_with_advisories
-    report: docs/sessions/S056-m0-stabilize-operator-trust/reports/qa-report.md
-    expected_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/qa-report.md
-    note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 10-e2e'
-    advisories: [QA-001, QA-002, QA-003, QA-004, QA-005]
-    advisories_note: 'AC6 ops deferred is primary (D-S054-ac6-waive=2)'
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 11-verify-impl'
+    skill_id: 09-qa
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_overall: pass_with_advisories
+    previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/qa-report.md
+    previous_s056_note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 10-e2e'
+    advisories: [QA-001, QA-002, QA-003, QA-004]
+    advisories_note: 'EV-048: tip unpushed; 12/13 waived; privacy Fn IDs out of regex; T3 Playwright skipped'
     decision_refs:
-    - D-S054-phaseC
-    - D-S054-t17-ci
-    - D-S054-gateB
-    - D-S054-ac6-waive
-    - D-S054-open
+    - D-S057-phaseC
+    - D-S057-ui-preview-verify
+    - D-S057-gateB
+    - D-S057-preset-reconfirm
     pending_commit: false
-    active_milestone: M1
+    active_milestone:
     active_task:
     active_task_status:
     prior_s050_session_id: S050-remove-db-tools-operator-throughput
@@ -12152,9 +12200,24 @@ stages:
     prior_s050_tip_sha: dff22265
     prior_s050_overall: pass_with_advisories
     prior_s050_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
-    main_ci_cd_pipeline_run: '31003268652'
-    main_ci_cd_pipeline_status: in_progress
+    main_ci_cd_pipeline_run:
+    main_ci_cd_pipeline_status:
     delta_substages:
+    - id: S057-strip-internal-doc-refs-09
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 09-qa
+      status: completed
+      mode: delta
+      started: '2026-08-08'
+      started_at: '2026-08-08'
+      completed: '2026-08-08'
+      completed_at: '2026-08-08'
+      tip_sha: 3a43da37
+      tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+      overall: pass_with_advisories
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+      note: 'COMPLETE — pass_with_advisories; report qa-report.md'
     - id: S054-rust-ci-crates-09
       session_id: S054-rust-ci-crates
       evolve_cycle_id: EV-045
@@ -12447,11 +12510,11 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa in_progress (T6.2; D-S011-EV008-c-to-d-pass)
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
-    status: completed
+    status: in_progress
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed: '2026-08-08'
-    completed_at: '2026-08-08'
+    completed:
+    completed_at:
     previous_started_at: '2026-08-08'
     previous_started: '2026-08-08'
     previous_completed: '2026-08-08'
@@ -12521,17 +12584,26 @@ stages:
     prior_s037_session_id: S037-quality-residuals-831
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 3889e4c
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
-    tip_sha: 3ca4f438
-    tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    tip_sha_pushed: true
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    tip_sha: 3a43da37
+    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    tip_sha_pushed: false
     mode: delta
-    overall: pass
-    report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verify-impl.md
-    expected_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verify-impl.md
-    note: 'COMPLETE — PASS @ 3ca4f438; D-S056-ac-bundle=1, D-S056-uj054=1, D-S056-advisories=1, D-S056-11-ui-preview=2; report verify-impl.md; phase_d passed; handoff phase4-close / PR #961'
+    overall:
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    note: 'IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff; report verify-impl.md draft; 09+10 complete'
+    skill_id: 11-verify-impl
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_overall: pass
+    previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verify-impl.md
+    previous_s056_note: 'COMPLETE — PASS @ 3ca4f438; D-S056-ac-bundle=1, D-S056-uj054=1, D-S056-advisories=1, D-S056-11-ui-preview=2; report verify-impl.md; phase_d passed; handoff phase4-close / PR #961'
     decision_refs:
+    - D-S057-phaseC
     - D-S056-ac-bundle
     - D-S056-uj054
     - D-S056-advisories
@@ -12546,26 +12618,22 @@ stages:
     prior_s050_overall: approved
     prior_s050_note: 'COMPLETE — D-S050-11-verify approve F33 + F7 deepen + F16–F19 deepen; UJ-051..053 approved (T3/H4–H5 waived until 13); UI preview accepted localhost:18000; fix adad127c hide Upload to Database; report verify-impl.md; tip adad127c; next 12-verify-deploy'
     prior_s050_report_note: 'S050/EV-042 11 COMPLETE — superseded by S054/EV-045'
-    report_status: approved
-    tip_note: 'S050/EV-042 tip adad127c — 11-verify-impl COMPLETE; tip_sha_pushed=false ahead_of_origin=4; next 12-verify-deploy'
-    awaiting_user_decision: false
-    awaiting_user_decision_note:
-    decision_id: D-S050-11-verify
+    report_status: draft
+    tip_note: 'S057/EV-048 tip 3a43da37 — 11-verify-impl IN_PROGRESS; awaiting UJ-055 + F7/F21 signoff'
+    awaiting_user_decision: true
+    awaiting_user_decision_note: 'Awaiting UJ-055 + F7/F21 signoff'
+    decision_id:
     decision_ids:
     - D-S050-11-verify
     - D-S047-11
     deepen_feature_ids:
     - F7
-    - F16
-    - F17
-    - F18
-    - F19
-    feature_ids:
-    - F33
-    active_milestone: M4
-    active_task: T4.3
-    active_task_status: in_progress
-    active_task_note: 'T4.3 handoff — 11 complete @ 18d028ed; 12-verify-deploy in_progress; watching tip CI'
+    - F21
+    feature_ids: []
+    active_milestone: M1
+    active_task:
+    active_task_status:
+    active_task_note: '11-verify-impl in_progress — awaiting UJ-055 + F7/F21 signoff'
     previous_s046_decision_id: D-S046-11
     previous_s045_session_id: S045-matrix-disposition-residuals
     previous_s045_evolve_cycle_id: EV-037
@@ -12609,6 +12677,22 @@ stages:
         status: completed
         path: docs/sessions/S050-remove-db-tools-operator-throughput/reports/verify-impl.md
     delta_substages:
+    - id: S057-strip-internal-doc-refs-11
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 11-verify-impl
+      status: in_progress
+      mode: delta
+      started_at: '2026-08-08'
+      started: '2026-08-08'
+      tip_sha: 3a43da37
+      tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+      report_status: draft
+      deepen_feature_ids:
+      - F7
+      - F21
+      note: 'IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff; report verify-impl.md draft'
     - id: S050-remove-db-tools-operator-throughput-11
       session_id: S050-remove-db-tools-operator-throughput
       evolve_cycle_id: EV-042
@@ -12888,19 +12972,43 @@ stages:
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e00000
-    session_id: S056-m0-stabilize-operator-trust
-    evolve_cycle_id: EV-047
-    tip_sha: 3ca4f438
-    tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    session_id: S057-strip-internal-doc-refs
+    evolve_cycle_id: EV-048
+    tip_sha: 3a43da37
+    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    tip_sha_pushed: false
     mode: delta
-    overall: pass
-    report: docs/sessions/S056-m0-stabilize-operator-trust/reports/e2e-report.md
-    note: 'COMPLETE — PASS UJ-054 Help; report e2e-report.md; handoff 11-verify-impl'
+    overall: PASS
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+    note: 'COMPLETE — PASS; report e2e-report.md; delta/light UJ-055 T0/T2; T3 skipped; handoff 11-verify-impl'
+    skill_id: 10-e2e
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_overall: pass
+    previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/e2e-report.md
+    previous_s056_note: 'COMPLETE — PASS UJ-054 Help; report e2e-report.md; handoff 11-verify-impl'
     active_milestone: M4
     active_task: T4.3
     active_task_status: completed
     pending_commit: false
     delta_substages:
+    - id: S057-strip-internal-doc-refs-10
+      session_id: S057-strip-internal-doc-refs
+      evolve_cycle_id: EV-048
+      skill_id: 10-e2e
+      status: completed
+      mode: delta
+      started: '2026-08-08'
+      started_at: '2026-08-08'
+      completed: '2026-08-08'
+      completed_at: '2026-08-08'
+      tip_sha: 3a43da37
+      tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+      overall: PASS
+      report: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+      note: 'COMPLETE — PASS; delta/light UJ-055 T0/T2; T3 skipped'
     - id: S050-remove-db-tools-operator-throughput-10
       session_id: S050-remove-db-tools-operator-throughput
       evolve_cycle_id: EV-042
@@ -15540,12 +15648,12 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: phase-c-checkpoint
-    current_child_stage_note: '08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC'
-    tip_sha: 71779d46
-    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    current_child_stage: 11-verify-impl
+    current_child_stage_note: 'Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; D-S057-ui-preview-verify=2'
+    tip_sha: 3a43da37
+    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
     tip_sha_pushed: false
-    note: 'IN_PROGRESS — S057/EV-048 Standard orchestrator; 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; tip 71779d46; ui_preview http://localhost:5173/; no git commit by workflow-state-manager'
+    note: 'IN_PROGRESS — S057/EV-048 Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; no git commit by workflow-state-manager'
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -15810,6 +15918,33 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-phaseC
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: phase_c_checkpoint
+  status: confirmed
+  topic: 'S057/EV-048 Phase C → Phase D; UI preview before Verify'
+  summary: 'D-S057-phaseC=1 + D-S057-ui-preview-verify=2 — Continue 09-qa + 10-e2e delta → 11-verify-impl; no non-deployed UI preview before Verify'
+  decision: |
+    D-S057-phaseC=1 — Continue 09-qa + 10-e2e delta → 11-verify-impl.
+    D-S057-ui-preview-verify=2 — No non-deployed UI preview before Verify (FE catalogs clean).
+    Phase C PASS; Phase D started (09-qa + 10-e2e in_progress). Tip 3a43da37.
+    No git commit by workflow-state-manager.
+  user_option: '1 / 2'
+  branch: evolve/EV-048-strip-internal-doc-refs
+  related_issues:
+  - '951'
+  tip_sha: 3a43da37
+  tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+  tip_sha_pushed: false
+  current_stage: 09-qa
+  note: 'Phase C PASS; Phase D 09+10 in progress; D-S057-ui-preview-verify=2'
 - id: D-S057-08-complete
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -33636,8 +33771,8 @@ evolve_cycles:
   - 951
   milestone: "M0 — Stabilize + operator trust + narrative"
   phase: 1
-  current_stage: phase-c-checkpoint
-  current_stage_note: "IN_PROGRESS — Phase C done (07+08 PASS); await D-S057-phaseC checkpoint before 09+10"
+  current_stage: 11-verify-impl
+  current_stage_note: "IN_PROGRESS — Phase D 11-verify-impl awaiting user sign-off; 09+10 complete"
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -33645,8 +33780,8 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: 71779d46
-  tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+  tip_sha: 3a43da37
+  tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
   tip_sha_pushed: false
   interrupted_by_hotfix: false
   parked: false
@@ -33666,6 +33801,8 @@ evolve_cycles:
   - D-S057-04-plan=1
   - D-S057-04-guard-ext=1
   - D-S057-gateB=1
+  - D-S057-phaseC=1
+  - D-S057-ui-preview-verify=2
   gate_a: PASS
   gate_a_decision: D-S057-gateA=1
   gate_b: PASS
@@ -33683,7 +33820,7 @@ evolve_cycles:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Standard orchestrator; Phase C done (07+08 PASS); await D-S057-phaseC before 09+10"
+    note: "IN_PROGRESS — Phase D in progress after D-S057-phaseC=1"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -33748,18 +33885,28 @@ evolve_cycles:
   - stage: 09-qa
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    overall: pass_with_advisories
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    note: "COMPLETE — pass_with_advisories; report qa-report.md; handoff 11-verify-impl"
   - stage: 10-e2e
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: completed
+    started: '2026-08-08'
+    completed: '2026-08-08'
+    overall: PASS
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+    note: "COMPLETE — PASS; report e2e-report.md; delta/light UJ-055 T0/T2; T3 skipped"
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: pending
-    note: "pending required (Standard)"
+    status: in_progress
+    started: '2026-08-08'
+    note: "IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff"
+    report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
   - stage: 12-verify-deploy
     required: false
     mode: skip
@@ -33770,7 +33917,7 @@ evolve_cycles:
     mode: skip
     status: skipped
     note: "waive unless deploy (Standard)"
-  note: "IN_PROGRESS — S057/EV-048 Standard; current_stage phase-c-checkpoint; 08 COMPLETE PASS; await D-S057-phaseC; tip 71779d46; 16-evolve orchestrator; ui_preview http://localhost:5173/"
+  note: "IN_PROGRESS — S057/EV-048 Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; 16-evolve orchestrator"
   artifacts:
   - docs/sessions/S057-strip-internal-doc-refs/
   - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
@@ -33864,6 +34011,27 @@ evolve_cycles:
     skill_id: 08-verify-build
     session_id: S057-strip-internal-doc-refs
     note: "COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    type: report
+    status: completed
+    stage: 09-qa
+    skill_id: 09-qa
+    session_id: S057-strip-internal-doc-refs
+    note: "COMPLETE — pass_with_advisories; report qa-report.md"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/e2e-report.md
+    type: report
+    status: completed
+    stage: 10-e2e
+    skill_id: 10-e2e
+    session_id: S057-strip-internal-doc-refs
+    note: "COMPLETE — PASS; report e2e-report.md"
+  - path: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    type: report
+    status: draft
+    stage: 11-verify-impl
+    skill_id: 11-verify-impl
+    session_id: S057-strip-internal-doc-refs
+    note: "DRAFT — awaiting UJ-055 + F7/F21 signoff"
 - id: EV-047
   session_id: S056-m0-stabilize-operator-trust
   status: completed

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,16 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: 014c9125
-  tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
-  tip_sha_pushed: false
-  branch_note: "ACTIVE — tip 014c9125; 11-verify-impl PASS; qa003 fixed; next push+PR to stage"
+  tip_sha: 923c7170
+  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha_pushed: true
+  branch_note: "ACTIVE — tip 748cbb84 pushed; PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval"
+  pr_number: 963
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+  pr_status: open
+  pr_base: stage
+  pr_note: "PR #963 OPEN → stage; tip 748cbb84; CI/CD Pipeline run 31290962521 SUCCESS"
+  github_pr: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
   github_issues:
   - 951
   issue_ids:
@@ -42,7 +48,7 @@ active_session:
   prior_session: S056-m0-stabilize-operator-trust
   artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
   current_stage: 16-evolve
-  current_stage_note: "IN_PROGRESS — 11 PASS; next push+PR to stage"
+  current_stage_note: "IN_PROGRESS — PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval"
   decisions:
     D-S057-open: "1 — open S057/EV-048 for #951"
     D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
@@ -61,7 +67,7 @@ active_session:
     D-S057-f7: "1 — Approve F7 deepen (operator UI copy)"
     D-S057-f21: "1 — Approve F21 deepen (public OpenAPI/error surfaces)"
     D-S057-qa003: "2 — Fixed (expand guard for product Fn IDs @ 014c9125)"
-    D-S057-11-next: "1 — Next push+PR to stage"
+    D-S057-11-next: "1 — Next push+PR to stage (PR #963 open)"
   routing_plan:
   - stage: 00-context
     required: true
@@ -75,7 +81,7 @@ active_session:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Phase D in progress after D-S057-phaseC=1"
+    note: "IN_PROGRESS — PR #963 open → stage; awaiting merge approval after D-S057-11-next=1"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -334,8 +340,9 @@ active_session:
     evolve_cycle_id: EV-048
     created_at: '2026-08-08'
     note: "COMPLETE — PASS; D-S057-uj055=1 + f7=1 + f21=1 + qa003=2 + 11-next=1"
-  note: "11 PASS; next push+PR to stage; tip 014c9125; qa003 fixed; 16-evolve orchestrator"
+  note: "PR #963 open → stage; tip 748cbb84 pushed; CI/CD 31290962521 SUCCESS; awaiting merge approval"
   notes:
+  - "2026-08-08 PR #963 OPEN → stage; tip 748cbb84 pushed; CI/CD Pipeline run 31290962521 SUCCESS; D-S057-11-next=1 PR opened; awaiting merge approval"
   - "2026-08-08 11-verify-impl COMPLETE PASS — D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; tip 014c9125; next push+PR to stage"
   - "2026-08-08 09-qa COMPLETE pass_with_advisories + 10-e2e COMPLETE PASS; 11-verify-impl IN_PROGRESS awaiting UJ-055 + F7/F21 signoff; tip 3a43da37; 16-evolve orchestrator"
   - "2026-08-08 D-S057-phaseC=1 + D-S057-ui-preview-verify=2 — Phase D started; 09-qa + 10-e2e in_progress; tip 3a43da37; 16-evolve orchestrator"
@@ -15670,11 +15677,13 @@ stages:
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
     current_child_stage: 11-verify-impl
-    current_child_stage_note: '11 PASS; next push+PR to stage; D-S057-11-next=1'
-    tip_sha: 014c9125
-    tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
-    tip_sha_pushed: false
-    note: 'IN_PROGRESS — S057/EV-048 11 PASS; tip 014c9125; qa003 fixed; next push+PR to stage'
+    current_child_stage_note: 'PR #963 open → stage; CI/CD 31290962521 SUCCESS; awaiting merge approval'
+    tip_sha: 923c7170
+    tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+    tip_sha_pushed: true
+    pr_number: 963
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+    note: 'IN_PROGRESS — S057/EV-048 PR #963 open → stage; tip 748cbb84 pushed; CI/CD 31290962521 SUCCESS; awaiting merge approval'
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -15939,6 +15948,39 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-11-next-pr
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: pr_opened
+  status: recorded
+  topic: 'S057/EV-048 D-S057-11-next=1 — PR #963 opened → stage'
+  summary: 'D-S057-11-next=1 PR opened — https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963; tip 748cbb84 pushed; CI/CD Pipeline run 31290962521 SUCCESS; awaiting merge approval'
+  decision: |
+    D-S057-11-next=1 — PR opened after 11-verify-impl PASS.
+    PR #963 OPEN → base stage.
+    Tip 748cbb84 (923c717070975f3c6201432f95b2890e024ae5cf) tip_sha_pushed=true.
+    CI/CD Pipeline run 31290962521 SUCCESS — https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31290962521
+    Awaiting merge approval.
+  branch: evolve/EV-048-strip-internal-doc-refs
+  related_issues:
+  - '951'
+  pr_number: 963
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+  pr_status: open
+  pr_base: stage
+  tip_sha: 923c7170
+  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha_pushed: true
+  ci_cd_pipeline_run: '31290962521'
+  ci_cd_pipeline_status: SUCCESS
+  ci_cd_pipeline_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31290962521
+  note: 'PR #963 open; CI green; awaiting merge approval'
 - id: D-S057-11-next
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -33824,7 +33866,7 @@ evolve_cycles:
   milestone: "M0 — Stabilize + operator trust + narrative"
   phase: 1
   current_stage: 11-verify-impl
-  current_stage_note: "COMPLETE — 11 PASS; qa003 fixed; awaiting PR to stage"
+  current_stage_note: "COMPLETE — 11 PASS; PR #963 open → stage; awaiting merge approval"
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -33832,9 +33874,18 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: 014c9125
-  tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
-  tip_sha_pushed: false
+  tip_sha: 923c7170
+  tip_sha_full: 923c717070975f3c6201432f95b2890e024ae5cf
+  tip_sha_pushed: true
+  pr_number: 963
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+  pr_status: open
+  pr_base: stage
+  github_pr: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+  pr_note: "PR #963 OPEN → stage; tip 748cbb84; CI/CD 31290962521 SUCCESS; awaiting merge approval"
+  ci_cd_pipeline_run: '31290962521'
+  ci_cd_pipeline_status: SUCCESS
+  ci_cd_pipeline_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31290962521
   interrupted_by_hotfix: false
   parked: false
   ui_preview: requested
@@ -33877,7 +33928,7 @@ evolve_cycles:
     mode: orchestrator
     status: in_progress
     started: '2026-08-08'
-    note: "IN_PROGRESS — Phase D in progress after D-S057-phaseC=1"
+    note: "IN_PROGRESS — PR #963 open → stage; awaiting merge approval after D-S057-11-next=1"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -33976,7 +34027,7 @@ evolve_cycles:
     mode: skip
     status: skipped
     note: "waive unless deploy (Standard)"
-  note: "11 PASS; qa003 fixed; awaiting PR to stage; tip 014c9125; 16-evolve orchestrator"
+  note: "PR #963 open → stage; tip 748cbb84 pushed; CI/CD 31290962521 SUCCESS; awaiting merge approval"
   artifacts:
   - docs/sessions/S057-strip-internal-doc-refs/
   - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,10 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: 70088767
-  tip_sha_full: 70088767a00b7ccab3fbf4f03e29f87c3aa67bd9
+  tip_sha: 014c9125
+  tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
   tip_sha_pushed: false
-  branch_note: "ACTIVE — tip 70088767 after 09+10 reports commit; Phase D 11-verify-impl awaiting sign-off"
+  branch_note: "ACTIVE — tip 014c9125; 11-verify-impl PASS; qa003 fixed; next push+PR to stage"
   github_issues:
   - 951
   issue_ids:
@@ -42,7 +42,7 @@ active_session:
   prior_session: S056-m0-stabilize-operator-trust
   artifacts_dir: docs/sessions/S057-strip-internal-doc-refs/
   current_stage: 16-evolve
-  current_stage_note: "IN_PROGRESS — Phase D 11-verify-impl awaiting user sign-off; 09+10 complete"
+  current_stage_note: "IN_PROGRESS — 11 PASS; next push+PR to stage"
   decisions:
     D-S057-open: "1 — open S057/EV-048 for #951"
     D-S057-scope: "1 — full #951 UI+OpenAPI+guard"
@@ -57,6 +57,11 @@ active_session:
     D-S057-gateB: "1 — PASS; accept S5.M1–S5.M3 defaults; proceed 07-build M1"
     D-S057-phaseC: "1 — Continue 09-qa + 10-e2e delta → 11-verify-impl"
     D-S057-ui-preview-verify: "2 — No non-deployed UI preview before Verify (FE catalogs clean)"
+    D-S057-uj055: "1 — Approve UJ-055"
+    D-S057-f7: "1 — Approve F7 deepen (operator UI copy)"
+    D-S057-f21: "1 — Approve F21 deepen (public OpenAPI/error surfaces)"
+    D-S057-qa003: "2 — Fixed (expand guard for product Fn IDs @ 014c9125)"
+    D-S057-11-next: "1 — Next push+PR to stage"
   routing_plan:
   - stage: 00-context
     required: true
@@ -153,10 +158,12 @@ active_session:
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff"
+    completed: '2026-08-08'
+    overall: PASS
     report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    note: "COMPLETE — PASS; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; tip 014c9125"
   - stage: 12-verify-deploy
     required: false
     mode: skip
@@ -320,15 +327,16 @@ active_session:
     note: "COMPLETE — PASS; report e2e-report.md"
   - path: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
     type: report
-    status: draft
+    status: completed
     stage: 11-verify-impl
     skill_id: 11-verify-impl
     session_id: S057-strip-internal-doc-refs
     evolve_cycle_id: EV-048
     created_at: '2026-08-08'
-    note: "DRAFT — awaiting UJ-055 + F7/F21 signoff"
-  note: "Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; 16-evolve orchestrator"
+    note: "COMPLETE — PASS; D-S057-uj055=1 + f7=1 + f21=1 + qa003=2 + 11-next=1"
+  note: "11 PASS; next push+PR to stage; tip 014c9125; qa003 fixed; 16-evolve orchestrator"
   notes:
+  - "2026-08-08 11-verify-impl COMPLETE PASS — D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; tip 014c9125; next push+PR to stage"
   - "2026-08-08 09-qa COMPLETE pass_with_advisories + 10-e2e COMPLETE PASS; 11-verify-impl IN_PROGRESS awaiting UJ-055 + F7/F21 signoff; tip 3a43da37; 16-evolve orchestrator"
   - "2026-08-08 D-S057-phaseC=1 + D-S057-ui-preview-verify=2 — Phase D started; 09-qa + 10-e2e in_progress; tip 3a43da37; 16-evolve orchestrator"
   - "2026-08-08 08-verify-build COMPLETE PASS; Phase C checkpoint pending D-S057-phaseC; 16-evolve orchestrator"
@@ -12510,11 +12518,11 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa in_progress (T6.2; D-S011-EV008-c-to-d-pass)
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
-    status: in_progress
+    status: completed
     started_at: '2026-08-08'
     started: '2026-08-08'
-    completed:
-    completed_at:
+    completed: '2026-08-08'
+    completed_at: '2026-08-08'
     previous_started_at: '2026-08-08'
     previous_started: '2026-08-08'
     previous_completed: '2026-08-08'
@@ -12586,14 +12594,14 @@ stages:
     prior_s037_tip_sha: 3889e4c
     session_id: S057-strip-internal-doc-refs
     evolve_cycle_id: EV-048
-    tip_sha: 3a43da37
-    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    tip_sha: 014c9125
+    tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
     tip_sha_pushed: false
     mode: delta
-    overall:
+    overall: PASS
     report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
     expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
-    note: 'IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff; report verify-impl.md draft; 09+10 complete'
+    note: 'COMPLETE — PASS @ 014c9125; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; next push+PR to stage'
     skill_id: 11-verify-impl
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
@@ -12603,6 +12611,11 @@ stages:
     previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verify-impl.md
     previous_s056_note: 'COMPLETE — PASS @ 3ca4f438; D-S056-ac-bundle=1, D-S056-uj054=1, D-S056-advisories=1, D-S056-11-ui-preview=2; report verify-impl.md; phase_d passed; handoff phase4-close / PR #961'
     decision_refs:
+    - D-S057-uj055
+    - D-S057-f7
+    - D-S057-f21
+    - D-S057-qa003
+    - D-S057-11-next
     - D-S057-phaseC
     - D-S056-ac-bundle
     - D-S056-uj054
@@ -12618,12 +12631,17 @@ stages:
     prior_s050_overall: approved
     prior_s050_note: 'COMPLETE — D-S050-11-verify approve F33 + F7 deepen + F16–F19 deepen; UJ-051..053 approved (T3/H4–H5 waived until 13); UI preview accepted localhost:18000; fix adad127c hide Upload to Database; report verify-impl.md; tip adad127c; next 12-verify-deploy'
     prior_s050_report_note: 'S050/EV-042 11 COMPLETE — superseded by S054/EV-045'
-    report_status: draft
-    tip_note: 'S057/EV-048 tip 3a43da37 — 11-verify-impl IN_PROGRESS; awaiting UJ-055 + F7/F21 signoff'
-    awaiting_user_decision: true
-    awaiting_user_decision_note: 'Awaiting UJ-055 + F7/F21 signoff'
-    decision_id:
+    report_status: approved
+    tip_note: 'S057/EV-048 tip 014c9125 — 11-verify-impl PASS; qa003 fixed; next push+PR to stage'
+    awaiting_user_decision: false
+    awaiting_user_decision_note:
+    decision_id: D-S057-11-next
     decision_ids:
+    - D-S057-uj055
+    - D-S057-f7
+    - D-S057-f21
+    - D-S057-qa003
+    - D-S057-11-next
     - D-S050-11-verify
     - D-S047-11
     deepen_feature_ids:
@@ -12632,8 +12650,8 @@ stages:
     feature_ids: []
     active_milestone: M1
     active_task:
-    active_task_status:
-    active_task_note: '11-verify-impl in_progress — awaiting UJ-055 + F7/F21 signoff'
+    active_task_status: completed
+    active_task_note: '11-verify-impl COMPLETE PASS — next push+PR to stage'
     previous_s046_decision_id: D-S046-11
     previous_s045_session_id: S045-matrix-disposition-residuals
     previous_s045_evolve_cycle_id: EV-037
@@ -12681,18 +12699,21 @@ stages:
       session_id: S057-strip-internal-doc-refs
       evolve_cycle_id: EV-048
       skill_id: 11-verify-impl
-      status: in_progress
+      status: completed
       mode: delta
       started_at: '2026-08-08'
       started: '2026-08-08'
-      tip_sha: 3a43da37
-      tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+      completed: '2026-08-08'
+      completed_at: '2026-08-08'
+      tip_sha: 014c9125
+      tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
+      overall: PASS
       report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
-      report_status: draft
+      report_status: approved
       deepen_feature_ids:
       - F7
       - F21
-      note: 'IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff; report verify-impl.md draft'
+      note: 'COMPLETE — PASS; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; tip 014c9125'
     - id: S050-remove-db-tools-operator-throughput-11
       session_id: S050-remove-db-tools-operator-throughput
       evolve_cycle_id: EV-042
@@ -15649,11 +15670,11 @@ stages:
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
     current_child_stage: 11-verify-impl
-    current_child_stage_note: 'Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; D-S057-ui-preview-verify=2'
-    tip_sha: 3a43da37
-    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    current_child_stage_note: '11 PASS; next push+PR to stage; D-S057-11-next=1'
+    tip_sha: 014c9125
+    tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
     tip_sha_pushed: false
-    note: 'IN_PROGRESS — S057/EV-048 Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; no git commit by workflow-state-manager'
+    note: 'IN_PROGRESS — S057/EV-048 11 PASS; tip 014c9125; qa003 fixed; next push+PR to stage'
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -15918,6 +15939,37 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S057-11-next
+  date: '2026-08-08'
+  timestamp: '2026-08-08'
+  resolved_at: '2026-08-08'
+  session_id: S057-strip-internal-doc-refs
+  evolve_cycle_id: EV-048
+  skill: 11-verify-impl
+  skill_id: 11-verify-impl
+  stage: 11-verify-impl
+  category: verify_impl_signoff
+  status: confirmed
+  topic: 'S057/EV-048 11-verify-impl PASS → push+PR to stage'
+  summary: 'D-S057-uj055=1, D-S057-f7=1, D-S057-f21=1, D-S057-qa003=2, D-S057-11-next=1 — 11 PASS; qa003 fixed @ 014c9125; next push+PR to stage'
+  decision: |
+    D-S057-uj055=1 — Approve UJ-055.
+    D-S057-f7=1 — Approve F7 deepen (operator UI copy).
+    D-S057-f21=1 — Approve F21 deepen (public OpenAPI/error surfaces).
+    D-S057-qa003=2 — Fixed (expand guard for product Fn IDs @ 014c9125).
+    D-S057-11-next=1 — Next push+PR to stage.
+    Report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md.
+    Tip 014c9125. tip_sha_pushed=false until push.
+  user_option: '1 / 1 / 1 / 2 / 1'
+  branch: evolve/EV-048-strip-internal-doc-refs
+  related_issues:
+  - '951'
+  tip_sha: 014c9125
+  tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
+  tip_sha_pushed: false
+  current_stage: 11-verify-impl
+  overall: PASS
+  note: '11 PASS; qa003 fixed; awaiting PR to stage'
 - id: D-S057-phaseC
   date: '2026-08-08'
   timestamp: '2026-08-08'
@@ -33772,7 +33824,7 @@ evolve_cycles:
   milestone: "M0 — Stabilize + operator trust + narrative"
   phase: 1
   current_stage: 11-verify-impl
-  current_stage_note: "IN_PROGRESS — Phase D 11-verify-impl awaiting user sign-off; 09+10 complete"
+  current_stage_note: "COMPLETE — 11 PASS; qa003 fixed; awaiting PR to stage"
   started: '2026-08-08'
   started_at: '2026-08-08'
   branch: evolve/EV-048-strip-internal-doc-refs
@@ -33780,8 +33832,8 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: 70088767
-  tip_sha_full: 70088767a00b7ccab3fbf4f03e29f87c3aa67bd9
+  tip_sha: 014c9125
+  tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
   tip_sha_pushed: false
   interrupted_by_hotfix: false
   parked: false
@@ -33803,6 +33855,11 @@ evolve_cycles:
   - D-S057-gateB=1
   - D-S057-phaseC=1
   - D-S057-ui-preview-verify=2
+  - D-S057-uj055=1
+  - D-S057-f7=1
+  - D-S057-f21=1
+  - D-S057-qa003=2
+  - D-S057-11-next=1
   gate_a: PASS
   gate_a_decision: D-S057-gateA=1
   gate_b: PASS
@@ -33903,10 +33960,12 @@ evolve_cycles:
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-08'
-    note: "IN_PROGRESS — awaiting UJ-055 + F7/F21 signoff"
+    completed: '2026-08-08'
+    overall: PASS
     report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    note: "COMPLETE — PASS; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; tip 014c9125"
   - stage: 12-verify-deploy
     required: false
     mode: skip
@@ -33917,7 +33976,7 @@ evolve_cycles:
     mode: skip
     status: skipped
     note: "waive unless deploy (Standard)"
-  note: "IN_PROGRESS — S057/EV-048 Phase D 11-verify-impl awaiting user sign-off; 09+10 complete; tip 3a43da37; 16-evolve orchestrator"
+  note: "11 PASS; qa003 fixed; awaiting PR to stage; tip 014c9125; 16-evolve orchestrator"
   artifacts:
   - docs/sessions/S057-strip-internal-doc-refs/
   - path: docs/sessions/S057-strip-internal-doc-refs/session-brief.md
@@ -34027,11 +34086,11 @@ evolve_cycles:
     note: "COMPLETE — PASS; report e2e-report.md"
   - path: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
     type: report
-    status: draft
+    status: completed
     stage: 11-verify-impl
     skill_id: 11-verify-impl
     session_id: S057-strip-internal-doc-refs
-    note: "DRAFT — awaiting UJ-055 + F7/F21 signoff"
+    note: "COMPLETE — PASS; D-S057-uj055=1 + f7=1 + f21=1 + qa003=2 + 11-next=1"
 - id: EV-047
   session_id: S056-m0-stabilize-operator-trust
   status: completed

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,10 +20,10 @@ active_session:
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
   branch_exists: true
-  tip_sha: 3a43da37
-  tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+  tip_sha: 70088767
+  tip_sha_full: 70088767a00b7ccab3fbf4f03e29f87c3aa67bd9
   tip_sha_pushed: false
-  branch_note: "ACTIVE — tip 3a43da37; Phase D 11-verify-impl awaiting sign-off; 09+10 complete"
+  branch_note: "ACTIVE — tip 70088767 after 09+10 reports commit; Phase D 11-verify-impl awaiting sign-off"
   github_issues:
   - 951
   issue_ids:
@@ -33780,8 +33780,8 @@ evolve_cycles:
   branch_base_sha: d7652d5d
   branch_base_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
   branch_status: active
-  tip_sha: 3a43da37
-  tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+  tip_sha: 70088767
+  tip_sha_full: 70088767a00b7ccab3fbf4f03e29f87c3aa67bd9
   tip_sha_pushed: false
   interrupted_by_hotfix: false
   parked: false


### PR DESCRIPTION
## Summary
- Strip internal planning vocabulary from operator-visible UI copy and public OpenAPI/error surfaces ([#951](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/951)).
- Add automated BE/FE guards (`TC-EV048-*`) covering Corpus/ADR/EV/S0/TC/E##/#NNN/**Fn** patterns; privacy inventory + residual OpenAPI `F2`/`F6` cites cleaned (`D-S057-qa003=2`).
- Deepens **F7** / **F21** (no new Fn). S057 / EV-048 — 11-verify-impl **PASS** (UJ-055 + AC1–AC6). T3 Playwright skipped (no FE hits). 12/13 waived — merge gate is tip CI → `stage`.

## Test plan
- [x] `make validate-fast`
- [x] `apps/backend` `test_tc_ev048_*` (OpenAPI + synthetic inject incl. Fn)
- [x] FE Vitest `internalDocRefGuard` + SoftPreview + privacy inventory
- [x] H0c CORS `tests/unit/test_cors_policy.py`
- [ ] Tip CI green on this branch before merge
- [ ] Confirm audit report listed in PR: `docs/sessions/S057-strip-internal-doc-refs/reports/audit-internal-doc-refs.md`

## Corpus
[Corpus: product §F7] [Corpus: product §F21] [Corpus: api] [Corpus: tests] [Corpus: journeys]

Closes #951


Made with [Cursor](https://cursor.com)