### PR TITLE
[EV-053] docs: session closeout after #973 merge

### DIFF
--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -9,7 +9,7 @@
 **Features**: deepen **F29**, **M5** (no new Fn)  
 **Started**: 2026-08-10  
 **Branch**: `evolve/EV-053-vitest-branches-95` (base `stage@6f25c0b1`)  
-**Status**: **in_progress** — 07 M2 COMPLETE; M3 inventory/AC5 proof done; tip CI + 08→11 next  
+**Status**: **completed** (`D-S062-merge=1` / `D-S062-close=1`) — [#973](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973) → `stage` @ `ef68ac67`; [#968](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/968) closed; no stage→main  
 **Corpus**: [Corpus: product §F29] [Corpus: product §M5] [Corpus: tests]
 [Corpus: adr/ADR-007] [Corpus: decisions §EV-052] [Corpus: decisions §EV-053]
 
@@ -21,6 +21,15 @@
 | FileConverter branches (AC5) | **95.95%** (521/543) — `reports/m3-ac5-coverage-proof.md` |
 | Inventory `branch_waiver` | **resolved** — S061 `coverage-surface-inventory.yaml` |
 | Parent waiver | `D-S061-cov-branches=3` closed by EV-053 / #968 |
+| Merge | [#973](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973) → `stage` @ `ef68ac67` (`D-S062-merge=1`) |
+| Issue | [#968](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/968) **CLOSED** (`D-S062-close=1`) |
+
+### Close decisions (2026-08-10)
+
+| ID | Decision |
+|----|----------|
+| D-S062-merge | **1** — Merge [#973](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973) → `stage` |
+| D-S062-close | **1** — Close #968; complete EV-053 / S062; no stage→main this cycle |
 
 ### Scope (Phase 0–1 — locked 2026-08-10)
 

--- a/docs/sessions/S062-vitest-branches-95/reports/11-verify-impl.md
+++ b/docs/sessions/S062-vitest-branches-95/reports/11-verify-impl.md
@@ -1,21 +1,14 @@
 # 11-verify-impl — S062 / EV-053
 
 **Date**: 2026-08-10  
-**Verdict**: **READY TO MERGE** → `stage` (await user approval)
+**Verdict**: **MERGED** → `stage` (`D-S062-merge=1` / `D-S062-close=1`)
 
 | Item | Value |
 |------|-------|
 | Branch | `evolve/EV-053-vitest-branches-95` |
-| Tip | `33485335` |
-| PR | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973 |
-| CI | success — https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31416416906 |
-| Issue | [#968](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/968) — close after merge |
-
-## Post-merge
-
-1. Merge #973 → `stage` (user approval).
-2. Close #968 citing EV-053 / AC1–AC5 + inventory resolve.
-3. Close S062 / EV-053 in `workflow-state.yaml` (`D-S062-close`).
+| PR | https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973 **MERGED** |
+| Merge SHA | `ef68ac67` |
+| Issue | [#968](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/968) **CLOSED** |
 
 ## Corpus
 

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -5,27 +5,30 @@ project:
   output_directory: docs/
 session_counter: 62
 evolve_cycle_counter: 53
-active_session: S062-vitest-branches-95
+active_session: null
 sessions:
 
 - id: S062-vitest-branches-95
   type: feature
   title: "Vitest branches ≥95% (FileConverter) — #968 EV-052 waiver follow-up"
   intent: "EV-053: close D-S061-cov-branches waiver; raise Vitest branches ≥95; FileConverter-heavy tests and/or justified excludes; resolve coverage inventory branch_waiver. Preset Standard. Parent #950/EV-052."
-  status: in_progress
+  status: completed
   started: '2026-08-10'
   started_at: '2026-08-10'
+  completed: '2026-08-10'
   orchestrator: 16-evolve
   evolve_cycle_id: EV-053
   branch: evolve/EV-053-vitest-branches-95
   branch_base: stage@6f25c0b1
   branch_base_sha: 6f25c0b1
   branch_base_sha_full: 6f25c0b189679d9ac00afaed97fb6b30a9791451
-  branch_status: open
+  branch_status: merged
   branch_exists: true
-  tip_sha: 33485335
-  tip_sha_full: 33485335542c9c1060a8c5e4559a8efb1548e03d
+  tip_sha: ef68ac67
+  tip_sha_full: ef68ac673481d895b5ae1c0c434554a3b883a0a5
   tip_sha_pushed: true
+  merge_pr: 973
+  merge_sha: ef68ac673481d895b5ae1c0c434554a3b883a0a5
   artifacts_dir: docs/sessions/S062-vitest-branches-95/
   github_issues:
   - 968
@@ -36,8 +39,8 @@ sessions:
   - F29
   - M5
   prior_session: S061-ci-polish-quality-pr-stats
-  current_stage: 11-verify-impl
-  current_stage_note: '07 COMPLETE; CI green PR #973; 08/09/11 verify READY TO MERGE'
+  current_stage: completed
+  current_stage_note: 'CLOSED — D-S062-merge=1 / D-S062-close=1; EV-053 COMPLETE; #973 → stage @ ef68ac67; #968 closed; active_session=null'
   decisions:
     D-S062-route: "1 — Standard 00→16→01→02→04→07→08→09→11; skip 03,05,06,10,12,13"
     D-S062-ui-preview: "2 — no local UI preview; Vitest/docs only"
@@ -48,6 +51,8 @@ sessions:
     D-S062-gateA: "1 — PASS Gate A + M1 approve (verify-report AC5 proof)"
     D-S062-m1: "1 — AC5 via coverage JSON/html + session verify; optional CI script if cheap"
     D-S062-04-plan: "1 — approve execution plan as drafted; skip 05; start 07 M1"
+    D-S062-merge: "1 — Merge #973 → stage @ ef68ac67"
+    D-S062-close: "1 — Close #968; complete EV-053 / S062; no stage→main"
   artifacts:
   - path: docs/sessions/S062-vitest-branches-95/
     status: present
@@ -75,8 +80,8 @@ sessions:
     status: completed
     note: "D-S062-route=1; opened S062 from stage@6f25c0b1"
   - stage: 16-evolve
-    status: in_progress
-    note: "Phase 0–1 locked intake; await proceed → 01"
+    status: completed
+    note: "EV-053 COMPLETE D-S062-close=1"
   - stage: 01-requirements
     status: completed
     note: "D-S062-01-ac=1; AC1–AC5; FileConverter re-include"
@@ -97,8 +102,9 @@ sessions:
     note: "AC map PASS; report 09-qa.md"
   - stage: 11-verify-impl
     status: completed
-    note: "READY TO MERGE PR #973; await D-S062-merge"
+    note: "APPROVED; #973 merged; #968 closed"
   notes:
+  - "2026-08-10 D-S062-merge=1 / D-S062-close=1 — #973 → stage @ ef68ac67; #968 CLOSED; EV-053/S062 COMPLETE"
   - "2026-08-10 M2 COMPLETE @ b3416505 — aggregate branches 96.39%; FileConverter 95.95% (AC5); M3 inventory resolved"
   - "2026-08-10 D-S062-04-plan=1 — 04 COMPLETE; 05 skipped; 07-build M1 START"
   - "2026-08-10 D-S062-gateA=1 / M1=1 — Gate A PASS; AC5 verify-report proof; 02 COMPLETE; 04-tech-plan START"


### PR DESCRIPTION
## Summary
- Record `D-S062-merge=1` / `D-S062-close=1` after [#973](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/973) → `stage` @ `ef68ac67`
- Close session S062 / EV-053 in `workflow-state.yaml` (`active_session: null`)
- [#968](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/968) already closed on GitHub

## Test plan
- [x] yamllint / secrets-check
- [ ] CI green on docs PR


Made with [Cursor](https://cursor.com)