### PR TITLE
chore: release prep 2026-08-10 (CHANGELOG + tac-validate 0.1.3)

### DIFF
--- a/deploy/doks/README.md
+++ b/deploy/doks/README.md
@@ -43,7 +43,9 @@ kubectl --context do-nyc1-metar-iwxxm-staging -n metar-iwxxm-staging create secr
   --from-literal=DISSEMINATION_EGRESS_ALLOWLIST='…'
 ```
 
-Also copy `ghcr-pull` and (if still required) `work-session-ssl-fix` into the staging namespace.
+Also copy `ghcr-pull` into the staging namespace. Do **not** remount
+`work_session_service.py` via ConfigMap (`work-session-ssl-fix` was a T7.1
+interim only — removed after BUG-2026-08-10; sslmode rewrite is in-image).
 
 ## CD image rollout (EV-034 / EV-043 / EV-044)
 

--- a/deploy/doks/base/deployment-api.yaml
+++ b/deploy/doks/base/deployment-api.yaml
@@ -43,13 +43,9 @@ spec:
                 name: metar-api-config
             - secretRef:
                 name: metar-api-secrets
-          # T7.1 interim: mount sslmode rewrite until GHCR push republishes ev031-doks
-          # with work_session_service._sync_database_url fix (remove after image bump).
-          volumeMounts:
-            - name: work-session-ssl-fix
-              mountPath: /app/apps/backend/src/services/work_session_service.py
-              subPath: work_session_service.py
-              readOnly: true
+          # sslmode rewrite lives in-image (_sync_database_url). Do not remount
+          # work_session_service.py via ConfigMap — stale mounts caused staging
+          # NameError: UUID (BUG-2026-08-10).
           readinessProbe:
             httpGet:
               path: /health
@@ -69,7 +65,3 @@ spec:
             limits:
               cpu: "1"
               memory: 1Gi
-      volumes:
-        - name: work-session-ssl-fix
-          configMap:
-            name: work-session-ssl-fix

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable user-facing and deployable changes for METAR to IWXXM.
 
+## 2026-08-10 — Promote EV-048..EV-053 (`stage` → `main`)
+
+### Added
+- **EV-050 / F12–F15 / F20 / F23 / F24 / F28**: Offline WMO codes membership harvest +
+  `tac-validate` Validated dual-profile lint (annex3 vs iwxxm_us); fixture matrix for
+  RE*/cloud/phenomena/SpaceWx membership.
+- **EV-051 / F30**: Tag-driven prod Deploy — `main` push runs full CI only; prod rolls on
+  `vYYYY.MM.DD-deploy` (or `workflow_dispatch`).
+- **EV-052 / F29 / M5 / F21**: Optional Sentry (API/FE/worker); Upstash-backed slowapi;
+  openapi-typescript FE types + `openapi:check`; coverage inventory + ≥95 lines/stmts/funcs
+  gates; quality sticky PR comment (product × profile).
+- **EV-053 / M5**: Vitest **branches** ≥95 (FileConverter re-included); closes EV-052 branch
+  waiver (#968).
+
+### Changed
+- **EV-048 / F7 / F21**: Strip internal doc refs (Corpus/ADR/EV/TC ids) from operator UI,
+  OpenAPI descriptions, and client-visible error copy.
+
+### Packages
+- `tac-validate` **0.1.2 → 0.1.3** (WMO membership Validated + dual-profile).
+- `tac2iwxxm` remains **0.2.4**.
+- `iwxxm-validate` remains **0.1.2**.
+
+### Deploy
+- Promote PR `stage` → `main` (this release).
+- Post-merge: tag `v2026.08.10-deploy`; optional PyPI `tac-validate-v0.1.3` after checklist.
+
 ## 2026-08-09 — Promote EV-043..EV-047 (`stage` → `main`)
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable user-facing and deployable changes for METAR to IWXXM.
 ### Changed
 - **EV-048 / F7 / F21**: Strip internal doc refs (Corpus/ADR/EV/TC ids) from operator UI,
   OpenAPI descriptions, and client-visible error copy.
+- **BUG-2026-08-10**: Remove DOKS ConfigMap mount over `work_session_service.py` (stale
+  overlay caused staging `NameError: UUID` on work-sessions).
 
 ### Packages
 - `tac-validate` **0.1.2 → 0.1.3** (WMO membership Validated + dual-profile).

--- a/docs/bug-reports/BUG-2026-08-10-staging-work-session-uuid-nameerror.md
+++ b/docs/bug-reports/BUG-2026-08-10-staging-work-session-uuid-nameerror.md
@@ -1,0 +1,60 @@
+# BUG-2026-08-10 — Staging work-sessions `NameError: UUID`
+
+## Error description
+
+Authenticated `GET /api/v1/work-sessions` on **staging** returned HTTP 500.
+Live Playwright UJ-046 / TC-F31-003–004 failed (login OK; sessions list / draft
+upload toast failed). Prod work-sessions remained healthy.
+
+## Error logs
+
+```text
+File "/app/apps/backend/src/services/work_session_service.py", line 141, in list_sessions
+    stmt = select(table).where(table.c.user_id == UUID(self.user_id))
+                                                  ^^^^
+NameError: name 'UUID' is not defined
+```
+
+| Field | Value |
+|-------|--------|
+| Env | staging DOKS `metar-iwxxm-staging` |
+| API | `https://api.staging.tac-to-iwxxm.com` |
+| Image tag | `ghcr.io/.../backend:20260810182452-b0565cc` (image itself **had** `UUID` import) |
+| Observed | 2026-08-10 |
+
+## Investigation
+
+1. Health/CORS/H1 connectivity green; only authenticated work-sessions path 500.
+2. GHCR image content matched git (`from uuid import UUID, uuid4` present).
+3. Running pod file **differed** (import + `uuid4()` id default missing).
+4. Root cause: Deployment volume `work-session-ssl-fix` mounts a **stale ConfigMap**
+   over `/app/apps/backend/src/services/work_session_service.py` (T7.1 interim sslmode
+   rewrite). Staging ConfigMap was out of date vs in-image `_sync_database_url` fix.
+
+## Repro test
+
+- Path: `tests/bugs/test_bug_2026_08_10_staging_work_session_ssl_fix_mount.py`
+- Asserts DOKS API Deployment no longer mounts ConfigMap over `work_session_service.py`
+- Asserts source file keeps runtime `UUID` / `uuid4` imports
+
+## Fix
+
+1. Live: refreshed staging ConfigMap from current source + rollout restart (immediate).
+2. Git: removed `work-session-ssl-fix` volume/mount from
+   `deploy/doks/base/deployment-api.yaml` (ssl rewrite is in-image).
+3. Docs: `deploy/doks/README.md` — ConfigMap no longer required.
+
+## Interview record
+
+N/A — AskQuestion unavailable; user asked to promote with UJs green; failure caught
+during staging UJ verification.
+
+## Prevention & countermeasures
+
+- Do not mount application Python modules from ConfigMaps after the fix is in the image.
+- Keep a regression test on the Deployment manifest.
+- Prefer image rebuilds over live file overlays for code hotfixes.
+
+## Cursor rule
+
+Deferred — covered by bug regression test + README note.

