### PR TITLE
[BUG-2026-08-11] Pretty-print Quality metrics C14N diffs

### DIFF
--- a/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
@@ -19,7 +19,6 @@ import {
   QUALITY_METRICS_SCHEMATRON_SKIPPED,
   validateDispositionChips,
 } from '@/utils/validateDispositionChips';
-import { c14nXml } from '@/utils/c14nXml';
 import type { QualityMetricsDetailResponse } from '@/utils/openapiTypes';
 
 const FORMATTING_ONLY: QualityMetricsDetailResponse = {
@@ -86,16 +85,19 @@ describe('QualityMetricsDetail C14N panes (TC-EV055-001)', () => {
   it('defaults to normalized panes and empty diff for formatting-only peers', () => {
     render(<QualityMetricsDetail detail={FORMATTING_ONLY} />);
 
-    const expected = c14nXml(FORMATTING_ONLY.official_xml);
+    const expected = qualityMetricsDisplayXml(FORMATTING_ONLY.official_xml);
     expect(screen.getByTestId('quality-metrics-xml-view-mode')).toHaveTextContent(
       QUALITY_METRICS_XML_VIEW_NORMALIZED,
     );
-    expect(screen.getByTestId('quality-metrics-pane-official-xml')).toHaveTextContent(
-      expected,
-    );
-    expect(screen.getByTestId('quality-metrics-pane-converted-xml')).toHaveTextContent(
-      expected,
-    );
+    const officialPre = screen
+      .getByTestId('quality-metrics-pane-official-xml')
+      .querySelector('pre');
+    const convertedPre = screen
+      .getByTestId('quality-metrics-pane-converted-xml')
+      .querySelector('pre');
+    expect(officialPre?.textContent).toBe(expected);
+    expect(convertedPre?.textContent).toBe(expected);
+    expect(expected.includes('\n')).toBe(true);
     expect(screen.getByTestId('quality-metrics-diff-empty')).toHaveTextContent(
       QUALITY_METRICS_DIFF_EMPTY_LABEL,
     );

--- a/apps/frontend/src/app/components/QualityMetricsDetail.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.tsx
@@ -20,7 +20,7 @@ export const QUALITY_METRICS_EMPTY_DIAGNOSTICS = 'None';
 export const QUALITY_METRICS_XML_VIEW_NORMALIZED = 'Normalized XML';
 export const QUALITY_METRICS_XML_VIEW_RAW = 'Raw XML';
 export const QUALITY_METRICS_XML_VIEW_HELP =
-  'Official and converted panes default to normalized XML. Turn on raw to inspect original formatting. The unified diff always compares normalized forms.';
+  'Official and converted panes default to normalized, pretty-printed XML. Turn on raw to inspect original formatting. The unified diff always compares normalized forms.';
 
 interface QualityMetricsDetailProps {
   /** Detail payload from GET /quality-metrics/{stem}. */
@@ -282,7 +282,7 @@ function DiffLineRow({ line }: { line: UnifiedDiffLine }) {
         ? 'text-red-400'
         : 'text-gray-300';
   return (
-    <div className={color}>
+    <div className={`${color} whitespace-pre-wrap break-all`}>
       {prefix}
       {line.text}
     </div>

--- a/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
@@ -231,10 +231,16 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
       'METAR YUDO',
     );
     expect(screen.getByTestId('quality-metrics-pane-official-xml')).toHaveTextContent(
-      '<a></a>',
+      '<a>',
+    );
+    expect(screen.getByTestId('quality-metrics-pane-official-xml')).toHaveTextContent(
+      '</a>',
     );
     expect(screen.getByTestId('quality-metrics-pane-converted-xml')).toHaveTextContent(
-      '<a></a>',
+      '<a>',
+    );
+    expect(screen.getByTestId('quality-metrics-pane-converted-xml')).toHaveTextContent(
+      '</a>',
     );
     expect(screen.getByTestId('quality-metrics-diff-empty')).toHaveTextContent(
       QUALITY_METRICS_DIFF_EMPTY_LABEL,
@@ -273,12 +279,10 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
     expect(screen.getByTestId('quality-metrics-match-status')).toHaveTextContent(
       'unequal',
     );
-    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent(
-      '<a></a>',
-    );
-    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent(
-      '<b></b>',
-    );
+    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('<a>');
+    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('</a>');
+    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('<b>');
+    expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('</b>');
     expect(screen.getByTestId('quality-metrics-pane-residuals')).toHaveTextContent(
       'token leftover',
     );

--- a/apps/frontend/src/utils/qualityMetricsDisplayXml.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsDisplayXml.test.ts
@@ -1,0 +1,35 @@
+/**
+ * BUG-2026-08-11 — Quality metrics display XML must be multi-line for human diffs.
+ *
+ * Compact C14N alone yields one mega-line; operators need pretty-printed peers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { qualityMetricsDisplayXml } from './qualityMetricsDisplayXml';
+import { splitLines, unifiedLineDiff } from './unifiedLineDiff';
+
+const NESTED = '<root xmlns="urn:x"><a><b>1</b></a><c>2</c></root>';
+const NESTED_DIFF = '<root xmlns="urn:x"><a><b>9</b></a><c>2</c></root>';
+
+describe('qualityMetricsDisplayXml (BUG-2026-08-11)', () => {
+  it('pretty-prints nested C14N so display is multi-line', () => {
+    const display = qualityMetricsDisplayXml(NESTED);
+    const lines = splitLines(display);
+    expect(lines.length).toBeGreaterThan(3);
+    expect(Math.max(...lines.map((line) => line.length))).toBeLessThan(120);
+  });
+
+  it('feeds multi-line peers into unifiedLineDiff (not one mega-line)', () => {
+    const left = qualityMetricsDisplayXml(NESTED);
+    const right = qualityMetricsDisplayXml(NESTED_DIFF);
+    const diff = unifiedLineDiff(left, right);
+    expect(diff.length).toBeGreaterThan(2);
+    expect(Math.max(...diff.map((line) => line.text.length))).toBeLessThan(120);
+    expect(
+      diff.some((line) => line.op === 'remove' && line.text.includes('<b>1</b>')),
+    ).toBe(true);
+    expect(
+      diff.some((line) => line.op === 'add' && line.text.includes('<b>9</b>')),
+    ).toBe(true);
+  });
+});

--- a/apps/frontend/src/utils/qualityMetricsDisplayXml.ts
+++ b/apps/frontend/src/utils/qualityMetricsDisplayXml.ts
@@ -1,11 +1,13 @@
 import { c14nXml } from '@/utils/c14nXml';
+import { prettyPrintXml } from '@/utils/prettyXml';
 
 /**
- * Prefer C14N form for Quality metrics display/diff; fall back to raw when XML
- * cannot be parsed.
+ * Prefer C14N form for Quality metrics display/diff, then pretty-print for
+ * human-readable line-oriented panes (BUG-2026-08-11). Fall back to raw when
+ * XML cannot be parsed.
  *
  * @param xml - Raw XML text
- * @returns C14N text or original when empty/invalid
+ * @returns Pretty-printed C14N text, or original when empty/invalid
  */
 export function qualityMetricsDisplayXml(xml: string): string {
   const trimmed = xml?.trim() ?? '';
@@ -13,7 +15,7 @@ export function qualityMetricsDisplayXml(xml: string): string {
     return '';
   }
   try {
-    return c14nXml(xml);
+    return prettyPrintXml(c14nXml(xml));
   } catch {
     return xml;
   }

--- a/docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
+++ b/docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
@@ -1,0 +1,71 @@
+# BUG-2026-08-11-quality-metrics-diff-long-line
+
+| Field | Value |
+|-------|-------|
+| **Status** | fix ready — PR pending |
+| **Feature** | F7.q (Quality metrics tab) |
+| **Severity** | medium |
+| **Classification** | code bug / UX regression after C14N |
+| **Remediation path** | 14-hotfix S065 |
+| **Environment** | staging — https://app.staging.tac-to-iwxxm.com/ |
+| **Session** | S065-quality-metrics-diff-long-line |
+
+## Error description
+
+On the Quality metrics tab, opening unequal stems (e.g. SIGMET `sigmet-A6-1a-TS`) shows the unified XML diff as a handful of extremely long lines (one ~3k-character C14N blob) instead of readable multi-line XML diffs. Official/Converted normalized panes have the same compact form.
+
+Operator asked for prettier XML and (later) a separate page + GitHub-style collapse around diffs. **This hotfix:** pretty-print only. Separate page + hunks deferred to evolve (`D-S065-scope=4`).
+
+## Error logs
+
+Staging browser probe (2026-08-11), stem `sigmet-A6-1a-TS`:
+
+```
+hasDetail: true
+hasDiff: true
+diffLines: 4
+longestLine: 2955
+firstDiffPreview: "-<iwxxm:SIGMET reportStatus=\"NORMAL\" xmlns:aixm=..."
+```
+
+## Investigation
+
+| Time | Note |
+|------|------|
+| 2026-08-11 | Confirmed on staging Quality metrics → SIGMET unequal |
+| 2026-08-11 | `c14nXml` serializes compact (no newlines); `qualityMetricsDisplayXml` returns that form |
+| 2026-08-11 | `unifiedLineDiff` splits on `\n` → one mega-line per document peer |
+| 2026-08-11 | `prettyPrintXml` already exists for workbench F10 preview |
+| 2026-08-11 | Root cause: display/diff path uses compact C14N without pretty-print |
+
+**Root cause:** Normalized panes and the unified diff feed compact C14N into a line-oriented diff, so humans see one long line.
+
+## Repro test
+
+| Path | Status |
+|------|--------|
+| `apps/frontend/src/utils/qualityMetricsDisplayXml.test.ts` | red → green (2026-08-11) |
+| `tests/bugs/test_bug_2026_08_11_quality_metrics_diff_long_line.py` | red → green (2026-08-11) |
+
+## Interview record
+
+- Intent: `/14-hotfix` staging Quality metrics long-line diffs
+- Scope: `D-S065-scope=4` — hotfix readability now; evolve later for separate page + GitHub hunks
+- Products: all stems
+- Page: keep inline detail for now
+- AskQuestion tool unavailable — numbered options; user chose “Proceed with recommended”
+- Repro/root-cause confirmation: waived by “Proceed with recommended” after staging probe + red tests
+
+## Fix
+
+`qualityMetricsDisplayXml` now returns `prettyPrintXml(c14nXml(xml))` so Official/Converted panes and the unified line diff operate on multi-line peers. Diff rows also use `whitespace-pre-wrap break-all` as a safety net for long attribute lines.
+
+## Prevention & countermeasures
+
+(pending Phase 5)
+
+## Follow-up
+
+Evolve deepen F7.q: dedicated detail route + GitHub-style expandable/collapsible unchanged context.
+
+See `docs/sessions/S065-quality-metrics-diff-long-line/FOLLOWUP.md` for seed prompt and ACs.

--- a/docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
+++ b/docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
@@ -2,11 +2,8 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | fix ready — PR pending |
-| **Feature** | F7.q (Quality metrics tab) |
-| **Severity** | medium |
-| **Classification** | code bug / UX regression after C14N |
-| **Remediation path** | 14-hotfix S065 |
+| **Status** | fix in review — PR #987 |
+| **Remediation path** | 14-hotfix S065 / PR #987 → stage |
 | **Environment** | staging — https://app.staging.tac-to-iwxxm.com/ |
 | **Session** | S065-quality-metrics-diff-long-line |
 

--- a/docs/sessions/S065-quality-metrics-diff-long-line/FOLLOWUP.md
+++ b/docs/sessions/S065-quality-metrics-diff-long-line/FOLLOWUP.md
@@ -1,0 +1,49 @@
+# Follow-up — Quality metrics GitHub-style diff page
+
+**Deferred from:** S065 / BUG-2026-08-11 (`D-S065-scope=4`)  
+**When ready:** open **00-context** → session type `feature` → **16-evolve** Lean (UX/docs/tests; no API unless needed)  
+**Corpus:** [Corpus: product] F7.q · [Corpus: tests] UJ-056 · deepen Quality metrics UX  
+**Depends on:** this hotfix merged to `stage` (pretty-printed C14N display/diff)
+
+## Goal
+
+Replace the inline Quality metrics detail+diff with a dedicated, readable inspection surface:
+
+1. **Separate page / route** for a stem (e.g. `/quality/:stem` or equivalent shell route) with back-to-list
+2. **Pretty XML** panes (already partially done by S065 — keep/extend)
+3. **GitHub-style unified diff** — collapse/expand unchanged context around change hunks (default collapsed with N lines of context; expand hunk / expand all)
+
+## Out of scope (unless decided otherwise)
+
+- Changing `match_status` / C14N equality / fixture generator
+- New npm diff library unless AskQuestion approves (today: LCS in `unifiedLineDiff.ts`)
+- Promote to `main` until Staging smoke + gate
+
+## Suggested acceptance
+
+| ID | Criterion |
+|----|-----------|
+| AC1 | List row opens a dedicated detail route (shareable URL) |
+| AC2 | Official/Converted/TAC panes remain; normalized = pretty C14N |
+| AC3 | Diff shows collapsible equal-context hunks (GitHub-like `@@` / “Expand N lines”) |
+| AC4 | Unequal SIGMET stems remain navigable and readable on staging |
+| AC5 | UJ-056 / TC-EV054–055 updated; FE unit + optional Playwright smoke |
+
+## Seed prompt (paste into next session)
+
+```
+/00-context then /16-evolve Lean — F7.q deepen:
+
+After S065 pretty-print hotfix, add a dedicated Quality metrics detail page
+with GitHub-style collapsible unified XML diffs (expand/collapse unchanged
+context). Keep C14N equality semantics; no API contract change unless needed
+for routing. Base stage. Cite UJ-056 / F7.q. Follow-up from
+docs/sessions/S065-quality-metrics-diff-long-line/FOLLOWUP.md
+```
+
+## Implementation notes
+
+- Reuse `unifiedLineDiff` + `qualityMetricsDisplayXml` / `prettyPrintXml`
+- Add hunk folding helper (e.g. `collapseEqualContext(lines, { context: 3 })`)
+- Wire route in frontend shell next to Quality metrics tab
+- Operator copy: no internal doc refs (EV-048)

--- a/docs/sessions/S065-quality-metrics-diff-long-line/routing-plan.md
+++ b/docs/sessions/S065-quality-metrics-diff-long-line/routing-plan.md
@@ -1,0 +1,19 @@
+# Routing plan — S065-quality-metrics-diff-long-line
+
+| Field | Value |
+|-------|-------|
+| **Preset** | Lean |
+| **auto_lean** | true |
+| **Rationale** | Hotfix UX readability; no API/arch; deferred page+hunks to evolve |
+
+## Stages
+
+| Stage | Status | Notes |
+|-------|--------|-------|
+| 00-context | completed | Session open |
+| 14-hotfix | in_progress | BUG + pretty-print C14N display/diff |
+| 15-service-health | optional | Only if user asks after staging deploy |
+
+## Follow-up (not this session)
+
+Lean **16-evolve** deepen F7.q: dedicated detail page + GitHub-style collapsible hunks.

--- a/docs/sessions/S065-quality-metrics-diff-long-line/session-brief.md
+++ b/docs/sessions/S065-quality-metrics-diff-long-line/session-brief.md
@@ -1,0 +1,33 @@
+# Session brief — S065-quality-metrics-diff-long-line
+
+| Field | Value |
+|-------|-------|
+| **Type** | hotfix |
+| **Intent** | Quality metrics unified XML diff renders as one long C14N line on staging; pretty-print for readable line diffs |
+| **Branch** | `fix/quality-metrics-diff-long-line` (base `stage`) |
+| **Orchestrator** | 14-hotfix |
+| **Bug report** | [docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md](../../bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md) |
+| **GitHub** | none (staging operator report) |
+| **Started** | 2026-08-11 |
+| **Status** | Phase 0–1 in progress |
+
+## Goal
+
+Make Quality metrics Official/Converted panes and the unified XML diff human-readable by pretty-printing C14N forms before line-oriented diff (F7.q / UJ-056).
+
+## Out of scope
+
+- Dedicated `/quality/:stem` (or similar) detail route
+- GitHub-style expand/collapse of unchanged hunks
+- API / `match_status` / fixture generator changes
+- Promote `stage` → `main` unless explicitly requested
+
+## Decisions
+
+- `D-S065-scope=4` — hotfix readability now; evolve later for separate page + hunks
+- `D-S065-products=all` — all Quality metrics stems
+- `D-S065-page=inline-for-now` — keep detail on current tab
+
+## Corpus
+
+[Corpus: product] F7.q · [Corpus: tests] UJ-056 / TC-EV055-001 · [Corpus: system-spec] Quality metrics UI

--- a/tests/bugs/test_bug_2026_08_11_quality_metrics_diff_long_line.py
+++ b/tests/bugs/test_bug_2026_08_11_quality_metrics_diff_long_line.py
@@ -1,0 +1,36 @@
+"""BUG-2026-08-11 — Quality metrics display XML must pretty-print after C14N.
+
+Staging showed unified diffs as one ~3k-character C14N line. The FE helper
+``qualityMetricsDisplayXml`` must pipe C14N through ``prettyPrintXml`` so
+line-oriented diffs stay human-readable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DISPLAY = ROOT / "apps" / "frontend" / "src" / "utils" / "qualityMetricsDisplayXml.ts"
+DETAIL = (
+    ROOT
+    / "apps"
+    / "frontend"
+    / "src"
+    / "app"
+    / "components"
+    / "QualityMetricsDetail.tsx"
+)
+
+
+def test_bug_2026_08_11_display_xml_pretty_prints_c14n() -> None:
+    src = DISPLAY.read_text(encoding="utf-8")
+    assert "prettyPrintXml" in src
+    assert "c14nXml" in src
+    # Must not return bare C14N without pretty-print.
+    assert "return c14nXml(" not in src.replace(" ", "")
+
+
+def test_bug_2026_08_11_detail_uses_display_helper_for_diff() -> None:
+    src = DETAIL.read_text(encoding="utf-8")
+    assert "qualityMetricsDisplayXml" in src
+    assert "unifiedLineDiff" in src

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -16,9 +16,10 @@ active_session:
   branch_base: stage@d80db688
   branch_base_sha: d80db688
   branch_base_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
-  branch_status: pending_create
-  branch_exists: false
-  branch_note: "Parent will create from stage@d80db688; workflow-state-manager records only (no git branch create)"
+  branch_status: ACTIVE
+  branch_exists: true
+  branch_pushed: true
+  branch_note: "ACTIVE — created+pushed; tip da1e48f8; PR #987 open → stage; CI 31541069003 watching"
   orchestrator: 14-hotfix
   evolve_cycle_id:
   artifacts_dir: docs/sessions/S065-quality-metrics-diff-long-line/
@@ -26,7 +27,10 @@ active_session:
   bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
   bug_report_status: open
   github_issues: []
-  github_issues_note: "none — user report from staging"
+  github_issues_note: "hotfix from staging UX report (no origin issue); follow-up evolve tracked as #988"
+  followup_github_issue: 988
+  followup_github_issue_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988
+  followup_github_issue_note: "evolve later — dedicated /quality/:stem page + GitHub-style hunk collapse (D-S065-scope=4 / D-S065-page=inline-for-now)"
   remediation_path: local-first
   goal: "Pretty-print Quality metrics unified XML diff for human-readable line diffs (C14N currently one long line)."
   out_of_scope:
@@ -44,15 +48,22 @@ active_session:
   auto_lean: true
   auto_lean_rationale: "hotfix UX readability — Auto-Lean"
   prior_session: S064-quality-metrics-2025-2-followups
-  tip_sha:
-  tip_sha_full:
-  tip_sha_pushed: false
-  tip_sha_note: "branch pending_create; base stage@d80db688"
+  tip_sha: "da1e48f8"
+  tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+  tip_sha_pushed: true
+  tip_sha_note: "tip da1e48f8 pushed on fix/quality-metrics-diff-long-line; PR #987 open → stage; CI 31541069003 watching"
+  tip_ci_run: '31541069003'
+  tip_ci_status: watching
+  tip_ci_note: "CI run 31541069003 watching on PR #987 / fix/quality-metrics-diff-long-line"
+  pr_number: 987
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
+  pr_status: open
   pr_base: stage
   decisions:
     D-S065-scope: "4 — hotfix readability now; evolve later for page+hunks"
     D-S065-products: "all"
     D-S065-page: "inline-for-now"
+    D-S065-pr: "1 — PR #987 opened → stage; follow-up #988; CI 31541069003 watching"
   routing_plan:
   - stage: 00-context
     required: true
@@ -66,17 +77,16 @@ active_session:
     mode: full
     status: in_progress
     started: '2026-08-11'
-    note: "IN PROGRESS — pretty-print unified XML diff; BUG-2026-08-11-quality-metrics-diff-long-line"
+    note: "IN PROGRESS — tip da1e48f8; PR #987 open → stage; follow-up #988; CI 31541069003 watching; awaiting CI + merge + user close"
   - stage: 15-service-health
     required: false
     mode: when_deployed
     status: pending
     skip_rationale: "optional after deploy; not required at Lean hotfix open"
   current_stage: 14-hotfix
-  current_stage_note: "open_session complete; 00 done; 14-hotfix in_progress; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688"
+  current_stage_note: "14-hotfix in_progress — tip da1e48f8 pushed; PR #987 open → stage; follow-up #988; CI 31541069003 watching; awaiting CI + merge + user close"
   context_briefs: []
-  note: "OPEN — Auto-Lean hotfix; D-S065-scope=4 / products=all / page=inline-for-now; no github issue; BUG-2026-08-11-quality-metrics-diff-long-line; [Corpus: product §F7.q] [Corpus: tests §UJ-056]"
-
+  note: "IN PROGRESS — Auto-Lean hotfix; tip da1e48f8; PR #987 open → stage; follow-up evolve #988; CI 31541069003 watching; D-S065-scope=4 / products=all / page=inline-for-now; session remains open; [Corpus: product §F7.q] [Corpus: tests §UJ-056]"
 
 sessions:
 
@@ -17926,32 +17936,32 @@ stages:
     bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
     bug_status: open
     github_issues: []
-    github_issues_note: none — user report from staging
+    github_issues_note: 'hotfix from staging UX report; follow-up evolve #988'
+    followup_github_issue: 988
+    followup_github_issue_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988
     remediation_path: local-first
     branch: fix/quality-metrics-diff-long-line
     branch_base: stage@d80db688
-    branch_status: pending_create
+    branch_status: ACTIVE
+    branch_exists: true
+    branch_pushed: true
     started_at: '2026-08-11'
     started: '2026-08-11'
     completed:
     completed_at:
-    tip_sha:
-    tip_sha_full:
-    tip_sha_note: 'branch pending_create from stage@d80db688; parent creates branch'
-    note: 'IN PROGRESS — S065 Auto-Lean hotfix; pretty-print Quality metrics unified XML diff (C14N one long line); D-S065-scope=4 / products=all / page=inline-for-now; defer /quality/:stem + hunk collapse to evolve; [Corpus: product §F7.q] [Corpus: tests §UJ-056]'
-    prior_session_id: S051-output-filename-download-stale
-    prior_bug: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
-    prior_bug_status: resolved
-    prior_completed: '2026-08-07'
-    prior_completed_at: '2026-08-07'
-    prior_pr_number: 905
-    prior_merge_sha: a15541e5
-    prior_prior_session_id: S028-sigmet-multiline-split
-    prior_prior_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
-    prior_prior_bug_status: resolved
-    prior_prior_pr_number: 796
-    prior_prior_merge_sha: 17c93bd
+    tip_sha: da1e48f8
+    tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+    tip_sha_pushed: true
+    tip_sha_note: 'tip da1e48f8 pushed; PR #987 open → stage; CI 31541069003 watching'
+    tip_ci_run: '31541069003'
+    tip_ci_status: watching
+    pr_number: 987
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
+    pr_status: open
+    pr_base: stage
+    note: 'IN PROGRESS — tip da1e48f8; PR #987 open → stage; follow-up #988; CI 31541069003 watching; awaiting CI + merge + user close; session remains open'
     notes:
+    - '2026-08-11 S065 PR #987 opened → stage; tip da1e48f8; follow-up #988; CI 31541069003 watching; 14 remains in_progress; session open'
     - '2026-08-11 — S065-quality-metrics-diff-long-line open (BUG-2026-08-11-quality-metrics-diff-long-line); staging UX report; Auto-Lean; D-S065-scope=4 / products=all / page=inline-for-now; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688; cleared S051 as current'
     - '2026-08-07 D-S051-close=1 — S051 CLOSED; closeout da2a6656; PR #905 @ a15541e5; 14-hotfix completed; active_session=null; optional 15 skipped; follow-ups deferred'
     - '2026-08-07 D-S051-cursor_rule=1 — Phase 5 complete; prevention_plan confirmed; Cursor rule `.cursor/rules/optional/workbench-live-output-filename-download.mdc` created; hotfix-log #13; bug_status resolved; tip PR #905 MERGED @ a15541e5; main CI 31226647517 SUCCESS'
@@ -18336,6 +18346,45 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S065-pr
+  date: '2026-08-11'
+  timestamp: '2026-08-11'
+  resolved_at: '2026-08-11'
+  session_id: S065-quality-metrics-diff-long-line
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: 14-hotfix
+  category: pr_open
+  status: confirmed
+  topic: 'S065 PR opened + evolve follow-up issue'
+  summary: 'PR #987 open → stage; follow-up #988; CI 31541069003 watching'
+  decision: |
+    D-S065-pr — PR opened; follow-up #988; CI run 31541069003 watching.
+    Commit da1e48f88b62aec754aa74c5ae6f84918551b493 on fix/quality-metrics-diff-long-line: "[BUG-2026-08-11] fix: pretty-print Quality metrics C14N diffs".
+    PR #987 → stage: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987 (status open).
+    Follow-up GitHub issue #988 tracks later evolve for dedicated /quality/:stem page + GitHub-style hunk collapse (D-S065-scope=4 / D-S065-page=inline-for-now).
+    stages.14-hotfix remains in_progress — awaiting CI + merge + user close.
+    Session S065 remains open (not closed).
+  user_option: recorded
+  branch: fix/quality-metrics-diff-long-line
+  tip_sha: 'da1e48f8'
+  tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+  tip_sha_pushed: true
+  tip_ci_run: '31541069003'
+  tip_ci_status: watching
+  pr_number: 987
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
+  pr_status: open
+  pr_base: stage
+  followup_github_issue: 988
+  followup_github_issue_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988
+  related_features:
+  - F7
+  related_decisions:
+  - D-S065-scope
+  - D-S065-page
+  bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+  note: '14-hotfix in_progress; session remains open'
 - id: D-S065-scope
   date: '2026-08-11'
   timestamp: '2026-08-11'
@@ -49349,16 +49398,16 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: stage
+  current_branch: fix/quality-metrics-diff-long-line
   ahead_of_origin: 0
   pushed: true
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml dirty after open_session S065; branch fix/quality-metrics-diff-long-line pending_create from stage@d80db688; no git commit by workflow-state-manager'
-  tip_sha: "d80db688"
-  tip_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
-  tip_note: "OPEN S065 — stage tip d80db688 (post EV-055/EV-054 closeouts); hotfix branch pending_create"
+  dirty_note: 'workflow-state.yaml dirty after S065 PR #987 / tip da1e48f8 / follow-up #988 / CI 31541069003; no git commit by workflow-state-manager'
+  tip_sha: "da1e48f8"
+  tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+  tip_note: "S065 tip da1e48f8 on fix/quality-metrics-diff-long-line; PR #987 open → stage; CI 31541069003 watching; follow-up #988"
   docs_tip_sha: "4af0dd90"
   docs_tip_sha_full: 4af0dd9064116c465a204f74c9ae5c697b8f137d
   docs_tip_branch: docs/EV-055-13-deploy-smoke
@@ -49384,9 +49433,10 @@ git_history:
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   recommended_branch: fix/quality-metrics-diff-long-line
-  note: 'S065 OPEN — Auto-Lean hotfix quality-metrics-diff-long-line; active_session=S065; session_counter=65; branch pending_create from stage@d80db688; D-S065-scope=4 / products=all / page=inline-for-now; dirty workflow-state; no git commit by workflow-state-manager'
+  note: 'S065 IN PROGRESS — tip da1e48f8 on fix/quality-metrics-diff-long-line; PR #987 open → stage; follow-up #988; CI 31541069003 watching; 14-hotfix remains in_progress (await CI+merge+close); dirty workflow-state; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-11 S065 PR #987 opened → stage; tip da1e48f8 pushed on fix/quality-metrics-diff-long-line; follow-up #988 (evolve page+hunks); CI 31541069003 watching; 14-hotfix in_progress; session remains open; no git commit by workflow-state-manager'
   - '2026-08-11 open_session S065 — Auto-Lean hotfix; session_counter 64→65; active_session=S065-quality-metrics-diff-long-line; stages.00 completed / 14 in_progress; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688; D-S065-scope=4 / products=all / page=inline-for-now; BUG-2026-08-11-quality-metrics-diff-long-line; [Corpus: product §F7.q] [Corpus: tests §UJ-056]; no git commit by workflow-state-manager'
   - '2026-08-11 D-S064-close=1 — Cycle + session closed on stage; EV-055/S064 completed; active_session=null; no git commit by workflow-state-manager'
   - '2026-08-11 D-S064-13=1 — Approve 13; close EV-055/S064 on stage (no promote); tip_ci 31534191417 success; tip_sha 4b48c8d8; board #982/#980/#979 Done'
@@ -49956,14 +50006,22 @@ git_history:
     base_sha: d80db688
     base_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
     purpose: "S065 hotfix — Quality metrics unified XML diff pretty-print (C14N long line)"
-    status: pending_create
+    status: ACTIVE
     created: "2026-08-11"
-    exists: false
+    exists: true
+    pushed: true
     session_id: S065-quality-metrics-diff-long-line
-    tip_sha:
-    tip_sha_full:
-    tip_sha_pushed: false
-    note: "Recorded only — parent creates branch from stage@d80db688; Auto-Lean hotfix; D-S065-scope=4"
+    tip_sha: da1e48f8
+    tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+    tip_sha_pushed: true
+    pr_number: 987
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
+    pr_status: open
+    pr_base: stage
+    tip_ci_run: '31541069003'
+    tip_ci_status: watching
+    followup_github_issue: 988
+    note: "ACTIVE — tip da1e48f8 pushed; PR #987 open → stage; follow-up #988; CI 31541069003 watching"
 
   - name: evolve/EV-055-quality-metrics-2025-2-followups
     base: stage@4fd51e39
@@ -51422,6 +51480,24 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: "da1e48f8"
+    sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+    message: "[BUG-2026-08-11] fix: pretty-print Quality metrics C14N diffs"
+    branch: fix/quality-metrics-diff-long-line
+    stage: 14-hotfix
+    session_id: S065-quality-metrics-diff-long-line
+    timestamp: "2026-08-11"
+    pushed: true
+    tip_sha: da1e48f8
+    tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+    tip_ci_run: '31541069003'
+    tip_ci_status: watching
+    pr_number: 987
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
+    pr_status: open
+    pr_base: stage
+    followup_github_issue: 988
+    note: "S065 hotfix commit; PR #987 open; CI 31541069003 watching; follow-up #988"
   - sha: "4af0dd90"
     sha_full: 4af0dd9064116c465a204f74c9ae5c697b8f137d
     message: "[13] docs: record EV-055 staging smoke READY in evolve-decisions"

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,9 +3,80 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 64
+session_counter: 65
 evolve_cycle_counter: 55
-active_session: null
+active_session:
+  id: S065-quality-metrics-diff-long-line
+  type: hotfix
+  intent: "Fix Quality metrics unified XML diff rendering as one long C14N line; pretty-print for human-readable line diffs. Defer separate detail page + GitHub-style hunk collapse to a later evolve."
+  status: in_progress
+  started: '2026-08-11'
+  started_at: '2026-08-11'
+  branch: fix/quality-metrics-diff-long-line
+  branch_base: stage@d80db688
+  branch_base_sha: d80db688
+  branch_base_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
+  branch_status: pending_create
+  branch_exists: false
+  branch_note: "Parent will create from stage@d80db688; workflow-state-manager records only (no git branch create)"
+  orchestrator: 14-hotfix
+  evolve_cycle_id:
+  artifacts_dir: docs/sessions/S065-quality-metrics-diff-long-line/
+  bug_report: docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
+  bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+  bug_report_status: open
+  github_issues: []
+  github_issues_note: "none — user report from staging"
+  remediation_path: local-first
+  goal: "Pretty-print Quality metrics unified XML diff for human-readable line diffs (C14N currently one long line)."
+  out_of_scope:
+  - dedicated /quality/:stem route
+  - GitHub-style expand/collapse hunks
+  - API/match_status changes
+  - promote to main unless asked
+  deepen_feature_ids:
+  - F7
+  feature_note: "F7.q Quality metrics UX readability"
+  corpus_cites:
+  - '[Corpus: product §F7.q]'
+  - '[Corpus: tests §UJ-056]'
+  preset: Lean
+  auto_lean: true
+  auto_lean_rationale: "hotfix UX readability — Auto-Lean"
+  prior_session: S064-quality-metrics-2025-2-followups
+  tip_sha:
+  tip_sha_full:
+  tip_sha_pushed: false
+  tip_sha_note: "branch pending_create; base stage@d80db688"
+  pr_base: stage
+  decisions:
+    D-S065-scope: "4 — hotfix readability now; evolve later for page+hunks"
+    D-S065-products: "all"
+    D-S065-page: "inline-for-now"
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — open_session S065; Auto-Lean; handoff 14-hotfix"
+  - stage: 14-hotfix
+    required: true
+    mode: full
+    status: in_progress
+    started: '2026-08-11'
+    note: "IN PROGRESS — pretty-print unified XML diff; BUG-2026-08-11-quality-metrics-diff-long-line"
+  - stage: 15-service-health
+    required: false
+    mode: when_deployed
+    status: pending
+    skip_rationale: "optional after deploy; not required at Lean hotfix open"
+  current_stage: 14-hotfix
+  current_stage_note: "open_session complete; 00 done; 14-hotfix in_progress; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688"
+  context_briefs: []
+  note: "OPEN — Auto-Lean hotfix; D-S065-scope=4 / products=all / page=inline-for-now; no github issue; BUG-2026-08-11-quality-metrics-diff-long-line; [Corpus: product §F7.q] [Corpus: tests §UJ-056]"
+
 
 sessions:
 
@@ -8948,29 +9019,30 @@ stages:
   00-context:
     status: completed
     mode: session
-    scoped_slug: tag-driven-prod-deploy
-    session_id: S060-tag-driven-prod-deploy
-    evolve_cycle_id: EV-051
-    started: '2026-08-09'
-    started_at: '2026-08-09'
-    completed: '2026-08-09'
-    completed_at: '2026-08-09'
-    note: 'S060/EV-051 COMPLETE — D-S060-open=1 + D-S060-scope=1 (2+3+4) + D-S060-route=1 Lean+; session-brief + routing-plan + evolve-plan-card; handoff 07-build (Gate A confirm pending)'
-    prior_note: 'S057/EV-048 COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve; session-brief + routing-plan written'
-    prior_session_id: S057-strip-internal-doc-refs
-    prior_evolve_cycle_id: EV-048
-    prior_scoped_slug: strip-internal-doc-refs
-    prior_completed: '2026-08-08'
-    prior_started: '2026-08-08'
-    prior_tip_sha: d7652d5d
-    prior_tip_sha_full: d7652d5dfba56db5d9878c75195c24b1ed0283d5
-    prior_prior_note: 'S055/EV-046 COMPLETE — open_session D-S055-open=2 Lean for #889; handoff 16-evolve Phase 0; EV-043/EV-044 remain PARKED'
-    prior_prior_session_id: S055-wmo-aviation-registers
-    prior_prior_evolve_cycle_id: EV-046
-    prior_prior_scoped_slug: wmo-aviation-registers
-    tip_sha: c146baec
-    tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    scoped_slug: quality-metrics-diff-long-line
+    session_id: S065-quality-metrics-diff-long-line
+    evolve_cycle_id:
+    started: '2026-08-11'
+    started_at: '2026-08-11'
+    completed: '2026-08-11'
+    completed_at: '2026-08-11'
+    note: 'S065 open_session COMPLETE — Auto-Lean hotfix; D-S065-scope=4 / products=all / page=inline-for-now; handoff 14-hotfix; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688; [Corpus: product §F7.q] [Corpus: tests §UJ-056]'
+    prior_note: 'S060/EV-051 COMPLETE — D-S060-open=1 + D-S060-scope=1 (2+3+4) + D-S060-route=1 Lean+; session-brief + routing-plan + evolve-plan-card; handoff 07-build (Gate A confirm pending)'
+    prior_session_id: S060-tag-driven-prod-deploy
+    prior_evolve_cycle_id: EV-051
+    prior_scoped_slug: tag-driven-prod-deploy
+    prior_completed: '2026-08-09'
+    prior_started: '2026-08-09'
+    prior_tip_sha: c146baec
+    prior_tip_sha_full: c146baecabdc5f1db429954e8f0eb66d3b391c84
+    prior_prior_note: 'S057/EV-048 COMPLETE — D-S057-preset-reconfirm=1 Standard amend; exit 00 → 16-evolve; session-brief + routing-plan written'
+    prior_prior_session_id: S057-strip-internal-doc-refs
+    prior_prior_evolve_cycle_id: EV-048
+    prior_prior_scoped_slug: strip-internal-doc-refs
+    tip_sha: d80db688
+    tip_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
     artifacts:
+    - docs/sessions/S065-quality-metrics-diff-long-line/
     - docs/sessions/S060-tag-driven-prod-deploy/
     - docs/sessions/S060-tag-driven-prod-deploy/session-brief.md
     - docs/sessions/S060-tag-driven-prod-deploy/routing-plan.md
@@ -17848,45 +17920,39 @@ stages:
     previous_s047_pr_number: 891
     close_decision_id: D-S047-close
   14-hotfix:
-    status: completed
-    session_id: S051-output-filename-download-stale
-    current_bug: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
-    bug_status: resolved
-    hotfix_log_entry: 13
-    cursor_rule_path: .cursor/rules/optional/workbench-live-output-filename-download.mdc
-    prevention_plan: confirmed
-    github_issue: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/904
+    status: in_progress
+    session_id: S065-quality-metrics-diff-long-line
+    current_bug: docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md
+    bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+    bug_status: open
+    github_issues: []
+    github_issues_note: none — user report from staging
     remediation_path: local-first
-    started_at: '2026-08-07'
-    started: '2026-08-07'
-    completed: '2026-08-07'
-    completed_at: '2026-08-07'
-    tip_sha: da2a6656
-    tip_sha_full: da2a6656257696ced3d046d4d19ea4515b9c73b5
-    tip_sha_note: 'CLOSED D-S051-close=1 — PR #905 MERGED @ a15541e5; tip closeout da2a6656; main CI 31226647517 SUCCESS at merge'
-    pr_number: 905
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/905
-    pr_status: merged
-    merge_sha: a15541e5
-    merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
-    closeout_sha: da2a6656
-    closeout_sha_full: da2a6656257696ced3d046d4d19ea4515b9c73b5
-    main_ci_cd_pipeline_run: '31226647517'
-    main_ci_cd_pipeline_status: SUCCESS
-    note: 'COMPLETE — D-S051-close=1; S051 closed; PR #905 MERGED @ a15541e5; tip closeout da2a6656; hotfix-log #13; Cursor rule; BUG resolved; follow-ups deferred; active_session=null; #904 / BUG-2026-08-07-output-filename-download-stale'
-    prior_session_id: S028-sigmet-multiline-split
-    prior_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
+    branch: fix/quality-metrics-diff-long-line
+    branch_base: stage@d80db688
+    branch_status: pending_create
+    started_at: '2026-08-11'
+    started: '2026-08-11'
+    completed:
+    completed_at:
+    tip_sha:
+    tip_sha_full:
+    tip_sha_note: 'branch pending_create from stage@d80db688; parent creates branch'
+    note: 'IN PROGRESS — S065 Auto-Lean hotfix; pretty-print Quality metrics unified XML diff (C14N one long line); D-S065-scope=4 / products=all / page=inline-for-now; defer /quality/:stem + hunk collapse to evolve; [Corpus: product §F7.q] [Corpus: tests §UJ-056]'
+    prior_session_id: S051-output-filename-download-stale
+    prior_bug: docs/bug-reports/BUG-2026-08-07-output-filename-download-stale.md
     prior_bug_status: resolved
-    prior_completed: '2026-07-30'
-    prior_completed_at: '2026-07-30'
-    prior_pr_number: 796
-    prior_merge_sha: 17c93bd
-    prior_prior_session_id: S012-empty-bearer-lint-tac
-    prior_prior_bug: docs/bug-reports/BUG-2026-07-15-empty-bearer-lint-tac.md
+    prior_completed: '2026-08-07'
+    prior_completed_at: '2026-08-07'
+    prior_pr_number: 905
+    prior_merge_sha: a15541e5
+    prior_prior_session_id: S028-sigmet-multiline-split
+    prior_prior_bug: docs/bug-reports/BUG-2026-07-30-sigmet-multiline-split.md
     prior_prior_bug_status: resolved
-    prior_prior_pr_number: 721
-    prior_prior_merge_sha: 6412b21
+    prior_prior_pr_number: 796
+    prior_prior_merge_sha: 17c93bd
     notes:
+    - '2026-08-11 — S065-quality-metrics-diff-long-line open (BUG-2026-08-11-quality-metrics-diff-long-line); staging UX report; Auto-Lean; D-S065-scope=4 / products=all / page=inline-for-now; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688; cleared S051 as current'
     - '2026-08-07 D-S051-close=1 — S051 CLOSED; closeout da2a6656; PR #905 @ a15541e5; 14-hotfix completed; active_session=null; optional 15 skipped; follow-ups deferred'
     - '2026-08-07 D-S051-cursor_rule=1 — Phase 5 complete; prevention_plan confirmed; Cursor rule `.cursor/rules/optional/workbench-live-output-filename-download.mdc` created; hotfix-log #13; bug_status resolved; tip PR #905 MERGED @ a15541e5; main CI 31226647517 SUCCESS'
     - '2026-08-07 D-S051-prod=2 — assume deploy good; Phase 5 prevention interview in progress; PR #905 MERGED @ a15541e5; main CI 31226647517 SUCCESS (Deploy + E2E); production user-verify waived'
@@ -17898,6 +17964,7 @@ stages:
     - 2026-07-12 — S006 closed (S006-R5); docs reorg unblocked — open via 00-context (process session), not 14-hotfix.
     - 2026-07-12 — S009-result-card-dismiss open (FileConverter result card dismiss after Cancel/Remove).
     - S009 Batch A recorded — production stuck results Card after Cancel/Remove; after last deploy
+
   17-retrospective:
     status: completed
     started: '2026-07-20'
@@ -18269,6 +18336,70 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+- id: D-S065-scope
+  date: '2026-08-11'
+  timestamp: '2026-08-11'
+  resolved_at: '2026-08-11'
+  session_id: S065-quality-metrics-diff-long-line
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: scope
+  status: confirmed
+  topic: 'S065 hotfix scope — readability now vs evolve later'
+  summary: '4 — hotfix readability now; evolve later for page+hunks'
+  decision: |
+    D-S065-scope=4 — hotfix readability now; evolve later for dedicated detail page + GitHub-style hunk collapse.
+    In scope: pretty-print Quality metrics unified XML diff (C14N currently one long line) for human-readable line diffs.
+    Out of scope: dedicated /quality/:stem route; GitHub-style expand/collapse hunks; API/match_status changes; promote to main unless asked.
+    Corpus: [Corpus: product §F7.q], [Corpus: tests §UJ-056].
+  user_option: '4'
+  branch: fix/quality-metrics-diff-long-line
+  related_features:
+  - F7
+  bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+  note: 'open_session recorded; Auto-Lean hotfix'
+- id: D-S065-products
+  date: '2026-08-11'
+  timestamp: '2026-08-11'
+  resolved_at: '2026-08-11'
+  session_id: S065-quality-metrics-diff-long-line
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: scope
+  status: confirmed
+  topic: 'S065 product coverage for Quality metrics diff fix'
+  summary: 'all — apply across Quality metrics products'
+  decision: |
+    D-S065-products=all — pretty-print / line-diff readability applies to all Quality metrics products (not a single-product carve-out).
+  user_option: all
+  branch: fix/quality-metrics-diff-long-line
+  related_features:
+  - F7
+  bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+- id: D-S065-page
+  date: '2026-08-11'
+  timestamp: '2026-08-11'
+  resolved_at: '2026-08-11'
+  session_id: S065-quality-metrics-diff-long-line
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: ux
+  status: confirmed
+  topic: 'S065 Quality metrics detail page vs inline diff'
+  summary: 'inline-for-now — keep inline; defer dedicated page to evolve'
+  decision: |
+    D-S065-page=inline-for-now — keep unified XML diff inline in current Quality metrics UI for this hotfix.
+    Dedicated /quality/:stem detail page deferred to a later evolve (paired with D-S065-scope=4).
+  user_option: inline-for-now
+  branch: fix/quality-metrics-diff-long-line
+  related_features:
+  - F7
+  bug_id: BUG-2026-08-11-quality-metrics-diff-long-line
+  related_decisions:
+  - D-S065-scope
 - id: D-S064-close
   date: '2026-08-11'
   timestamp: '2026-08-11'
@@ -49218,30 +49349,30 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: docs/EV-055-13-deploy-smoke
+  current_branch: stage
   ahead_of_origin: 0
   pushed: true
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'workflow-state.yaml dirty after D-S064-13=1 / D-S064-close=1 close_session; tip_sha deployed 4b48c8d8; tip_ci 31534191417 success; docs tip 4af0dd90 / PR #986; no git commit by workflow-state-manager'
-  tip_sha: "4b48c8d8"
-  tip_sha_full: 4b48c8d85ff88b16641cd7f7fa66b1450dfbe6a3
-  tip_note: "CLOSED D-S064-13=1 / D-S064-close=1; #985@4b48c8d8 Staging CD 31534191417 success; H1–H5 PASS; closed on stage (no promote)"
+  dirty_note: 'workflow-state.yaml dirty after open_session S065; branch fix/quality-metrics-diff-long-line pending_create from stage@d80db688; no git commit by workflow-state-manager'
+  tip_sha: "d80db688"
+  tip_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
+  tip_note: "OPEN S065 — stage tip d80db688 (post EV-055/EV-054 closeouts); hotfix branch pending_create"
   docs_tip_sha: "4af0dd90"
   docs_tip_sha_full: 4af0dd9064116c465a204f74c9ae5c697b8f137d
   docs_tip_branch: docs/EV-055-13-deploy-smoke
   docs_tip_pr_number: 986
   docs_tip_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/986
-  docs_tip_pr_status: open
+  docs_tip_pr_status: merged
   evolve_branch: evolve/EV-055-quality-metrics-2025-2-followups
   evolve_tip_sha: "a648f486"
   evolve_tip_sha_full: a648f48644a82fde07aba610ec0f27410b705591
   evolve_tip_sha_pushed: true
-  stage_merge_sha: 4b48c8d8
-  stage_merge_sha_full: 4b48c8d85ff88b16641cd7f7fa66b1450dfbe6a3
-  stage_tip_sha: 4b48c8d8
-  stage_tip_sha_full: 4b48c8d85ff88b16641cd7f7fa66b1450dfbe6a3
+  stage_merge_sha: d80db688
+  stage_merge_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
+  stage_tip_sha: d80db688
+  stage_tip_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
   stash:
   - name: S039-EV031-WIP
     note: 'S048/EV-040 CLOSED D-S048-close=1,1,1 — tip 5a9f28ef; PR #893 merged (merge SHA pending); #894; active_session=null; no git commit by workflow-state-manager'
@@ -49252,10 +49383,11 @@ git_history:
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-  recommended_branch: docs/EV-055-13-deploy-smoke
-  note: 'S064/EV-055 CLOSED — D-S064-13=1 / D-S064-close=1; tip_sha 4b48c8d8; tip_ci 31534191417 success; docs tip 4af0dd90 / PR #986; board #982/#980/#979 Done; active_session=null; dirty workflow-state'
+  recommended_branch: fix/quality-metrics-diff-long-line
+  note: 'S065 OPEN — Auto-Lean hotfix quality-metrics-diff-long-line; active_session=S065; session_counter=65; branch pending_create from stage@d80db688; D-S065-scope=4 / products=all / page=inline-for-now; dirty workflow-state; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-11 open_session S065 — Auto-Lean hotfix; session_counter 64→65; active_session=S065-quality-metrics-diff-long-line; stages.00 completed / 14 in_progress; branch pending_create fix/quality-metrics-diff-long-line @ stage@d80db688; D-S065-scope=4 / products=all / page=inline-for-now; BUG-2026-08-11-quality-metrics-diff-long-line; [Corpus: product §F7.q] [Corpus: tests §UJ-056]; no git commit by workflow-state-manager'
   - '2026-08-11 D-S064-close=1 — Cycle + session closed on stage; EV-055/S064 completed; active_session=null; no git commit by workflow-state-manager'
   - '2026-08-11 D-S064-13=1 — Approve 13; close EV-055/S064 on stage (no promote); tip_ci 31534191417 success; tip_sha 4b48c8d8; board #982/#980/#979 Done'
   - '2026-08-11 13 READY — tip_ci 31534191417 success (Deploy+Staging smoke); H1–H5 PASS; tip_sha remains 4b48c8d8; docs tip 22f629fd recorded; PR #986 open; deploy-smoke.md present; board #982/#980/#979 On stage; await D-S064-13; no git commit by workflow-state-manager'
@@ -49819,6 +49951,20 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: fix/quality-metrics-diff-long-line
+    base: stage@d80db688
+    base_sha: d80db688
+    base_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
+    purpose: "S065 hotfix — Quality metrics unified XML diff pretty-print (C14N long line)"
+    status: pending_create
+    created: "2026-08-11"
+    exists: false
+    session_id: S065-quality-metrics-diff-long-line
+    tip_sha:
+    tip_sha_full:
+    tip_sha_pushed: false
+    note: "Recorded only — parent creates branch from stage@d80db688; Auto-Lean hotfix; D-S065-scope=4"
+
   - name: evolve/EV-055-quality-metrics-2025-2-followups
     base: stage@4fd51e39
     purpose: "EV-055 / S064 Quality metrics 2025-2 follow-ups"


### PR DESCRIPTION
## Summary
- Quality metrics unified XML diffs rendered as one mega-line because C14N is compact; staging showed ~3k-char lines on unequal SIGMETs.
- `qualityMetricsDisplayXml` now pretty-prints after C14N so Official/Converted panes and the line-oriented unified diff are multi-line and readable.
- Diff rows also wrap long attribute lines; dedicated detail page + GitHub-style hunk collapse deferred to a later evolve (`FOLLOWUP.md`).

## Test plan
- [x] Vitest `qualityMetricsDisplayXml.test.ts` (red → green)
- [x] `tests/bugs/test_bug_2026_08_11_quality_metrics_diff_long_line.py` (red → green)
- [x] `QualityMetricsDetail` unit tests updated
- [ ] After merge: staging Quality metrics → `sigmet-A6-1a-TS` shows multi-line unified diff

## Corpus
[Corpus: product] F7.q · [Corpus: tests] UJ-056 · S065 / BUG-2026-08-11

## Out of scope
Separate `/quality/:stem` page and GitHub-style expand/collapse hunks — see `docs/sessions/S065-quality-metrics-diff-long-line/FOLLOWUP.md`.

Made with [Cursor](https://cursor.com)