### PR TITLE
[EV-056] Quality metrics detail page + collapsible diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/ci-cd.yml)
 [![E2E](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/e2e-tests.yml)
-[![E2E tests](https://img.shields.io/badge/E2E_tests-83-blue)](apps/e2e)
+[![E2E tests](https://img.shields.io/badge/E2E_tests-84-blue)](apps/e2e)
 [![Unit coverage gate](https://img.shields.io/badge/unit_coverage-%E2%89%A598%25-success)](docs/test-plan.md)
 
 Convert aviation METAR/SPECI TAC messages to WMO IWXXM XML. React frontend, FastAPI backend,

--- a/apps/e2e/uj056-quality-metrics.e2e.spec.ts
+++ b/apps/e2e/uj056-quality-metrics.e2e.spec.ts
@@ -71,7 +71,7 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007 / TC-EV05
       timeout: 15_000,
     });
     await expect(page.getByTestId('quality-metrics-match-status')).toContainText(
-      /equal/i,
+      /Matches official/i,
     );
     await expect(page.getByTestId('quality-metrics-pane-tac')).toBeVisible();
     await expect(page.getByTestId('quality-metrics-pane-official-xml')).toBeVisible();
@@ -112,10 +112,10 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007 / TC-EV05
     );
     await expect(
       page.getByTestId('quality-metrics-validate-chip-schematron'),
-    ).toContainText(/Schematron: evaluated/i);
+    ).toContainText(/Schematron rules: checked/i);
     await expect(
       page.getByTestId('quality-metrics-validate-chip-schema-import'),
-    ).toContainText(/Schema import: resolved/i);
+    ).toContainText(/XML schema imports: OK/i);
     await expect(page.getByTestId('quality-metrics-diff-empty')).toBeVisible();
 
     const officialBefore = await page
@@ -145,7 +145,7 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007 / TC-EV05
       timeout: 15_000,
     });
     await expect(page.getByTestId('quality-metrics-match-status')).toContainText(
-      /equal/i,
+      /Matches official/i,
     );
     await expect(page.getByTestId('quality-metrics-detail-close')).toBeVisible();
   });

--- a/apps/e2e/uj056-quality-metrics.e2e.spec.ts
+++ b/apps/e2e/uj056-quality-metrics.e2e.spec.ts
@@ -1,8 +1,8 @@
 /**
- * UJ-056 / TC-EV054-007 + TC-EV055-007 — Quality metrics tab (EV-054 / EV-055).
+ * UJ-056 / TC-EV054-007 + TC-EV055-007 + TC-EV056-005 — Quality metrics tab.
  *
- * Open shell tab → filter product → open passer → C14N panes + validate chips.
- * Live H4–H5 after staging remains stages 12/13.
+ * Open shell tab → filter product → open passer on `/quality/:stem` → C14N panes.
+ * Live H4–H5 after staging remains stage 13.
  */
 import { expect, test } from '@playwright/test';
 import {
@@ -13,7 +13,7 @@ import {
 const PASSER_STEM = 'metar-A3-1';
 const DEFERRED_STEM = 'metar-NIL-collect';
 
-test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => {
+test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007 / TC-EV056)', () => {
   test('open tab → filter METAR → passer detail + deferred gap label', async ({
     page,
   }) => {
@@ -43,6 +43,7 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => 
     await expect(page.getByTestId('quality-metrics-page')).toBeVisible({
       timeout: 15_000,
     });
+    await expect(page).toHaveURL(/\/quality\/?$/);
     await expect(page.getByTestId('quality-metrics-summary')).toBeVisible({
       timeout: 15_000,
     });
@@ -65,6 +66,7 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => 
 
     await page.getByTestId(`quality-metrics-row-${PASSER_STEM}`).click();
 
+    await expect(page).toHaveURL(new RegExp(`/quality/${PASSER_STEM}$`));
     await expect(page.getByTestId('quality-metrics-detail')).toBeVisible({
       timeout: 15_000,
     });
@@ -77,6 +79,12 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => 
     await expect(page.getByTestId('quality-metrics-unified-diff')).toBeVisible();
     // After EV-055 C14N + volatile-attr strip, equal stems should show empty diff.
     await expect(page.getByTestId('quality-metrics-diff-empty')).toBeVisible();
+
+    await page.getByTestId('quality-metrics-detail-close').click();
+    await expect(page).toHaveURL(/\/quality\/?$/);
+    await expect(page.getByTestId('quality-metrics-file-list')).toBeVisible({
+      timeout: 15_000,
+    });
 
     expect(listResponses.length).toBeGreaterThan(0);
     expect(detailResponses.length).toBeGreaterThan(0);
@@ -97,6 +105,7 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => 
     await expect(page.getByTestId('quality-metrics-detail')).toBeVisible({
       timeout: 15_000,
     });
+    await expect(page).toHaveURL(new RegExp(`/quality/${PASSER_STEM}$`));
 
     await expect(page.getByTestId('quality-metrics-xml-view-mode')).toContainText(
       /Normalized XML/i,
@@ -126,5 +135,18 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007)', () => 
     // Raw toggle should change pane text for pretty-printed official XML.
     expect(officialRaw.length).toBeGreaterThan(0);
     expect(officialRaw === officialBefore || officialRaw.includes('\n')).toBeTruthy();
+  });
+
+  test('TC-EV056-005: deep-link /quality/:stem loads detail', async ({ page }) => {
+    await page.goto(`/quality/${PASSER_STEM}`);
+    await dismissPrivacyNoticeIfPresent(page);
+
+    await expect(page.getByTestId('quality-metrics-detail')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('quality-metrics-match-status')).toContainText(
+      /equal/i,
+    );
+    await expect(page.getByTestId('quality-metrics-detail-close')).toBeVisible();
   });
 });