--- a/packages/tac-validate/pyproject.toml
+++ b/packages/tac-validate/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tac-validate"
-version = "0.1.2"
+version = "0.1.3"
 description = "Lint TAC aviation weather products (METAR/SPECI/TAF and related) with structured issues"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/tac-validate/src/tac_validate/__init__.py
+++ b/packages/tac-validate/src/tac_validate/__init__.py
@@ -6,6 +6,6 @@ from tac_validate.api import lint
 from tac_validate.models import Fix, Issue, LintReport
 from tac_validate.products import PRODUCTS
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = ["PRODUCTS", "Fix", "Issue", "LintReport", "__version__", "lint"]

--- a/scripts/ops/apply_doks_work_session_ssl_fix.sh
+++ b/scripts/ops/apply_doks_work_session_ssl_fix.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Apply T7.1 interim ConfigMap mount for work_session_service sslmode rewrite.
+# DEPRECATED (BUG-2026-08-10): sslmode rewrite is in-image via _sync_database_url.
+# Do not remount work_session_service.py — stale ConfigMaps caused staging
+# NameError: UUID. Kept only to delete leftover ConfigMaps if needed.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 NS="${DOKS_NAMESPACE:-metar-iwxxm}"
-SRC="$ROOT/apps/backend/src/services/work_session_service.py"
 
-kubectl -n "$NS" create configmap work-session-ssl-fix \
-  --from-file=work_session_service.py="$SRC" \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-echo "Applied work-session-ssl-fix from $SRC"
-echo "Ensure deploy/metar-api mounts this ConfigMap (see deployment-api.yaml)."
+echo "DEPRECATED: refusing to create work-session-ssl-fix."
+echo "Remove any leftover mount from deploy/doks/base/deployment-api.yaml (already done)."
+echo "Optional cleanup: kubectl -n $NS delete configmap work-session-ssl-fix --ignore-not-found"
+echo "Source of truth: $ROOT/apps/backend/src/services/work_session_service.py (in image)."
+exit 1

--- a/tests/bugs/test_bug_2026_08_10_staging_work_session_ssl_fix_mount.py
+++ b/tests/bugs/test_bug_2026_08_10_staging_work_session_ssl_fix_mount.py
@@ -1,0 +1,28 @@
+"""BUG-2026-08-10 — do not ConfigMap-mount over work_session_service.py.
+
+Staging returned ``NameError: UUID`` because a stale ``work-session-ssl-fix``
+ConfigMap overrode the in-image module (which already includes ``_sync_database_url``
+sslmode rewriting and ``from uuid import UUID, uuid4``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_API = ROOT / "deploy" / "doks" / "base" / "deployment-api.yaml"
+SERVICE = ROOT / "apps" / "backend" / "src" / "services" / "work_session_service.py"
+
+
+def test_bug_2026_08_10_deployment_does_not_mount_work_session_override() -> None:
+    text = DEPLOY_API.read_text(encoding="utf-8")
+    assert "work-session-ssl-fix" not in text
+    assert "work_session_service.py" not in text or "Do not remount" in text
+
+
+def test_bug_2026_08_10_work_session_service_imports_uuid_at_runtime() -> None:
+    src = SERVICE.read_text(encoding="utf-8")
+    assert "from uuid import UUID, uuid4" in src
+    assert "UUID(self.user_id)" in src
+    assert "uuid4()" in src
+    assert "_sync_database_url" in src

--- a/uv.lock
+++ b/uv.lock
@@ -2479,7 +2479,7 @@ wheels = [
 
 [[package]]
 name = "tac-validate"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/tac-validate" }
 dependencies = [
     { name = "msgspec" },


### PR DESCRIPTION
## Summary
- Cut `docs/CHANGELOG.md` for promote window EV-048..EV-053
- Bump publishable `tac-validate` **0.1.2 → 0.1.3** (EV-050 membership Validated) + `uv.lock`

## Test plan
- [ ] Stage CI green on this PR
- [ ] Merge to `stage`, then open promote PR `stage` → `main`
- [ ] After main CI green: tag `v2026.08.10-deploy`


Made with [Cursor](https://cursor.com)