### PR TITLE
[EV-051] Tag-driven prod Deploy + full CI Deploy needs

### DIFF
--- a/.cursor/rules/core/atomic-commits.mdc
+++ b/.cursor/rules/core/atomic-commits.mdc
@@ -105,7 +105,8 @@ Commits and PRs are structured, but **no file is auto-updated** for end users. W
 release, promoting **`stage` → `main`**, or completing deploy, aggregate merged work into
 `docs/CHANGELOG.md` and/or the deploy report (see `.cursor/skills/considerations.md`).
 
-**Promote = release (recommended):** bump changed publishable package semver on `stage`,
-cut CHANGELOG, merge via Staging gate, then tag `vYYYY.MM.DD-deploy` on `main` (+ PyPI
-package tags when publishing). Details: [docs/deploy.md](../../../docs/deploy.md) §Promote ·
-[doks-promote-from-stage.mdc](../optional/doks-promote-from-stage.mdc) §Release on promote.
+**Promote = release:** bump changed publishable package semver on `stage`, cut CHANGELOG,
+merge via Staging gate to `main` (CI only), then push `vYYYY.MM.DD-deploy` to roll **prod**
+(+ PyPI package tags when publishing). Details: [docs/deploy.md](../../../docs/deploy.md)
+§Promote · [doks-promote-from-stage.mdc](../optional/doks-promote-from-stage.mdc)
+§Release on promote (EV-051).

--- a/.cursor/rules/optional/ci-after-push.mdc
+++ b/.cursor/rules/optional/ci-after-push.mdc
@@ -10,11 +10,12 @@ session, open a PR as ready, or mark work complete after `git push` without watc
 
 ## Workflows (monorepo)
 
-| Branch | Workflow | Must pass |
-|--------|----------|-----------|
-| Any | `.github/workflows/ci-cd.yml` | Test matrix (+ alembic/native as required) |
-| `stage` | same | **Deploy (stage)** + **Staging smoke** (after merge/push) |
-| `main` | same | **Deploy (main)** to prod |
+| Branch / event | Workflow | Must pass |
+|----------------|----------|-----------|
+| Any PR / push | `.github/workflows/ci-cd.yml` | Test matrix (+ alembic/native/`e2e-smoke` as required) |
+| `stage` push | same | **Deploy (stage)** + **Staging smoke** (after merge/push) |
+| `main` push | same | Full CI; **no** auto prod Deploy (EV-051) |
+| Tag `v*-*-deploy` or prod `workflow_dispatch` | same | Full CI + **Deploy (production)** |
 | PR → `main` | same | **Staging gate** — head must be `stage` + tip **Staging smoke** green |
 
 ## Promote to main (DOKS / ADR-034)

--- a/.cursor/rules/optional/doks-promote-from-stage.mdc
+++ b/.cursor/rules/optional/doks-promote-from-stage.mdc
@@ -23,19 +23,22 @@ DOKS clusters** (not only namespaces). Use env-scoped kubeconfigs.
 ## Promote path
 
 1. Feature → PR → `stage` (required CI).
-2. Merge to `stage` → auto Deploy **staging cluster** + **Staging smoke** (HTTPS or
-   Host-header via staging LB `143.244.202.13` / `STAGING_LB_IP`).
+2. Merge to `stage` → auto Deploy **staging cluster** after full Deploy `needs` (incl.
+   `e2e-smoke`) + **Staging smoke** (HTTPS or Host-header via staging LB
+   `143.244.202.13` / `STAGING_LB_IP`).
 3. **Release prep on `stage` (recommended before every promote):** bump publishable
    package semver when those packages changed, cut `docs/CHANGELOG.md`, commit on
    `stage` — see §Release on promote and [Corpus: deploy] §Promote.
 4. Promote: PR **`stage` → `main` only**. CI **Staging gate** (`staging-gate`) must pass
    (head=`stage` + tip Staging smoke green). No feature→`main`.
-5. Merge to `main` → auto Deploy **prod cluster**.
-6. **Tag the release** on the merged `main` tip (deploy tag + any PyPI package tags).
+5. Merge to `main` → **full CI only** (no auto prod Deploy — EV-051).
+6. **Ship prod:** push `vYYYY.MM.DD-deploy` on the merged `main` tip (triggers prod
+   Deploy after CI). Optional escape hatch: `workflow_dispatch` → production. Then any
+   PyPI package tags when publishing.
 
-Never push directly to `stage`/`main` when rulesets are enabled. Solo-dev: PR is the
-manual gate (no Environment reviewers required). Do not promote while Staging smoke or
-Staging gate is red/missing.
+Never push directly to `stage`/`main` when rulesets are enabled. Solo-dev gates: PR
+`stage`→`main`, then deploy tag (or dispatch). No Environment reviewers. Do not promote
+while Staging smoke or Staging gate is red/missing.
 
 ## Release on promote
 
@@ -46,7 +49,7 @@ deploy). Recommendation (soft — Staging gate does not fail on missing bumps):
 |------|------|--------|
 | Semver | On `stage`, before opening/updating the promote PR | For each changed publishable package (`tac2iwxxm`, `tac-validate`, `iwxxm-validate`): decide none/patch/minor/major; sync `pyproject.toml` + `__version__` + Cargo/locks when present |
 | CHANGELOG | Same commit(s) on `stage` | Move Unreleased bullets into a dated section; note promote PR |
-| Deploy tag | After merge to `main` | `git tag vYYYY.MM.DD-deploy` (or next agreed scheme) on the merge tip; push tag |
+| Deploy tag | After merge to `main` + tip CI green | `git tag vYYYY.MM.DD-deploy`; `git push origin <tag>` — **this** rolls prod (EV-051) |
 | PyPI tags | After merge when publishing | Per-package tags only (`tac2iwxxm-v*`, …); run **pypi-release-checklist** first |
 
 Docs-only / infra-only promotes with **no** package tree changes may skip package semver

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,8 +4,19 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main, stage]
+    # EV-051 — prod Deploy gate (solo): tag on main tip, not bare main push
+    tags:
+      - 'v*-*-deploy'
   pull_request:
     branches: [main, stage]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deploy target (escape hatch after full CI)'
+        type: choice
+        options:
+          - production
+        default: production
 
 env:
   REGISTRY: ghcr.io
@@ -569,17 +580,21 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # DEPLOY — build/push GHCR images, then roll DOKS (F30 / EV-034 / EV-043 / EV-044).
-  # stage → staging cluster (env staging); main → prod cluster (env production).
+  # DEPLOY — build/push GHCR images, then roll DOKS (F30 / EV-034 / EV-043 / EV-044 / EV-051).
+  # stage push → staging (auto). main push → CI only (no Deploy).
+  # Prod Deploy: tag v*-*-deploy or workflow_dispatch → production (solo gate).
   # Promote to main only via PR stage→main after Staging smoke + staging-gate (ADR-034).
-  # Render hooks optional (main only).
+  # Render hooks optional (prod Deploy only).
   # ============================================================================
   deploy:
     runs-on: ubuntu-latest
     name: Deploy (${{ github.ref_name }})
-    needs: [test, test-alembic, rust-crates-gate, tac2iwxxm-native, converter-perf]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    needs: [test, test-alembic, rust-crates-gate, tac2iwxxm-native, converter-perf, e2e-smoke]
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/stage') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'v') && endsWith(github.ref_name, '-deploy')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'production')
+    environment: ${{ github.ref == 'refs/heads/stage' && 'staging' || 'production' }}
     permissions:
       contents: read
       packages: write
@@ -599,18 +614,19 @@ jobs:
         id: target
         run: |
           set -euo pipefail
-          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-            echo "namespace=metar-iwxxm" >> "$GITHUB_OUTPUT"
-            echo "latest_tag=main-latest" >> "$GITHUB_OUTPUT"
-            echo "app_url=https://app.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
-            echo "api_url=https://api.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
-            echo "env_role=prod" >> "$GITHUB_OUTPUT"
-          else
+          # stage branch → staging; deploy tags / workflow_dispatch → prod (EV-051)
+          if [ "${GITHUB_REF}" = "refs/heads/stage" ]; then
             echo "namespace=metar-iwxxm-staging" >> "$GITHUB_OUTPUT"
             echo "latest_tag=stage-latest" >> "$GITHUB_OUTPUT"
             echo "app_url=https://app.staging.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
             echo "api_url=https://api.staging.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
             echo "env_role=staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "namespace=metar-iwxxm" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=main-latest" >> "$GITHUB_OUTPUT"
+            echo "app_url=https://app.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "api_url=https://api.tac-to-iwxxm.com" >> "$GITHUB_OUTPUT"
+            echo "env_role=prod" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Guard CD credentials (skip if GHCR unavailable)
@@ -718,8 +734,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.tags.outputs.image_tag }}
             ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.target.outputs.latest_tag }}
 
-      - name: Optional Render hooks (non-blocking, main/prod only)
-        if: steps.guard.outputs.skip != 'true' && github.ref == 'refs/heads/main'
+      - name: Optional Render hooks (non-blocking, prod Deploy only)
+        if: steps.guard.outputs.skip != 'true' && steps.target.outputs.env_role == 'prod'
         continue-on-error: true
         env:
           IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}

--- a/docs/adr/ADR-034-doks-staging-promote-from-stage.md
+++ b/docs/adr/ADR-034-doks-staging-promote-from-stage.md
@@ -1,12 +1,13 @@
 # ADR-034: DOKS staging + promote-from-stage CD (F30 deepen / #886)
 
 > **Status**: Accepted (S052 / EV-043); **Amended** (S053 / EV-044 — dual DOKS clusters;
-> S056 follow-up — release bump+tag on promote)  
-> **Date**: 2026-08-08  
-> **Deciders**: User (issue #886 + Evolve Plan Card; EV-044 project visibility; promote-release)  
+> S056 follow-up — release bump+tag on promote; **S060 / EV-051 — tag-driven prod Deploy**)  
+> **Date**: 2026-08-08 (EV-051 amend 2026-08-09)  
+> **Deciders**: User (issue #886 + Evolve Plan Card; EV-044 project visibility; promote-release;
+> EV-051 solo tag/dispatch gate)  
 > **Amends**: [ADR-033](ADR-033-platform-independence-auth-do-doks.md) (single prod DOKS → dual env)  
 > **Related**: F30; F12–F14; [docs/deploy.md](../deploy.md); EV-034 CD rollout  
-> **Sessions**: S052-doks-staging-prod-branch-deploys / EV-043; S053-separate-staging-doks-project / EV-044
+> **Sessions**: S052 / EV-043; S053 / EV-044; **S060-tag-driven-prod-deploy / EV-051**
 
 ## Context
 
@@ -28,19 +29,23 @@ visible and isolated in the DigitalOcean control plane.
 2. **Dual managed Postgres** — prod DB `metar-iwxxm` (defaultdb) on **TAC-to-IWXXM**;
    staging DB `metar-iwxxm-staging` (`db-s-1vcpu-1gb`) on **Staging TAC-to-IWXXM**.
    Never share prod `DATABASE_URL` with staging.
-3. **Branches** — `stage` → staging CD; `main` → prod CD. Both require PRs (no direct push /
-   no force-push via rulesets when admin can apply them).
+3. **Branches** — `stage` → staging **auto** CD after full CI; `main` → full CI **without**
+   auto prod Deploy (EV-051). Both require PRs (no direct push / no force-push via rulesets
+   when admin can apply them).
 4. **DNS** — Staging: `api.staging.tac-to-iwxxm.com` / `app.staging.tac-to-iwxxm.com` →
    **staging cluster LB** (new EXTERNAL-IP after provision). Prod hosts unchanged on prod LB
    (`168.144.12.70` until rotated).
 5. **Promote path** — Only PRs from `stage` → `main`. CI job `staging-gate` requires green
-   **Staging smoke** for the tip SHA. After merge to `main`, prod Deploy runs automatically.
-6. **Release on promote (recommended)** — Treat each `stage` → `main` cutover as a release:
+   **Staging smoke** for the tip SHA. Merge to `main` lands code + runs CI; **prod Deploy**
+   waits for a deploy tag (or dispatch) — see (6)/(7).
+6. **Release on promote (required for prod cutover)** — Treat each prod ship as a release:
    on `stage` before the promote PR, bump publishable package semver when those packages
-   changed and cut `docs/CHANGELOG.md`; after merge to `main`, tag a deploy release
-   (`vYYYY.MM.DD-deploy`) and any PyPI package tags (F12–F14) when publishing. Soft
-   recommendation — Staging gate remains smoke/path enforcement only (prints a reminder).
-7. **Solo-dev** — No required Environment reviewers; the PR is the manual step.
+   changed and cut `docs/CHANGELOG.md`; after merge to `main` and green CI, push
+   `vYYYY.MM.DD-deploy` on the `main` tip to trigger prod Deploy; add PyPI package tags
+   (F12–F14) when publishing. Staging gate remains smoke/path enforcement (prints a reminder).
+7. **Solo-dev prod gate** — No required Environment reviewers. Manual steps: (a) PR
+   `stage`→`main`, (b) push deploy tag (or `workflow_dispatch`). Deploy `needs` include
+   full unit/native/perf matrix **plus** `e2e-smoke`.
 8. **IaC** — Kustomize overlays `deploy/doks/overlays/{staging,prod}`; CD uses
    **per-environment kubeconfig** (`KUBE_CONFIG` / `KUBE_CONFIG_STAGING` or GH Env secrets).
 9. **Teardown** — After staging cluster smokes green, delete shared-cluster namespace
@@ -49,9 +54,10 @@ visible and isolated in the DigitalOcean control plane.
 ## Consequences
 
 - Skills 12/13/15/16 and ci-after-push must distinguish `env_role: staging | prod` **and**
-  cluster/project (not only namespace).
-- Promote PRs should include release prep (semver + CHANGELOG) and post-merge tags; agents
-  follow `.cursor/rules/optional/doks-promote-from-stage.mdc` §Release on promote.
+  cluster/project (not only namespace); prod Deploy is tag/dispatch-gated, not `main` push.
+- Promote PRs should include release prep (semver + CHANGELOG); agents follow
+  `.cursor/rules/optional/doks-promote-from-stage.mdc` §Release on promote — **tag push is
+  what rolls prod**.
 - Staging and prod no longer share node-pool memory; staging worker may run at 1 replica
   without starving prod.
 - Cost: second cheapest DOKS node + cheapest managed PG.
@@ -60,6 +66,7 @@ visible and isolated in the DigitalOcean control plane.
 ## Alternatives considered
 
 - App Platform dual apps — rejected (diverges from F30 DOKS).
-- Environment approval for prod — rejected for solo-dev friction.
+- Environment approval for prod — rejected for solo-dev friction (EV-051 uses tag/dispatch).
+- Auto Deploy on every `main` push — superseded by EV-051 (CI on `main`; Deploy on tag).
 - Same-cluster two namespaces (EV-043) — superseded for DO Project visibility / isolation