--- a/apps/frontend/src/app/App.test.tsx
+++ b/apps/frontend/src/app/App.test.tsx
@@ -126,8 +126,6 @@ vi.mock('./components/MyMetarsPage', () => ({
 
 vi.mock('./components/QualityMetricsPage', () => ({
   QualityMetricsPage: () => <div data-testid="quality-metrics-page" />,
-  QUALITY_METRICS_PAGE_TITLE: 'Quality metrics',
-  QUALITY_METRICS_DEFERRED_LABEL: 'Deferred gap',
 }));
 
 vi.mock('./components/ThemeProvider', () => ({

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -20,6 +20,11 @@ import {
   listLocalWorkSessions,
   migrateGuestSessionStorageToIndexedDb,
 } from '@/utils/localWorkSessionStore';
+import {
+  parseQualityMetricsPath,
+  QUALITY_METRICS_LIST_PATH,
+  qualityMetricsDetailPath,
+} from '@/utils/qualityMetricsPath';
 import { listWorkSessions } from '@/utils/workSessionApi';
 
 /**
@@ -57,7 +62,13 @@ function isPrimaryShellView(view: AppView): view is ShellPrimaryView {
  */
 function App() {
   const initiallyLoggedIn = isLoggedIn();
-  const [currentView, setCurrentView] = useState<AppView>('converter');
+  const initialQuality = parseQualityMetricsPath(window.location.pathname);
+  const [currentView, setCurrentView] = useState<AppView>(() =>
+    initialQuality ? 'quality' : 'converter',
+  );
+  const [qualityStem, setQualityStem] = useState<string | null>(() =>
+    initialQuality?.kind === 'detail' ? initialQuality.stem : null,
+  );
   const [userEmail, setUserEmail] = useState('');
   const [isAuthenticated, setIsAuthenticated] = useState(initiallyLoggedIn);
   const [accessToken, setAccessToken] = useState(() =>
@@ -69,6 +80,22 @@ function App() {
 
   useEffect(() => {
     validateApiEnv();
+  }, []);
+
+  useEffect(() => {
+    const onPopState = () => {
+      const parsed = parseQualityMetricsPath(window.location.pathname);
+      if (parsed) {
+        setCurrentView('quality');
+        setQualityStem(parsed.kind === 'detail' ? parsed.stem : null);
+        return;
+      }
+      if (window.location.pathname.includes('/auth/callback')) {
+        setCurrentView('callback');
+      }
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
   const initializeWorkSessions = useCallback(async (token?: string | null) => {
@@ -211,6 +238,36 @@ function App() {
 
   const handleShellNavigate = (view: ShellPrimaryView) => {
     setCurrentView(view);
+    if (view === 'quality') {
+      setQualityStem(null);
+      if (window.location.pathname !== QUALITY_METRICS_LIST_PATH) {
+        window.history.pushState({}, '', QUALITY_METRICS_LIST_PATH);
+      }
+      return;
+    }
+    if (
+      window.location.pathname === QUALITY_METRICS_LIST_PATH ||
+      window.location.pathname.startsWith(`${QUALITY_METRICS_LIST_PATH}/`)
+    ) {
+      window.history.pushState({}, '', '/');
+    }
+  };
+
+  const handleOpenQualityDetail = (stem: string) => {
+    setCurrentView('quality');
+    setQualityStem(stem);
+    const path = qualityMetricsDetailPath(stem);
+    if (window.location.pathname !== path) {
+      window.history.pushState({}, '', path);
+    }
+  };
+
+  const handleBackToQualityList = () => {
+    setCurrentView('quality');
+    setQualityStem(null);
+    if (window.location.pathname !== QUALITY_METRICS_LIST_PATH) {
+      window.history.pushState({}, '', QUALITY_METRICS_LIST_PATH);
+    }
   };
 
   const handleRequestLogin = () => {
@@ -299,7 +356,13 @@ function App() {
         />
       )}
 
-      {currentView === 'quality' && <QualityMetricsPage />}
+      {currentView === 'quality' && (
+        <QualityMetricsPage
+          routeStem={qualityStem}
+          onOpenDetailRoute={handleOpenQualityDetail}
+          onBackToList={handleBackToQualityList}
+        />
+      )}
 
       {currentView === 'callback' && (
         <AuthCallback

--- a/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
@@ -155,8 +155,6 @@ describe('QualityMetricsDetail C14N panes (TC-EV055-001)', () => {
       validate_issues: [{ code: 'X', other: true }],
     };
     render(<QualityMetricsDetail detail={detail} />);
-    expect(screen.getByTestId('quality-metrics-pane-validate')).toHaveTextContent(
-      '"code":"X"',
-    );
+    expect(screen.getByTestId('quality-metrics-pane-validate')).toHaveTextContent('X');
   });
 });

--- a/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
@@ -157,4 +157,104 @@ describe('QualityMetricsDetail C14N panes (TC-EV055-001)', () => {
     render(<QualityMetricsDetail detail={detail} />);
     expect(screen.getByTestId('quality-metrics-pane-validate')).toHaveTextContent('X');
   });
+
+  it('formats diagnostics from detail when message is absent', () => {
+    const detail: QualityMetricsDetailResponse = {
+      ...FORMATTING_ONLY,
+      residuals: [{ detail: 'leftover token' }],
+      lint_issues: [{ code: 'LINT1', message: 'bad group' }],
+    };
+    render(<QualityMetricsDetail detail={detail} />);
+    expect(screen.getByTestId('quality-metrics-pane-residuals')).toHaveTextContent(
+      'leftover token',
+    );
+    expect(screen.getByTestId('quality-metrics-pane-lint')).toHaveTextContent(
+      'LINT1: bad group',
+    );
+  });
+
+  it('collapses distant equal context and expands on click', async () => {
+    const user = userEvent.setup();
+    const makeXml = (mid: string) => {
+      const rows = Array.from({ length: 40 }, (_, i) =>
+        i === 20 ? `  <v>${mid}</v>` : `  <n${i}/>`,
+      );
+      return `<root xmlns="urn:x">\n${rows.join('\n')}\n</root>`;
+    };
+    const detail: QualityMetricsDetailResponse = {
+      ...FORMATTING_ONLY,
+      stem: 'metar-long-diff',
+      match_status: 'unequal',
+      official_xml: makeXml('1'),
+      converted_xml: makeXml('2'),
+    };
+    render(<QualityMetricsDetail detail={detail} />);
+
+    expect(screen.getByTestId('quality-metrics-diff-body')).toBeInTheDocument();
+    const expandHunks = screen.getAllByTestId('quality-metrics-diff-expand-hunk');
+    expect(expandHunks.length).toBeGreaterThan(0);
+    expect(screen.getByTestId('quality-metrics-diff-expand-all')).toHaveTextContent(
+      /Show all unchanged lines/i,
+    );
+
+    await user.click(expandHunks[0]!);
+    // Expanding one hunk may leave other collapse controls.
+    expect(screen.getByTestId('quality-metrics-diff-expand-all')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('quality-metrics-diff-expand-all'));
+    expect(screen.getByTestId('quality-metrics-diff-expand-all')).toHaveTextContent(
+      /Hide distant unchanged lines/i,
+    );
+    expect(screen.queryAllByTestId('quality-metrics-diff-expand-hunk')).toHaveLength(0);
+
+    await user.click(screen.getByTestId('quality-metrics-diff-expand-all'));
+    expect(
+      screen.getAllByTestId('quality-metrics-diff-expand-hunk').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows plain-language match status for unequal and deferred', () => {
+    const unequal: QualityMetricsDetailResponse = {
+      ...SEMANTIC_DIFF,
+      deferred: true,
+      match_status: 'unequal',
+    };
+    const { rerender } = render(<QualityMetricsDetail detail={unequal} />);
+    expect(screen.getByTestId('quality-metrics-match-status')).toHaveTextContent(
+      'Differs from official',
+    );
+    expect(screen.getByText(/Deferred — not scored yet/i)).toBeInTheDocument();
+
+    rerender(
+      <QualityMetricsDetail
+        detail={{
+          ...FORMATTING_ONLY,
+          match_status: 'deferred',
+          deferred: true,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('quality-metrics-match-status')).toHaveTextContent(
+      'Deferred — not scored yet',
+    );
+  });
+
+  it('shows empty pane placeholders when payloads are blank', () => {
+    render(
+      <QualityMetricsDetail
+        detail={{
+          ...FORMATTING_ONLY,
+          tac: '',
+          official_xml: '',
+          converted_xml: '',
+        }}
+      />,
+    );
+    expect(screen.getByTestId('quality-metrics-pane-tac')).toHaveTextContent(
+      /No TAC available/i,
+    );
+    expect(screen.getByTestId('quality-metrics-pane-official-xml')).toHaveTextContent(
+      /No official XML available/i,
+    );
+  });
 });

--- a/apps/frontend/src/app/components/QualityMetricsDetail.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.tsx
@@ -19,6 +19,10 @@ import {
   type UnifiedDiffLine,
 } from '@/utils/unifiedLineDiff';
 import { validateDispositionChips } from '@/utils/validateDispositionChips';
+import {
+  formatMatchStatusLabel,
+  QUALITY_METRICS_DEFERRED_LABEL,
+} from '@/utils/qualityMetricsCopy';
 import { Card } from './ui/card';
 
 export const QUALITY_METRICS_DIFF_EMPTY_LABEL = 'No XML differences';
@@ -26,10 +30,17 @@ export const QUALITY_METRICS_EMPTY_DIAGNOSTICS = 'None';
 export const QUALITY_METRICS_XML_VIEW_NORMALIZED = 'Normalized XML';
 export const QUALITY_METRICS_XML_VIEW_RAW = 'Raw XML';
 export const QUALITY_METRICS_XML_VIEW_HELP =
-  'Official and converted panes default to normalized, pretty-printed XML. Turn on raw to inspect original formatting. The unified diff always compares normalized forms.';
-export const QUALITY_METRICS_DIFF_EXPAND_ALL = 'Expand all context';
-export const QUALITY_METRICS_DIFF_COLLAPSE_ALL = 'Collapse unchanged context';
+  'Official and converted panes default to normalized, pretty-printed XML so formatting noise is hidden. Turn on Raw XML to inspect original whitespace. The line-by-line diff below always compares the normalized forms.';
+export const QUALITY_METRICS_DIFF_EXPAND_ALL = 'Show all unchanged lines';
+export const QUALITY_METRICS_DIFF_COLLAPSE_ALL = 'Hide distant unchanged lines';
 export const QUALITY_METRICS_BACK_TO_LIST = 'Back to list';
+export const QUALITY_METRICS_DIFF_HEADING = 'Line-by-line XML differences';
+export const QUALITY_METRICS_RESIDUALS_HELP =
+  'TAC tokens left over after conversion (should usually be empty).';
+export const QUALITY_METRICS_LINT_HELP =
+  'TAC business-rule findings from the lint engine.';
+export const QUALITY_METRICS_VALIDATE_HELP =
+  'IWXXM schema and Schematron findings from the validate engine.';
 
 interface QualityMetricsDetailProps {
   /** Detail payload from GET /quality-metrics/{stem}. */
@@ -115,11 +126,13 @@ export function QualityMetricsDetail({
             {detail.stem}
           </h2>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {detail.product.toUpperCase()} · {detail.tier} · match{' '}
+            {detail.product.toUpperCase()} · {detail.tier} ·{' '}
             <span data-testid="quality-metrics-match-status">
-              {detail.match_status}
+              {formatMatchStatusLabel(detail.match_status)}
             </span>
-            {detail.deferred ? ' · deferred' : ''}
+            {detail.deferred && detail.match_status !== 'deferred'
+              ? ` · ${QUALITY_METRICS_DEFERRED_LABEL}`
+              : ''}
           </p>
           {detail.deferral_reason ? (
             <p className="mt-1 text-sm text-amber-800 dark:text-amber-200">
@@ -129,7 +142,7 @@ export function QualityMetricsDetail({
           <div
             className="mt-2 flex flex-wrap gap-2"
             data-testid="quality-metrics-validate-chips"
-            aria-label="Validate disposition"
+            aria-label="Validation status"
           >
             {dispositionChips.map((chip) => (
               <span
@@ -209,7 +222,7 @@ export function QualityMetricsDetail({
       <Card className="p-4" data-testid="quality-metrics-unified-diff">
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            Unified XML diff
+            {QUALITY_METRICS_DIFF_HEADING}
           </h3>
           {!diffEmpty && hasCollapseSegments ? (
             <button
@@ -276,16 +289,19 @@ export function QualityMetricsDetail({
       <div className="grid gap-4 md:grid-cols-3">
         <DiagnosticsPane
           title="Residuals"
+          help={QUALITY_METRICS_RESIDUALS_HELP}
           testId="quality-metrics-pane-residuals"
           items={detail.residuals}
         />
         <DiagnosticsPane
           title="Lint issues"
+          help={QUALITY_METRICS_LINT_HELP}
           testId="quality-metrics-pane-lint"
           items={detail.lint_issues}
         />
         <DiagnosticsPane
-          title="Validate issues"
+          title="Validation issues"
+          help={QUALITY_METRICS_VALIDATE_HELP}
           testId="quality-metrics-pane-validate"
           items={detail.validate_issues}
         />
@@ -324,18 +340,21 @@ function TextPane({
 
 function DiagnosticsPane({
   title,
+  help,
   testId,
   items,
 }: {
   title: string;
+  help: string;
   testId: string;
   items: Record<string, unknown>[];
 }) {
   return (
     <Card className="p-3" data-testid={testId}>
-      <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+      <h3 className="mb-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
         {title}
       </h3>
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">{help}</p>
       {items.length === 0 ? (
         <p
           className="text-sm text-gray-500 dark:text-gray-400"
@@ -376,9 +395,22 @@ function DiffLineRow({ line }: { line: UnifiedDiffLine }) {
 }
 
 function formatDiagnostic(item: Record<string, unknown>): string {
-  if (typeof item.message === 'string' && item.message.trim()) {
-    const code = typeof item.code === 'string' ? `${item.code}: ` : '';
-    return `${code}${item.message}`;
+  const message =
+    typeof item.message === 'string' && item.message.trim()
+      ? item.message.trim()
+      : typeof item.detail === 'string' && item.detail.trim()
+        ? item.detail.trim()
+        : '';
+  const code =
+    typeof item.code === 'string' && item.code.trim() ? item.code.trim() : '';
+  if (message && code) {
+    return `${code}: ${message}`;
+  }
+  if (message) {
+    return message;
+  }
+  if (code) {
+    return code;
   }
   try {
     return JSON.stringify(item);

--- a/apps/frontend/src/app/components/QualityMetricsDetail.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.tsx
@@ -1,11 +1,17 @@
 /**
  * Per-stem Quality metrics detail — TAC/XML panes, diagnostics, unified diff.
  *
- * F7.q / EV-054 M4 + EV-055 M4 (AC1/AC6 — C14N panes + validate chips).
+ * F7.q / EV-054 M4 + EV-055 M4 (AC1/AC6 — C14N panes + validate chips) +
+ * EV-056 collapsible equal-context hunks (`D-S066-context-n=1`).
  */
 
 import { useMemo, useState } from 'react';
 import type { QualityMetricsDetailResponse } from '@/utils/openapiTypes';
+import {
+  collapseEqualContext,
+  DEFAULT_DIFF_CONTEXT,
+  type CollapsedDiffSegment,
+} from '@/utils/collapseEqualContext';
 import { qualityMetricsDisplayXml } from '@/utils/qualityMetricsDisplayXml';
 import {
   isUnifiedDiffEmpty,
@@ -21,12 +27,17 @@ export const QUALITY_METRICS_XML_VIEW_NORMALIZED = 'Normalized XML';
 export const QUALITY_METRICS_XML_VIEW_RAW = 'Raw XML';
 export const QUALITY_METRICS_XML_VIEW_HELP =
   'Official and converted panes default to normalized, pretty-printed XML. Turn on raw to inspect original formatting. The unified diff always compares normalized forms.';
+export const QUALITY_METRICS_DIFF_EXPAND_ALL = 'Expand all context';
+export const QUALITY_METRICS_DIFF_COLLAPSE_ALL = 'Collapse unchanged context';
+export const QUALITY_METRICS_BACK_TO_LIST = 'Back to list';
 
 interface QualityMetricsDetailProps {
   /** Detail payload from GET /quality-metrics/{stem}. */
   detail: QualityMetricsDetailResponse;
   /** Clear selection / return to list focus. */
   onClose?: () => void;
+  /** Label for the close / back control (default Close detail). */
+  closeLabel?: string;
 }
 
 /**
@@ -34,9 +45,18 @@ interface QualityMetricsDetailProps {
  *
  * @param props.detail - Stem detail response
  * @param props.onClose - Optional close handler
+ * @param props.closeLabel - Optional close button label
  */
-export function QualityMetricsDetail({ detail, onClose }: QualityMetricsDetailProps) {
+export function QualityMetricsDetail({
+  detail,
+  onClose,
+  closeLabel = 'Close detail',
+}: QualityMetricsDetailProps) {
   const [showRawXml, setShowRawXml] = useState(false);
+  const [expandAll, setExpandAll] = useState(false);
+  const [expandedCollapseKeys, setExpandedCollapseKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const officialC14n = useMemo(
     () => qualityMetricsDisplayXml(detail.official_xml ?? ''),
@@ -56,10 +76,32 @@ export function QualityMetricsDetail({ detail, onClose }: QualityMetricsDetailPr
   );
   const diffEmpty = isUnifiedDiffEmpty(diffLines);
 
+  const collapsedSegments = useMemo(
+    () => collapseEqualContext(diffLines, { context: DEFAULT_DIFF_CONTEXT }),
+    [diffLines],
+  );
+
   const dispositionChips = useMemo(
     () => validateDispositionChips(detail.validate_issues ?? []),
     [detail.validate_issues],
   );
+
+  const hasCollapseSegments = collapsedSegments.some((s) => s.type === 'collapse');
+
+  const collapseKey = (segment: CollapsedDiffSegment): string =>
+    `c-${segment.startIndex}-${segment.lines.length}`;
+
+  const toggleCollapse = (key: string) => {
+    setExpandedCollapseKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
   return (
     <section
@@ -112,7 +154,7 @@ export function QualityMetricsDetail({ detail, onClose }: QualityMetricsDetailPr
             data-testid="quality-metrics-detail-close"
             onClick={onClose}
           >
-            Close detail
+            {closeLabel}
           </button>
         ) : null}
       </div>
@@ -165,9 +207,28 @@ export function QualityMetricsDetail({ detail, onClose }: QualityMetricsDetailPr
       </div>
 
       <Card className="p-4" data-testid="quality-metrics-unified-diff">
-        <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
-          Unified XML diff
-        </h3>
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Unified XML diff
+          </h3>
+          {!diffEmpty && hasCollapseSegments ? (
+            <button
+              type="button"
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
+              data-testid="quality-metrics-diff-expand-all"
+              onClick={() => {
+                setExpandAll((prev) => !prev);
+                if (expandAll) {
+                  setExpandedCollapseKeys(new Set());
+                }
+              }}
+            >
+              {expandAll
+                ? QUALITY_METRICS_DIFF_COLLAPSE_ALL
+                : QUALITY_METRICS_DIFF_EXPAND_ALL}
+            </button>
+          ) : null}
+        </div>
         {diffEmpty ? (
           <p
             className="text-sm text-gray-500 dark:text-gray-400"
@@ -180,9 +241,34 @@ export function QualityMetricsDetail({ detail, onClose }: QualityMetricsDetailPr
             className="max-h-96 overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100 dark:border-gray-700"
             data-testid="quality-metrics-diff-body"
           >
-            {diffLines.map((line, index) => (
-              <DiffLineRow key={`${line.op}-${index}`} line={line} />
-            ))}
+            {collapsedSegments.map((segment) => {
+              if (segment.type === 'lines') {
+                return segment.lines.map((line, index) => (
+                  <DiffLineRow key={`l-${segment.startIndex}-${index}`} line={line} />
+                ));
+              }
+              const key = collapseKey(segment);
+              const expanded = expandAll || expandedCollapseKeys.has(key);
+              if (expanded) {
+                return segment.lines.map((line, index) => (
+                  <DiffLineRow key={`${key}-${index}`} line={line} />
+                ));
+              }
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className="block w-full bg-gray-900 py-1 text-left text-blue-300 hover:bg-gray-800"
+                  data-testid="quality-metrics-diff-expand-hunk"
+                  data-hidden-count={segment.lines.length}
+                  onClick={() => toggleCollapse(key)}
+                >
+                  {`Expand ${segment.lines.length} unchanged line${
+                    segment.lines.length === 1 ? '' : 's'
+                  }`}
+                </button>
+              );
+            })}
           </pre>
         )}
       </Card>

--- a/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
@@ -348,4 +348,54 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
       expect(screen.queryByTestId('quality-metrics-detail')).not.toBeInTheDocument();
     });
   });
+
+  it('uses route callbacks for open and back navigation', async () => {
+    const user = userEvent.setup();
+    const onOpenDetailRoute = vi.fn();
+    const onBackToList = vi.fn();
+    apiMocks.fetchQualityMetricsDetail.mockResolvedValue(MOCK_DETAIL_EQUAL);
+
+    const { rerender } = render(
+      <QualityMetricsPage
+        onOpenDetailRoute={onOpenDetailRoute}
+        onBackToList={onBackToList}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quality-metrics-row-metar-A3-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('quality-metrics-row-metar-A3-1'));
+    expect(onOpenDetailRoute).toHaveBeenCalledWith('metar-A3-1');
+
+    rerender(
+      <QualityMetricsPage
+        routeStem="metar-A3-1"
+        onOpenDetailRoute={onOpenDetailRoute}
+        onBackToList={onBackToList}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quality-metrics-detail')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('quality-metrics-detail-close'));
+    expect(onBackToList).toHaveBeenCalled();
+  });
+
+  it('shows empty-list copy when the filter has no files', async () => {
+    apiMocks.fetchQualityMetrics.mockResolvedValue({
+      ...MOCK_LIST,
+      files: [],
+      summaries: [],
+    });
+
+    render(<QualityMetricsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No files for this product filter/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsPage.test.tsx
@@ -9,10 +9,8 @@ import {
   QUALITY_METRICS_DIFF_EMPTY_LABEL,
   QUALITY_METRICS_EMPTY_DIAGNOSTICS,
 } from './QualityMetricsDetail';
-import {
-  QUALITY_METRICS_DEFERRED_LABEL,
-  QualityMetricsPage,
-} from './QualityMetricsPage';
+import { QualityMetricsPage } from './QualityMetricsPage';
+import { QUALITY_METRICS_DEFERRED_LABEL } from '@/utils/qualityMetricsCopy';
 
 const apiMocks = vi.hoisted(() => ({
   fetchQualityMetrics: vi.fn(),
@@ -129,7 +127,7 @@ describe('QualityMetricsPage (TC-EV054-002)', () => {
     expect(screen.getByTestId('quality-metrics-row-taf-A5-1')).toBeInTheDocument();
 
     const summary = screen.getByTestId('quality-metrics-summary');
-    expect(within(summary).getByText('Match pass')).toBeInTheDocument();
+    expect(within(summary).getByText('Matches')).toBeInTheDocument();
     expect(within(summary).getByText('2')).toBeInTheDocument();
   });
 
@@ -225,7 +223,7 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
       stem: 'metar-A3-1',
     });
     expect(screen.getByTestId('quality-metrics-match-status')).toHaveTextContent(
-      'equal',
+      'Matches official',
     );
     expect(screen.getByTestId('quality-metrics-pane-tac')).toHaveTextContent(
       'METAR YUDO',
@@ -277,7 +275,7 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
     });
 
     expect(screen.getByTestId('quality-metrics-match-status')).toHaveTextContent(
-      'unequal',
+      'Differs from official',
     );
     expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('<a>');
     expect(screen.getByTestId('quality-metrics-diff-body')).toHaveTextContent('</a>');
@@ -324,7 +322,7 @@ describe('QualityMetricsPage detail (TC-EV054-003..004)', () => {
     await user.click(screen.getByTestId('quality-metrics-row-metar-A3-1'));
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load stem detail')).toBeInTheDocument();
+      expect(screen.getByText('Failed to load file detail')).toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/src/app/components/QualityMetricsPage.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsPage.tsx
@@ -17,12 +17,15 @@ import {
   QualityMetricsDetail,
 } from './QualityMetricsDetail';
 import { Card } from './ui/card';
-
-/** Operator-visible label for deferred / gap stems (AC5). */
-export const QUALITY_METRICS_DEFERRED_LABEL = 'Deferred gap';
-
-/** Page title — primary shell tab. */
-export const QUALITY_METRICS_PAGE_TITLE = 'Quality metrics';
+import {
+  formatMatchStatusLabel,
+  QUALITY_METRICS_DEFERRED_LABEL,
+  QUALITY_METRICS_DETAIL_LOAD_FAILED,
+  QUALITY_METRICS_DETAIL_LOADING,
+  QUALITY_METRICS_EMPTY_LIST,
+  QUALITY_METRICS_PAGE_SUBTITLE,
+  QUALITY_METRICS_PAGE_TITLE,
+} from '@/utils/qualityMetricsCopy';
 
 interface QualityMetricsPageProps {
   /** Optional stem select hook (in addition to route navigation). */
@@ -108,7 +111,7 @@ export function QualityMetricsPage({
         if (!cancelled) {
           setDetail(null);
           setDetailError(
-            err instanceof Error ? err.message : 'Failed to load stem detail',
+            err instanceof Error ? err.message : QUALITY_METRICS_DETAIL_LOAD_FAILED,
           );
         }
       } finally {
@@ -194,7 +197,7 @@ export function QualityMetricsPage({
                 {QUALITY_METRICS_PAGE_TITLE}
               </h1>
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                Official WMO corpus match, residuals, lint, and validate diagnostics
+                {QUALITY_METRICS_PAGE_SUBTITLE}
                 {iwxxmPin ? ` · IWXXM ${iwxxmPin}` : ''}
                 {generatedAt ? ` · generated ${generatedAt}` : ''}
               </p>
@@ -208,7 +211,7 @@ export function QualityMetricsPage({
                     className="ml-2 rounded border px-2 py-1 text-sm dark:bg-gray-800"
                     value={productFilter}
                     data-testid="quality-metrics-product-filter"
-                    aria-label="Filter corpus by product"
+                    aria-label="Filter by product"
                     onChange={(e) => setProductFilter(e.target.value)}
                   >
                     <option value="all">All products</option>
@@ -243,21 +246,18 @@ export function QualityMetricsPage({
                   data-testid="quality-metrics-summary"
                   aria-label="Quality metrics summary"
                 >
-                  <SummaryStat label="Match pass" value={activeSummary.match_pass} />
-                  <SummaryStat label="Match fail" value={activeSummary.match_fail} />
+                  <SummaryStat label="Matches" value={activeSummary.match_pass} />
+                  <SummaryStat label="Mismatches" value={activeSummary.match_fail} />
                   <SummaryStat
-                    label="Residuals"
+                    label="With residuals"
                     value={activeSummary.residual_nonempty}
                   />
-                  <SummaryStat label="Lint fail" value={activeSummary.lint_fail} />
+                  <SummaryStat label="Lint fails" value={activeSummary.lint_fail} />
                   <SummaryStat
-                    label="Validate fail"
+                    label="Validation fails"
                     value={activeSummary.validate_fail}
                   />
-                  <SummaryStat
-                    label="Deferred gaps"
-                    value={activeSummary.deferred_gaps}
-                  />
+                  <SummaryStat label="Deferred" value={activeSummary.deferred_gaps} />
                 </div>
               )}
 
@@ -268,7 +268,7 @@ export function QualityMetricsPage({
                 >
                   {files.length === 0 ? (
                     <li className="py-3 text-sm text-gray-500 dark:text-gray-400">
-                      No corpus files for this filter.
+                      {QUALITY_METRICS_EMPTY_LIST}
                     </li>
                   ) : (
                     files.map((row) => (
@@ -284,8 +284,8 @@ export function QualityMetricsPage({
                               {row.stem}
                             </div>
                             <div className="text-xs text-gray-500 dark:text-gray-400">
-                              {row.product.toUpperCase()} · {row.tier} · match{' '}
-                              {row.match_status}
+                              {row.product.toUpperCase()} · {row.tier} ·{' '}
+                              {formatMatchStatusLabel(row.match_status)}
                             </div>
                           </div>
                           <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -297,8 +297,12 @@ export function QualityMetricsPage({
                                 {QUALITY_METRICS_DEFERRED_LABEL}
                               </span>
                             ) : null}
-                            <span className="text-gray-500 dark:text-gray-400">
-                              R{row.residual_count} L{row.lint_error_count} V
+                            <span
+                              className="text-gray-500 dark:text-gray-400"
+                              title="Counts of residuals, lint findings, and validation issues"
+                            >
+                              Residuals {row.residual_count} · Lint{' '}
+                              {row.lint_error_count} · Validation{' '}
                               {row.validate_error_count}
                             </span>
                           </div>
@@ -320,7 +324,7 @@ export function QualityMetricsPage({
                 data-testid="quality-metrics-detail-loading"
               >
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                Loading stem detail…
+                {QUALITY_METRICS_DETAIL_LOADING}
               </div>
             )}
             {detailError && (
@@ -346,7 +350,7 @@ export function QualityMetricsPage({
                 data-testid="quality-metrics-detail-loading"
               >
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                Loading stem detail…
+                {QUALITY_METRICS_DETAIL_LOADING}
               </div>
             )}
             {detailError && (

--- a/apps/frontend/src/app/components/QualityMetricsPage.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsPage.tsx
@@ -1,7 +1,7 @@
 /**
  * Quality metrics corpus browser — product filter, summary strip, file list, detail.
  *
- * List + detail for F7.q / EV-054 (AC1–AC5).
+ * List + detail for F7.q / EV-054 (AC1–AC5) + EV-056 shareable `/quality/:stem`.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -12,7 +12,10 @@ import type {
   QualityMetricsFileRow,
   QualityMetricsSummary,
 } from '@/utils/openapiTypes';
-import { QualityMetricsDetail } from './QualityMetricsDetail';
+import {
+  QUALITY_METRICS_BACK_TO_LIST,
+  QualityMetricsDetail,
+} from './QualityMetricsDetail';
 import { Card } from './ui/card';
 
 /** Operator-visible label for deferred / gap stems (AC5). */
@@ -22,16 +25,30 @@ export const QUALITY_METRICS_DEFERRED_LABEL = 'Deferred gap';
 export const QUALITY_METRICS_PAGE_TITLE = 'Quality metrics';
 
 interface QualityMetricsPageProps {
-  /** Optional stem select hook (in addition to in-page detail). */
+  /** Optional stem select hook (in addition to route navigation). */
   onSelectStem?: (stem: string) => void;
+  /** Stem from `/quality/:stem` — when set, show detail-only view. */
+  routeStem?: string | null;
+  /** Navigate to shareable detail path (list → detail). */
+  onOpenDetailRoute?: (stem: string) => void;
+  /** Return to list path (`/quality`). */
+  onBackToList?: () => void;
 }
 
 /**
  * Browse precomputed official-corpus quality metrics by product.
  *
  * @param props.onSelectStem - Optional callback when a file row is activated
+ * @param props.routeStem - Active detail stem from the URL
+ * @param props.onOpenDetailRoute - Push `/quality/:stem`
+ * @param props.onBackToList - Push `/quality`
  */
-export function QualityMetricsPage({ onSelectStem }: QualityMetricsPageProps) {
+export function QualityMetricsPage({
+  onSelectStem,
+  routeStem = null,
+  onOpenDetailRoute,
+  onBackToList,
+}: QualityMetricsPageProps) {
   const [productFilter, setProductFilter] = useState<string>('all');
   const [summaries, setSummaries] = useState<QualityMetricsSummary[]>([]);
   const [files, setFiles] = useState<QualityMetricsFileRow[]>([]);
@@ -39,10 +56,13 @@ export function QualityMetricsPage({ onSelectStem }: QualityMetricsPageProps) {
   const [iwxxmPin, setIwxxmPin] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedStem, setSelectedStem] = useState<string | null>(null);
+  const [localStem, setLocalStem] = useState<string | null>(null);
   const [detail, setDetail] = useState<QualityMetricsDetailResponse | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
+
+  const useRoute = typeof onOpenDetailRoute === 'function';
+  const selectedStem = useRoute ? routeStem : localStem;
 
   const loadMetrics = useCallback(async () => {
     setLoading(true);
@@ -136,19 +156,30 @@ export function QualityMetricsPage({ onSelectStem }: QualityMetricsPageProps) {
   }, [productFilter, summaries]);
 
   const handleSelectStem = (stem: string) => {
-    setSelectedStem(stem);
+    onSelectStem?.(stem);
+    if (useRoute && onOpenDetailRoute) {
+      onOpenDetailRoute(stem);
+      return;
+    }
+    setLocalStem(stem);
     setDetail(null);
     setDetailError(null);
     setDetailLoading(true);
-    onSelectStem?.(stem);
   };
 
   const handleCloseDetail = () => {
-    setSelectedStem(null);
+    if (useRoute && onBackToList) {
+      onBackToList();
+      return;
+    }
+    setLocalStem(null);
     setDetail(null);
     setDetailError(null);
     setDetailLoading(false);
   };
+
+  const detailOnly = useRoute && Boolean(selectedStem);
+  const showInlineDetail = !useRoute && Boolean(selectedStem);
 
   return (
     <div
@@ -156,127 +187,158 @@ export function QualityMetricsPage({ onSelectStem }: QualityMetricsPageProps) {
       data-testid="quality-metrics-page"
     >
       <div className="mx-auto max-w-5xl space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {QUALITY_METRICS_PAGE_TITLE}
-          </h1>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Official WMO corpus match, residuals, lint, and validate diagnostics
-            {iwxxmPin ? ` · IWXXM ${iwxxmPin}` : ''}
-            {generatedAt ? ` · generated ${generatedAt}` : ''}
-          </p>
-        </div>
-
-        <Card className="p-4">
-          <div className="mb-4 flex flex-wrap items-center gap-3">
-            <label className="text-sm text-gray-700 dark:text-gray-300">
-              Product
-              <select
-                className="ml-2 rounded border px-2 py-1 text-sm dark:bg-gray-800"
-                value={productFilter}
-                data-testid="quality-metrics-product-filter"
-                aria-label="Filter corpus by product"
-                onChange={(e) => setProductFilter(e.target.value)}
-              >
-                <option value="all">All products</option>
-                {productOptions.map((product) => (
-                  <option key={product} value={product}>
-                    {product.toUpperCase()}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          {loading && (
-            <div
-              className="flex items-center gap-2 text-sm text-gray-500"
-              data-testid="quality-metrics-loading"
-            >
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-              Loading quality metrics…
+        {!detailOnly ? (
+          <>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {QUALITY_METRICS_PAGE_TITLE}
+              </h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Official WMO corpus match, residuals, lint, and validate diagnostics
+                {iwxxmPin ? ` · IWXXM ${iwxxmPin}` : ''}
+                {generatedAt ? ` · generated ${generatedAt}` : ''}
+              </p>
             </div>
-          )}
 
-          {error && (
-            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
-              {error}
-            </p>
-          )}
+            <Card className="p-4">
+              <div className="mb-4 flex flex-wrap items-center gap-3">
+                <label className="text-sm text-gray-700 dark:text-gray-300">
+                  Product
+                  <select
+                    className="ml-2 rounded border px-2 py-1 text-sm dark:bg-gray-800"
+                    value={productFilter}
+                    data-testid="quality-metrics-product-filter"
+                    aria-label="Filter corpus by product"
+                    onChange={(e) => setProductFilter(e.target.value)}
+                  >
+                    <option value="all">All products</option>
+                    {productOptions.map((product) => (
+                      <option key={product} value={product}>
+                        {product.toUpperCase()}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
 
-          {!loading && !error && activeSummary && (
-            <div
-              className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6"
-              data-testid="quality-metrics-summary"
-              aria-label="Quality metrics summary"
-            >
-              <SummaryStat label="Match pass" value={activeSummary.match_pass} />
-              <SummaryStat label="Match fail" value={activeSummary.match_fail} />
-              <SummaryStat label="Residuals" value={activeSummary.residual_nonempty} />
-              <SummaryStat label="Lint fail" value={activeSummary.lint_fail} />
-              <SummaryStat label="Validate fail" value={activeSummary.validate_fail} />
-              <SummaryStat label="Deferred gaps" value={activeSummary.deferred_gaps} />
-            </div>
-          )}
-
-          {!loading && !error && (
-            <ul
-              className="divide-y divide-gray-200 dark:divide-gray-700"
-              data-testid="quality-metrics-file-list"
-            >
-              {files.length === 0 ? (
-                <li className="py-3 text-sm text-gray-500 dark:text-gray-400">
-                  No corpus files for this filter.
-                </li>
-              ) : (
-                files.map((row) => {
-                  const selected = selectedStem === row.stem;
-                  return (
-                    <li key={row.stem}>
-                      <button
-                        type="button"
-                        className={`flex w-full flex-wrap items-center justify-between gap-2 px-1 py-3 text-left text-sm ${
-                          selected
-                            ? 'bg-blue-50 dark:bg-blue-950/40'
-                            : 'hover:bg-gray-50 dark:hover:bg-gray-800/60'
-                        }`}
-                        data-testid={`quality-metrics-row-${row.stem}`}
-                        aria-pressed={selected}
-                        onClick={() => handleSelectStem(row.stem)}
-                      >
-                        <div className="min-w-0">
-                          <div className="font-medium text-gray-900 dark:text-gray-100">
-                            {row.stem}
-                          </div>
-                          <div className="text-xs text-gray-500 dark:text-gray-400">
-                            {row.product.toUpperCase()} · {row.tier} · match{' '}
-                            {row.match_status}
-                          </div>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2 text-xs">
-                          {row.deferred ? (
-                            <span
-                              className="rounded bg-amber-100 px-2 py-0.5 font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
-                              data-testid={`quality-metrics-deferred-${row.stem}`}
-                            >
-                              {QUALITY_METRICS_DEFERRED_LABEL}
-                            </span>
-                          ) : null}
-                          <span className="text-gray-500 dark:text-gray-400">
-                            R{row.residual_count} L{row.lint_error_count} V
-                            {row.validate_error_count}
-                          </span>
-                        </div>
-                      </button>
-                    </li>
-                  );
-                })
+              {loading && (
+                <div
+                  className="flex items-center gap-2 text-sm text-gray-500"
+                  data-testid="quality-metrics-loading"
+                >
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Loading quality metrics…
+                </div>
               )}
-            </ul>
-          )}
-        </Card>
 
-        {selectedStem ? (
+              {error && (
+                <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                  {error}
+                </p>
+              )}
+
+              {!loading && !error && activeSummary && (
+                <div
+                  className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6"
+                  data-testid="quality-metrics-summary"
+                  aria-label="Quality metrics summary"
+                >
+                  <SummaryStat label="Match pass" value={activeSummary.match_pass} />
+                  <SummaryStat label="Match fail" value={activeSummary.match_fail} />
+                  <SummaryStat
+                    label="Residuals"
+                    value={activeSummary.residual_nonempty}
+                  />
+                  <SummaryStat label="Lint fail" value={activeSummary.lint_fail} />
+                  <SummaryStat
+                    label="Validate fail"
+                    value={activeSummary.validate_fail}
+                  />
+                  <SummaryStat
+                    label="Deferred gaps"
+                    value={activeSummary.deferred_gaps}
+                  />
+                </div>
+              )}
+
+              {!loading && !error && (
+                <ul
+                  className="divide-y divide-gray-200 dark:divide-gray-700"
+                  data-testid="quality-metrics-file-list"
+                >
+                  {files.length === 0 ? (
+                    <li className="py-3 text-sm text-gray-500 dark:text-gray-400">
+                      No corpus files for this filter.
+                    </li>
+                  ) : (
+                    files.map((row) => (
+                      <li key={row.stem}>
+                        <button
+                          type="button"
+                          className="flex w-full flex-wrap items-center justify-between gap-2 px-1 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-800/60"
+                          data-testid={`quality-metrics-row-${row.stem}`}
+                          onClick={() => handleSelectStem(row.stem)}
+                        >
+                          <div className="min-w-0">
+                            <div className="font-medium text-gray-900 dark:text-gray-100">
+                              {row.stem}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              {row.product.toUpperCase()} · {row.tier} · match{' '}
+                              {row.match_status}
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-xs">
+                            {row.deferred ? (
+                              <span
+                                className="rounded bg-amber-100 px-2 py-0.5 font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+                                data-testid={`quality-metrics-deferred-${row.stem}`}
+                              >
+                                {QUALITY_METRICS_DEFERRED_LABEL}
+                              </span>
+                            ) : null}
+                            <span className="text-gray-500 dark:text-gray-400">
+                              R{row.residual_count} L{row.lint_error_count} V
+                              {row.validate_error_count}
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              )}
+            </Card>
+          </>
+        ) : null}
+
+        {detailOnly ? (
+          <Card className="p-4" data-testid="quality-metrics-detail-route">
+            {detailLoading && (
+              <div
+                className="flex items-center gap-2 text-sm text-gray-500"
+                data-testid="quality-metrics-detail-loading"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Loading stem detail…
+              </div>
+            )}
+            {detailError && (
+              <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                {detailError}
+              </p>
+            )}
+            {!detailLoading && !detailError && detail ? (
+              <QualityMetricsDetail
+                detail={detail}
+                onClose={handleCloseDetail}
+                closeLabel={QUALITY_METRICS_BACK_TO_LIST}
+              />
+            ) : null}
+          </Card>
+        ) : null}
+
+        {showInlineDetail ? (
           <Card className="p-4">
             {detailLoading && (
               <div

--- a/apps/frontend/src/utils/collapseEqualContext.test.ts
+++ b/apps/frontend/src/utils/collapseEqualContext.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for GitHub-style equal-context collapse (TC-EV056-003).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  collapseEqualContext,
+  DEFAULT_DIFF_CONTEXT,
+  visibleEqualContextMask,
+} from './collapseEqualContext';
+import { unifiedLineDiff, type UnifiedDiffLine } from './unifiedLineDiff';
+
+function equals(n: number): UnifiedDiffLine[] {
+  return Array.from({ length: n }, (_, i) => ({
+    op: 'equal' as const,
+    text: `eq${i}`,
+    leftLine: i + 1,
+    rightLine: i + 1,
+  }));
+}
+
+describe('collapseEqualContext', () => {
+  it('defaults context to 3', () => {
+    expect(DEFAULT_DIFF_CONTEXT).toBe(3);
+  });
+
+  it('shows all lines when there are no changes', () => {
+    const lines = equals(10);
+    const segments = collapseEqualContext(lines, { context: 3 });
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.type).toBe('lines');
+    if (segments[0]?.type === 'lines') {
+      expect(segments[0].lines).toHaveLength(10);
+    }
+  });
+
+  it('collapses equal runs far from a change with context=3', () => {
+    const left = Array.from({ length: 20 }, (_, i) => `L${i}`).join('\n');
+    const rightLines = Array.from({ length: 20 }, (_, i) => `L${i}`);
+    rightLines[10] = 'CHANGED';
+    const right = rightLines.join('\n');
+    const lines = unifiedLineDiff(left, right);
+    const segments = collapseEqualContext(lines, { context: 3 });
+
+    const collapsed = segments.filter((s) => s.type === 'collapse');
+    expect(collapsed.length).toBeGreaterThan(0);
+    const hiddenCount = collapsed.reduce((n, s) => n + s.lines.length, 0);
+    expect(hiddenCount).toBeGreaterThan(0);
+
+    const visibleLines = segments
+      .filter((s) => s.type === 'lines')
+      .flatMap((s) => (s.type === 'lines' ? s.lines : []));
+    expect(visibleLines.some((l) => l.op !== 'equal')).toBe(true);
+    // Context window around change: roughly 3 before + change(s) + 3 after
+    expect(visibleLines.length).toBeLessThan(lines.length);
+  });
+
+  it('visibleEqualContextMask marks neighbors of removes/adds', () => {
+    const lines: UnifiedDiffLine[] = [
+      ...equals(5),
+      { op: 'remove', text: 'old', leftLine: 6, rightLine: null },
+      { op: 'add', text: 'new', leftLine: null, rightLine: 6 },
+      ...equals(5).map((l, i) => ({
+        ...l,
+        text: `after${i}`,
+        leftLine: 7 + i,
+        rightLine: 7 + i,
+      })),
+    ];
+    const mask = visibleEqualContextMask(lines, 2);
+    const visibleIdx = mask.map((v, i) => (v ? i : -1)).filter((i) => i >= 0);
+    expect(visibleIdx[0]).toBe(3); // 5-2
+    expect(visibleIdx.at(-1)).toBe(8); // change at 5-6 + 2
+  });
+});

--- a/apps/frontend/src/utils/collapseEqualContext.ts
+++ b/apps/frontend/src/utils/collapseEqualContext.ts
@@ -1,0 +1,110 @@
+/**
+ * GitHub-style equal-context collapse for unified line diffs (F7.q / EV-056).
+ *
+ * Keeps `context` equal lines around each change hunk; collapses longer equal runs.
+ */
+
+import type { UnifiedDiffLine } from './unifiedLineDiff';
+
+/** Default equal lines kept around each change hunk (`D-S066-context-n=1`). */
+export const DEFAULT_DIFF_CONTEXT = 3;
+
+export type CollapsedDiffSegment =
+  | {
+      /** Visible contiguous lines (mix of equal/add/remove within a hunk window). */
+      type: 'lines';
+      /** Inclusive start index into the original unified diff. */
+      startIndex: number;
+      /** Lines to render. */
+      lines: UnifiedDiffLine[];
+    }
+  | {
+      /** Collapsed run of equal lines. */
+      type: 'collapse';
+      /** Inclusive start index into the original unified diff. */
+      startIndex: number;
+      /** Hidden equal lines (expand restores these). */
+      lines: UnifiedDiffLine[];
+    };
+
+export type CollapseEqualContextOptions = {
+  /** Equal lines retained on each side of a change (default {@link DEFAULT_DIFF_CONTEXT}). */
+  context?: number;
+};
+
+/**
+ * Mark which unified-diff indices stay visible given context around changes.
+ *
+ * @param lines - Unified diff lines
+ * @param context - Equal lines kept around each non-equal line
+ * @returns Boolean mask aligned with `lines`
+ */
+export function visibleEqualContextMask(
+  lines: UnifiedDiffLine[],
+  context: number = DEFAULT_DIFF_CONTEXT,
+): boolean[] {
+  const n = lines.length;
+  const visible = Array.from({ length: n }, () => false);
+  const ctx = Math.max(0, context);
+
+  for (let i = 0; i < n; i += 1) {
+    if (lines[i]?.op !== 'equal') {
+      const from = Math.max(0, i - ctx);
+      const to = Math.min(n - 1, i + ctx);
+      for (let j = from; j <= to; j += 1) {
+        visible[j] = true;
+      }
+    }
+  }
+
+  // All-equal (or empty) diffs: show everything — caller usually short-circuits empty.
+  if (!visible.some(Boolean) && n > 0) {
+    return Array.from({ length: n }, () => true);
+  }
+
+  return visible;
+}
+
+/**
+ * Collapse long equal runs outside change hunks into expand-able segments.
+ *
+ * @param lines - Output of {@link unifiedLineDiff}
+ * @param options.context - Equal lines kept around each change (default 3)
+ * @returns Segments for rendering (lines vs collapse placeholders)
+ */
+export function collapseEqualContext(
+  lines: UnifiedDiffLine[],
+  options: CollapseEqualContextOptions = {},
+): CollapsedDiffSegment[] {
+  const context = options.context ?? DEFAULT_DIFF_CONTEXT;
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const visible = visibleEqualContextMask(lines, context);
+  const segments: CollapsedDiffSegment[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    if (visible[i]) {
+      const startIndex = i;
+      const chunk: UnifiedDiffLine[] = [];
+      while (i < lines.length && visible[i]) {
+        chunk.push(lines[i]!);
+        i += 1;
+      }
+      segments.push({ type: 'lines', startIndex, lines: chunk });
+      continue;
+    }
+
+    const startIndex = i;
+    const hidden: UnifiedDiffLine[] = [];
+    while (i < lines.length && !visible[i]) {
+      hidden.push(lines[i]!);
+      i += 1;
+    }
+    segments.push({ type: 'collapse', startIndex, lines: hidden });
+  }
+
+  return segments;
+}

--- a/apps/frontend/src/utils/operatorVisibleCopy.ts
+++ b/apps/frontend/src/utils/operatorVisibleCopy.ts
@@ -9,15 +9,25 @@ import { EXAMPLES } from '@/fixtures/examples/examplesCatalog';
 import { SHELL_NAV_LABELS } from '@/app/components/AppShellNav';
 import {
   QUALITY_METRICS_DIFF_EMPTY_LABEL,
+  QUALITY_METRICS_DIFF_EXPAND_ALL,
+  QUALITY_METRICS_DIFF_COLLAPSE_ALL,
+  QUALITY_METRICS_DIFF_HEADING,
   QUALITY_METRICS_EMPTY_DIAGNOSTICS,
+  QUALITY_METRICS_LINT_HELP,
+  QUALITY_METRICS_RESIDUALS_HELP,
+  QUALITY_METRICS_VALIDATE_HELP,
   QUALITY_METRICS_XML_VIEW_HELP,
   QUALITY_METRICS_XML_VIEW_NORMALIZED,
   QUALITY_METRICS_XML_VIEW_RAW,
 } from '@/app/components/QualityMetricsDetail';
 import {
   QUALITY_METRICS_DEFERRED_LABEL,
+  QUALITY_METRICS_DETAIL_LOAD_FAILED,
+  QUALITY_METRICS_DETAIL_LOADING,
+  QUALITY_METRICS_EMPTY_LIST,
+  QUALITY_METRICS_PAGE_SUBTITLE,
   QUALITY_METRICS_PAGE_TITLE,
-} from '@/app/components/QualityMetricsPage';
+} from '@/utils/qualityMetricsCopy';
 import {
   SOFT_PREVIEW_HELP,
   SOFT_PREVIEW_LABEL,
@@ -53,12 +63,34 @@ export function collectOperatorVisibleCopy(): OperatorVisibleCopyEntry[] {
     { id: 'shell.nav.history', text: SHELL_NAV_LABELS.history },
     { id: 'shell.nav.quality', text: SHELL_NAV_LABELS.quality },
     { id: 'quality-metrics.title', text: QUALITY_METRICS_PAGE_TITLE },
+    { id: 'quality-metrics.subtitle', text: QUALITY_METRICS_PAGE_SUBTITLE },
     { id: 'quality-metrics.deferred-label', text: QUALITY_METRICS_DEFERRED_LABEL },
+    { id: 'quality-metrics.empty-list', text: QUALITY_METRICS_EMPTY_LIST },
+    {
+      id: 'quality-metrics.detail-load-failed',
+      text: QUALITY_METRICS_DETAIL_LOAD_FAILED,
+    },
+    {
+      id: 'quality-metrics.detail-loading',
+      text: QUALITY_METRICS_DETAIL_LOADING,
+    },
     { id: 'quality-metrics.diff-empty', text: QUALITY_METRICS_DIFF_EMPTY_LABEL },
+    { id: 'quality-metrics.diff-heading', text: QUALITY_METRICS_DIFF_HEADING },
+    {
+      id: 'quality-metrics.diff-expand-all',
+      text: QUALITY_METRICS_DIFF_EXPAND_ALL,
+    },
+    {
+      id: 'quality-metrics.diff-collapse-all',
+      text: QUALITY_METRICS_DIFF_COLLAPSE_ALL,
+    },
     {
       id: 'quality-metrics.empty-diagnostics',
       text: QUALITY_METRICS_EMPTY_DIAGNOSTICS,
     },
+    { id: 'quality-metrics.residuals-help', text: QUALITY_METRICS_RESIDUALS_HELP },
+    { id: 'quality-metrics.lint-help', text: QUALITY_METRICS_LINT_HELP },
+    { id: 'quality-metrics.validate-help', text: QUALITY_METRICS_VALIDATE_HELP },
     {
       id: 'quality-metrics.xml-view-normalized',
       text: QUALITY_METRICS_XML_VIEW_NORMALIZED,

--- a/apps/frontend/src/utils/qualityMetricsCopy.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsCopy.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Unit tests for Quality metrics operator copy helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  formatMatchStatusLabel,
+  QUALITY_METRICS_DEFERRED_LABEL,
+} from './qualityMetricsCopy';
+
+describe('formatMatchStatusLabel', () => {
+  it('maps known API statuses to plain language', () => {
+    expect(formatMatchStatusLabel('equal')).toBe('Matches official');
+    expect(formatMatchStatusLabel('unequal')).toBe('Differs from official');
+    expect(formatMatchStatusLabel('deferred')).toBe(QUALITY_METRICS_DEFERRED_LABEL);
+  });
+
+  it('passes through unknown statuses unchanged', () => {
+    expect(formatMatchStatusLabel('unknown-status')).toBe('unknown-status');
+  });
+});

--- a/apps/frontend/src/utils/qualityMetricsCopy.ts
+++ b/apps/frontend/src/utils/qualityMetricsCopy.ts
@@ -1,0 +1,43 @@
+/**
+ * Operator-visible Quality metrics copy (plain language; no planning ids).
+ *
+ * [Corpus: product §F7.q] [Corpus: product §F7] — EV-048 / EV-056.
+ */
+
+/** Operator-visible label for deferred / unscored files (AC5). */
+export const QUALITY_METRICS_DEFERRED_LABEL = 'Deferred — not scored yet';
+
+/** Page title — primary shell tab. */
+export const QUALITY_METRICS_PAGE_TITLE = 'Quality metrics';
+
+/** Page subtitle — plain-language purpose. */
+export const QUALITY_METRICS_PAGE_SUBTITLE =
+  'Compare our converted IWXXM to official WMO examples. See match status, leftover TAC (residuals), lint findings, and validation results.';
+
+/** Empty list when the product filter has no rows. */
+export const QUALITY_METRICS_EMPTY_LIST = 'No files for this product filter.';
+
+/** Detail load fallback error (non-Error throws). */
+export const QUALITY_METRICS_DETAIL_LOAD_FAILED = 'Failed to load file detail';
+
+/** Detail loading indicator. */
+export const QUALITY_METRICS_DETAIL_LOADING = 'Loading file detail…';
+
+/**
+ * Plain-language match status for list/detail headers.
+ *
+ * @param status - API `match_status` value
+ * @returns Operator-visible label
+ */
+export function formatMatchStatusLabel(status: string): string {
+  switch (status) {
+    case 'equal':
+      return 'Matches official';
+    case 'unequal':
+      return 'Differs from official';
+    case 'deferred':
+      return QUALITY_METRICS_DEFERRED_LABEL;
+    default:
+      return status;
+  }
+}

--- a/apps/frontend/src/utils/qualityMetricsPath.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsPath.test.ts
@@ -40,4 +40,18 @@ describe('qualityMetricsPath', () => {
       stem: 'sigmet/foo',
     });
   });
+
+  it('returns list path for blank stems', () => {
+    expect(qualityMetricsDetailPath('')).toBe(QUALITY_METRICS_LIST_PATH);
+    expect(qualityMetricsDetailPath('   ')).toBe(QUALITY_METRICS_LIST_PATH);
+  });
+
+  it('rejects multi-segment or empty detail segments', () => {
+    expect(parseQualityMetricsPath('/quality/a/b')).toBeNull();
+    expect(parseQualityMetricsPath('/quality/%20%20')).toEqual({ kind: 'list' });
+  });
+
+  it('returns null when the stem cannot be decoded', () => {
+    expect(parseQualityMetricsPath('/quality/%E0%A4%A')).toBeNull();
+  });
 });

--- a/apps/frontend/src/utils/qualityMetricsPath.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsPath.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for Quality metrics path helpers (TC-EV056-001).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  parseQualityMetricsPath,
+  QUALITY_METRICS_LIST_PATH,
+  qualityMetricsDetailPath,
+} from './qualityMetricsPath';
+
+describe('qualityMetricsPath', () => {
+  it('builds and parses a detail stem path', () => {
+    const path = qualityMetricsDetailPath('metar-A3-1');
+    expect(path).toBe('/quality/metar-A3-1');
+    expect(parseQualityMetricsPath(path)).toEqual({
+      kind: 'detail',
+      stem: 'metar-A3-1',
+    });
+  });
+
+  it('parses list path with optional trailing slash', () => {
+    expect(parseQualityMetricsPath(QUALITY_METRICS_LIST_PATH)).toEqual({
+      kind: 'list',
+    });
+    expect(parseQualityMetricsPath('/quality/')).toEqual({ kind: 'list' });
+  });
+
+  it('returns null for unrelated paths', () => {
+    expect(parseQualityMetricsPath('/')).toBeNull();
+    expect(parseQualityMetricsPath('/convert')).toBeNull();
+  });
+
+  it('encodes special characters in stems', () => {
+    const path = qualityMetricsDetailPath('sigmet/foo');
+    // Slash in stem is encoded so path stays single segment.
+    expect(path).toBe('/quality/sigmet%2Ffoo');
+    expect(parseQualityMetricsPath(path)).toEqual({
+      kind: 'detail',
+      stem: 'sigmet/foo',
+    });
+  });
+});

--- a/apps/frontend/src/utils/qualityMetricsPath.ts
+++ b/apps/frontend/src/utils/qualityMetricsPath.ts
@@ -1,0 +1,54 @@
+/**
+ * Path helpers for Quality metrics shareable detail routes (F7.q / EV-056).
+ *
+ * Uses the History API — the shell does not depend on react-router.
+ */
+
+/** List URL for the Quality metrics primary tab. */
+export const QUALITY_METRICS_LIST_PATH = '/quality';
+
+/**
+ * Build a shareable detail path for a corpus stem.
+ *
+ * @param stem - Corpus stem id (e.g. `metar-A3-1`)
+ * @returns Path `/quality/:stem` with URI encoding
+ */
+export function qualityMetricsDetailPath(stem: string): string {
+  const trimmed = stem.trim();
+  if (!trimmed) {
+    return QUALITY_METRICS_LIST_PATH;
+  }
+  return `${QUALITY_METRICS_LIST_PATH}/${encodeURIComponent(trimmed)}`;
+}
+
+/**
+ * Parse Quality metrics list vs detail from a pathname.
+ *
+ * @param pathname - `window.location.pathname`
+ * @returns `list` or `detail` with decoded stem; `null` when not a quality path
+ */
+export function parseQualityMetricsPath(
+  pathname: string,
+): { kind: 'list' } | { kind: 'detail'; stem: string } | null {
+  const normalized = pathname.replace(/\/+$/, '') || '/';
+  if (normalized === QUALITY_METRICS_LIST_PATH) {
+    return { kind: 'list' };
+  }
+  const prefix = `${QUALITY_METRICS_LIST_PATH}/`;
+  if (!normalized.startsWith(prefix)) {
+    return null;
+  }
+  const raw = normalized.slice(prefix.length);
+  if (!raw || raw.includes('/')) {
+    return null;
+  }
+  try {
+    const stem = decodeURIComponent(raw).trim();
+    if (!stem) {
+      return { kind: 'list' };
+    }
+    return { kind: 'detail', stem };
+  } catch {
+    return null;
+  }
+}

--- a/apps/frontend/src/utils/validateDispositionChips.ts
+++ b/apps/frontend/src/utils/validateDispositionChips.ts
@@ -11,10 +11,10 @@ export const VALIDATE_CODE_SCHEMATRON_SKIPPED = 'SCHEMATRON_SKIPPED';
 /** Soft schema-import warning code from the validate engine. */
 export const VALIDATE_CODE_SCHEMA_IMPORT_WARNING = 'SCHEMA_IMPORT_WARNING';
 
-export const QUALITY_METRICS_SCHEMATRON_EVALUATED = 'Schematron: evaluated';
-export const QUALITY_METRICS_SCHEMATRON_SKIPPED = 'Schematron: skipped';
-export const QUALITY_METRICS_SCHEMA_IMPORT_RESOLVED = 'Schema import: resolved';
-export const QUALITY_METRICS_SCHEMA_IMPORT_WARNING = 'Schema import: unresolved';
+export const QUALITY_METRICS_SCHEMATRON_EVALUATED = 'Schematron rules: checked';
+export const QUALITY_METRICS_SCHEMATRON_SKIPPED = 'Schematron rules: skipped';
+export const QUALITY_METRICS_SCHEMA_IMPORT_RESOLVED = 'XML schema imports: OK';
+export const QUALITY_METRICS_SCHEMA_IMPORT_WARNING = 'XML schema imports: unresolved';
 
 export type ValidateDispositionChip = {
   /** Stable test id suffix. */

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,46 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-056 — Quality metrics detail page + collapsible diffs (#988) (S066)
+
+**Session**: S066-quality-metrics-diff-page  
+**Features**: deepen **F7.q** only  
+**Started**: 2026-08-11  
+**Branch**: `evolve/EV-056-quality-metrics-diff-page` (base `stage@340b3cf6`)  
+**Status**: **in_progress** — 02-verify-plan (Gate A) after `D-S066-01-ac=1`  
+**Issues**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988)  
+**Parent**: S065 / #987 pretty-print hotfix; EV-054 / EV-055 Quality metrics  
+**Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests]
+[Corpus: decisions §EV-056]
+
+### Scope (Phase 0 — locked 2026-08-11)
+
+| ID | Decision |
+|----|----------|
+| D-S066-route | **1** — Lean (`00→16→01→02→10→13`); PR → stage |
+| D-S066-ui-preview | **1** — non-deployed http://127.0.0.1:18000/ |
+| D-S066-route-shape | **1** — `/quality/:stem` + back-to-list |
+| D-S066-context-n | **1** — default 3 context lines |
+| D-S066-list | **1** — navigate to detail; list via back |
+| D-S066-board | **1** — #988 In progress |
+
+### Acceptance (`D-S066-01-ac=1`)
+
+1. List row opens dedicated `/quality/:stem` (shareable) with back-to-list.
+2. Official/Converted/TAC panes remain; normalized = pretty C14N.
+3. Diff shows collapsible equal-context hunks (default 3; expand hunk / expand all).
+4. Unequal SIGMET stems remain navigable and readable on staging.
+5. UJ-056 / TC-EV056; FE unit + Playwright; H4–H5 via 13.
+
+### Out of scope
+
+- `match_status` / C14N equality / fixture generator changes
+- New npm diff library unless AskQuestion
+- Promote to `main` unless asked
+- API contract change unless routing requires it
+
+---
+
 ## Cycle EV-055 — Quality metrics 2025-2 follow-ups (#982 / #980 / #979) (S064)
 
 **Session**: S064-quality-metrics-2025-2-followups  

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -1,6 +1,23 @@
 # Requirements Decisions Log
 
-> Stage: 01-requirements | Last updated: 2026-08-11 (S064 / EV-055)
+> Stage: 01-requirements | Last updated: 2026-08-11 (S066 / EV-056)
+
+## EV-056 / S066 — Quality metrics detail page + collapsible diffs (#988) (`D-S066-01-ac=1`)
+
+| Topic | Decision | Notes | Status |
+|-------|----------|-------|--------|
+| EV-056 / Fn | Deepen **F7.q** only | No new top-level Fn; no F2/F13 this cycle | confirmed |
+| EV-056 / journey | Deepen **UJ-056** only | No UJ-057 (`D-S066-uj=1`) | confirmed |
+| EV-056 / route | `/quality/:stem` + back-to-list | `D-S066-route-shape=1` / `D-S066-list=1` | confirmed |
+| EV-056 / context | Default **3** lines | Expand hunk / expand all (`D-S066-context-n=1`) | confirmed |
+| EV-056 / C14N | Unchanged | No `match_status` / fixture regen | confirmed |
+| EV-056 / deps | Reuse LCS helpers | No new npm diff lib unless AskQuestion | confirmed |
+| EV-056 / AC | AC1–AC5 | See feature-list §F7.q EV-056 (`D-S066-01-ac=1`) | confirmed |
+| EV-056 / docs | Delta manifest | feature-list + journeys + test-plan + decisions; skip api/config/spec | confirmed |
+| EV-056 / UI preview | Accepted | Non-deployed http://127.0.0.1:18000/ (`D-S066-ui-preview=1`) | confirmed |
+| EV-056 / route preset | Lean | PR → stage; `00→16→01→02→10→13` | confirmed |
+
+[Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests] [Corpus: decisions §EV-056]
 
 ## EV-055 / S064 — Quality metrics normalize + 2025-2 validate (#982 / #980 / #979) (`D-S064-01-ac=1`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -2,7 +2,7 @@
 
 > **Project**: METAR to IWXXM Converter
 > **Repository**: https://github.com/EMPIRIC2/TAC-to-IWXXM
-> **Last updated**: 2026-08-11 (S064 / EV-055 — #982/#980/#979 Quality metrics + 2025-2 validate; prior EV-054)
+> **Last updated**: 2026-08-11 (S066 / EV-056 — #988 Quality metrics detail page + collapsible diffs; prior EV-055)
 
 ## Summary
 
@@ -14,7 +14,7 @@
 | F4 | IWXXM version handling | Implemented | Product | docs/domain/iwxxm/IWXXM_VERSION_SWITCHING.md; **deepen** S046 / EV-038 release-line SoT/UX (#851–#855) |
 | F5 | User METAR work history | Implemented | Product | S038 / EV-031 / F31 hybrid: guest IndexedDB + logged-in DO Postgres |
 | F6 | General TAC→IWXXM (`tac2iwxxm`) | Implemented | Product | S008, ADR-013/014/019; bulletin split; **deepen** S055 / EV-046 #889; **deepen** S059 / EV-050 #959 annex3 vs iwxxm_us membership compare |
-| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S063 / EV-054 **F7.q** (#836); **deepen** S064 / EV-055 F7.q whitespace-normalize + validate disposition (#982/#980/#979) |
+| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S063 / EV-054 **F7.q** (#836); **deepen** S064 / EV-055 F7.q whitespace-normalize + validate disposition (#982/#980/#979); **deepen** S066 / EV-056 F7.q detail page + collapsible diffs (#988) |
 | F8 | Near-realtime TAC ingest → IWXXM gate | Implemented | Product | S008 ADR-018; **F30** writers → DO Postgres (not Supabase DB) |
 | F9 | Value-aware live decode + plain-language summary | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723) |
 | F10 | Workbench preview clarity (IWXXM pane + lint UX) | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723); **deepen** S048 / EV-040 full lint console lines + preserve input on convert |
@@ -309,7 +309,7 @@
   | F7.g | #780 | Pre-loaded golden examples (convert + validate) — S021 / EV-016 |
   | F7.h | #783 | IndexedDB local sessions (all products); drop JWT session APIs — S023 / EV-017 |
   | F7.i | #842 / F31 | Hybrid: guest IndexedDB + logged-in DO Postgres; auto-upload on login — S038 / EV-031 |
-  | F7.q | #836 / #982 | Quality metrics tab — official WMO corpus; W3C C14N match/diff (S063 / EV-054; S064 / EV-055) |
+  | F7.q | #836 / #982 / #988 | Quality metrics tab — official WMO corpus; W3C C14N match/diff (S063 / EV-054; S064 / EV-055); dedicated detail route + collapsible diffs (S066 / EV-056) |
 - **Inputs**: TAC text/files (`.txt` / `.metar` / `.tac`); `product` / `profile` /
   `iwxxm_version`; optional `bulletin_id` / `issuing_center` / `stop_on_error` /
   `validate_output` / `validation_level` (ADR-023); editor cursor and character spans
@@ -422,6 +422,20 @@
   6. Quality metrics: validate chips reflect fixed/enabled disposition; detail XML panes
      default to normalized with override to un-normalized; no internal planning ids.
   7. `corpus_metrics` regenerated for new match semantics; UJ-056 deepen / TC-EV055 smoke.
+- **S066 / EV-056 deepen (F7.q / #988 — detail page + collapsible diffs)**: After S065
+  pretty-print hotfix (#987), replace inline Quality metrics detail+diff with a **dedicated
+  shareable route** `/quality/:stem` (`D-S066-route-shape=1`) and **GitHub-style** unified
+  diff hunk folding (default **3** context lines; expand hunk / expand all —
+  `D-S066-context-n=1`). List navigates to detail; back returns to list (`D-S066-list=1`).
+  Keep **C14N equality** / `match_status` unchanged; no API contract change unless shell
+  routing needs it; reuse `unifiedLineDiff` + pretty C14N helpers (no new npm diff lib
+  unless AskQuestion). Does **not** flip F7 → Implemented.
+- **Acceptance (EV-056 / #988 — F7.q)** — **approved** (`D-S066-01-ac=1`):
+  1. List row opens dedicated detail route `/quality/:stem` (shareable URL) with back-to-list.
+  2. Official/Converted/TAC panes remain; normalized panes = pretty C14N (S065 helpers).
+  3. Diff shows collapsible equal-context hunks (default 3 lines; expand N / expand all).
+  4. Unequal SIGMET stems remain navigable and readable on staging.
+  5. UJ-056 / TC-EV056 updated; FE unit + Playwright smoke (H4–H5 via 13).
 - **Resolved gaps (S011 Feature List Batch 2)**:
   | ID | Decision |
   |----|----------|

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,7 +25,9 @@ Then invoke stages from the approved plan (e.g. `@10-e2e`, `@16-evolve`).
 
 | Session ID | Type | Status | Intent | Branch | Started | Completed |
 |------------|------|--------|--------|--------|---------|-----------|
-| [S064-quality-metrics-2025-2-followups](S064-quality-metrics-2025-2-followups/session-brief.md) | feature | in_progress | #982/#980/#979 Quality metrics normalize + 2025-2 validate; EV-055 Standard | evolve/EV-055-quality-metrics-2025-2-followups | 2026-08-11 | — |
+| [S066-quality-metrics-diff-page](S066-quality-metrics-diff-page/session-brief.md) | feature | in_progress | #988 F7.q detail page + GitHub-style collapsible diffs; EV-056 Lean | evolve/EV-056-quality-metrics-diff-page | 2026-08-11 | — |
+| [S065-quality-metrics-diff-long-line](S065-quality-metrics-diff-long-line/session-brief.md) | hotfix | completed | Pretty-print Quality metrics C14N diffs; PR #987 → stage | fix/quality-metrics-diff-long-line | 2026-08-11 | 2026-08-11 |
+| [S064-quality-metrics-2025-2-followups](S064-quality-metrics-2025-2-followups/session-brief.md) | feature | completed | #982/#980/#979 Quality metrics normalize + 2025-2 validate; EV-055 Standard | evolve/EV-055-quality-metrics-2025-2-followups | 2026-08-11 | 2026-08-11 |
 | [S059-codes-wmo-validated](S059-codes-wmo-validated/session-brief.md) | feature | in_progress | #959 codes.wmo.int Validated harvest + tac-validate; EV-050 Standard | evolve/EV-050-codes-wmo-validated | 2026-08-09 | — |
 | [S058-ams-2027-abstract](S058-ams-2027-abstract/session-brief.md) | feature | parked | #958 AMS 2027 abstract (handwritten); EV-049 Lean — parked `D-S058-park=1a` | evolve/EV-049-ams-2027-abstract | 2026-08-09 | parked 2026-08-09 |
 | [S057-strip-internal-doc-refs](S057-strip-internal-doc-refs/session-brief.md) | feature | completed | #951 strip internal doc refs from UI/API; EV-048; PR #963 → stage | evolve/EV-048-strip-internal-doc-refs | 2026-08-08 | 2026-08-09 |

--- a/docs/sessions/S065-quality-metrics-diff-long-line/routing-plan.md
+++ b/docs/sessions/S065-quality-metrics-diff-long-line/routing-plan.md
@@ -5,15 +5,17 @@
 | **Preset** | Lean |
 | **auto_lean** | true |
 | **Rationale** | Hotfix UX readability; no API/arch; deferred page+hunks to evolve |
+| **Status** | **closed** (`D-S065-close=1`) |
 
 ## Stages
 
 | Stage | Status | Notes |
 |-------|--------|-------|
 | 00-context | completed | Session open |
-| 14-hotfix | in_progress | BUG + pretty-print C14N display/diff |
-| 15-service-health | optional | Only if user asks after staging deploy |
+| 14-hotfix | completed | BUG + pretty-print C14N display/diff; PR #987 merged → stage @ `340b3cf6` |
+| 15-service-health | skipped | Optional; staging CD `31541772688` left running; not required for close |
 
-## Follow-up (not this session)
+## Close
 
-Lean **16-evolve** deepen F7.q: dedicated detail page + GitHub-style collapsible hunks.
+- `D-S065-close=1` — merge #987 → `stage`; archive S065; hand off to S066 / EV-056 / #988
+- Follow-up: Lean **16-evolve** deepen F7.q — dedicated detail page + GitHub-style collapsible hunks

--- a/docs/sessions/S065-quality-metrics-diff-long-line/session-brief.md
+++ b/docs/sessions/S065-quality-metrics-diff-long-line/session-brief.md
@@ -1,3 +1,15 @@
+---
+session_id: S065-quality-metrics-diff-long-line
+type: hotfix
+status: completed
+branch: fix/quality-metrics-diff-long-line
+orchestrator: 14-hotfix
+github_issues: []
+followup_github_issue: 988
+opened: 2026-08-11
+closed: 2026-08-11
+---
+
 # Session brief — S065-quality-metrics-diff-long-line
 
 | Field | Value |
@@ -7,18 +19,19 @@
 | **Branch** | `fix/quality-metrics-diff-long-line` (base `stage`) |
 | **Orchestrator** | 14-hotfix |
 | **Bug report** | [docs/bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md](../../bug-reports/BUG-2026-08-11-quality-metrics-diff-long-line.md) |
-| **GitHub** | none (staging operator report) |
+| **GitHub** | none (staging operator report); follow-up [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988) |
+| **PR** | [#987](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987) → `stage` @ `340b3cf6` |
 | **Started** | 2026-08-11 |
-| **Status** | Phase 0–1 in progress |
+| **Status** | **completed** (`D-S065-close=1`) |
 
 ## Goal
 
 Make Quality metrics Official/Converted panes and the unified XML diff human-readable by pretty-printing C14N forms before line-oriented diff (F7.q / UJ-056).
 
-## Out of scope
+## Out of scope (this session)
 
-- Dedicated `/quality/:stem` (or similar) detail route
-- GitHub-style expand/collapse of unchanged hunks
+- Dedicated `/quality/:stem` (or similar) detail route → **S066 / EV-056 / #988**
+- GitHub-style expand/collapse of unchanged hunks → **S066**
 - API / `match_status` / fixture generator changes
 - Promote `stage` → `main` unless explicitly requested
 
@@ -27,7 +40,13 @@ Make Quality metrics Official/Converted panes and the unified XML diff human-rea
 - `D-S065-scope=4` — hotfix readability now; evolve later for separate page + hunks
 - `D-S065-products=all` — all Quality metrics stems
 - `D-S065-page=inline-for-now` — keep detail on current tab
+- `D-S065-pr=1` — PR #987 → stage
+- `D-S065-close=1` — merge #987; close session; open S066 Lean evolve for #988
 
 ## Corpus
 
 [Corpus: product] F7.q · [Corpus: tests] UJ-056 / TC-EV055-001 · [Corpus: system-spec] Quality metrics UI
+
+## Follow-up
+
+[FOLLOWUP.md](./FOLLOWUP.md) → **S066 / EV-056** / [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988)

--- a/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
@@ -25,7 +25,7 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 
 ## Next child stage
 
-**Implement FE** (Lean) — `collapseEqualContext` + `/quality/:stem`; then **10-e2e**
+**13-deploy-smoke** — after merge of PR #989 → `stage` + Staging smoke green (`D-S066-pr=1`)
 
 ## Locked intake (Phase 0)
 
@@ -36,7 +36,9 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 | D-S066-list | **1** — navigate to detail; list via back |
 | D-S066-01-ac | **1** — AC1–AC5 approved |
 | D-S066-gateA | **1** — Gate A PASS |
+| D-S066-pr | **1** — Push + PR → stage → CI → 13 |
 
 ## Risks / open decisions
 
-- Staging CD for #987 may still be landing — evolve bases on merged stage tip `340b3cf6`
+- PR #989 CI green @ `c87f67b8` — awaiting merge approval for stage + 13-deploy-smoke
+- Plain-language UI copy pass landed (no operator-visible planning ids; EV-048)

--- a/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
@@ -25,10 +25,18 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 
 ## Next child stage
 
-**01-requirements** (delta) — lock AC1–AC5 from FOLLOWUP; deepen F7.q + UJ-056; no new Fn
+**Implement FE** (Lean) — `collapseEqualContext` + `/quality/:stem`; then **10-e2e**
+
+## Locked intake (Phase 0)
+
+| ID | Decision |
+|----|----------|
+| D-S066-route-shape | **1** — `/quality/:stem` + back-to-list |
+| D-S066-context-n | **1** — 3 context lines |
+| D-S066-list | **1** — navigate to detail; list via back |
+| D-S066-01-ac | **1** — AC1–AC5 approved |
+| D-S066-gateA | **1** — Gate A PASS |
 
 ## Risks / open decisions
 
-- Route shape (React Router path vs shell tab query) — decide in 01
-- Default collapsed context lines (suggest 3) — decide in 01
-- Staging CD for #987 still landing — evolve bases on merged stage tip
+- Staging CD for #987 may still be landing — evolve bases on merged stage tip `340b3cf6`

--- a/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
@@ -1,0 +1,34 @@
+# Evolve Plan Card
+
+> Cycle: EV-056 | Session: S066-quality-metrics-diff-page | Updated: 2026-08-11
+
+## Goal
+
+Dedicated Quality metrics detail route with GitHub-style collapsible unified XML diffs; C14N equality unchanged.
+
+## Features
+
+- F7.q — Quality metrics detail page + collapsible diffs — [Corpus: product §F7.q]
+- UJ-056 deepen — [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]
+
+## In / out of scope
+
+- In: `/quality/:stem` (or shell-equivalent) shareable detail; pretty C14N panes; hunk fold/expand; FE unit + UJ-056 e2e; PR → stage
+- Out: `match_status` / C14N semantics; new npm diff lib unless AskQuestion; promote to main; API contract unless routing requires
+
+## Preset + routing
+
+- Preset: **Lean** (`D-S066-route=1`)
+- Stages (ordered): `00 → 16 → 01 → 02 → 10 → 13`
+- UI preview: non-deployed http://127.0.0.1:18000/ (`D-S066-ui-preview=1`)
+- Issue: #988 In progress · base `stage@340b3cf6`
+
+## Next child stage
+
+**01-requirements** (delta) — lock AC1–AC5 from FOLLOWUP; deepen F7.q + UJ-056; no new Fn
+
+## Risks / open decisions
+
+- Route shape (React Router path vs shell tab query) — decide in 01
+- Default collapsed context lines (suggest 3) — decide in 01
+- Staging CD for #987 still landing — evolve bases on merged stage tip

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/01-requirements.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/01-requirements.md
@@ -1,0 +1,41 @@
+# 01-requirements — EV-056 / S066 (delta)
+
+**Mode**: delta (deepen F7.q — #988)  
+**Status**: **completed** (`D-S066-01-ac=1`)  
+**Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests] [Corpus: decisions]
+
+## Document manifest (approved)
+
+| Doc | Action |
+|-----|--------|
+| `docs/feature-list.md` | F7 / F7.q EV-056 deepen + AC1–AC5 |
+| `docs/user-journeys.md` | UJ-056 deepen (detail route + hunk fold) |
+| `docs/test-plan.md` | TC-EV056-001..005; UJ-056 map |
+| `docs/decisions/requirements-decisions.md` | §EV-056 |
+| `docs/decisions/evolve-decisions.md` | §EV-056 |
+| api-contract / config / system-spec | **skip** — no API/`match_status` change |
+
+## Acceptance (approved `D-S066-01-ac=1`)
+
+| ID | Criterion |
+|----|-----------|
+| AC1 | List → `/quality/:stem` shareable + back-to-list |
+| AC2 | Official/Converted/TAC panes; pretty C14N normalized |
+| AC3 | Collapsible equal-context hunks (default 3; expand hunk/all) |
+| AC4 | Unequal SIGMET stems navigable/readable on staging |
+| AC5 | UJ-056 / TC-EV056; FE unit + Playwright; H4–H5 via 13 |
+
+## Phase 0 locked
+
+| ID | Choice |
+|----|--------|
+| D-S066-route-shape | 1 — `/quality/:stem` |
+| D-S066-context-n | 1 — 3 lines |
+| D-S066-list | 1 — navigate; back to list |
+| D-S066-ui-preview | 1 — http://127.0.0.1:18000/ |
+
+## Out of scope
+
+- C14N / `match_status` / corpus regen
+- New npm diff library
+- Promote to main

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/02-verify-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/02-verify-plan.md
@@ -1,0 +1,54 @@
+# 02-verify-plan — Gate A (S066 / EV-056)
+
+**Date**: 2026-08-11  
+**Mode**: delta — F7.q detail page + collapsible diffs (#988)  
+**Status**: Gate A PASS — `D-S066-gateA=1`  
+**01**: completed (`D-S066-01-ac=1`)
+
+## Inventory (touched)
+
+| # | Document | Delta | Status |
+|---|----------|-------|--------|
+| 1 | feature-list.md | F7.q EV-056 AC1–AC5 | audited |
+| 2 | user-journeys.md | UJ-056 deepen | audited |
+| 3 | test-plan.md | TC-EV056-001..005 | audited |
+| 4 | evolve-decisions / requirements-decisions | EV-056 locks | reference |
+| — | api-contract / config / spec | skipped — no API/`match_status` change | OK |
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Journey | **PASS** — UJ-056 |
+| Journey ↔ Test | **PASS** — TC-EV056-001..005 |
+| Feature ↔ Test | **PASS** — AC1–AC5 ↔ TC-EV056-* |
+| Feature ↔ API | **PASS** — no contract change; FE route only |
+| Connectivity H4–H5 | **PASS** — UJ-056 still H4–H5 via **13** |
+| C14N / match_status | **PASS** — explicitly unchanged |
+
+## Statements (high — auto-approved)
+
+| ID | Statement | Verdict |
+|----|-----------|---------|
+| S1.1 | Shareable `/quality/:stem` + back-to-list | auto-approved (`D-S066-route-shape=1`) |
+| S1.2 | Default 3 context lines; expand hunk/all | auto-approved (`D-S066-context-n=1`) |
+| S1.3 | Navigate to detail; list via back | auto-approved (`D-S066-list=1`) |
+| S1.4 | C14N / `match_status` unchanged | auto-approved |
+| S1.5 | Reuse `unifiedLineDiff` + pretty C14N helpers | auto-approved |
+| S1.6 | Lean path; PR → stage | auto-approved (`D-S066-route=1`) |
+
+## Medium / low
+
+None blocking. Pathname routing without adding `react-router` is an implementation choice (History API) — consistent with existing auth callback pathname handling.
+
+## Contradictions
+
+None.
+
+## Gate A decision (`D-S066-gateA=1`)
+
+User: proceed with recommended → **PASS**; implement FE (Lean — no 04/07).
+
+## Next
+
+Implement `collapseEqualContext` + `/quality/:stem` shell sync → FE unit → **10-e2e**.

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/e2e-report.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/e2e-report.md
@@ -1,0 +1,21 @@
+# 10-e2e — UJ-056 / TC-EV056 (S066 / EV-056)
+
+**Date**: 2026-08-11  
+**Env**: local non-deployed http://127.0.0.1:18000/ + API :18001  
+**Result**: **PASS** — 3/3 Playwright
+
+| Test | Result |
+|------|--------|
+| open tab → filter → detail `/quality/:stem` + back | PASS |
+| TC-EV055-007 normalized panes + chips | PASS |
+| TC-EV056-005 deep-link `/quality/:stem` | PASS |
+
+**Command**:
+```bash
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:18000 \
+PLAYWRIGHT_API_BASE_URL=http://127.0.0.1:18001 \
+PLAYWRIGHT_SKIP_WEBSERVER=1 \
+pnpm exec playwright test uj056-quality-metrics.e2e.spec.ts
+```
+
+Live H4–H5 → **13-deploy-smoke** after PR → stage.

--- a/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
@@ -21,9 +21,7 @@
 | 07-build | no | — | skipped | Implementation via 16 Agent after Gate A (Lean) |
 | 08-verify-build | no | — | skipped | Lean |
 | 09-qa | no | — | skipped | Lean |
-| 10-e2e | yes | delta | pending | UJ-056 / Playwright deepen |
-| 11-verify-impl | no | — | skipped | Lean |
-| 12-verify-deploy | no | — | skipped | Lean — merge path via 13 |
+| 10-e2e | yes | delta | **completed** | UJ-056 3/3 PASS local; H4–H5 via 13 |
 | 13-deploy-smoke | yes | delta | pending | Staging smoke after PR → stage |
 
 ## Recommended ordered stages

--- a/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
@@ -1,0 +1,51 @@
+# Routing plan — S066 / EV-056
+
+**Status:** **approved** (`D-S066-route=1`)  
+**Preset:** **Lean** (user-requested; not Auto-Lean — dedicated route + UJ-056 deepen)  
+**PR target:** `stage`  
+**Branch:** `evolve/EV-056-quality-metrics-diff-page` @ `stage@340b3cf6`  
+**UI preview:** **Yes** — non-deployed local (`D-S066-ui-preview=1`) → http://127.0.0.1:18000/
+
+## Stages
+
+| Stage | Include? | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | Close S065; open S066; #988 In progress; `D-S066-route=1` / `D-S066-ui-preview=1` |
+| 16-evolve | yes | orchestrate | **in_progress** | Plan card + Phase 0–1 → child stages |
+| 01-requirements | yes | delta | pending | F7.q AC + UJ-056 deepen; no new Fn |
+| 02-verify-plan | yes | delta | pending | Gate A |
+| 03-plan-tooling | no | — | skipped | No new Cursor rules expected |
+| 04-tech-plan | no | — | skipped | Lean — FE route + hunk fold; no API/arch |
+| 05-verify-tech | no | — | skipped | Lean |
+| 06-tech-tooling | no | — | skipped | No new deps unless AskQuestion |
+| 07-build | no | — | skipped | Implementation via 16 Agent after Gate A (Lean) |
+| 08-verify-build | no | — | skipped | Lean |
+| 09-qa | no | — | skipped | Lean |
+| 10-e2e | yes | delta | pending | UJ-056 / Playwright deepen |
+| 11-verify-impl | no | — | skipped | Lean |
+| 12-verify-deploy | no | — | skipped | Lean — merge path via 13 |
+| 13-deploy-smoke | yes | delta | pending | Staging smoke after PR → stage |
+
+## Recommended ordered stages
+
+`00 → 16 → 01 → 02 → 10 → 13`
+
+## Skip rationale
+
+- **Lean (user):** UX/docs/tests deepen on existing Quality metrics; C14N semantics unchanged; API only if routing needs a path (prefer FE shell route).
+- **Skip 03/04/05/06/07/08/09/11/12:** no new guardrails, stack, or Standard build milestones; 16 orchestrates Agent implementation after 01/02 Gate A.
+- **Include 10 + 13:** operator UI + staging H4–H5 / smoke for UJ-056.
+
+## Board / velocity
+
+- WIP: #988 **In progress** (1 ≤ 2)
+- Ready: 4 shippable (#948, #958, #981, #983) — within 3–5
+
+## Locked / pending decisions
+
+| ID | Decision |
+|----|----------|
+| D-S065-close | **1** — merge #987; close S065; open S066 |
+| D-S066-board | **1** — #988 → In progress |
+| D-S066-route | **1** — Lean as drafted (`00 → 16 → 01 → 02 → 10 → 13`) |
+| D-S066-ui-preview | **1** — non-deployed local UI at http://127.0.0.1:18000/ |

--- a/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
@@ -12,8 +12,8 @@
 |-------|----------|------|--------|-------|
 | 00-context | yes | session | **completed** | Close S065; open S066; #988 In progress; `D-S066-route=1` / `D-S066-ui-preview=1` |
 | 16-evolve | yes | orchestrate | **in_progress** | Plan card + Phase 0–1 → child stages |
-| 01-requirements | yes | delta | pending | F7.q AC + UJ-056 deepen; no new Fn |
-| 02-verify-plan | yes | delta | pending | Gate A |
+| 01-requirements | yes | delta | **completed** | `D-S066-01-ac=1`; AC1–AC5; UJ-056 deepen |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS `D-S066-gateA=1` |
 | 03-plan-tooling | no | — | skipped | No new Cursor rules expected |
 | 04-tech-plan | no | — | skipped | Lean — FE route + hunk fold; no API/arch |
 | 05-verify-tech | no | — | skipped | Lean |
@@ -49,3 +49,8 @@
 | D-S066-board | **1** — #988 → In progress |
 | D-S066-route | **1** — Lean as drafted (`00 → 16 → 01 → 02 → 10 → 13`) |
 | D-S066-ui-preview | **1** — non-deployed local UI at http://127.0.0.1:18000/ |
+| D-S066-route-shape | **1** — `/quality/:stem` + back-to-list |
+| D-S066-context-n | **1** — 3 context lines |
+| D-S066-list | **1** — navigate to detail; list via back |
+| D-S066-01-ac | **1** — AC1–AC5 + UJ-056 deepen + manifest |
+| D-S066-gateA | **1** — Gate A PASS → implement FE (Lean) |

--- a/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
@@ -1,0 +1,75 @@
+---
+session_id: S066-quality-metrics-diff-page
+type: feature
+status: in_progress
+branch: evolve/EV-056-quality-metrics-diff-page
+orchestrator: 16-evolve
+evolve_cycle_id: EV-056
+github_issues: [988]
+prior_session: S065-quality-metrics-diff-long-line
+opened: 2026-08-11
+---
+
+# Session brief — S066-quality-metrics-diff-page
+
+> **Cycle**: EV-056 · **Type**: feature · **Opened**: 2026-08-11  
+> **Branch**: `evolve/EV-056-quality-metrics-diff-page` (base `stage@340b3cf6`)  
+> **Orchestrator**: **16-evolve** · **Preset**: Lean (user-requested)  
+> **Issue**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988)  
+> **Prior**: S065 pretty-print hotfix ([#987](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987) merged)  
+> **Corpus**: [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]
+
+## Goal
+
+Add a dedicated Quality metrics detail page with GitHub-style collapsible unified XML diffs (expand/collapse unchanged context), keeping C14N equality semantics.
+
+## Intent
+
+Follow-up from [S065 FOLLOWUP.md](../S065-quality-metrics-diff-long-line/FOLLOWUP.md) after pretty-print C14N display landed. Operators need a shareable stem route and readable hunk folding — not another change to match semantics.
+
+| Decision | Choice |
+|----------|--------|
+| D-S065-close | **1** — merge #987; close S065; open this evolve |
+| D-S066-route | **1** — Lean as drafted (`00 → 16 → 01 → 02 → 10 → 13`) |
+| D-S066-ui-preview | **1** — non-deployed local UI at http://127.0.0.1:18000/ |
+| D-S066-board | **1** — #988 → In progress (WIP 0→1) |
+
+## Out of scope
+
+- Changing `match_status` / C14N equality / fixture generator semantics
+- New npm diff library unless AskQuestion approves (reuse `unifiedLineDiff.ts` + hunk fold helper)
+- Promote `stage` → `main` unless explicitly approved
+- API contract change unless shell routing genuinely requires it
+
+## Features
+
+- Deepen **F7.q** — Quality metrics dedicated detail route + collapsible diffs  
+  ([Corpus: product §F7.q])
+- Journey / tests: deepen **UJ-056** ([Corpus: journeys §UJ-056] [Corpus: tests §UJ-056])
+
+## Acceptance (seed from FOLLOWUP — refine in 01)
+
+| ID | Criterion |
+|----|-----------|
+| AC1 | List row opens a dedicated detail route (shareable URL) with back-to-list |
+| AC2 | Official/Converted/TAC panes remain; normalized = pretty C14N |
+| AC3 | Diff shows collapsible equal-context hunks (GitHub-like expand N lines / expand all) |
+| AC4 | Unequal SIGMET stems remain navigable and readable on staging |
+| AC5 | UJ-056 / related TCs updated; FE unit + optional Playwright smoke |
+
+## Implementation notes
+
+- Reuse `unifiedLineDiff` + `qualityMetricsDisplayXml` / `prettyPrintXml`
+- Add hunk folding helper (e.g. `collapseEqualContext(lines, { context: 3 })`)
+- Wire route in frontend shell next to Quality metrics tab
+- Operator copy: no internal doc refs (EV-048)
+
+## Board
+
+- Project [#7 TAC-to-IWXXM](https://github.com/orgs/EMPIRIC2/projects/7)
+- #988 → **In progress**
+- Ready queue remains 3–5 (currently 4: #948, #958, #981, #983)
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).

--- a/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
@@ -33,6 +33,9 @@ Follow-up from [S065 FOLLOWUP.md](../S065-quality-metrics-diff-long-line/FOLLOWU
 | D-S066-route | **1** — Lean as drafted (`00 → 16 → 01 → 02 → 10 → 13`) |
 | D-S066-ui-preview | **1** — non-deployed local UI at http://127.0.0.1:18000/ |
 | D-S066-board | **1** — #988 → In progress (WIP 0→1) |
+| D-S066-route-shape | **1** — shareable `/quality/:stem` + back-to-list |
+| D-S066-context-n | **1** — default **3** context lines around hunks |
+| D-S066-list | **1** — navigate to detail; list via back |
 
 ## Out of scope
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -110,7 +110,7 @@ Unified manual live test harness against **DOKS** production endpoints after F30
 | UJ-053 | F16–F19 deepen (EV-042) | Operator UI has no dissemination destinations | **H4–H5 required** | TC-EV042-001..002 |
 | UJ-054 | F7 deepen (EV-047) | Operator Help → one-pager / handbook (#956/#957) | T0/T2; H4–H5 when FE deploy | TC-EV047-009..011 |
 | UJ-055 | F7+F21 deepen (EV-048) | Operator UI + OpenAPI free of internal planning vocabulary (#951) | T0/T2; T3 if UI hits | TC-EV048-001..005 |
-| UJ-056 | F7.q deepen (EV-054 / EV-055) | Quality metrics primary tab — match/residuals/lint/validate; W3C C14N diffs (#982); 2025-2 validate disposition (#980/#979) | **H4–H5 required** | TC-EV054-001..008; TC-EV055-001..007 |
+| UJ-056 | F7.q deepen (EV-054 / EV-055 / EV-056) | Quality metrics primary tab — match/residuals/lint/validate; W3C C14N diffs (#982); 2025-2 validate disposition (#980/#979); dedicated `/quality/:stem` + collapsible hunks (#988) | **H4–H5 required** | TC-EV054-001..008; TC-EV055-001..007; TC-EV056-001..005 |
 | UJ-DEV-007 | M5 deepen (EV-047) | Slim husky lint commit + fast-unit push (#833) | — | TC-EV047-001..004 |
 | UJ-DEV-008 | F6 deepen (EV-047) | Converter perf regression blocks PR (#834) | CI | TC-EV047-005..008 |
 
@@ -2122,6 +2122,52 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
   un-normalized; quieter C14N diff; validate chips match enabled/fixed disposition
 - **Pass criteria**: Local Playwright/Vitest green; H4–H5 after staging deploy (12/13)
 - **Source**: EV-055 AC1 / AC6 / AC7; UJ-056; `D-S064-gateA-M2=override`
+
+### EV-056 / S066 — Quality metrics detail page + collapsible diffs (#988 / F7.q)
+
+- **Mode**: delta deepen F7.q (UX/docs/tests; C14N semantics unchanged)
+- **Pass criteria**: AC1–AC5 in evolve-decisions §EV-056; TC-EV056-001..005; **UJ-056** deepen
+- **Source**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988); S065 FOLLOWUP;
+  parent EV-054 / EV-055; pretty-print hotfix #987
+
+### TC-EV056-001: Dedicated `/quality/:stem` detail route
+
+- **Level**: T0 / T2
+- **Objective**: List row navigates to shareable `/quality/:stem` with back-to-list
+  (`D-S066-route-shape=1` / `D-S066-list=1`)
+- **Pass criteria**: Vitest and/or Playwright assert route + back navigation
+- **Source**: EV-056 AC1; UJ-056
+
+### TC-EV056-002: Pretty C14N panes preserved
+
+- **Level**: T0 / T2
+- **Objective**: Official/Converted/TAC panes remain; normalized = pretty C14N (S065 helpers)
+- **Pass criteria**: FE unit asserts pretty multi-line display XML for C14N peers
+- **Source**: EV-056 AC2; S065; UJ-056
+
+### TC-EV056-003: Collapsible equal-context hunks (default 3)
+
+- **Level**: T0 / T2
+- **Objective**: Unified diff collapses unchanged context to GitHub-like expand controls;
+  default **3** context lines; expand hunk / expand all (`D-S066-context-n=1`)
+- **Pass criteria**: Unit test on `collapseEqualContext` (or equivalent); UI control smoke
+- **Source**: EV-056 AC3; UJ-056
+
+### TC-EV056-004: Unequal SIGMET stems remain readable
+
+- **Level**: T2 / T3 / H4–H5
+- **Objective**: Non-equal SIGMET (or other unequal) stems open on detail route with
+  navigable collapsed hunks
+- **Pass criteria**: Playwright or staging smoke opens an unequal stem; no single-line dump
+- **Source**: EV-056 AC4; UJ-056
+
+### TC-EV056-005: UJ-056 smoke — detail route + hunk fold
+
+- **Level**: T2 / T3 / H4–H5
+- **Objective**: Open Quality metrics → open stem → land on `/quality/:stem` → see
+  collapsible unified diff; C14N/`match_status` unchanged
+- **Pass criteria**: Local Playwright green; H4–H5 after staging deploy (13)
+- **Source**: EV-056 AC5; UJ-056
 
 ### Live harness — staging (EV-043 / EV-044)
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -7,7 +7,7 @@
 > S019 / EV-014 dissemination epic F16–F19; S020 / EV-015 F20 TAF+SPECI quality (#735/#734);
 > S023 / EV-017 public app + privacy (#783); S038 / EV-031 platform independence F30/F31;
 > S040 / EV-032 F32 VONA + #846 corpus
-> **Last updated**: 2026-08-11 (S064 / EV-055 UJ-056 deepen — W3C C14N + 2025-2 validate; prior EV-054)
+> **Last updated**: 2026-08-11 (S066 / EV-056 UJ-056 deepen — detail route + collapsible diffs; prior EV-055)
 
 Product-facing journeys (UJ-*) describe end-user flows. Developer journeys (UJ-DEV-*)
 describe monorepo workflows introduced by migration features M1–M6 and F6.
@@ -72,7 +72,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-053 | Operator UI has no dissemination destinations | apps/frontend | F16–F19 deepen (EV-042) | T2 / **T3** / H4–H5 |
 | UJ-054 | Operator Help → one-pager / handbook | apps/frontend | F7 deepen (EV-047 / #956/#957) | T0 / T2 / **T3** |
 | UJ-055 | Operator UI + API docs free of internal planning vocabulary | apps/frontend / OpenAPI | F7+F21 deepen (EV-048 / #951) | T0 / T2 / **T3** |
-| UJ-056 | Browse official corpus Quality metrics tab | apps/frontend | F7.q deepen (EV-054 / #836; EV-055 / #982+#980+#979) | T0 / T2 / **T3** / H4–H5 |
+| UJ-056 | Browse official corpus Quality metrics tab | apps/frontend | F7.q deepen (EV-054 / #836; EV-055 / #982+#980+#979; EV-056 / #988) | T0 / T2 / **T3** / H4–H5 |
 | UJ-DEV-001 | Clone and run monorepo | `git clone` + `make dev` | M1, M5 | T0 |
 | UJ-DEV-002 | Sync vendor schemas | Scheduled Action / manual | M2, M6, F6 | CI |
 | UJ-DEV-003 | ~~Merge GIFTs upstream~~ | — | M3 | **Deprecated** (ADR-014) |
@@ -831,21 +831,25 @@ residuals, lint, validate, with a unified XML diff vs our conversion.
    public **`GET /api/v1/quality-metrics`** (precomputed fixture-backed — not live WMO fetch).
 3. Filter to one product (e.g. METAR); open a known passer stem
    (`GET /api/v1/quality-metrics/{stem}`).
-4. In the detail pane: inspect TAC, official XML, our XML; confirm **match status** and a
-   **unified XML diff**; residuals / lint / validate panels show empty or expected diagnostics.
-   **EV-055**: detail XML panes **default to C14N-normalized** official/converted with an
-   operator override to show un-normalized (`D-S064-gateA-M2=override`); `match_status` and
-   unified diff use the same C14N peers (`D-S064-c14n=1`). Validate chips reflect **enabled**
-   Schematron / **fixed** schema-import disposition for 2025-2 (#980 / #979) without internal
-   planning ids.
-5. Confirm a deferred / gap stem is labeled (not silently missing).
-6. Optional later: deep-link the same stem into the convert workbench.
+4. **EV-056**: selecting a row **navigates** to shareable **`/quality/:stem`** with
+   back-to-list (`D-S066-route-shape=1` / `D-S066-list=1`). Detail remains Official /
+   Converted / TAC panes (normalized = pretty C14N by default with override) plus
+   **GitHub-style** unified diff with collapsible equal-context hunks (default **3**
+   context lines; expand hunk / expand all — `D-S066-context-n=1`). C14N /
+   `match_status` semantics unchanged from EV-055.
+5. In the detail view: confirm **match status** and unified XML diff; residuals / lint /
+   validate panels show empty or expected diagnostics. **EV-055**: panes default to
+   C14N-normalized with override to un-normalized; validate chips reflect enabled /
+   fixed 2025-2 disposition without internal planning ids.
+6. Confirm a deferred / gap stem is labeled (not silently missing).
+7. Optional later: deep-link the same stem into the convert workbench.
 
 **Acceptance**: AC1–AC7 in evolve-decisions §EV-054 (tab shell) **and** AC1–AC7 in
-evolve-decisions §EV-055 (normalize + validate disposition); TC-EV054-001..008 +
-TC-EV055-001..007. Default view needs no Supabase and no live upstream WMO fetch — metrics
-come from public `GET /api/v1/quality-metrics*` backed by precomputed fixtures
-(`D-S063-gateA=2`; regen under `D-S064-regen=1`).
+evolve-decisions §EV-055 (normalize + validate disposition) **and** AC1–AC5 in
+evolve-decisions §EV-056 (detail route + collapsible diffs); TC-EV054-001..008 +
+TC-EV055-001..007 + TC-EV056-001..005. Default view needs no Supabase and no live
+upstream WMO fetch — metrics come from public `GET /api/v1/quality-metrics*` backed by
+precomputed fixtures (`D-S063-gateA=2`; regen under `D-S064-regen=1`).
 **Tier: T0 / T2 / T3 / H4–H5**.
 Related: UJ-032 / UJ-039 / UJ-042.
 [Corpus: product §F7] [Corpus: product §F2] [Corpus: product §F13] [Corpus: product §F25]

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -3,23 +3,152 @@ project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 65
-evolve_cycle_counter: 55
+session_counter: 66
+evolve_cycle_counter: 56
 active_session:
-  id: S065-quality-metrics-diff-long-line
+  id: S066-quality-metrics-diff-page
+  type: feature
+  intent: "EV-056: F7.q deepen — dedicated Quality metrics detail page + GitHub-style collapsible unified XML diffs (expand/collapse unchanged context). Keep C14N equality; no API change unless routing needs it. Base stage. Cite UJ-056 / F7.q. Follow-up from S065 / #988."
+  status: in_progress
+  started: '2026-08-11'
+  started_at: '2026-08-11'
+  branch: evolve/EV-056-quality-metrics-diff-page
+  branch_base: stage@340b3cf6
+  branch_base_sha: 340b3cf6
+  branch_base_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
+  branch_status: ACTIVE
+  branch_exists: true
+  branch_pushed: false
+  branch_note: "local evolve/EV-056-quality-metrics-diff-page @ stage@340b3cf6 (not pushed yet)"
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-056
+  artifacts_dir: docs/sessions/S066-quality-metrics-diff-page/
+  github_issues:
+  - 988
+  prior_session: S065-quality-metrics-diff-long-line
+  deepen_feature_ids:
+  - F7
+  feature_note: "F7.q Quality metrics dedicated detail page + collapsible diffs"
+  corpus_cites:
+  - '[Corpus: product §F7.q]'
+  - '[Corpus: tests §UJ-056]'
+  - '[Corpus: journeys §UJ-056]'
+  preset: Lean
+  auto_lean: false
+  auto_lean_rationale: "User requested Lean; UX route+tests deepen — not Auto-Lean skip"
+  goal: "Dedicated Quality metrics detail route with GitHub-style collapsible unified XML diffs; C14N semantics unchanged."
+  out_of_scope:
+  - match_status/C14N equality changes
+  - new npm diff library unless AskQuestion
+  - promote to main unless asked
+  - API contract change unless routing requires
+  ui_preview: accepted
+  ui_preview_url: http://127.0.0.1:18000/
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — open_session S066; Lean preset; Phase 0 open; handoff routing + UI preview AskQuestion"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrate
+    status: in_progress
+    started: '2026-08-11'
+    note: "IN PROGRESS — D-S066-route=1 / ui-preview=1; Plan orchestrator Phase 0–1; next 01-requirements"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: pending
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: pending
+  - stage: 10-e2e
+    required: true
+    mode: delta
+    status: pending
+  - stage: 13-deploy-smoke
+    required: true
+    mode: delta
+    status: pending
+  - stage: 03-plan-tooling
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — tooling plan not in path; implementation via 16-evolve child Agent stages"
+  - stage: 04-tech-plan
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — tech plan not in path; implementation via 16-evolve child Agent stages"
+  - stage: 05-verify-tech
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-tech not in path"
+  - stage: 06-tech-tooling
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — tech tooling not in path"
+  - stage: 07-build
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — build stage not in path; implementation via 16-evolve child Agent stages"
+  - stage: 08-verify-build
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-build not in path"
+  - stage: 09-qa
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — qa not in path"
+  - stage: 11-verify-impl
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-impl not in path"
+  - stage: 12-verify-deploy
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-deploy not in path"
+  current_stage: 16-evolve
+  current_stage_note: "16-evolve in_progress — Lean approved; local UI preview; next child 01-requirements"
+  decisions:
+    D-S065-close: "1 — recorded on archived S065; PR #987 MERGED → stage @ 340b3cf6; open S066/EV-056"
+    D-S066-route: "1 — Lean as drafted"
+    D-S066-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
+    D-S066-board: "1 — #988 → In progress"
+  context_briefs: []
+  note: "IN PROGRESS — D-S066-route=1 / ui-preview=1 / board=1; Lean approved; local UI preview http://127.0.0.1:18000/; 16-evolve Phase 0–1; next 01-requirements; base stage@340b3cf6; branch evolve/EV-056-quality-metrics-diff-page (not pushed); #988; [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]"
+
+sessions:
+
+
+- id: S065-quality-metrics-diff-long-line
   type: hotfix
   intent: "Fix Quality metrics unified XML diff rendering as one long C14N line; pretty-print for human-readable line diffs. Defer separate detail page + GitHub-style hunk collapse to a later evolve."
-  status: in_progress
+  status: completed
+  completed: '2026-08-11'
+  completed_at: '2026-08-11'
+  closed_at: '2026-08-11'
   started: '2026-08-11'
   started_at: '2026-08-11'
   branch: fix/quality-metrics-diff-long-line
   branch_base: stage@d80db688
   branch_base_sha: d80db688
   branch_base_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
-  branch_status: ACTIVE
+  branch_status: merged
   branch_exists: true
   branch_pushed: true
-  branch_note: "ACTIVE — created+pushed; tip da1e48f8; PR #987 open → stage; CI 31541069003 watching"
+  branch_note: "CLOSED — D-S065-close=1; PR #987 MERGED → stage @ 340b3cf6 (hotfix tip was da1e48f8); follow-up #988 → S066/EV-056"
   orchestrator: 14-hotfix
   evolve_cycle_id:
   artifacts_dir: docs/sessions/S065-quality-metrics-diff-long-line/
@@ -30,7 +159,7 @@ active_session:
   github_issues_note: "hotfix from staging UX report (no origin issue); follow-up evolve tracked as #988"
   followup_github_issue: 988
   followup_github_issue_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988
-  followup_github_issue_note: "evolve later — dedicated /quality/:stem page + GitHub-style hunk collapse (D-S065-scope=4 / D-S065-page=inline-for-now)"
+  followup_github_issue_note: "S066/EV-056 — dedicated /quality/:stem page + GitHub-style hunk collapse (D-S065-scope=4 / D-S065-page=inline-for-now)"
   remediation_path: local-first
   goal: "Pretty-print Quality metrics unified XML diff for human-readable line diffs (C14N currently one long line)."
   out_of_scope:
@@ -48,22 +177,28 @@ active_session:
   auto_lean: true
   auto_lean_rationale: "hotfix UX readability — Auto-Lean"
   prior_session: S064-quality-metrics-2025-2-followups
-  tip_sha: "da1e48f8"
-  tip_sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
+  tip_sha: "340b3cf6"
+  tip_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
   tip_sha_pushed: true
-  tip_sha_note: "tip da1e48f8 pushed on fix/quality-metrics-diff-long-line; PR #987 open → stage; CI 31541069003 watching"
-  tip_ci_run: '31541069003'
-  tip_ci_status: watching
-  tip_ci_note: "CI run 31541069003 watching on PR #987 / fix/quality-metrics-diff-long-line"
+  tip_sha_note: "CLOSED D-S065-close=1 — PR #987 MERGED → stage @ 340b3cf6 (hotfix tip da1e48f8); Staging CI/CD 31541772688 queued/running (close without waiting green)"
+  tip_ci_run: '31541772688'
+  tip_ci_status: queued
+  tip_ci_note: "Staging CI/CD run 31541772688 queued/running on stage@340b3cf6; close without waiting green (D-S065-close=1)"
   pr_number: 987
   pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987
-  pr_status: open
+  pr_status: merged
   pr_base: stage
+  merge_sha: 340b3cf6
+  merge_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
+  merge_at: '2026-08-11T22:17:31Z'
+  close_decision_id: D-S065-close
+  close_note: "D-S065-close=1 — PR #987 MERGED → stage @ 340b3cf6; follow-up #988 → S066/EV-056; Staging CI/CD 31541772688 not awaited"
   decisions:
     D-S065-scope: "4 — hotfix readability now; evolve later for page+hunks"
     D-S065-products: "all"
     D-S065-page: "inline-for-now"
     D-S065-pr: "1 — PR #987 opened → stage; follow-up #988; CI 31541069003 watching"
+    D-S065-close: "1 — close S065 after #987 MERGED → stage @ 340b3cf6; open S066/EV-056 for #988"
   routing_plan:
   - stage: 00-context
     required: true
@@ -75,21 +210,19 @@ active_session:
   - stage: 14-hotfix
     required: true
     mode: full
-    status: in_progress
+    status: completed
     started: '2026-08-11'
-    note: "IN PROGRESS — tip da1e48f8; PR #987 open → stage; follow-up #988; CI 31541069003 watching; awaiting CI + merge + user close"
+    completed: '2026-08-11'
+    note: "COMPLETE — D-S065-close=1; tip da1e48f8; PR #987 MERGED → stage @ 340b3cf6; follow-up #988 → S066/EV-056"
   - stage: 15-service-health
     required: false
     mode: when_deployed
-    status: pending
-    skip_rationale: "optional after deploy; not required at Lean hotfix open"
-  current_stage: 14-hotfix
-  current_stage_note: "14-hotfix in_progress — tip da1e48f8 pushed; PR #987 open → stage; follow-up #988; CI 31541069003 watching; awaiting CI + merge + user close"
+    status: skipped
+    skip_rationale: "optional after deploy; not required at D-S065-close=1; Staging CI/CD 31541772688 left running"
+  current_stage: completed
+  current_stage_note: "CLOSED — D-S065-close=1; PR #987 MERGED → stage @ 340b3cf6; follow-up #988 → S066/EV-056"
   context_briefs: []
-  note: "IN PROGRESS — Auto-Lean hotfix; tip da1e48f8; PR #987 open → stage; follow-up evolve #988; CI 31541069003 watching; D-S065-scope=4 / products=all / page=inline-for-now; session remains open; [Corpus: product §F7.q] [Corpus: tests §UJ-056]"
-
-sessions:
-
+  note: "CLOSED — D-S065-close=1; PR #987 MERGED → stage @ 340b3cf6 (hotfix tip da1e48f8); follow-up #988 → S066/EV-056; Staging CI/CD 31541772688 queued/running (not awaited); [Corpus: product §F7.q] [Corpus: tests §UJ-056]"
 
 - id: S064-quality-metrics-2025-2-followups
   type: feature
@@ -37812,6 +37945,68 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-056
+  title: "F7.q Quality metrics detail page + collapsible diffs (#988)"
+  status: in_progress
+  cycle_type: feature
+  session_id: S066-quality-metrics-diff-page
+  feature_ids: []
+  deepen_feature_ids:
+  - F7
+  feature_note: "F7.q Quality metrics dedicated detail page + collapsible diffs"
+  github_issues:
+  - 988
+  issues:
+  - 988
+  branch: evolve/EV-056-quality-metrics-diff-page
+  branch_base: stage@340b3cf6
+  branch_base_sha: 340b3cf6
+  branch_base_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
+  branch_status: ACTIVE
+  branch_exists: true
+  branch_pushed: false
+  branch_note: "local evolve/EV-056-quality-metrics-diff-page @ stage@340b3cf6 (not pushed yet)"
+  tip_sha:
+  tip_sha_full:
+  tip_sha_pushed: false
+  current_stage: 16-evolve
+  current_stage_status: in_progress
+  current_stage_note: "16-evolve in_progress — Lean approved; local UI preview; next child 01-requirements"
+  started: "2026-08-11"
+  started_at: "2026-08-11"
+  preset: Lean
+  auto_lean: false
+  auto_lean_rationale: "User requested Lean; UX route+tests deepen — not Auto-Lean skip"
+  ui_preview_url: http://127.0.0.1:18000/
+  routing_plan:
+  - 00-context
+  - 16-evolve
+  - 01-requirements
+  - 02-verify-plan
+  - 10-e2e
+  - 13-deploy-smoke
+  skip_stages:
+  - 03-plan-tooling
+  - 04-tech-plan
+  - 05-verify-tech
+  - 06-tech-tooling
+  - 07-build
+  - 08-verify-build
+  - 09-qa
+  - 11-verify-impl
+  - 12-verify-deploy
+  scope_summary: "Dedicated Quality metrics detail route + GitHub-style collapsible unified XML diffs; keep C14N equality; follow-up from S065 / #988; base stage@340b3cf6"
+  decisions_locked: false
+  decisions:
+    D-S065-close: "1 — prior session closed; #987@340b3cf6; open EV-056/S066"
+    D-S066-route: "1 — Lean as drafted"
+    D-S066-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
+    D-S066-board: "1 — #988 → In progress"
+  artifacts:
+  - docs/sessions/S066-quality-metrics-diff-page/
+  prior_session: S065-quality-metrics-diff-long-line
+  prior_evolve_note: "Follow-up from S065 hotfix #987 (pretty-print); page+hunks deferred to EV-056 / #988"
+  note: "IN PROGRESS — D-S066-route=1 / ui-preview=1; Plan orchestrator Phase 0–1; next 01-requirements; [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]"
 - id: EV-055
   title: "Quality metrics 2025-2 follow-ups (#982/#980/#979)"
   status: completed

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -20,6 +20,10 @@ active_session:
   branch_exists: true
   branch_pushed: false
   branch_note: "local evolve/EV-056-quality-metrics-diff-page @ stage@340b3cf6 (not pushed yet)"
+  tip_sha: "f065d808"
+  tip_sha_full: f065d808b015612a876dc4a10687e33a5f192629
+  tip_sha_pushed: false
+  tip_sha_note: "session open commit; Lean approved; local UI preview"
   orchestrator: 16-evolve
   evolve_cycle_id: EV-056
   artifacts_dir: docs/sessions/S066-quality-metrics-diff-page/
@@ -51675,6 +51679,18 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: "f065d808"
+    sha_full: f065d808b015612a876dc4a10687e33a5f192629
+    message: "docs: open S066/EV-056 Quality metrics detail page session"
+    branch: evolve/EV-056-quality-metrics-diff-page
+    stage: 00-context
+    session_id: S066-quality-metrics-diff-page
+    timestamp: "2026-08-11"
+    pushed: false
+    tip_sha: f065d808
+    tip_sha_full: f065d808b015612a876dc4a10687e33a5f192629
+    tip_sha_pushed: false
+    note: "session open commit; Lean approved; local UI preview"
   - sha: "da1e48f8"
     sha_full: da1e48f88b62aec754aa74c5ae6f84918551b493
     message: "[BUG-2026-08-11] fix: pretty-print Quality metrics C14N diffs"


### PR DESCRIPTION
## Summary
- Dedicated shareable `/quality/:stem` detail route with back-to-list navigation ([Corpus: product §F7.q])
- GitHub-style collapsible equal-context hunks (default 3 lines) on the unified XML diff
- Plain-language operator copy pass: no corpus/stem jargon, spelled-out residual/lint/validation counts, clearer match status and diagnostic help ([Corpus: product §F7] EV-048)

## Test plan
- [x] FE Vitest: QualityMetricsPage / Detail / internalDocRefGuard
- [x] Local UJ-056 e2e 3/3
- [ ] CI green on PR
- [ ] Staging smoke after merge (13-deploy-smoke)

Closes #988


Made with [Cursor](https://cursor.com)