-  (EV-044); promote CD policy retained.
+  (EV-044); promote CD path retained with tag-driven prod.

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,51 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-051 — Tag-driven prod deploy + full CI Deploy needs (S060)
+
+**Session**: S060-tag-driven-prod-deploy  
+**Features**: deepen **F30** (no new Fn)  
+**Started**: 2026-08-09  
+**Branch**: `evolve/EV-051-tag-driven-prod-deploy` (base `stage@c146baec`)  
+**Status**: **in_progress** — Phase A (01)  
+**Corpus**: [Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034] [Corpus: tests]
+
+### Scope (Phase 0–1 — locked 2026-08-09)
+
+| ID | Decision |
+|----|----------|
+| D-S060-open | **1** — Open S060 / EV-051; EV-043/044 remain parked |
+| D-S060-scope | **1** — Design 2+3+4: widen Deploy `needs` (+ `e2e-smoke`); no auto Deploy on `main` push; prod via `vYYYY.MM.DD-deploy` tag + optional `workflow_dispatch`; staging stays auto after full CI |
+| D-S060-route | **1** — Lean+: `00→16→01→02→03→07→08→09→11`; skip `04,05,06,10,12,13` |
+| D-S060-gateA | **1** — Gate A PASS; handoff 07/08/09/11 |
+| D-S060-11-next | **1** — Approve AC1–AC6; push + PR → `stage` (12/13 skipped) |
+
+### Acceptance
+
+| AC | Criterion | TC |
+|----|-----------|-----|
+| AC1 | Deploy `needs` includes prior set **plus** `e2e-smoke` (frontend remains inside `test` matrix) | TC-EV051-001 |
+| AC2 | Push/merge to `stage` still auto-Deploys **staging** after those needs pass | TC-F30-010 (amended) / TC-EV051-002 |
+| AC3 | Push/merge to `main` runs full CI but **does not** Deploy prod | TC-EV051-003 |
+| AC4 | Push tag matching `vYYYY.MM.DD-deploy` (pattern `v*-*-deploy`) on a commit runs prod Deploy after full CI | TC-EV051-004 / TC-F30-014 |
+| AC5 | `workflow_dispatch` can trigger prod Deploy (escape hatch) after full CI | TC-EV051-005 |
+| AC6 | ADR-034, `docs/deploy.md`, `doks-promote-from-stage.mdc`, feature-list F30 / TC-F30-010 amended; solo-dev approval = tag (or dispatch), not Environment reviewers | TC-EV051-006 |
+
+### Out of scope
+
+- GitHub Environment required reviewers
+- Quality-pack workflows as Deploy `needs`
+- Chat/Slack approve
+- PyPI publish path changes
+- Resume EV-043 / EV-044
+- Promote `stage`→`main` / first prod tag cutover in this cycle (docs+workflow only → `stage`)
+
+### Preset
+
+**Lean+** — `00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11`.
+
+---
+
 ## Cycle EV-050 — codes.wmo.int Validated: harvest + tac-validate membership (#959) (S059)
 
 **Session**: S059-codes-wmo-validated  

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -60,19 +60,20 @@ Render archive: [ops/render-decommission-archive.md](ops/render-decommission-arc
 `--skip-if-suspended` / `RENDER_SKIP_IF_SUSPENDED` so main CI Deploy skips suspended Render
 services without failing (see BUG-2026-08-03). GHCR push continues; DOKS is the prod target.
 
-### CD — DOKS image rollout (S042 / EV-034 / EV-043 / EV-044 dual cluster)
+### CD — DOKS image rollout (S042 / EV-034 / EV-043 / EV-044 / EV-051 tag-driven prod)
 
-| Branch | GH Environment | Cluster | Namespace | Latest tag | Post-deploy |
-|--------|----------------|---------|-----------|------------|-------------|
-| `stage` | `staging` | `metar-iwxxm-staging` | `metar-iwxxm-staging` | `stage-latest` | **Staging smoke** job |
-| `main` | `production` | `metar-iwxxm` | `metar-iwxxm` | `main-latest` | (prod smoke via 13 / Makefile) |
+| Trigger | GH Environment | Cluster | Namespace | Latest tag | Post-deploy |
+|---------|----------------|---------|-----------|------------|-------------|
+| Push `stage` | `staging` | `metar-iwxxm-staging` | `metar-iwxxm-staging` | `stage-latest` | **Staging smoke** job |
+| Push `main` | — | — | — | — | **CI only** (no Deploy) |
+| Tag `vYYYY.MM.DD-deploy` (`v*-*-deploy`) or `workflow_dispatch` → production | `production` | `metar-iwxxm` | `metar-iwxxm` | `main-latest` | prod smoke via 13 / Makefile |
 
-On push to `stage` or `main`, **Deploy** in `.github/workflows/ci-cd.yml`:
+**Deploy** in `.github/workflows/ci-cd.yml` waits on full CI including **`e2e-smoke`**, then:
 
 1. Builds/pushes GHCR images tagged `TIMESTAMP-SHA` and `{stage\|main}-latest`.
 2. **Rolls DOKS** with `DOKS_NAMESPACE` + **env-scoped kubeconfig** via
    `scripts/deploy/doks_rollout_images.sh <tag>` (staging secret ≠ prod secret after EV-044).
-3. **Render hooks** (optional, **main only**): `--skip-if-suspended` (`E34-4`).
+3. **Render hooks** (optional, **prod Deploy only**): `--skip-if-suspended` (`E34-4`).
 
 **Promote (required before any merge to `main`):** [Corpus: adr/ADR-034]
 
@@ -86,16 +87,20 @@ On push to `stage` or `main`, **Deploy** in `.github/workflows/ci-cd.yml`:
 4. Open PR **`stage` → `main` only** (never feature → `main`). Job **Staging gate**
    (`scripts/ci/staging_gate.sh` / TC-F30-012) must pass: head branch = `stage` and tip has a
    successful **Staging smoke** check-run. The gate prints a **release reminder** (advisory).
-5. Merge to `main` → **Deploy (main)** to prod cluster.
-6. **Tag the release** on the merged `main` tip: deploy tag + any PyPI package tags (F12–F14).
+5. Merge to `main` → full CI on `main` (**no** prod Deploy).
+6. **Ship prod:** on the merged `main` tip, `git tag vYYYY.MM.DD-deploy` &&
+   `git push origin <tag>` (triggers prod Deploy after CI). Optional escape hatch:
+   Actions → CI/CD Pipeline → **Run workflow** (`workflow_dispatch`, production).
+7. PyPI package tags (F12–F14) when publishing — separate from the deploy tag.
 
-Solo-dev: the PR is the manual gate (no Environment reviewers). Do **not** promote while
-Staging smoke or Staging gate is red/missing. See [ADR-034](adr/ADR-034-doks-staging-promote-from-stage.md)
-and [ops/doks-staging-dns-runbook.md](ops/doks-staging-dns-runbook.md).
+Solo-dev gates: (1) PR `stage`→`main`, (2) deploy tag or dispatch. No Environment reviewers.
+Do **not** promote while Staging smoke or Staging gate is red/missing. See
+[ADR-034](adr/ADR-034-doks-staging-promote-from-stage.md) and
+[ops/doks-staging-dns-runbook.md](ops/doks-staging-dns-runbook.md).
 
-### Release checklist (`stage` → `main`)
+### Release checklist (`stage` → `main` → tag)
 
-Treat every promote to prod as a release. Soft recommendation (does not block Staging gate):
+Treat every prod cutover as a release:
 
 - [ ] Diff `stage` vs last deploy tag / last promote: note which of `packages/tac2iwxxm`,
       `packages/tac-validate`, `packages/iwxxm-validate` changed
@@ -103,14 +108,15 @@ Treat every promote to prod as a release. Soft recommendation (does not block St
       `pyproject.toml`, `__version__`, and Cargo/locks when present
 - [ ] Cut `docs/CHANGELOG.md` (dated section; link the promote PR when known)
 - [ ] Open/update PR `stage` → `main`; Staging smoke + Staging gate green
-- [ ] After merge: `git tag vYYYY.MM.DD-deploy` on `main` tip; `git push origin <tag>`
+- [ ] Merge to `main`; wait for tip CI green (**Deploy must not run** on that push)
+- [ ] `git tag vYYYY.MM.DD-deploy` on `main` tip; `git push origin <tag>` → prod Deploy
 - [ ] If publishing to PyPI: per-package tags (`tac2iwxxm-v*`, `tac-validate-v*`,
       `iwxxm-validate-v*`) only after [pypi-release-checklist](../.cursor/skills/pypi-release-checklist/SKILL.md)
 - [ ] Docs-only / infra-only with no package diffs: skip package semver + PyPI tags; still
       cut CHANGELOG + deploy tag when shipping to prod
 
 Rule: [`.cursor/rules/optional/doks-promote-from-stage.mdc`](../.cursor/rules/optional/doks-promote-from-stage.mdc)
-§Release on promote. [Corpus: product §F12–F14]
+§Release on promote. [Corpus: product §F12–F14] [Corpus: product §F30]
 
 | Actions secret | Required | Description |
 |----------------|----------|-------------|

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -37,7 +37,7 @@
 | F27 | TCA quality bar (TropicalCycloneAdvisory) | Done | Product | S027 / EV-021; #737; PR #794; **deepen** S055 / EV-046 #889 |
 | F28 | SWXA quality bar (SpaceWeatherAdvisory) | Done | Product | S036 / EV-029; #823/#740 closed; PR #828; **deepen** S055 / EV-046 #889; **deepen** S059 / EV-050 #959 SpaceWxPhenomena fixtures |
 | F29 | Parameterized lint/convert/validate rule matrices | Done | Product | S037 / EV-030; #831; shipped 2026-08-03 (#832) |
-| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; S042 / EV-034 CD; S052 / EV-043 staging CD (#886); **deepen** S053 / EV-044 separate staging DOKS + DO Project |
+| F30 | Platform independence (Auth / DO DB / DOKS) | Done | Platform | S038 / EV-031; S042 / EV-034 CD; S052 / EV-043 staging CD (#886); S053 / EV-044 dual DOKS; **deepen** S060 / EV-051 tag-driven prod Deploy |
 | F31 | Hybrid operator sessions (guest local + Auth long-term) | Done | Product | S038 / EV-031; amends F5/F7/F21/F22 |
 | F32 | VONA quality bar (VolcanoObservatoryNoticeForAviation) | Done | Product | S040 / EV-032; #741 closed; **deepen** S055 / EV-046 #889; prior S046 / EV-038; epic #846 |
 | F33 | Secure mass file/folder ingest | Implemented | Product | S050 / EV-042; #897; auth + caps + sniff/zip-bomb; multi-file + folder/zip; 11 approved |
@@ -1341,12 +1341,16 @@
   5. **CD auto-rollout (EV-034)**: On `main` Deploy after GHCR push, pin `metar-api` /
      `metar-frontend` / `metar-worker` to the immutable `TIMESTAMP-SHA` tag via kubectl
      (`KUBE_CONFIG` Actions secret). Render hooks optional/non-blocking.
-  6. **Dual-env CD (EV-043 / #886)**: `stage` → staging; `main` → prod. PR-required branches;
-     promote `stage`→`main` only after Staging smoke green (`staging-gate`). Solo-dev: PR is
-     the manual promote step (no Environment reviewers).
+  6. **Dual-env CD (EV-043 / #886)**: `stage` → staging auto-Deploy; promote `stage`→`main`
+     only after Staging smoke green (`staging-gate`). Solo-dev: PR is the promote-to-`main`
+     step (no Environment reviewers).
   7. **Dual DOKS + DO Projects (EV-044)**: Staging cluster + managed PG under DO Project
      **Staging TAC-to-IWXXM**; prod cluster + PG under **TAC-to-IWXXM**. Amends ADR-034
      (supersedes same-cluster two-namespace staging).
+  8. **Tag-driven prod (EV-051 / S060)**: Push to `main` runs full CI **without** prod Deploy.
+     Prod Deploy runs after full CI on `vYYYY.MM.DD-deploy` tag push (pattern `v*-*-deploy`)
+     or optional `workflow_dispatch`. Deploy `needs` include `e2e-smoke`. Solo-dev “approval”
+     = cutting the deploy tag (or dispatch).
 - **Convert APIs**: Remain public (no JWT) for convert/lint/validate/disseminate (`D-S038-F30`).
 - **Acceptance**:
   1. Product path boots/smokes without Supabase **database** credentials (**TC-F30-001**)
@@ -1355,16 +1359,21 @@
   4. DOKS hosts API + worker + static; cutover runbook + H0–H5 against new endpoints (**TC-F30-004**)
   5. Render decommissioned after soak or residual ticket with checklist (**TC-F30-005**)
   6. Docs/CORPUS/env-contract no longer require Supabase as data plane (**TC-F30-006**)
-  7. `main` CD rolls DOKS images to the pushed immutable tag without manual kubectl (**TC-F30-007**)
+  7. Prod CD rolls DOKS images to the immutable tag without manual kubectl when a deploy
+     tag (or dispatch) runs (**TC-F30-007**)
   8. Staging DOKS + isolated DB/secrets on DO Project **Staging TAC-to-IWXXM**; prod on
      **TAC-to-IWXXM** (**TC-F30-008** / **TC-F30-008′**)
   9. Staging DNS + TLS for `api|app.staging.tac-to-iwxxm.com` → staging LB (**TC-F30-009**)
-  10. `stage`/`main` auto-deploy to staging/prod clusters respectively (**TC-F30-010**)
+  10. `stage` auto-deploys staging after full CI; `main` push does **not** auto-deploy prod
+      (**TC-F30-010** amended EV-051)
   11. Branch protection / rulesets: PR required on `stage` and `main` (**TC-F30-011**)
   12. PRs to `main` require head=`stage` + Staging smoke green (**TC-F30-012**)
   13. Shared-cluster staging namespace removed after dual-cluster cutover (**TC-F30-013**)
-- **Out of scope**: Convert/validate engine rewrites; App Platform; multi-reviewer prod approvals
-- **Source**: E31-*; E34-*; E43-*; E44-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712/#886; S042 / EV-034; S052 / EV-043; S053 / EV-044
+  14. Prod Deploy via `vYYYY.MM.DD-deploy` tag (or `workflow_dispatch`) after full CI incl.
+      `e2e-smoke` (**TC-F30-014** / TC-EV051-*)
+- **Out of scope**: Convert/validate engine rewrites; App Platform; multi-reviewer Environment
+  approvals (solo uses tag/dispatch)
+- **Source**: E31-*; E34-*; E43-*; E44-*; E51-*; [Context: platform-independence-842](context/platform-independence-842.md); #842/#830/#712/#886; S042 / EV-034; S052 / EV-043; S053 / EV-044; S060 / EV-051
 
 ### F31: Hybrid Operator Sessions — S038 / EV-031
 

--- a/docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
@@ -1,0 +1,36 @@
+# Evolve Plan Card
+
+> Cycle: EV-051 | Session: S060-tag-driven-prod-deploy | Updated: 2026-08-09
+
+## Goal
+
+Full CI before Deploy; staging auto on `stage`; prod only via `vYYYY.MM.DD-deploy`
+tag (+ optional `workflow_dispatch`); amend ADR-034 / deploy docs / promote rule.
+
+## Features
+
+- F30 — deepen platform CD / promote — [Corpus: product §F30] [Corpus: deploy]
+  [Corpus: adr/ADR-034]
+
+## In / out of scope
+
+- In: widen Deploy `needs` (+ `e2e-smoke`); no auto Deploy on `main` push; tag-driven
+  prod; optional dispatch; docs/ADR/rule/`ci-cd.yml`; amend TC-F30-010
+- Out: Environment reviewers; Slack bots; PyPI path change; resume EV-043/044; quality
+  packs as Deploy needs (unless expanded); `stage`→`main` promote this cycle
+
+## Preset + routing
+
+- Preset: **Lean+** (`D-S060-route=1`) — `00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11`
+- Skip: `04`, `05`, `06`, `10`, `12`, `13`
+
+## Next child stage
+
+**08-verify-build** / **09-qa** after Gate A user confirm — then 11 + PR → `stage`.
+
+## Risks / open decisions
+
+- Tag workflow must pin SHA on `main` tip (reject tags on wrong commit?)
+- Hotfix via `workflow_dispatch` vs tag-only
+- Whether quality-pack workflows join Deploy `needs`
+- First real prod cutover after merge needs a deliberate tag (behavior change)

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/01-requirements.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/01-requirements.md
@@ -1,0 +1,19 @@
+# 01-requirements — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Decisions:** `D-S060-scope=1`, `D-S060-route=1`  
+**Corpus:** [Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034] [Corpus: tests]
+
+## AC lock
+
+| AC | Status | Standing deltas |
+|----|--------|-----------------|
+| AC1–AC6 | locked | evolve-decisions §EV-051; feature-list F30; test-plan TC-F30-010/014 + TC-EV051-001..006 |
+
+## UI preview
+
+N/A — no UI (`ui_preview: n/a`).
+
+## Exit
+
+Hand off **02-verify-plan** (Gate A) then **03** / **07** (workflow already drafted in-cycle).

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/02-verify-plan.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/02-verify-plan.md
@@ -1,0 +1,26 @@
+# 02-verify-plan — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Verdict:** **PASS** (recommended) — Gate A  
+**Corpus:** [Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034] [Corpus: tests]
+
+## Consistency
+
+| Check | Result |
+|-------|--------|
+| AC ↔ TC-EV051 / TC-F30-010/014 | PASS |
+| ADR-034 vs deploy.md vs doks-promote rule | PASS (amended together) |
+| feature-list F30 AC10/AC14 | PASS |
+| No Environment-reviewer requirement | PASS (solo tag/dispatch) |
+| Parked EV-043/044 not resumed | PASS |
+
+## Advisories
+
+| ID | Note |
+|----|------|
+| A1 | First prod cutover after merge must intentionally push a deploy tag |
+| A2 | Quality packs remain non-blocking for Deploy `needs` (OOS) |
+
+## Gate A
+
+Recommend **PASS** → 03-plan-tooling (rules done) + 07-build (`ci-cd.yml` done).

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/03-plan-tooling.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/03-plan-tooling.md
@@ -1,0 +1,16 @@
+# 03-plan-tooling — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Corpus:** [Corpus: adr/ADR-034] [Corpus: deploy]
+
+## Updated
+
+| Artifact | Change |
+|----------|--------|
+| `.cursor/rules/optional/doks-promote-from-stage.mdc` | Tag-driven prod; no auto Deploy on `main` |
+| `.cursor/rules/optional/ci-after-push.mdc` | Event matrix for stage / main / deploy tag |
+| `.cursor/rules/core/atomic-commits.mdc` | Promote = tag rolls prod |
+
+## Exit
+
+→ 07-build / 08-verify-build.

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/qa-report.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/qa-report.md
@@ -1,0 +1,21 @@
+# 09-qa — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Verdict:** **PASS**  
+**Corpus:** [Corpus: tests] [Corpus: product §F30]
+
+| ID | Check | Result |
+|----|-------|--------|
+| QA-001 | TC-EV051-001..006 static (workflow + docs) | PASS |
+| QA-002 | TC-F30-010 amended / TC-F30-014 present | PASS |
+| QA-003 | ADR-034 ↔ deploy.md ↔ promote rule | PASS |
+| QA-004 | No Environment-reviewer requirement reintroduced | PASS |
+
+## Advisories
+
+- First prod ship after this lands on `stage`/`main` requires an intentional deploy tag.
+- Tip CI on the PR validates workflow parse + full matrix; prod Deploy path is not exercised this cycle (12/13 skipped).
+
+## Exit
+
+→ 11-verify-impl

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/verification-report.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/verification-report.md
@@ -1,0 +1,21 @@
+# 08-verify-build — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Verdict:** **PASS**  
+**Corpus:** [Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034]
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| `deploy.needs` includes `e2e-smoke` | PASS |
+| Deploy `if` allows `stage` push | PASS |
+| Deploy `if` excludes bare `main` | PASS |
+| Tag `v*-*-deploy` + `workflow_dispatch` → prod | PASS |
+| Resolve target: stage vs prod | PASS |
+| Render hooks on `env_role=prod` | PASS |
+| staging-smoke still `stage` only | PASS |
+
+## Exit
+
+→ 09-qa

--- a/docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
@@ -1,0 +1,23 @@
+# 11-verify-impl — S060 / EV-051
+
+**Date:** 2026-08-09  
+**Corpus:** [Corpus: product §F30] [Corpus: tests] [Corpus: decisions §EV-051]
+
+## Acceptance
+
+| AC | TC | Status |
+|----|-----|--------|
+| AC1 Deploy needs + e2e-smoke | TC-EV051-001 | met |
+| AC2 stage auto Deploy | TC-EV051-002 / TC-F30-010 | met |
+| AC3 main push no prod Deploy | TC-EV051-003 | met |
+| AC4 tag → prod Deploy | TC-EV051-004 / TC-F30-014 | met |
+| AC5 workflow_dispatch | TC-EV051-005 | met |
+| AC6 docs/ADR/rule parity | TC-EV051-006 | met |
+
+## Deploy
+
+12/13 **waived** — PR → `stage` only; first tag-driven prod cutover is a later promote.
+
+## User approval
+
+**`D-S060-gateA=1`** + **`D-S060-11-next=1`** (2026-08-09) — Gate A PASS; finish verify; push + PR → `stage`.

--- a/docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
@@ -1,0 +1,35 @@
+# Routing plan — S060 / EV-051
+
+**Status:** approved (`D-S060-route=1`)  
+**Preset:** **Lean+**
+
+| Stage | Include? | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | Opened S060 |
+| 16-evolve | yes | orchestrate | **in_progress** | |
+| 01-requirements | yes | delta | **completed** | AC1–AC6 locked |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS (await confirm) |
+| 03-plan-tooling | yes | delta | **completed** | Rules updated |
+| 04-tech-plan | no | — | skipped | |
+| 05-verify-tech | no | — | skipped | |
+| 06-tech-tooling | no | — | skipped | |
+| 07-build | yes | delta | **completed** | `ci-cd.yml` amended |
+| 08-verify-build | yes | delta | **completed** | verification-report.md |
+| 09-qa | yes | delta | **completed** | qa-report.md |
+| 10-e2e | no | — | skipped | |
+| 11-verify-impl | yes | delta | **completed** | `D-S060-11-next=1` |
+| 12-verify-deploy | no | — | skipped | |
+| 13-deploy-smoke | no | — | skipped | |
+
+## Recommended ordered stages
+
+`00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11`
+
+Skip: `04`, `05`, `06`, `10`, `12`, `13` (unless user upgrades to Standard with 04/05).
+
+## Skip rationale
+
+- Config/CD/docs change deepening F30; no new Fn UI.
+- 03 included because Cursor rule + promote semantics change.
+- 04/05 optional: execution plan can live in session report if Lean stays.
+- 12/13 waived: cycle ships workflow to `stage`; first tag-driven prod cutover is a later promote.

--- a/docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
+++ b/docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
@@ -1,0 +1,45 @@
+# Session brief — S060-tag-driven-prod-deploy
+
+> **Cycle**: EV-051 · **Type**: feature · **Opened**: 2026-08-09  
+> **Branch**: `evolve/EV-051-tag-driven-prod-deploy` (base `stage@c146baec`)  
+> **Orchestrator**: 16-evolve  
+> **Corpus**: [Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034] [Corpus: tests]
+
+## Goal
+
+Solo-dev prod cutover: full CI must pass before Deploy; **staging** still auto-deploys
+after full CI on `stage` push; **prod** deploys only when a `vYYYY.MM.DD-deploy` tag is
+pushed (optional `workflow_dispatch` escape hatch) — not on bare `main` push.
+
+## Intent (locked draft — await D-S060-scope)
+
+Design **2 + 3 + 4** (user):
+
+1. **Widen Deploy `needs`** to include at least `e2e-smoke` (frontend already inside
+   `test` matrix) so Deploy waits on “full” CI in `ci-cd.yml`.
+2. **Split**: push to `main` runs full CI **without** prod Deploy.
+3. **Tag-driven prod**: Deploy prod on `vYYYY.MM.DD-deploy` (and optional
+   `workflow_dispatch` for a SHA).
+4. Amend ADR-034 / `docs/deploy.md` / `doks-promote-from-stage.mdc` / TC-F30-010 wording.
+
+## Out of scope
+
+- GitHub Environment required reviewers (solo cannot rely on them)
+- Chat/Slack approve bots
+- Changing PyPI package-tag publish path
+- Resuming parked EV-043 / EV-044 sessions (remain parked; this cycle deepens F30)
+- Quality-pack workflows as Deploy `needs` unless user expands scope
+- UI / product feature work (`ui_preview: n/a`)
+
+## Features
+
+- Deepen **F30** only (no new Fn) — platform CD / promote path
+
+## UI preview
+
+N/A — no browser UI in this session.
+
+## Related
+
+- Parked: S052/EV-043, S053/EV-044 (F30 DOKS) — not resumed
+- Prior auto-deploy-on-main: ADR-034 / feature-list TC-F30-010 — to amend

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1744,14 +1744,16 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
   `/health` 200 on API; FE returns 200; cert-manager Certificate Ready
 - **Source**: F30 AC9; D-S052-dns; D-S053-dns
 
-### TC-F30-010: Dual-branch auto CD
+### TC-F30-010: Dual-branch CD (amended EV-051)
 
 - **Level**: Ops / CI
-- **Objective**: Push/merge to `stage` deploys **staging cluster**; push/merge to `main`
-  deploys **prod cluster**
-- **Pass criteria**: Deploy jobs bound to GH Environments `staging` / `production`;
-  env-scoped kubeconfig + `DOKS_NAMESPACE` correct per branch; image tags rolled
-- **Source**: F30 AC10; #886; EV-044
+- **Objective**: Push/merge to `stage` deploys **staging cluster** after full Deploy
+  `needs` (incl. `e2e-smoke`). Push/merge to `main` runs full CI but **does not** Deploy
+  prod (EV-051).
+- **Pass criteria**: Staging Deploy bound to GH Environment `staging`; `main` push workflow
+  has no successful prod Deploy job for that event; env-scoped kubeconfig + `DOKS_NAMESPACE`
+  correct when Deploy runs
+- **Source**: F30 AC10; #886; EV-044; **EV-051 / S060** (`D-S060-scope=1`)
 
 ### TC-F30-011: Branch protection on stage and main
 
@@ -1777,6 +1779,59 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
 - **Pass criteria**: `kubectl --context prod get ns metar-iwxxm-staging` is NotFound (or
   empty/terminating with no Deployments); staging smoke uses staging cluster context only
 - **Source**: F30 AC13; D-S053-teardown
+
+### TC-F30-014: Tag-driven prod Deploy (EV-051)
+
+- **Level**: Ops / CI
+- **Objective**: Prod Deploy runs only for `vYYYY.MM.DD-deploy` tag pushes (pattern
+  `v*-*-deploy`) or `workflow_dispatch` targeting production — after Deploy `needs`
+  including `e2e-smoke` pass. Solo-dev approval = tag/dispatch (no Environment reviewers).
+- **Pass criteria**: Workflow `on.push.tags` / `workflow_dispatch` documented; Deploy job
+  `if` excludes bare `main` push; `needs` includes `e2e-smoke`; ADR-034 + deploy.md match
+- **Source**: F30 AC14; EV-051 / S060; TC-EV051-001..006
+
+### TC-EV051-001: Deploy needs include e2e-smoke
+
+- **Level**: T0 (workflow review)
+- **Objective**: `deploy.needs` lists prior jobs plus `e2e-smoke`
+- **Pass criteria**: `.github/workflows/ci-cd.yml` `deploy.needs` contains `e2e-smoke`
+- **Source**: EV-051 AC1
+
+### TC-EV051-002: stage push still auto-deploys staging
+
+- **Level**: Ops / CI
+- **Objective**: Unchanged staging path after needs widen
+- **Pass criteria**: `deploy` `if` allows `refs/heads/stage` push; Environment `staging`
+- **Source**: EV-051 AC2
+
+### TC-EV051-003: main push does not Deploy prod
+
+- **Level**: Ops / CI
+- **Objective**: Bare `main` push is CI-only for Deploy purposes
+- **Pass criteria**: `deploy` `if` excludes `refs/heads/main`
+- **Source**: EV-051 AC3
+
+### TC-EV051-004: deploy tag triggers prod Deploy
+
+- **Level**: Ops / CI
+- **Objective**: Tag `v*-*-deploy` triggers prod Deploy path
+- **Pass criteria**: `on.push.tags` includes pattern; Deploy resolves `env_role=prod`
+- **Source**: EV-051 AC4; TC-F30-014
+
+### TC-EV051-005: workflow_dispatch prod escape hatch
+
+- **Level**: Ops / CI
+- **Objective**: Manual `workflow_dispatch` can Deploy production
+- **Pass criteria**: `on.workflow_dispatch` present; Deploy `if` includes dispatch → production
+- **Source**: EV-051 AC5
+
+### TC-EV051-006: Docs / ADR / rule parity
+
+- **Level**: T0
+- **Objective**: Standing docs describe tag-driven prod + full CI needs
+- **Pass criteria**: ADR-034, deploy.md §CD, doks-promote-from-stage.mdc, feature-list F30
+  AC10/AC14 consistent
+- **Source**: EV-051 AC6
 
 ### Live harness — staging (EV-043 / EV-044)
 

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -21,20 +21,31 @@ active_session:
   branch_base_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
   branch_status: active
   branch_exists: true
-  tip_sha: c146baec
-  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-  tip_sha_pushed: false
-  tip_sha_note: "Opened at stage tip c146baec (includes #965 EV-050 closeout); no session commits yet"
+  tip_sha: cb8d9771
+  tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+  tip_sha_pushed: true
+  tip_sha_note: "PR #966 tip cb8d9771 — tag-driven prod Deploy after full CI; awaiting merge → stage"
+  pr_number: 966
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+  pr_status: open
+  pr_base: stage
+  github_pr: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
   artifacts_dir: docs/sessions/S060-tag-driven-prod-deploy/
   artifacts:
   - path: docs/sessions/S060-tag-driven-prod-deploy/
     status: in_progress
-    note: "session-brief.md, routing-plan.md, evolve-plan-card.md"
+    note: "session-brief.md, routing-plan.md, evolve-plan-card.md + reports; PR #966 open → stage"
   - path: docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
     status: present
   - path: docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
     status: present
   - path: docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/reports/qa-report.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/reports/verification-report.md
     status: present
   feature_ids:
   - F30
@@ -84,7 +95,7 @@ active_session:
     mode: orchestrator
     status: in_progress
     started: '2026-08-09'
-    note: "Orchestrating Lean+; current child 07-build; gates.a_to_b pending user Gate A confirm"
+    note: "Orchestrating Lean+; 07/08/09/11 COMPLETE; awaiting merge PR #966 → stage"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -98,7 +109,7 @@ active_session:
     status: completed
     started: '2026-08-09'
     completed: '2026-08-09'
-    note: "Gate A draft PASS — awaiting user Gate A confirm (gates.a_to_b pending)"
+    note: "Gate A PASS D-S060-gateA=1; gates.a_to_b passed"
   - stage: 03-plan-tooling
     required: true
     mode: delta
@@ -124,17 +135,24 @@ active_session:
   - stage: 07-build
     required: true
     mode: delta
-    status: in_progress
+    status: completed
     started: '2026-08-09'
-    note: "ci-cd.yml / ADR-034 / deploy docs amend in progress"
+    completed: '2026-08-09'
+    note: "COMPLETE @ cb8d9771 — ci-cd.yml / ADR-034 / deploy docs / promote rule"
   - stage: 08-verify-build
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "COMPLETE — verification-report.md; gates.c_to_d passed"
   - stage: 09-qa
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "COMPLETE — qa-report.md"
   - stage: 10-e2e
     required: false
     mode: skip
@@ -143,36 +161,48 @@ active_session:
   - stage: 11-verify-impl
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "COMPLETE — D-S060-11-next=1; PR #966 OPEN → stage; awaiting merge"
   - stage: 12-verify-deploy
     required: false
     mode: skip
     status: skipped
-    note: "Lean+ skip — first tag-driven prod cutover later promote"
+    note: "Lean+ skip — first tag-driven prod cutover later promote; deploy waived"
   - stage: 13-deploy-smoke
     required: false
     mode: skip
     status: skipped
-    note: "Lean+ skip"
+    note: "Lean+ skip — deploy waived"
   routing_plan_note: "D-S060-route=1 Lean+ approved; required_stages 00/16/01/02/03/07/08/09/11"
-  current_stage: 07-build
-  current_stage_note: "D-S060-scope=1 + D-S060-route=1; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm; EV-043/EV-044 remain parked"
-  open_decision: D-S060-open=1
+  current_stage: 11-verify-impl
+  current_stage_status: completed
+  current_stage_note: "11-verify-impl COMPLETE — D-S060-gateA=1 + D-S060-11-next=1; PR #966 OPEN → stage @ tip cb8d9771; awaiting merge; deploy waived"
+  open_decision: D-S060-11-next=1
   decisions:
     D-S060-open: "1 — open evolve S060/EV-051 tag-driven prod deploy (design 2+3+4); do not resume parked EV-043/EV-044"
     D-S060-scope: "1 — lock scope to design 2+3+4 (full CI Deploy needs; no auto Deploy on main; tag-driven prod + optional workflow_dispatch; staging auto; amend ADR-034/deploy docs/rule/ci-cd)"
     D-S060-route: "1 — Lean+ as drafted: 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13"
+    D-S060-gateA: "1 — Gate A PASS; proceed build/verify"
+    D-S060-11-next: "1 — PR #966 opened → stage; awaiting merge"
   decisions_locked:
   - D-S060-open=1
   - D-S060-scope=1
   - D-S060-route=1
+  - D-S060-gateA=1
+  - D-S060-11-next=1
   gates:
-    a_to_b: pending
-    a_to_b_note: "pending user Gate A confirm (02 completed; await confirm before treating Phase A→B as passed)"
-    b_to_c: pending
-    c_to_d: pending
-    deploy: pending
+    a_to_b: passed
+    a_to_b_note: "D-S060-gateA=1 — Gate A PASS"
+    b_to_c: passed
+    b_to_c_note: "Lean+ skip 04/05; proceed 07 after Gate A"
+    c_to_d: passed
+    c_to_d_note: "08-verify-build COMPLETE; Phase C→D passed"
+    deploy: waived
+    deploy_note: "Lean+ skip 12/13; first tag-driven prod cutover later promote"
   notes:
+  - "2026-08-09 D-S060-gateA=1 + D-S060-11-next=1 — Gate A PASS; 07/08/09/11 COMPLETE; PR #966 OPEN → stage @ tip cb8d9771; gates.a_to_b/c_to_d passed; deploy waived; awaiting merge"
   - "2026-08-09 D-S060-scope=1 — scope locked to design 2+3+4; artifacts under docs/sessions/S060-tag-driven-prod-deploy/"
   - "2026-08-09 D-S060-route=1 — Lean+ approved; 00/01/02/03 completed; current_stage 07-build in_progress; gates.a_to_b pending user Gate A confirm"
   - "2026-08-09 D-S060-open=1 — session opened; EV-051 deepens F30; EV-043/EV-044 remain parked unless user later chooses resume"
@@ -9009,20 +9039,21 @@ stages:
     session_id: S060-tag-driven-prod-deploy
     evolve_cycle_id: EV-051
     skill_id: 02-verify-plan
-    tip_sha: c146baec
-    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
     deepen_feature_ids: [F30]
     feature_ids: []
     delta_only: true
-    gate_a: pending_user_confirm
-    gate_a_status: pending
-    gate_a_decision:
-    gate_a_note: 'draft PASS — gates.a_to_b pending user Gate A confirm'
-    report:
+    gate_a: PASS
+    gate_a_status: pass
+    gate_a_decision: D-S060-gateA=1
+    gate_a_note: 'D-S060-gateA=1 — Gate A PASS; gates.a_to_b passed'
+    report: docs/sessions/S060-tag-driven-prod-deploy/reports/02-verify-plan.md
     decision_refs:
+    - D-S060-gateA
     - D-S060-scope
     - D-S060-route
-    note: 'S060/EV-051 COMPLETE — 02 done; Gate A awaiting user confirm (gates.a_to_b pending); Lean+ skip 04/05 → 07-build'
+    note: 'S060/EV-051 COMPLETE — Gate A PASS D-S060-gateA=1; Lean+ skip 04/05 → 07-build'
     prior_session_id: S057-strip-internal-doc-refs
     prior_evolve_cycle_id: EV-048
     prior_started: '2026-08-08'
@@ -11359,11 +11390,11 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: in_progress
+    status: completed
     started_at: '2026-08-09'
     started: '2026-08-09'
-    completed_at:
-    completed:
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
     previous_session_id: S057-strip-internal-doc-refs
@@ -11392,30 +11423,32 @@ stages:
     evolve_cycle_id: EV-051
     skill_id: 07-build
     mode: delta
-    note: 'IN PROGRESS — S060/EV-051 Lean+; ci-cd.yml / ADR-034 / deploy docs / promote rule; gates.a_to_b pending user Gate A confirm'
-    tip_sha: c146baec
-    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-    tip_sha_pushed: false
-    pr_number:
-    pr_url:
-    pr_status:
+    note: 'COMPLETE — S060/EV-051 @ cb8d9771; ci-cd.yml / ADR-034 / deploy docs / promote rule; D-S060-gateA=1'
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
+    pr_number: 966
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    pr_status: open
     pr_base: stage
     pr_supersedes:
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: 'S060/EV-051 07-build in_progress @ tip c146baec; prior S057 tip 71779d46 archived under previous_*'
+    ci_cd_pipeline_note: 'S060/EV-051 07 COMPLETE @ tip cb8d9771; PR #966 OPEN → stage; prior S057 tip 71779d46 archived under previous_*'
     pending_commit: false
     current_milestone:
     current_task:
     active_milestone:
     active_task:
-    active_task_status: in_progress
+    active_task_status: completed
     completed_through:
     progress:
     skipped_tasks: []
     deepen_feature_ids: [F30]
     feature_ids: []
     decision_refs:
+    - D-S060-gateA
+    - D-S060-11-next
     - D-S060-scope
     - D-S060-route
     - D-S060-open
@@ -12818,21 +12851,32 @@ stages:
     - 2026-07-14 S011/EV-008 T6.3 11-verify-impl in_progress (user option 1 — start without committing first); active_task T6.3 in_progress
   09-qa:
     status: completed
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
-    previous_started_at: '2026-08-07'
-    previous_started: '2026-08-07'
-    previous_completed_at: '2026-08-07'
-    previous_completed: '2026-08-07'
-    previous_session_id: S050-remove-db-tools-operator-throughput
-    previous_evolve_cycle_id: EV-042
-    previous_tip_sha: dff22265
-    previous_tip_sha_full: dff22265cd77e68549238d93c15e1de931b64da8
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
+    previous_started_at: '2026-08-08'
+    previous_started: '2026-08-08'
+    previous_completed_at: '2026-08-08'
+    previous_completed: '2026-08-08'
+    previous_session_id: S057-strip-internal-doc-refs
+    previous_evolve_cycle_id: EV-048
+    previous_tip_sha: 3a43da37
+    previous_tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
     previous_overall: pass_with_advisories
-    previous_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
-    previous_note: 'S050/EV-042 09 PASS pass_with_advisories @ dff22265 — superseded by S054/EV-045'
+    previous_report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    previous_note: 'S057/EV-048 09 PASS pass_with_advisories @ 3a43da37 — superseded by S060/EV-051'
+    previous_s050_started_at: '2026-08-07'
+    previous_s050_started: '2026-08-07'
+    previous_s050_completed_at: '2026-08-07'
+    previous_s050_completed: '2026-08-07'
+    previous_s050_session_id: S050-remove-db-tools-operator-throughput
+    previous_s050_evolve_cycle_id: EV-042
+    previous_s050_tip_sha: dff22265
+    previous_s050_tip_sha_full: dff22265cd77e68549238d93c15e1de931b64da8
+    previous_s050_overall: pass_with_advisories
+    previous_s050_report: docs/sessions/S050-remove-db-tools-operator-throughput/reports/qa-report.md
+    previous_s050_note: 'S050/EV-042 09 PASS pass_with_advisories @ dff22265 — superseded by S054/EV-045'
     previous_s048_started_at: '2026-08-06'
     previous_s048_started: '2026-08-06'
     previous_s048_completed_at: '2026-08-06'
@@ -12872,17 +12916,24 @@ stages:
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e00000
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
-    tip_sha: 3a43da37
-    tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
-    tip_sha_pushed: false
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
     mode: delta
-    overall: pass_with_advisories
-    report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
-    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
-    note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 11-verify-impl'
+    overall: pass
+    report: docs/sessions/S060-tag-driven-prod-deploy/reports/qa-report.md
+    expected_report: docs/sessions/S060-tag-driven-prod-deploy/reports/qa-report.md
+    note: 'COMPLETE — S060/EV-051 qa-report.md; handoff 11-verify-impl; tip cb8d9771'
     skill_id: 09-qa
+    previous_s057_session_id: S057-strip-internal-doc-refs
+    previous_s057_evolve_cycle_id: EV-048
+    previous_s057_tip_sha: 3a43da37
+    previous_s057_tip_sha_full: 3a43da37ba2aca0fe4a1a992f7adef1f8ae6dbb4
+    previous_s057_overall: pass_with_advisories
+    previous_s057_report: docs/sessions/S057-strip-internal-doc-refs/reports/qa-report.md
+    previous_s057_note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 11-verify-impl'
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
     previous_s056_tip_sha: 3ca4f438
@@ -12890,9 +12941,11 @@ stages:
     previous_s056_overall: pass_with_advisories
     previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/qa-report.md
     previous_s056_note: 'COMPLETE — pass_with_advisories; report qa-report.md; handoff 10-e2e'
-    advisories: [QA-001, QA-002, QA-003, QA-004]
-    advisories_note: 'EV-048: tip unpushed; 12/13 waived; privacy Fn IDs out of regex; T3 Playwright skipped'
+    advisories: []
+    advisories_note: 'S060/EV-051 Lean+; 12/13 waived (deploy waived)'
     decision_refs:
+    - D-S060-gateA
+    - D-S060-11-next
     - D-S057-phaseC
     - D-S057-ui-preview-verify
     - D-S057-gateB
@@ -13217,18 +13270,22 @@ stages:
     - 2026-07-14 S011/EV-008 09-qa completed — pass_with_advisories; see reports/qa-report.md
   11-verify-impl:
     status: completed
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed: '2026-08-08'
-    completed_at: '2026-08-08'
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    completed_at: '2026-08-09'
     previous_started_at: '2026-08-08'
     previous_started: '2026-08-08'
     previous_completed: '2026-08-08'
     previous_completed_at: '2026-08-08'
-    previous_session_id: S054-rust-ci-crates
-    previous_evolve_cycle_id: EV-045
-    previous_overall: approved
-    previous_note: 'S054/EV-045 11 COMPLETE — superseded by S056/EV-047 Phase D'
+    previous_session_id: S057-strip-internal-doc-refs
+    previous_evolve_cycle_id: EV-048
+    previous_overall: PASS
+    previous_note: 'S057/EV-048 11 COMPLETE @ 014c9125 — superseded by S060/EV-051'
+    previous_s054_session_id: S054-rust-ci-crates
+    previous_s054_evolve_cycle_id: EV-045
+    previous_s054_overall: approved
+    previous_s054_note: 'S054/EV-045 11 COMPLETE — superseded by S056/EV-047 Phase D'
     previous_s048_started_at: '2026-08-06'
     previous_s048_started: '2026-08-06'
     previous_s048_completed_at: '2026-08-06'
@@ -13290,17 +13347,28 @@ stages:
     prior_s037_session_id: S037-quality-residuals-831
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 3889e4c
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
-    tip_sha: 014c9125
-    tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
-    tip_sha_pushed: false
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
     mode: delta
     overall: PASS
-    report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
-    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
-    note: 'COMPLETE — PASS @ 014c9125; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1; next push+PR to stage'
+    report: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+    expected_report: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+    note: 'COMPLETE — PASS @ cb8d9771; D-S060-gateA=1 + D-S060-11-next=1; PR #966 OPEN → stage; awaiting merge; deploy waived'
     skill_id: 11-verify-impl
+    pr_number: 966
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    pr_status: open
+    pr_base: stage
+    previous_s057_session_id: S057-strip-internal-doc-refs
+    previous_s057_evolve_cycle_id: EV-048
+    previous_s057_tip_sha: 014c9125
+    previous_s057_tip_sha_full: 014c9125f9e3b40518613879b14657cd53a9d5a1
+    previous_s057_overall: PASS
+    previous_s057_report: docs/sessions/S057-strip-internal-doc-refs/reports/verify-impl.md
+    previous_s057_note: 'COMPLETE — PASS @ 014c9125; D-S057-uj055=1, f7=1, f21=1, qa003=2, 11-next=1'
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
     previous_s056_tip_sha: 3ca4f438
@@ -13309,6 +13377,8 @@ stages:
     previous_s056_report: docs/sessions/S056-m0-stabilize-operator-trust/reports/verify-impl.md
     previous_s056_note: 'COMPLETE — PASS @ 3ca4f438; D-S056-ac-bundle=1, D-S056-uj054=1, D-S056-advisories=1, D-S056-11-ui-preview=2; report verify-impl.md; phase_d passed; handoff phase4-close / PR #961'
     decision_refs:
+    - D-S060-gateA
+    - D-S060-11-next
     - D-S057-uj055
     - D-S057-f7
     - D-S057-f21
@@ -13330,11 +13400,13 @@ stages:
     prior_s050_note: 'COMPLETE — D-S050-11-verify approve F33 + F7 deepen + F16–F19 deepen; UJ-051..053 approved (T3/H4–H5 waived until 13); UI preview accepted localhost:18000; fix adad127c hide Upload to Database; report verify-impl.md; tip adad127c; next 12-verify-deploy'
     prior_s050_report_note: 'S050/EV-042 11 COMPLETE — superseded by S054/EV-045'
     report_status: approved
-    tip_note: 'S057/EV-048 tip 014c9125 — 11-verify-impl PASS; qa003 fixed; next push+PR to stage'
-    awaiting_user_decision: false
-    awaiting_user_decision_note:
-    decision_id: D-S057-11-next
+    tip_note: 'S060/EV-051 tip cb8d9771 — 11-verify-impl PASS; PR #966 OPEN → stage; awaiting merge'
+    awaiting_user_decision: true
+    awaiting_user_decision_note: 'awaiting merge approval for PR #966 → stage'
+    decision_id: D-S060-11-next
     decision_ids:
+    - D-S060-gateA
+    - D-S060-11-next
     - D-S057-uj055
     - D-S057-f7
     - D-S057-f21
@@ -13343,10 +13415,9 @@ stages:
     - D-S050-11-verify
     - D-S047-11
     deepen_feature_ids:
-    - F7
-    - F21
+    - F30
     feature_ids: []
-    active_milestone: M1
+    active_milestone:
     active_task:
     active_task_status: completed
     active_task_note: '11-verify-impl COMPLETE PASS — next push+PR to stage'
@@ -14175,17 +14246,24 @@ stages:
   08-verify-build:
     status: completed
     mode: delta
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
-    previous_session_id: S056-m0-stabilize-operator-trust
-    previous_evolve_cycle_id: EV-047
-    previous_tip_sha: 3ca4f438
-    previous_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    previous_note: 'COMPLETE — PASS @ tip 3ca4f438; superseded by S057/EV-048'
+    previous_session_id: S057-strip-internal-doc-refs
+    previous_evolve_cycle_id: EV-048
+    previous_tip_sha: 71779d46
+    previous_tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    previous_note: 'COMPLETE — PASS @ tip 71779d46; superseded by S060/EV-051'
+    previous_s056_started_at: '2026-08-08'
+    previous_s056_completed_at: '2026-08-08'
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_note_archived: 'COMPLETE — PASS @ tip 3ca4f438; superseded by S057/EV-048'
     previous_s050_started_at: '2026-08-07'
     previous_s050_completed_at: '2026-08-07'
     previous_s050_session_id: S050-remove-db-tools-operator-throughput
@@ -14246,18 +14324,25 @@ stages:
     prior_s037_evolve_cycle_id: EV-030
     prior_s037_tip_sha: 1f47eb5
     prior_s037_note: 'COMPLETE (M3 gate + T4.1) — PASS @ tip 1f47eb5; report docs/sessions/S037-quality-residuals-831/reports/verification-report-m3.md; prior M2 verification-report-m2.md; CI 30823368642 SUCCESS; reopen for final M4 08; PR #832 open; #831→#835'
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
-    tip_sha: 71779d46
-    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
-    tip_sha_pushed: false
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: '08 PASS locally; tip CI optional before PR'
-    note: 'COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md'
-    expected_report: docs/sessions/S057-strip-internal-doc-refs/reports/verification-report.md
-    report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+    ci_cd_pipeline_note: 'S060/EV-051 08 PASS; tip cb8d9771; PR #966 OPEN → stage'
+    note: 'COMPLETE — PASS S060/EV-051; report verification-report.md; gates.c_to_d passed'
+    expected_report: docs/sessions/S060-tag-driven-prod-deploy/reports/verification-report.md
+    report: docs/sessions/S060-tag-driven-prod-deploy/reports/verification-report.md
     overall: PASS
+    previous_s057_session_id: S057-strip-internal-doc-refs
+    previous_s057_evolve_cycle_id: EV-048
+    previous_s057_tip_sha: 71779d46
+    previous_s057_tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    previous_s057_note: 'COMPLETE — PASS validate-fast + EV-048 unit/Vitest; report 08-verify-build.md'
+    previous_s057_report: docs/sessions/S057-strip-internal-doc-refs/reports/08-verify-build.md
+    previous_s057_overall: PASS
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
     previous_s056_tip_sha: 3ca4f438
@@ -14267,9 +14352,9 @@ stages:
     previous_s056_overall: pass
     previous_s056_phase_c_checkpoint: passed
     skill_id: 08-verify-build
-    next_stage: phase-c-checkpoint
-    next_stage_status: pending
-    next_stage_note: 'await D-S057-phaseC before 09+10'
+    next_stage: 09-qa
+    next_stage_status: completed
+    next_stage_note: 'S060/EV-051 Phase C→D passed; 09+11 completed; awaiting merge #966'
     prior_s050_session_id: S050-remove-db-tools-operator-throughput
     prior_s050_evolve_cycle_id: EV-042
     prior_s050_tip_sha: 6bc756ef
@@ -16375,19 +16460,20 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: 07-build
-    current_child_stage_note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm'
-    tip_sha: c146baec
-    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-    tip_sha_pushed: false
-    pr_number:
-    pr_url:
-    pr_status:
+    current_child_stage: 11-verify-impl
+    current_child_stage_status: completed
+    current_child_stage_note: 'S060/EV-051 — 07/08/09/11 COMPLETE; D-S060-gateA=1 + D-S060-11-next=1; PR #966 OPEN → stage @ cb8d9771; awaiting merge'
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
+    pr_number: 966
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    pr_status: open
     merge_sha:
     merge_sha_full:
     merge_target: stage
     branch_status: active
-    note: 'IN PROGRESS — S060/EV-051; scope+route locked; current_child 07-build; gates.a_to_b pending user Gate A confirm; artifacts docs/sessions/S060-tag-driven-prod-deploy/'
+    note: 'IN PROGRESS — S060/EV-051; 11-verify-impl COMPLETE / awaiting merge PR #966 → stage; gates.a_to_b/c_to_d passed; deploy waived; tip cb8d9771'
     prior_s057_pr_number: 963
     prior_s057_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
     prior_s057_merge_sha: 06a9543f
@@ -16656,6 +16742,71 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S060-11-next
+  date: '2026-08-09'
+  timestamp: '2026-08-09'
+  resolved_at: '2026-08-09'
+  session_id: S060-tag-driven-prod-deploy
+  evolve_cycle_id: EV-051
+  skill: 11-verify-impl
+  skill_id: 11-verify-impl
+  stage: 11-verify-impl
+  category: verify_impl_signoff
+  status: confirmed
+  topic: 'S060/EV-051 11-verify-impl PASS → PR #966 → stage'
+  summary: 'D-S060-11-next=1 — 11 PASS; PR #966 OPEN → stage @ tip cb8d9771; awaiting merge; deploy waived'
+  decision: |
+    D-S060-11-next=1 — Finish verify-impl and open PR → stage.
+    PR #966 OPEN → base stage — https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    Tip cb8d9771 (cb8d97719d89a97b540115a21a533640c6397e4c) tip_sha_pushed=true.
+    Stages 07/08/09/11 COMPLETE. gates.a_to_b/c_to_d passed; deploy waived (Lean+ skip 12/13).
+    Report: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md.
+    Awaiting merge approval. No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  related_features:
+  - F30
+  related_decisions:
+  - D-S060-gateA
+  - D-S060-route
+  - D-S060-scope
+  pr_number: 966
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+  pr_status: open
+  pr_base: stage
+  tip_sha: cb8d9771
+  tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+  tip_sha_pushed: true
+  report: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+  note: 'PR #966 open; awaiting merge approval'
+- id: D-S060-gateA
+  date: '2026-08-09'
+  timestamp: '2026-08-09'
+  resolved_at: '2026-08-09'
+  session_id: S060-tag-driven-prod-deploy
+  evolve_cycle_id: EV-051
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: gate
+  status: confirmed
+  topic: 'S060 Gate A — PASS; proceed 07-build'
+  summary: 'D-S060-gateA=1 — Gate A PASS; gates.a_to_b passed; Lean+ proceed 07→08→09→11'
+  decision: |
+    D-S060-gateA=1 — PASS Gate A.
+    gates.a_to_b passed. Lean+ skips 04/05/06; proceed 07-build through 11-verify-impl.
+    Report: docs/sessions/S060-tag-driven-prod-deploy/reports/02-verify-plan.md.
+    16-evolve remains orchestrator. No git commit by workflow-state-manager.
+  user_option: '1'
+  gate_a: PASS
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  related_features:
+  - F30
+  related_decisions:
+  - D-S060-scope
+  - D-S060-route
+  report: docs/sessions/S060-tag-driven-prod-deploy/reports/02-verify-plan.md
+  note: 'Gate A PASS; unlock Phase B build'
 - id: D-S060-route
   date: '2026-08-09'
   timestamp: '2026-08-09'
@@ -34821,9 +34972,15 @@ evolve_cycles:
   branch_base_sha: c146baec
   branch_base_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
   branch_status: active
-  tip_sha: c146baec
-  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-  tip_sha_pushed: false
+  tip_sha: cb8d9771
+  tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+  tip_sha_pushed: true
+  tip_sha_note: "PR #966 tip cb8d9771; awaiting merge → stage"
+  pr_number: 966
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+  pr_status: open
+  pr_base: stage
+  github_pr: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
   preset: Lean+
   scope_summary: "LOCKED D-S060-scope=1 — design 2+3+4: widen Deploy needs to full CI (+e2e-smoke); no auto Deploy on main push; prod Deploy only on vYYYY.MM.DD-deploy tag (+ optional workflow_dispatch); staging auto after full CI; amend ADR-034 / docs/deploy.md / doks-promote-from-stage.mdc / ci-cd.yml / TC-F30-010"
   scope_note: "Phase 0 locked via D-S060-scope=1 (design 2+3+4)"
@@ -34850,46 +35007,60 @@ evolve_cycles:
     - 13-deploy-smoke
     ordered: "00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11"
   routing_plan_note: "D-S060-route=1 Lean+ approved; artifact docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md"
-  current_stage: 07-build
-  current_stage_note: "D-S060-scope=1 + D-S060-route=1; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm"
+  current_stage: 11-verify-impl
+  current_stage_status: completed
+  current_stage_note: "11-verify-impl COMPLETE — D-S060-gateA=1 + D-S060-11-next=1; PR #966 OPEN → stage @ tip cb8d9771; awaiting merge; deploy waived"
   gates:
-    a_to_b: pending
-    a_to_b_note: "pending user Gate A confirm"
-    b_to_c: pending
-    c_to_d: pending
-    deploy: pending
+    a_to_b: passed
+    a_to_b_note: "D-S060-gateA=1 — Gate A PASS"
+    b_to_c: passed
+    b_to_c_note: "Lean+ skip 04/05; proceed 07 after Gate A"
+    c_to_d: passed
+    c_to_d_note: "08-verify-build COMPLETE"
+    deploy: waived
+    deploy_note: "Lean+ skip 12/13; first tag-driven prod cutover later promote"
   checkpoints:
-    phase_a: pending
-    phase_a_note: "02 completed; Gate A user confirm pending"
-    phase_b: pending
-    phase_c: pending
-    phase_d: pending
-    deploy: pending
+    phase_a: passed
+    phase_a_note: "D-S060-gateA=1"
+    phase_b: passed
+    phase_b_note: "Lean+ skip 04/05; 07 COMPLETE"
+    phase_c: passed
+    phase_c_note: "08 COMPLETE; gates.c_to_d passed"
+    phase_d: passed
+    phase_d_note: "09+11 COMPLETE; awaiting merge #966"
+    deploy: waived
   adrs:
   - docs/adr/ADR-034-doks-staging-promote-from-stage.md
   artifacts:
   - path: docs/sessions/S060-tag-driven-prod-deploy/
     status: in_progress
-    note: "session-brief.md, routing-plan.md, evolve-plan-card.md"
+    note: "session-brief.md, routing-plan.md, evolve-plan-card.md + reports; PR #966 open"
   - path: docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
     status: present
   - path: docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
     status: present
   - path: docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
     status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/reports/verify-impl.md
+    status: present
   decisions:
     D-S060-open: "1 — open evolve S060/EV-051; deepen F30; EV-043/EV-044 remain parked"
     D-S060-scope: "1 — lock scope to design 2+3+4"
     D-S060-route: "1 — Lean+: 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13"
+    D-S060-gateA: "1 — Gate A PASS; proceed build/verify"
+    D-S060-11-next: "1 — PR #966 opened → stage; awaiting merge"
   decisions_locked:
   - D-S060-open=1
   - D-S060-scope=1
   - D-S060-route=1
+  - D-S060-gateA=1
+  - D-S060-11-next=1
   notes:
+  - "2026-08-09 D-S060-gateA=1 + D-S060-11-next=1 — Gate A PASS; 07/08/09/11 COMPLETE; PR #966 OPEN → stage @ tip cb8d9771; gates.a_to_b/c_to_d passed; deploy waived; awaiting merge"
   - "2026-08-09 D-S060-scope=1 — scope locked to design 2+3+4"
   - "2026-08-09 D-S060-route=1 — Lean+ approved; current_stage 07-build; gates.a_to_b pending user Gate A confirm"
   - "2026-08-09 D-S060-open=1 — EV-051 opened; deepens F30; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend; parked EV-043/EV-044 remain parked — do not resume unless user later chooses"
-  note: "IN PROGRESS — scope+route locked; 07-build in_progress; gates.a_to_b pending user Gate A confirm; parked EV-043/EV-044 unchanged"
+  note: "IN PROGRESS — 11 COMPLETE / awaiting merge PR #966 → stage; tip cb8d9771; deploy waived; parked EV-043/EV-044 unchanged"
 - id: EV-050
   session_id: S059-codes-wmo-validated
   type: feature
@@ -45641,18 +45812,18 @@ evolve_cycles:
 git_history:
   current_branch: evolve/EV-051-tag-driven-prod-deploy
   ahead_of_origin: 0
-  pushed: false
+  pushed: true
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml dirty after D-S060-scope=1 + D-S060-route=1 (00/01/02/03 completed; 07-build in_progress); no git commit by workflow-state-manager'
-  tip_sha: c146baec
-  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-  tip_note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; current_stage 07-build; gates.a_to_b pending Gate A confirm; tip still c146baec; active_session=S060-tag-driven-prod-deploy'
+  dirty_note: 'workflow-state.yaml dirty after D-S060-gateA=1 + D-S060-11-next=1 (07/08/09/11 COMPLETE; PR #966 open); no git commit by workflow-state-manager'
+  tip_sha: cb8d9771
+  tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+  tip_note: 'S060/EV-051 — D-S060-gateA=1 + D-S060-11-next=1; 11 COMPLETE / awaiting merge PR #966 → stage; tip cb8d9771 pushed; active_session=S060-tag-driven-prod-deploy'
   evolve_branch: evolve/EV-051-tag-driven-prod-deploy
-  evolve_tip_sha: c146baec
-  evolve_tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-  evolve_tip_sha_pushed: false
+  evolve_tip_sha: cb8d9771
+  evolve_tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+  evolve_tip_sha_pushed: true
   stage_merge_sha: 2815ffbe
   stage_merge_sha_full: 2815ffbe3a9f91e1b1da1677b93b8e6a025f20d1
   stage_tip_sha: c146baec
@@ -45668,9 +45839,11 @@ git_history:
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   recommended_branch: evolve/EV-051-tag-driven-prod-deploy
-  note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; 00/01/02/03 completed; current_stage 07-build in_progress; gates.a_to_b pending user Gate A confirm; EV-043/EV-044 remain parked'
+  note: 'S060/EV-051 — 11-verify-impl COMPLETE / awaiting merge PR #966 → stage @ tip cb8d9771; gates.a_to_b/c_to_d passed; deploy waived; EV-043/EV-044 remain parked'
 
   notes:
+  - '2026-08-09 D-S060-gateA=1 + D-S060-11-next=1 — Gate A PASS; 07/08/09/11 COMPLETE; PR #966 OPEN → stage @ tip cb8d9771; gates.a_to_b/c_to_d passed; deploy waived; awaiting merge; no git commit by workflow-state-manager'
+  - '2026-08-09 commit cb8d9771 — [EV-051] feat: tag-driven prod Deploy after full CI (solo gate); tip cb8d9771 pushed; PR #966; stages 07-build/16-evolve'
   - '2026-08-09 D-S060-scope=1 + D-S060-route=1 — scope locked 2+3+4; Lean+ routing; 00/01/02/03 completed; current_stage 07-build; gates.a_to_b pending user Gate A confirm; artifacts docs/sessions/S060-tag-driven-prod-deploy/; no git commit by workflow-state-manager'
   - '2026-08-09 D-S060-open=1 — open S060/EV-051 on evolve/EV-051-tag-driven-prod-deploy @ stage@c146baec; deepen F30; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend; EV-043/EV-044 remain parked; no git commit by workflow-state-manager'
   - '2026-08-09 D-S059-close=1 — EV-050 / S059 completed; active_session cleared; PR #964 MERGED → stage @ 2815ffbe; #959 closed; #889 already CLOSED; no git commit by workflow-state-manager'
@@ -46211,11 +46384,14 @@ git_history:
     purpose: "EV-051 / S060 tag-driven prod deploy + full CI Deploy needs (deepen F30)"
     session_id: S060-tag-driven-prod-deploy
     evolve_cycle_id: EV-051
-    tip_sha: c146baec
-    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
-    tip_sha_pushed: false
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    tip_sha_pushed: true
+    pr_number: 966
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    pr_status: open
     pr_base: stage
-    note: "S060/EV-051 D-S060-scope=1 + D-S060-route=1 Lean+; 07-build in_progress; gates.a_to_b pending Gate A confirm; tip c146baec; no git commit by workflow-state-manager"
+    note: "S060/EV-051 D-S060-gateA=1 + D-S060-11-next=1; 11 COMPLETE / awaiting merge PR #966 → stage; tip cb8d9771; no git commit by workflow-state-manager"
   - name: evolve/EV-050-codes-wmo-validated
     base: stage
     base_sha: b57f2a87
@@ -47599,6 +47775,22 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: cb8d9771
+    sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    message: "[EV-051] feat: tag-driven prod Deploy after full CI (solo gate)"
+    branch: evolve/EV-051-tag-driven-prod-deploy
+    stage: 07-build
+    skill_id: 16-evolve
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    files_changed: 19
+    timestamp: '2026-08-09'
+    pushed: true
+    tip_sha: cb8d9771
+    tip_sha_full: cb8d97719d89a97b540115a21a533640c6397e4c
+    pr_number: 966
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/966
+    note: 'S060/EV-051 tip; stages 07-build + 16-evolve; PR #966 OPEN → stage; 08/09/11 completed after tip'
   - sha: 271efa49
     sha_full: 271efa494e06f6926de010fb378f327982f4536a
     message: "[T3.4] test: TC-EV050-008 REMARK_US_EXTENSION profile regressions"

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,9 +3,180 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 59
-evolve_cycle_counter: 50
-active_session: null
+session_counter: 60
+evolve_cycle_counter: 51
+active_session:
+  id: S060-tag-driven-prod-deploy
+  type: feature
+  title: "Tag-driven prod deploy + full CI Deploy needs (solo)"
+  intent: "Deepen F30: widen Deploy needs to full CI; stop auto Deploy on main push; prod Deploy only on vYYYY.MM.DD-deploy tag (and optional workflow_dispatch); staging stays auto after full CI; amend ADR-034, docs/deploy.md, doks-promote-from-stage.mdc, ci-cd.yml. Design 2+3+4. User chose open evolve option 1."
+  status: in_progress
+  started: '2026-08-09'
+  started_at: '2026-08-09'
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-051
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  branch_base: stage@c146baec
+  branch_base_sha: c146baec
+  branch_base_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  branch_status: active
+  branch_exists: true
+  tip_sha: c146baec
+  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  tip_sha_pushed: false
+  tip_sha_note: "Opened at stage tip c146baec (includes #965 EV-050 closeout); no session commits yet"
+  artifacts_dir: docs/sessions/S060-tag-driven-prod-deploy/
+  artifacts:
+  - path: docs/sessions/S060-tag-driven-prod-deploy/
+    status: in_progress
+    note: "session-brief.md, routing-plan.md, evolve-plan-card.md"
+  - path: docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
+    status: present
+  feature_ids:
+  - F30
+  deepen_feature_ids:
+  - F30
+  feature_note: "Deepen F30 — tag-driven prod Deploy + full CI Deploy needs; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend"
+  prior_session: S059-codes-wmo-validated
+  preset: Lean+
+  preset_status: approved
+  preset_note: "D-S060-route=1 Lean+ — 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13"
+  auto_lean: false
+  ui_preview: n/a
+  ui_preview_note: "N/A — no browser UI"
+  scope_summary: "LOCKED D-S060-scope=1 — design 2+3+4: widen Deploy needs to full CI (+e2e-smoke); no auto Deploy on main push; prod Deploy only on vYYYY.MM.DD-deploy tag (+ optional workflow_dispatch); staging auto after full CI; amend ADR-034 / docs/deploy.md / doks-promote-from-stage.mdc / ci-cd.yml / TC-F30-010"
+  routing_plan_meta:
+    status: approved
+    decision: D-S060-route=1
+    preset: Lean+
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 03-plan-tooling
+    - 07-build
+    - 08-verify-build
+    - 09-qa
+    - 11-verify-impl
+    skipped_stages:
+    - 04-tech-plan
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 10-e2e
+    - 12-verify-deploy
+    - 13-deploy-smoke
+    ordered: "00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11"
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "D-S060-open=1; D-S060-scope=1 locked 2+3+4"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrator
+    status: in_progress
+    started: '2026-08-09'
+    note: "Orchestrating Lean+; current child 07-build; gates.a_to_b pending user Gate A confirm"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "AC1–AC6 locked (design 2+3+4)"
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "Gate A draft PASS — awaiting user Gate A confirm (gates.a_to_b pending)"
+  - stage: 03-plan-tooling
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-09'
+    completed: '2026-08-09'
+    note: "Rules / promote semantics updated"
+  - stage: 04-tech-plan
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip"
+  - stage: 05-verify-tech
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip"
+  - stage: 06-tech-tooling
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip"
+  - stage: 07-build
+    required: true
+    mode: delta
+    status: in_progress
+    started: '2026-08-09'
+    note: "ci-cd.yml / ADR-034 / deploy docs amend in progress"
+  - stage: 08-verify-build
+    required: true
+    mode: delta
+    status: pending
+  - stage: 09-qa
+    required: true
+    mode: delta
+    status: pending
+  - stage: 10-e2e
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip"
+  - stage: 11-verify-impl
+    required: true
+    mode: delta
+    status: pending
+  - stage: 12-verify-deploy
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip — first tag-driven prod cutover later promote"
+  - stage: 13-deploy-smoke
+    required: false
+    mode: skip
+    status: skipped
+    note: "Lean+ skip"
+  routing_plan_note: "D-S060-route=1 Lean+ approved; required_stages 00/16/01/02/03/07/08/09/11"
+  current_stage: 07-build
+  current_stage_note: "D-S060-scope=1 + D-S060-route=1; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm; EV-043/EV-044 remain parked"
+  open_decision: D-S060-open=1
+  decisions:
+    D-S060-open: "1 — open evolve S060/EV-051 tag-driven prod deploy (design 2+3+4); do not resume parked EV-043/EV-044"
+    D-S060-scope: "1 — lock scope to design 2+3+4 (full CI Deploy needs; no auto Deploy on main; tag-driven prod + optional workflow_dispatch; staging auto; amend ADR-034/deploy docs/rule/ci-cd)"
+    D-S060-route: "1 — Lean+ as drafted: 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13"
+  decisions_locked:
+  - D-S060-open=1
+  - D-S060-scope=1
+  - D-S060-route=1
+  gates:
+    a_to_b: pending
+    a_to_b_note: "pending user Gate A confirm (02 completed; await confirm before treating Phase A→B as passed)"
+    b_to_c: pending
+    c_to_d: pending
+    deploy: pending
+  notes:
+  - "2026-08-09 D-S060-scope=1 — scope locked to design 2+3+4; artifacts under docs/sessions/S060-tag-driven-prod-deploy/"
+  - "2026-08-09 D-S060-route=1 — Lean+ approved; 00/01/02/03 completed; current_stage 07-build in_progress; gates.a_to_b pending user Gate A confirm"
+  - "2026-08-09 D-S060-open=1 — session opened; EV-051 deepens F30; EV-043/EV-044 remain parked unless user later chooses resume"
+  - "EV-051 supersedes auto-deploy-on-main behavior from ADR-034 / TC-F30-010 pending amend"
 sessions:
 - id: S059-codes-wmo-validated
   type: feature
@@ -8002,29 +8173,33 @@ stages:
   00-context:
     status: completed
     mode: session
-    scoped_slug: strip-internal-doc-refs
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
-    started: '2026-08-08'
-    started_at: '2026-08-08'
-    completed: '2026-08-08'
-    completed_at: '2026-08-08'
-    note: 'S057/EV-048 COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve; session-brief + routing-plan written'
-    prior_note: 'S055/EV-046 COMPLETE — open_session D-S055-open=2 Lean for #889; handoff 16-evolve Phase 0; EV-043/EV-044 remain PARKED'
-    prior_session_id: S055-wmo-aviation-registers
-    prior_evolve_cycle_id: EV-046
-    prior_scoped_slug: wmo-aviation-registers
+    scoped_slug: tag-driven-prod-deploy
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    started: '2026-08-09'
+    started_at: '2026-08-09'
+    completed: '2026-08-09'
+    completed_at: '2026-08-09'
+    note: 'S060/EV-051 COMPLETE — D-S060-open=1 + D-S060-scope=1 (2+3+4) + D-S060-route=1 Lean+; session-brief + routing-plan + evolve-plan-card; handoff 07-build (Gate A confirm pending)'
+    prior_note: 'S057/EV-048 COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve; session-brief + routing-plan written'
+    prior_session_id: S057-strip-internal-doc-refs
+    prior_evolve_cycle_id: EV-048
+    prior_scoped_slug: strip-internal-doc-refs
     prior_completed: '2026-08-08'
     prior_started: '2026-08-08'
-    prior_tip_sha: d0a51f5a
-    prior_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-    prior_prior_note: 'S052/EV-043 COMPLETE — open_session for #886; D-S052-open/scope/product/gh locked; handoff 16-evolve Phase 0; Standard pending Plan approval'
-    prior_prior_session_id: S052-doks-staging-prod-branch-deploys
-    prior_prior_evolve_cycle_id: EV-043
-    prior_prior_scoped_slug: doks-staging-prod-branch-deploys
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    prior_tip_sha: d7652d5d
+    prior_tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
+    prior_prior_note: 'S055/EV-046 COMPLETE — open_session D-S055-open=2 Lean for #889; handoff 16-evolve Phase 0; EV-043/EV-044 remain PARKED'
+    prior_prior_session_id: S055-wmo-aviation-registers
+    prior_prior_evolve_cycle_id: EV-046
+    prior_prior_scoped_slug: wmo-aviation-registers
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
     artifacts:
+    - docs/sessions/S060-tag-driven-prod-deploy/
+    - docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
+    - docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
+    - docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
     - docs/sessions/S057-strip-internal-doc-refs/
     - docs/sessions/S057-strip-internal-doc-refs/session-brief.md
     - docs/sessions/S057-strip-internal-doc-refs/routing-plan.md
@@ -8055,36 +8230,41 @@ stages:
   01-requirements:
     status: completed
     mode: delta
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
     skill_id: 01-requirements
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
-    deepen_feature_ids: [F7, F21]
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    deepen_feature_ids: [F30]
     feature_ids: []
     delta_only: true
     corpus_cites:
-    - '[Corpus: api]'
-    - '[Corpus: product §F7]'
-    - '[Corpus: product §F21]'
+    - '[Corpus: product §F30]'
+    - '[Corpus: deploy]'
+    - '[Corpus: adr/ADR-034]'
     - '[Corpus: tests]'
-    report: docs/sessions/S057-strip-internal-doc-refs/reports/01-requirements.md
+    report:
     decision_refs:
-    - D-S057-01-ac
-    - D-S057-guard-s0
-    note: 'S057/EV-048 COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; AC1–AC6 + UJ-055; report 01-requirements.md; handoff 02-verify-plan'
-    prior_session_id: S055-wmo-aviation-registers
-    prior_evolve_cycle_id: EV-046
+    - D-S060-scope
+    - D-S060-route
+    note: 'S060/EV-051 COMPLETE — D-S060-scope=1 design 2+3+4; AC1–AC6 locked; handoff 02-verify-plan'
+    prior_session_id: S057-strip-internal-doc-refs
+    prior_evolve_cycle_id: EV-048
     prior_started: '2026-08-08'
     prior_completed: '2026-08-08'
-    prior_note: 'S055/EV-046 COMPLETE — D-S055-01-ac=1; AC1–AC6 confirmed; handoff 02-verify-plan'
-    prior_prior_session_id: S047-sql-ingest-live-e2e
-    prior_prior_evolve_cycle_id: EV-039
-    prior_prior_note: 'S047/EV-039 01-requirements COMPLETE (delta) — D-S047-ac=1 AC1–AC7 + manifest; reports/01-requirements-summary.md; tip a4f4d3a6; handoff 02-verify-plan'
+    prior_note: 'S057/EV-048 COMPLETE — D-S057-01-ac=1 + D-S057-guard-s0=1; AC1–AC6 + UJ-055; report 01-requirements.md; handoff 02-verify-plan'
+    prior_prior_session_id: S055-wmo-aviation-registers
+    prior_prior_evolve_cycle_id: EV-046
+    prior_prior_started: '2026-08-08'
+    prior_prior_completed: '2026-08-08'
+    prior_prior_note: 'S055/EV-046 COMPLETE — D-S055-01-ac=1; AC1–AC6 confirmed; handoff 02-verify-plan'
+    prior_prior_prior_session_id: S047-sql-ingest-live-e2e
+    prior_prior_prior_evolve_cycle_id: EV-039
+    prior_prior_prior_note: 'S047/EV-039 01-requirements COMPLETE (delta) — D-S047-ac=1 AC1–AC7 + manifest; reports/01-requirements-summary.md; tip a4f4d3a6; handoff 02-verify-plan'
     prior_decision_refs:
     - D-S055-01-ac
     - D-S055-phase01
@@ -8822,43 +9002,49 @@ stages:
   02-verify-plan:
     status: completed
     mode: delta
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
     skill_id: 02-verify-plan
-    tip_sha: d7652d5d
-    tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
-    deepen_feature_ids: [F7, F21]
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    deepen_feature_ids: [F30]
     feature_ids: []
     delta_only: true
-    gate_a: PASS
-    gate_a_status: pass
-    gate_a_decision: D-S057-gateA=1
-    report: docs/sessions/S057-strip-internal-doc-refs/reports/02-verify-plan.md
+    gate_a: pending_user_confirm
+    gate_a_status: pending
+    gate_a_decision:
+    gate_a_note: 'draft PASS — gates.a_to_b pending user Gate A confirm'
+    report:
     decision_refs:
-    - D-S057-gateA
-    - D-S057-01-ac
-    - D-S057-guard-s0
-    note: 'S057/EV-048 COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; handoff 04-tech-plan'
-    prior_session_id: S055-wmo-aviation-registers
-    prior_evolve_cycle_id: EV-046
+    - D-S060-scope
+    - D-S060-route
+    note: 'S060/EV-051 COMPLETE — 02 done; Gate A awaiting user confirm (gates.a_to_b pending); Lean+ skip 04/05 → 07-build'
+    prior_session_id: S057-strip-internal-doc-refs
+    prior_evolve_cycle_id: EV-048
     prior_started: '2026-08-08'
     prior_completed: '2026-08-08'
-    prior_note: 'S055/EV-046 COMPLETE — Gate A PASS (D-S055-gateA=1); accept M1/M2/L1; handoff lean-docs-execution'
+    prior_note: 'S057/EV-048 COMPLETE — Gate A PASS D-S057-gateA=1; S2.1–S2.4 as 04/07 defaults; report 02-verify-plan.md; handoff 04-tech-plan'
     prior_gate_a: PASS
     prior_gate_a_status: pass
-    prior_gate_a_decision: D-S055-gateA=1
+    prior_gate_a_decision: D-S057-gateA=1
+    prior_prior_session_id: S055-wmo-aviation-registers
+    prior_prior_evolve_cycle_id: EV-046
+    prior_prior_note: 'S055/EV-046 COMPLETE — Gate A PASS (D-S055-gateA=1); accept M1/M2/L1; handoff lean-docs-execution'
+    prior_prior_gate_a: PASS
+    prior_prior_gate_a_status: pass
+    prior_prior_gate_a_decision: D-S055-gateA=1
     prior_decision_refs:
     - D-S055-gateA
     - D-S055-01-ac
     - D-S055-phase01
     - D-S055-open
-    prior_prior_session_id: S047-sql-ingest-live-e2e
-    prior_prior_evolve_cycle_id: EV-039
-    prior_prior_note: 'S047/EV-039 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S047-02-gate-a=2); S02.M3 via spec.md; tip 7970ba46; handoff 04-tech-plan'
+    prior_prior_prior_session_id: S047-sql-ingest-live-e2e
+    prior_prior_prior_evolve_cycle_id: EV-039
+    prior_prior_prior_note: 'S047/EV-039 02-verify-plan COMPLETE (delta) — Gate A PASS (D-S047-02-gate-a=2); S02.M3 via spec.md; tip 7970ba46; handoff 04-tech-plan'
     substeps:
       inventory:
         status: completed
@@ -9599,8 +9785,20 @@ stages:
     - Product plan verification complete; 4 source docs updated
   03-plan-tooling:
     status: completed
-    started_at: '2026-06-14T23:59:00Z'
-    completed_at: '2026-06-15T00:15:00Z'
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at: '2026-08-09'
+    completed: '2026-08-09'
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    skill_id: 03-plan-tooling
+    mode: delta
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    deepen_feature_ids: [F30]
+    note: 'S060/EV-051 COMPLETE — D-S060-route=1 Lean+ includes 03; rules/promote semantics updated; handoff 07-build'
+    previous_started_at: '2026-06-14T23:59:00Z'
+    previous_completed_at: '2026-06-15T00:15:00Z'
     substeps:
       analyze_plan:
         status: completed
@@ -9625,6 +9823,7 @@ stages:
     - docs/sessions/S019-dissemination-upload/reports/03-plan-tooling.md
     - .cursor/rules/optional/dissemination-egress-ssrf.mdc
     notes:
+    - 2026-08-09 S060/EV-051 03-plan-tooling COMPLETE (D-S060-route=1 Lean+) — promote/rule semantics; handoff 07-build; gates.a_to_b pending user Gate A confirm
     - 2026-07-28 S023/EV-017 03-plan-tooling skipped — Standard routing skip; 04 prerequisite waived (D-S023-02-phase-a-A)
     - 2026-07-21 S019/EV-014 03 COMPLETE (D-S019-EV014-Q30A-03-tooling) — plan-adherence F16–F19; dissemination-egress-ssrf; feature_drift/scope_check; Phase A awaiting checkpoint
     - 2026-07-21 S019/EV-014 03-plan-tooling delta starting (Q29=A) — F16–F19 dissemination guardrails
@@ -11160,18 +11359,25 @@ stages:
       completed_at: '2026-07-21'
       note: T0.1 done — coverage + CI Compose hooks; Phase B Assumed PASS; next 07-build
   07-build:
-    status: completed
-    started_at: '2026-08-08'
-    started: '2026-08-08'
-    completed_at: '2026-08-08'
-    completed: '2026-08-08'
+    status: in_progress
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    completed_at:
+    completed:
     previous_started_at: '2026-08-08'
     previous_completed_at: '2026-08-08'
-    previous_session_id: S056-m0-stabilize-operator-trust
-    previous_evolve_cycle_id: EV-047
-    previous_tip_sha: 3ca4f438
-    previous_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
-    previous_note: 'COMPLETE — M1–M3+M2.5 done @ 3ca4f438; T1.5 deferred (D-S056-t15-admin); superseded by S057/EV-048'
+    previous_session_id: S057-strip-internal-doc-refs
+    previous_evolve_cycle_id: EV-048
+    previous_tip_sha: 71779d46
+    previous_tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    previous_note: 'COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46; superseded by S060/EV-051'
+    previous_s056_started_at: '2026-08-08'
+    previous_s056_completed_at: '2026-08-08'
+    previous_s056_session_id: S056-m0-stabilize-operator-trust
+    previous_s056_evolve_cycle_id: EV-047
+    previous_s056_tip_sha: 3ca4f438
+    previous_s056_tip_sha_full: 3ca4f43863063beb56ac0ca20b6a23a52c8306f0
+    previous_s056_note: 'COMPLETE — M1–M3+M2.5 done @ 3ca4f438; T1.5 deferred (D-S056-t15-admin); superseded by S057/EV-048'
     prior_session_id: S054-rust-ci-crates
     prior_evolve_cycle_id: EV-045
     prior_started: '2026-08-08'
@@ -11182,13 +11388,13 @@ stages:
     prior_prior_session_id: S050-remove-db-tools-operator-throughput
     prior_prior_evolve_cycle_id: EV-042
     prior_prior_note: 'S050/EV-042 07-build COMPLETE — M4 done; superseded by S054/EV-045'
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
     skill_id: 07-build
-    mode: full
-    note: 'COMPLETE — M1–M3; OpenAPI strip + BE/FE guards; T3.3 skipped; commit 71779d46'
-    tip_sha: 71779d46
-    tip_sha_full: 71779d46e5a6f53da5d4244b0f465e1e5c420773
+    mode: delta
+    note: 'IN PROGRESS — S060/EV-051 Lean+; ci-cd.yml / ADR-034 / deploy docs / promote rule; gates.a_to_b pending user Gate A confirm'
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
     tip_sha_pushed: false
     pr_number:
     pr_url:
@@ -11197,19 +11403,23 @@ stages:
     pr_supersedes:
     ci_cd_pipeline_run:
     ci_cd_pipeline_status:
-    ci_cd_pipeline_note: 'S056 prior tip CI archived under previous_*; S057 tip 71779d46 on evolve/EV-048'
+    ci_cd_pipeline_note: 'S060/EV-051 07-build in_progress @ tip c146baec; prior S057 tip 71779d46 archived under previous_*'
     pending_commit: false
-    current_milestone: M3
+    current_milestone:
     current_task:
-    active_milestone: M3
+    active_milestone:
     active_task:
-    active_task_status: completed
-    completed_through: T3.2
-    progress: 8/9
-    skipped_tasks: [T3.3]
-    deepen_feature_ids: [F7, F21]
+    active_task_status: in_progress
+    completed_through:
+    progress:
+    skipped_tasks: []
+    deepen_feature_ids: [F30]
     feature_ids: []
     decision_refs:
+    - D-S060-scope
+    - D-S060-route
+    - D-S060-open
+    decision_refs_s057:
     - D-S057-gateB
     - D-S057-04-plan
     - D-S057-04-guard-ext
@@ -16125,15 +16335,20 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: completed
-    completed: '2026-08-09'
-    completed_at: '2026-08-09'
-    close_decision: D-S057-close=1
+    status: in_progress
+    completed:
+    completed_at:
+    close_decision:
     mode: orchestrator
-    session_id: S057-strip-internal-doc-refs
-    evolve_cycle_id: EV-048
-    started_at: '2026-08-08'
-    started: '2026-08-08'
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    started_at: '2026-08-09'
+    started: '2026-08-09'
+    previous_s057_session_id: S057-strip-internal-doc-refs
+    previous_s057_evolve_cycle_id: EV-048
+    previous_s057_completed: '2026-08-09'
+    previous_s057_close_decision: D-S057-close=1
+    previous_s057_note: 'CLOSED — D-S057-close=1; EV-048 COMPLETE; PR #963 MERGED → stage @ 06a9543f; #951 closed'
     previous_s056_session_id: S056-m0-stabilize-operator-trust
     previous_s056_evolve_cycle_id: EV-047
     previous_s056_completed: '2026-08-08'
@@ -16160,19 +16375,23 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: completed
-    current_child_stage_note: 'CLOSED D-S057-close=1; EV-048 COMPLETE; PR #963 MERGED → stage @ 06a9543f; #951 closed'
-    tip_sha: c52521c7
-    tip_sha_full: c52521c772a950d9e43ca088933dd5163ad59a12
-    tip_sha_pushed: true
-    pr_number: 963
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
-    pr_status: merged
-    merge_sha: 06a9543f
-    merge_sha_full: 06a9543ff4ccd586191dafeec63d9521e967d933
+    current_child_stage: 07-build
+    current_child_stage_note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm'
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    tip_sha_pushed: false
+    pr_number:
+    pr_url:
+    pr_status:
+    merge_sha:
+    merge_sha_full:
     merge_target: stage
-    branch_status: merged
-    note: 'CLOSED — D-S057-close=1; S057/EV-048 COMPLETE; PR #963 MERGED → stage @ 06a9543f; #951 closed; active_session=null'
+    branch_status: active
+    note: 'IN PROGRESS — S060/EV-051; scope+route locked; current_child 07-build; gates.a_to_b pending user Gate A confirm; artifacts docs/sessions/S060-tag-driven-prod-deploy/'
+    prior_s057_pr_number: 963
+    prior_s057_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
+    prior_s057_merge_sha: 06a9543f
+    prior_s057_merge_sha_full: 06a9543ff4ccd586191dafeec63d9521e967d933
     prior_close_decision: D-S056-close=1
 
     prior_s054_session_id: S054-rust-ci-crates
@@ -16437,6 +16656,108 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S060-route
+  date: '2026-08-09'
+  timestamp: '2026-08-09'
+  resolved_at: '2026-08-09'
+  session_id: S060-tag-driven-prod-deploy
+  evolve_cycle_id: EV-051
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: routing
+  status: confirmed
+  topic: Approve Lean+ routing for S060/EV-051
+  summary: "D-S060-route=1 — Lean+ approved: 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13; current_stage 07-build; gates.a_to_b pending user Gate A confirm"
+  decision: |
+    D-S060-route=1 — User approved Lean+ routing as drafted.
+    Required stages: 00-context, 16-evolve, 01-requirements, 02-verify-plan, 03-plan-tooling,
+    07-build, 08-verify-build, 09-qa, 11-verify-impl.
+    Skip: 04-tech-plan, 05-verify-tech, 06-tech-tooling, 10-e2e, 12-verify-deploy, 13-deploy-smoke.
+    Stages 00/01/02/03 marked completed; 07-build in_progress.
+    gates.a_to_b remains pending until user Gate A confirm.
+    Artifacts: docs/sessions/S060-tag-driven-prod-deploy/{session-brief,routing-plan,evolve-plan-card}.md
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  related_features:
+  - F30
+  related_decisions:
+  - D-S060-open
+  - D-S060-scope
+  note: "Lean+; Gate A user confirm still pending"
+- id: D-S060-scope
+  date: '2026-08-09'
+  timestamp: '2026-08-09'
+  resolved_at: '2026-08-09'
+  session_id: S060-tag-driven-prod-deploy
+  evolve_cycle_id: EV-051
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 00-context
+  category: scope_lock
+  status: confirmed
+  topic: Lock EV-051 scope to design 2+3+4
+  summary: "D-S060-scope=1 — lock scope to design 2+3+4 (full CI Deploy needs; no auto Deploy on main; tag-driven prod + optional workflow_dispatch; staging auto; amend ADR-034/deploy docs/rule/ci-cd)"
+  decision: |
+    D-S060-scope=1 — User locked Phase 0 scope to design 2+3+4.
+    (2) Widen Deploy needs to full CI (include e2e-smoke; frontend already in test matrix).
+    (3) Split: push to main runs full CI without prod Deploy.
+    (4) Tag-driven prod: Deploy prod on vYYYY.MM.DD-deploy (+ optional workflow_dispatch);
+    staging stays auto after full CI on stage.
+    Amend ADR-034, docs/deploy.md, doks-promote-from-stage.mdc, ci-cd.yml, TC-F30-010 wording.
+    Out: Environment reviewers; Slack bots; PyPI path change; resume EV-043/EV-044; quality packs as Deploy needs.
+    Artifacts noted under docs/sessions/S060-tag-driven-prod-deploy/.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  related_features:
+  - F30
+  related_decisions:
+  - D-S060-open
+  related_adrs:
+  - docs/adr/ADR-034-doks-staging-promote-from-stage.md
+  related_test_cases:
+  - TC-F30-010
+  parked_cycles_unchanged:
+  - EV-043
+  - EV-044
+  note: "Scope locked; routing D-S060-route=1 follows"
+- id: D-S060-open
+  date: '2026-08-09'
+  timestamp: '2026-08-09'
+  resolved_at: '2026-08-09'
+  session_id: S060-tag-driven-prod-deploy
+  evolve_cycle_id: EV-051
+  skill: 00-context
+  skill_id: 00-context
+  stage: 00-context
+  category: session_open
+  status: confirmed
+  topic: Open S060/EV-051 tag-driven prod deploy (deepen F30)
+  summary: "D-S060-open=1 — open S060/EV-051; deepen F30 tag-driven prod Deploy + full CI Deploy needs; design 2+3+4; EV-051 supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend; parked EV-043/EV-044 remain parked"
+  decision: |
+    D-S060-open=1 — User chose open evolve option 1.
+    Allocate S060-tag-driven-prod-deploy / EV-051 on branch evolve/EV-051-tag-driven-prod-deploy based on stage@c146baec.
+    Deepen F30: widen Deploy needs to full CI; stop auto Deploy on main push; prod Deploy only on
+    vYYYY.MM.DD-deploy tag (and optional workflow_dispatch); staging stays auto after full CI;
+    amend ADR-034, docs/deploy.md, doks-promote-from-stage.mdc, ci-cd.yml. Design 2+3+4.
+    EV-051 supersedes auto-deploy-on-main behavior from ADR-034 / TC-F30-010 pending amend.
+    Parked cycles EV-043 and EV-044 remain parked — do NOT resume unless user later chooses.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  related_features:
+  - F30
+  related_decisions: []
+  related_adrs:
+  - docs/adr/ADR-034-doks-staging-promote-from-stage.md
+  related_test_cases:
+  - TC-F30-010
+  parked_cycles_unchanged:
+  - EV-043
+  - EV-044
+  note: "Parked EV-043/EV-044 remain parked; new cycle deepens F30 rather than resuming those sessions"
 - id: D-S059-close
   date: '2026-08-09'
   timestamp: '2026-08-09'
@@ -34478,6 +34799,97 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-051
+  session_id: S060-tag-driven-prod-deploy
+  type: feature
+  cycle_type: general
+  status: in_progress
+  parked: false
+  started: '2026-08-09'
+  started_at: '2026-08-09'
+  completed:
+  completed_at:
+  title: "Tag-driven prod deploy + full CI gates (solo)"
+  slug: tag-driven-prod-deploy
+  feature_ids:
+  - F30
+  deepen_feature_ids:
+  - F30
+  feature_note: "Deepen F30 — tag-driven prod Deploy + full CI Deploy needs; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend"
+  branch: evolve/EV-051-tag-driven-prod-deploy
+  branch_base: stage@c146baec
+  branch_base_sha: c146baec
+  branch_base_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  branch_status: active
+  tip_sha: c146baec
+  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  tip_sha_pushed: false
+  preset: Lean+
+  scope_summary: "LOCKED D-S060-scope=1 — design 2+3+4: widen Deploy needs to full CI (+e2e-smoke); no auto Deploy on main push; prod Deploy only on vYYYY.MM.DD-deploy tag (+ optional workflow_dispatch); staging auto after full CI; amend ADR-034 / docs/deploy.md / doks-promote-from-stage.mdc / ci-cd.yml / TC-F30-010"
+  scope_note: "Phase 0 locked via D-S060-scope=1 (design 2+3+4)"
+  routing_plan:
+    status: approved
+    decision: D-S060-route=1
+    preset: Lean+
+    required_stages:
+    - 00-context
+    - 16-evolve
+    - 01-requirements
+    - 02-verify-plan
+    - 03-plan-tooling
+    - 07-build
+    - 08-verify-build
+    - 09-qa
+    - 11-verify-impl
+    skipped_stages:
+    - 04-tech-plan
+    - 05-verify-tech
+    - 06-tech-tooling
+    - 10-e2e
+    - 12-verify-deploy
+    - 13-deploy-smoke
+    ordered: "00 → 16 → 01 → 02 → 03 → 07 → 08 → 09 → 11"
+  routing_plan_note: "D-S060-route=1 Lean+ approved; artifact docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md"
+  current_stage: 07-build
+  current_stage_note: "D-S060-scope=1 + D-S060-route=1; 00/01/02/03 completed; 07-build in_progress; gates.a_to_b pending user Gate A confirm"
+  gates:
+    a_to_b: pending
+    a_to_b_note: "pending user Gate A confirm"
+    b_to_c: pending
+    c_to_d: pending
+    deploy: pending
+  checkpoints:
+    phase_a: pending
+    phase_a_note: "02 completed; Gate A user confirm pending"
+    phase_b: pending
+    phase_c: pending
+    phase_d: pending
+    deploy: pending
+  adrs:
+  - docs/adr/ADR-034-doks-staging-promote-from-stage.md
+  artifacts:
+  - path: docs/sessions/S060-tag-driven-prod-deploy/
+    status: in_progress
+    note: "session-brief.md, routing-plan.md, evolve-plan-card.md"
+  - path: docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
+    status: present
+  - path: docs/sessions/S060-tag-driven-prod-deploy/evolve-plan-card.md
+    status: present
+  decisions:
+    D-S060-open: "1 — open evolve S060/EV-051; deepen F30; EV-043/EV-044 remain parked"
+    D-S060-scope: "1 — lock scope to design 2+3+4"
+    D-S060-route: "1 — Lean+: 00→16→01→02→03→07→08→09→11; skip 04,05,06,10,12,13"
+  decisions_locked:
+  - D-S060-open=1
+  - D-S060-scope=1
+  - D-S060-route=1
+  notes:
+  - "2026-08-09 D-S060-scope=1 — scope locked to design 2+3+4"
+  - "2026-08-09 D-S060-route=1 — Lean+ approved; current_stage 07-build; gates.a_to_b pending user Gate A confirm"
+  - "2026-08-09 D-S060-open=1 — EV-051 opened; deepens F30; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend; parked EV-043/EV-044 remain parked — do not resume unless user later chooses"
+  note: "IN PROGRESS — scope+route locked; 07-build in_progress; gates.a_to_b pending user Gate A confirm; parked EV-043/EV-044 unchanged"
 - id: EV-050
   session_id: S059-codes-wmo-validated
   type: feature
@@ -45227,24 +45639,24 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: stage
+  current_branch: evolve/EV-051-tag-driven-prod-deploy
   ahead_of_origin: 0
-  pushed: true
+  pushed: false
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml dirty after D-S059-close=1 closeout; no git commit by workflow-state-manager'
-  tip_sha: 2815ffbe
-  tip_sha_full: 2815ffbe3a9f91e1b1da1677b93b8e6a025f20d1
-  tip_note: 'S059/EV-050 CLOSED — PR #964 MERGED → stage @ 2815ffbe; tip 856471fe; active_session=null'
-  evolve_branch: evolve/EV-050-codes-wmo-validated
-  evolve_tip_sha: 856471fe
-  evolve_tip_sha_full: 856471fe1110c1679577390a1f2c5f1068675eaa
-  evolve_tip_sha_pushed: true
+  dirty_note: 'workflow-state.yaml dirty after D-S060-scope=1 + D-S060-route=1 (00/01/02/03 completed; 07-build in_progress); no git commit by workflow-state-manager'
+  tip_sha: c146baec
+  tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  tip_note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; current_stage 07-build; gates.a_to_b pending Gate A confirm; tip still c146baec; active_session=S060-tag-driven-prod-deploy'
+  evolve_branch: evolve/EV-051-tag-driven-prod-deploy
+  evolve_tip_sha: c146baec
+  evolve_tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+  evolve_tip_sha_pushed: false
   stage_merge_sha: 2815ffbe
   stage_merge_sha_full: 2815ffbe3a9f91e1b1da1677b93b8e6a025f20d1
-  stage_tip_sha: 2815ffbe
-  stage_tip_sha_full: 2815ffbe3a9f91e1b1da1677b93b8e6a025f20d1
+  stage_tip_sha: c146baec
+  stage_tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -45255,10 +45667,12 @@ git_history:
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-  recommended_branch: stage
-  note: 'S059/EV-050 CLOSED — D-S059-close=1; PR #964 MERGED → stage @ 2815ffbe; #959 closed; #889 already CLOSED; active_session=null'
+  recommended_branch: evolve/EV-051-tag-driven-prod-deploy
+  note: 'S060/EV-051 — D-S060-scope=1 + D-S060-route=1 Lean+; 00/01/02/03 completed; current_stage 07-build in_progress; gates.a_to_b pending user Gate A confirm; EV-043/EV-044 remain parked'
 
   notes:
+  - '2026-08-09 D-S060-scope=1 + D-S060-route=1 — scope locked 2+3+4; Lean+ routing; 00/01/02/03 completed; current_stage 07-build; gates.a_to_b pending user Gate A confirm; artifacts docs/sessions/S060-tag-driven-prod-deploy/; no git commit by workflow-state-manager'
+  - '2026-08-09 D-S060-open=1 — open S060/EV-051 on evolve/EV-051-tag-driven-prod-deploy @ stage@c146baec; deepen F30; supersedes ADR-034 TC-F30-010 auto-deploy-on-main pending amend; EV-043/EV-044 remain parked; no git commit by workflow-state-manager'
   - '2026-08-09 D-S059-close=1 — EV-050 / S059 completed; active_session cleared; PR #964 MERGED → stage @ 2815ffbe; #959 closed; #889 already CLOSED; no git commit by workflow-state-manager'
   - '2026-08-09 D-S059-merge=1 — merge #964 → stage; close #959; #889 already CLOSED (residuals defer+cite in session reports); merge 2815ffbe; tip 856471fe; no git commit by workflow-state-manager'
   - '2026-08-09 tip 271efa49 — M2+M3 complete (T2.4@d6dc64e0; T3.1@848c01a7; T3.2@926342fe+f38f9466; T3.3@3d06b144; T3.4@271efa49); next M4 T4.1 #882 design note; local ahead ~15 not pushed; tip_sha_pushed=false; 07-build remains in_progress; dirty workflow-state expected; ignore untracked no-internal-doc-refs if present (do not add); no git commit by workflow-state-manager'
@@ -45787,6 +46201,21 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-051-tag-driven-prod-deploy
+    base: stage
+    base_sha: c146baec
+    base_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    status: active
+    created: '2026-08-09'
+    exists: true
+    purpose: "EV-051 / S060 tag-driven prod deploy + full CI Deploy needs (deepen F30)"
+    session_id: S060-tag-driven-prod-deploy
+    evolve_cycle_id: EV-051
+    tip_sha: c146baec
+    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    tip_sha_pushed: false
+    pr_base: stage
+    note: "S060/EV-051 D-S060-scope=1 + D-S060-route=1 Lean+; 07-build in_progress; gates.a_to_b pending Gate A confirm; tip c146baec; no git commit by workflow-state-manager"
   - name: evolve/EV-050-codes-wmo-validated
     base: stage
     base_sha: b57f2a87


### PR DESCRIPTION
## Summary
- Deepen **F30**: Deploy waits on full CI including **`e2e-smoke`**
- Push to **`stage`** still auto-Deploys staging
- Push to **`main`** runs CI only — **no** auto prod Deploy
- Prod Deploy on **`vYYYY.MM.DD-deploy`** (`v*-*-deploy`) or **`workflow_dispatch`**
- Amends ADR-034, `docs/deploy.md`, promote/ci-after-push rules, TC-F30-010/014 + TC-EV051-*

## Test plan
- [x] Static TC-EV051 checks on `ci-cd.yml` `needs` / `if`
- [ ] Tip CI green on this PR → `stage`
- [ ] After merge: confirm next `main` merge does not Deploy until a deploy tag
- [ ] 12/13 waived this cycle

## Issues
Deepens F30 / ADR-034 (EV-051 / S060). No new GitHub issue required unless maintainers want a tracker.

[Corpus: product §F30] [Corpus: deploy] [Corpus: adr/ADR-034] [Corpus: decisions §EV-051]

Made with [Cursor](https://cursor.com)