### PR TITLE
[EV-056] docs: 13-deploy-smoke closeout

### DIFF
--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -9,7 +9,7 @@
 **Features**: deepen **F7.q** only  
 **Started**: 2026-08-11  
 **Branch**: `evolve/EV-056-quality-metrics-diff-page` (base `stage@340b3cf6`)  
-**Status**: **in_progress** — 02-verify-plan (Gate A) after `D-S066-01-ac=1`  
+**Status**: **completed** — closed on stage (`D-S066-13=1` / `D-S066-close=1`; #989 @ `b4a63ab8`)  
 **Issues**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988)  
 **Parent**: S065 / #987 pretty-print hotfix; EV-054 / EV-055 Quality metrics  
 **Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests]
@@ -25,6 +25,9 @@
 | D-S066-context-n | **1** — default 3 context lines |
 | D-S066-list | **1** — navigate to detail; list via back |
 | D-S066-board | **1** — #988 In progress |
+| D-S066-pr | **1** — Push + PR → stage → CI → 13 |
+| D-S066-13 | **1** — Approve 13; H0c–H5 PASS on staging |
+| D-S066-close | **1** — Close EV-056 / S066 on stage; #988 Done; promote deferred |
 
 ### Acceptance (`D-S066-01-ac=1`)
 

--- a/docs/evolve-report-EV-056.md
+++ b/docs/evolve-report-EV-056.md
@@ -1,0 +1,34 @@
+# Evolve report — EV-056
+
+**Session:** S066-quality-metrics-diff-page  
+**Status:** **completed** (`D-S066-13=1` / `D-S066-close=1`)  
+**Product merge:** [#989](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989) → `stage` @ `b4a63ab8`  
+**Docs follow-up:** [#990](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/990) → `stage`  
+**Summary:** [docs/sessions/S066-quality-metrics-diff-page/reports/evolve-summary.md](sessions/S066-quality-metrics-diff-page/reports/evolve-summary.md)
+
+## Outcome
+
+Deepened **F7.q**: shareable Quality metrics detail route `/quality/:stem` with back-to-list; GitHub-style collapsible unified XML equal-context hunks (default 3 lines); plain-language operator copy (no planning ids). C14N equality semantics unchanged. Staging Deploy + H0c–H5 green. No `stage`→`main` this cycle.
+
+## Stages
+
+Lean completed: `00 → 16 → 01 → 02 → 10 → 13`.  
+Skipped: `03`–`09`, `11`, `12`.
+
+## Merge / close
+
+| Decision | Result |
+|----------|--------|
+| `D-S066-pr=1` | #989 MERGED → `stage` @ `b4a63ab8` |
+| Staging CD | [31545833142](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31545833142) Deploy + Staging smoke **success** |
+| `D-S066-13=1` | H0c + H1–H5 PASS on staging; 13 COMPLETE |
+| `D-S066-close=1` | EV-056 / S066 closed on stage; promote deferred |
+| Tickets | #988 → **Done** |
+
+## Decisions
+
+`D-S066-13=1` · `D-S066-close=1` · `D-S066-pr=1` · `D-S066-route=1` · `D-S066-route-shape=1` · `D-S066-context-n=1` · see [Corpus: decisions §EV-056]
+
+## Corpus
+
+[Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests] [Corpus: tech-spec] [Corpus: decisions §EV-056]

--- a/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
@@ -25,7 +25,7 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 
 ## Next child stage
 
-**None** — 13 evidence PASS; awaiting `D-S066-13` / cycle close AskQuestion
+**None** — cycle closed (`D-S066-13=1` / `D-S066-close=1`)
 
 ## Locked intake (Phase 0)
 
@@ -37,8 +37,9 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 | D-S066-01-ac | **1** — AC1–AC5 approved |
 | D-S066-gateA | **1** — Gate A PASS |
 | D-S066-pr | **1** — Push + PR → stage → CI → 13 |
+| D-S066-13 | **1** — Approve 13; H0c–H5 PASS |
+| D-S066-close | **1** — Close on stage; #988 Done |
 
 ## Risks / open decisions
 
-- #989 **MERGED** → `stage` @ `b4a63ab8`; Staging Deploy + smoke green; H0c–H5 PASS
-- Promote to `main` deferred unless asked
+- Closed on stage @ `b4a63ab8`; promote deferred unless asked

--- a/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/evolve-plan-card.md
@@ -25,7 +25,7 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 
 ## Next child stage
 
-**13-deploy-smoke** — after merge of PR #989 → `stage` + Staging smoke green (`D-S066-pr=1`)
+**None** — 13 evidence PASS; awaiting `D-S066-13` / cycle close AskQuestion
 
 ## Locked intake (Phase 0)
 
@@ -40,5 +40,5 @@ Dedicated Quality metrics detail route with GitHub-style collapsible unified XML
 
 ## Risks / open decisions
 
-- PR #989 CI green @ `c87f67b8` — awaiting merge approval for stage + 13-deploy-smoke
-- Plain-language UI copy pass landed (no operator-visible planning ids; EV-048)
+- #989 **MERGED** → `stage` @ `b4a63ab8`; Staging Deploy + smoke green; H0c–H5 PASS
+- Promote to `main` deferred unless asked

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/deploy-smoke.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/deploy-smoke.md
@@ -1,0 +1,55 @@
+# Deploy smoke — S066 / EV-056 (13-deploy-smoke)
+
+> Date: 2026-08-11  
+> Status: **COMPLETE** — awaiting `D-S066-13` user approve  
+> PR: [#989](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989) **MERGED** → `stage` @ `b4a63ab8`  
+> Product tip (pre-merge): `d63265c2` · merge: `b4a63ab8ec09f47d8ea95a50008c698fa37b7734`  
+> `env_role`: **staging** (`api|app.staging.tac-to-iwxxm.com`; cluster `metar-iwxxm-staging`)  
+> CD: [CI/CD Pipeline 31545833142](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31545833142) **success** — Deploy (stage) + Staging smoke  
+> Corpus: [Corpus: tests] [Corpus: tech-spec] [Corpus: product §F7.q] [Corpus: journeys §UJ-056]  
+> Board: #988 → **On stage** (after smoke)
+
+## Sequence
+
+| Step | Result | Notes |
+|------|--------|-------|
+| Merge #989 → `stage` | PASS | merge `b4a63ab8` (`D-S066-pr=1`) |
+| Stage CI + Deploy (stage) | PASS | run 31545833142 |
+| Staging smoke (CI) | PASS | job success |
+| H0c CORS unit | PASS | 6/6 |
+| H1 live API (staging) | PASS | 20 passed, 1 skipped (auth-gated) |
+| H2 / Staging health | PASS | API awake; FE `/` via H5 path |
+| H3 primary journey | PASS | `GET /api/v1/quality-metrics` + `/{stem}` OK; FE `/quality` + `/quality/:stem` **200** |
+| H4 live CORS | PASS | convert + work_sessions PATCH + mass ingest POST |
+| H5 FE `config.json` | PASS | `api.baseUrl=https://api.staging.tac-to-iwxxm.com` |
+| Live UJ-056 Playwright | deferred | local T0 3/3 PASS at 10-e2e; live optional |
+
+## H4–H5 evidence
+
+```
+Live API awake: https://api.staging.tac-to-iwxxm.com
+== H0c: CORS policy unit tests == … 6 passed
+== H4: Live CORS preflight == … 3 passed
+== H5: Frontend runtime config check ==
+OK: https://app.staging.tac-to-iwxxm.com/config.json api.baseUrl=https://api.staging.tac-to-iwxxm.com
+Connectivity verification complete.
+quality-metrics files … pin 2025-2
+detail stem metar-A3-1 match equal
+FE /quality 200
+FE /quality/metar-A3-1 200
+Staging smoke: PASS
+```
+
+## Rollback
+
+Prior staging DOKS/GHCR tag via Deploy job; no DB migrations this cycle.
+
+## Promote (deferred)
+
+Promote `stage`→`main` only after Staging gate green + explicit user request. **Not** requested at this 13 gate.
+
+## Sign-Off
+
+- [x] #989 merged + Staging Deploy + Staging smoke green
+- [x] H0c + H1–H5 on staging
+- [ ] User approves 13 complete (`D-S066-13`) — then close EV-056 / S066 on stage

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/deploy-smoke.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/deploy-smoke.md
@@ -1,13 +1,13 @@
 # Deploy smoke — S066 / EV-056 (13-deploy-smoke)
 
 > Date: 2026-08-11  
-> Status: **COMPLETE** — awaiting `D-S066-13` user approve  
+> Status: **COMPLETE** — `D-S066-13=1` / `D-S066-close=1`  
 > PR: [#989](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989) **MERGED** → `stage` @ `b4a63ab8`  
 > Product tip (pre-merge): `d63265c2` · merge: `b4a63ab8ec09f47d8ea95a50008c698fa37b7734`  
 > `env_role`: **staging** (`api|app.staging.tac-to-iwxxm.com`; cluster `metar-iwxxm-staging`)  
 > CD: [CI/CD Pipeline 31545833142](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31545833142) **success** — Deploy (stage) + Staging smoke  
 > Corpus: [Corpus: tests] [Corpus: tech-spec] [Corpus: product §F7.q] [Corpus: journeys §UJ-056]  
-> Board: #988 → **On stage** (after smoke)
+> Board: #988 → **Done** (session close)
 
 ## Sequence
 
@@ -52,4 +52,4 @@ Promote `stage`→`main` only after Staging gate green + explicit user request. 
 
 - [x] #989 merged + Staging Deploy + Staging smoke green
 - [x] H0c + H1–H5 on staging
-- [ ] User approves 13 complete (`D-S066-13`) — then close EV-056 / S066 on stage
+- [x] User approves 13 complete (`D-S066-13=1`) — EV-056 / S066 closed on stage (`D-S066-close=1`)

--- a/docs/sessions/S066-quality-metrics-diff-page/reports/evolve-summary.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/reports/evolve-summary.md
@@ -1,0 +1,30 @@
+# Evolve summary — S066 / EV-056
+
+> Closed: 2026-08-11 · `D-S066-13=1` · `D-S066-close=1`  
+> Product: [#989](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989) → `stage` @ `b4a63ab8`  
+> Staging CD: [31545833142](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31545833142)  
+> Docs: [#990](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/990) → `stage`  
+> Standing report: [docs/evolve-report-EV-056.md](../../../evolve-report-EV-056.md)
+
+## Shipped
+
+| Ticket | Outcome |
+|--------|---------|
+| #988 | Dedicated `/quality/:stem` detail route; GitHub-style collapsible equal-context hunks (default 3); plain-language operator copy |
+
+## Verify
+
+| Stage | Verdict |
+|-------|---------|
+| 01 / Gate A | PASS (`D-S066-01-ac=1` / `D-S066-gateA=1`) |
+| 10-e2e | PASS (UJ-056 local 3/3) |
+| 13-deploy-smoke | PASS (`D-S066-13=1`) — H0c–H5 staging |
+
+## Deferred
+
+- Promote `stage`→`main` (explicit AskQuestion later)
+- Live Playwright UJ-056 against staging (local T0 already PASS)
+
+## Corpus
+
+[Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056] [Corpus: decisions §EV-056]

--- a/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
@@ -53,4 +53,5 @@
 | D-S066-01-ac | **1** — AC1–AC5 + UJ-056 deepen + manifest |
 | D-S066-gateA | **1** — Gate A PASS → implement FE (Lean) |
 | D-S066-pr | **1** — Push + PR → stage → CI → 13 |
-| D-S066-13 | pending — approve 13 / close on stage |
+| D-S066-13 | **1** — Approve 13; close on stage |
+| D-S066-close | **1** — Close EV-056 / S066; #988 Done; promote deferred |

--- a/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/routing-plan.md
@@ -22,7 +22,7 @@
 | 08-verify-build | no | — | skipped | Lean |
 | 09-qa | no | — | skipped | Lean |
 | 10-e2e | yes | delta | **completed** | UJ-056 3/3 PASS local; H4–H5 via 13 |
-| 13-deploy-smoke | yes | delta | pending | Staging smoke after PR → stage |
+| 13-deploy-smoke | yes | delta | **completed** | #989 merged; Deploy+Staging smoke [31545833142](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/runs/31545833142); H0c–H5 PASS — await `D-S066-13` |
 
 ## Recommended ordered stages
 
@@ -52,3 +52,5 @@
 | D-S066-list | **1** — navigate to detail; list via back |
 | D-S066-01-ac | **1** — AC1–AC5 + UJ-056 deepen + manifest |
 | D-S066-gateA | **1** — Gate A PASS → implement FE (Lean) |
+| D-S066-pr | **1** — Push + PR → stage → CI → 13 |
+| D-S066-13 | pending — approve 13 / close on stage |

--- a/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
+++ b/docs/sessions/S066-quality-metrics-diff-page/session-brief.md
@@ -1,22 +1,23 @@
 ---
 session_id: S066-quality-metrics-diff-page
 type: feature
-status: in_progress
+status: completed
 branch: evolve/EV-056-quality-metrics-diff-page
 orchestrator: 16-evolve
 evolve_cycle_id: EV-056
 github_issues: [988]
 prior_session: S065-quality-metrics-diff-long-line
 opened: 2026-08-11
+closed: 2026-08-11
 ---
 
 # Session brief — S066-quality-metrics-diff-page
 
-> **Cycle**: EV-056 · **Type**: feature · **Opened**: 2026-08-11  
-> **Branch**: `evolve/EV-056-quality-metrics-diff-page` (base `stage@340b3cf6`)  
-> **Orchestrator**: **16-evolve** · **Preset**: Lean (user-requested)  
-> **Issue**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988)  
-> **Prior**: S065 pretty-print hotfix ([#987](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/987) merged)  
+> **Cycle**: EV-056 · **Type**: feature · **Opened**: 2026-08-11 · **Closed**: 2026-08-11  
+> **Branch**: `evolve/EV-056-quality-metrics-diff-page` → [#989](https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989) **MERGED** `stage` @ `b4a63ab8`  
+> **Orchestrator**: **16-evolve** · **Preset**: Lean  
+> **Issue**: [#988](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/988) → **Done**  
+> **Close**: `D-S066-13=1` / `D-S066-close=1` — [evolve-summary](reports/evolve-summary.md) · [deploy-smoke](reports/deploy-smoke.md)  
 > **Corpus**: [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]
 
 ## Goal
@@ -70,8 +71,7 @@ Follow-up from [S065 FOLLOWUP.md](../S065-quality-metrics-diff-long-line/FOLLOWU
 ## Board
 
 - Project [#7 TAC-to-IWXXM](https://github.com/orgs/EMPIRIC2/projects/7)
-- #988 → **In progress**
-- Ready queue remains 3–5 (currently 4: #948, #958, #981, #983)
+- #988 → **Done** (`D-S066-close=1`)
 
 ## Routing plan
 

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,34 +1,55 @@
-overall_status: in_progress
+overall_status: idle
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
 session_counter: 66
 evolve_cycle_counter: 56
-active_session:
-  id: S066-quality-metrics-diff-page
+active_session: null
+
+sessions:
+
+- id: S066-quality-metrics-diff-page
   type: feature
   intent: "EV-056: F7.q deepen — dedicated Quality metrics detail page + GitHub-style collapsible unified XML diffs (expand/collapse unchanged context). Keep C14N equality; no API change unless routing needs it. Base stage. Cite UJ-056 / F7.q. Follow-up from S065 / #988."
-  status: in_progress
+  status: completed
+  completed: '2026-08-11'
+  completed_at: '2026-08-11'
+  closed_at: '2026-08-11'
   started: '2026-08-11'
   started_at: '2026-08-11'
   branch: evolve/EV-056-quality-metrics-diff-page
   branch_base: stage@340b3cf6
   branch_base_sha: 340b3cf6
   branch_base_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
-  branch_status: ACTIVE
+  branch_status: merged
   branch_exists: true
-  branch_pushed: false
-  branch_note: "local evolve/EV-056-quality-metrics-diff-page @ stage@340b3cf6 (not pushed yet)"
-  tip_sha: "f065d808"
-  tip_sha_full: f065d808b015612a876dc4a10687e33a5f192629
-  tip_sha_pushed: false
-  tip_sha_note: "session open commit; Lean approved; local UI preview"
+  branch_pushed: true
+  branch_note: "CLOSED — D-S066-13=1 / D-S066-close=1; PR #989 MERGED → stage @ b4a63ab8; Staging CD 31545833142 success; promote deferred"
+  tip_sha: "b4a63ab8"
+  tip_sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+  tip_sha_pushed: true
+  tip_sha_note: "CLOSED D-S066-13=1 / D-S066-close=1 — #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; #988 Done; promote deferred"
+  tip_ci_run: '31545833142'
+  tip_ci_status: success
+  tip_ci_note: "Staging CD run 31545833142 success on stage@b4a63ab8; H0c–H5 PASS; D-S066-13=1"
+  pr_number: 989
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989
+  pr_status: merged
+  pr_base: stage
+  merge_sha: b4a63ab8
+  merge_sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+  merge_at: '2026-08-11T23:16:21Z'
+  followup_pr_number: 990
+  followup_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/990
+  followup_pr_status: open
+  followup_pr_note: "docs closeout PR #990 open → stage; product tip remains #989@b4a63ab8"
   orchestrator: 16-evolve
   evolve_cycle_id: EV-056
   artifacts_dir: docs/sessions/S066-quality-metrics-diff-page/
   github_issues:
   - 988
+  board_note: "#988 Done"
   prior_session: S065-quality-metrics-diff-long-line
   deepen_feature_ids:
   - F7
@@ -48,6 +69,8 @@ active_session:
   - API contract change unless routing requires
   ui_preview: accepted
   ui_preview_url: http://127.0.0.1:18000/
+  close_decision_id: D-S066-close
+  close_note: "D-S066-13=1 / D-S066-close=1 — #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; #988 Done; promote deferred"
   routing_plan:
   - stage: 00-context
     required: true
@@ -59,25 +82,38 @@ active_session:
   - stage: 16-evolve
     required: true
     mode: orchestrate
-    status: in_progress
+    status: completed
     started: '2026-08-11'
-    note: "IN PROGRESS — D-S066-route=1 / ui-preview=1; Plan orchestrator Phase 0–1; next 01-requirements"
+    completed: '2026-08-11'
+    note: "COMPLETE — D-S066-13=1 / D-S066-close=1; #989 → stage @ b4a63ab8; Staging CD 31545833142 success"
   - stage: 01-requirements
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — Lean delta requirements for F7.q detail page + collapsible diffs"
   - stage: 02-verify-plan
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — plan gate PASS"
   - stage: 10-e2e
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — UJ-056 / quality metrics e2e delta"
   - stage: 13-deploy-smoke
     required: true
     mode: delta
-    status: pending
+    status: completed
+    started: '2026-08-11'
+    completed: '2026-08-11'
+    note: "COMPLETE — D-S066-13=1; Staging CD 31545833142 success; H0c–H5 PASS; promote deferred"
   - stage: 03-plan-tooling
     required: false
     mode: null
@@ -123,18 +159,18 @@ active_session:
     mode: null
     status: skipped
     skip_rationale: "Lean preset — verify-deploy not in path"
-  current_stage: 16-evolve
-  current_stage_note: "16-evolve in_progress — Lean approved; local UI preview; next child 01-requirements"
+  current_stage: 13-deploy-smoke
+  current_stage_note: "CLOSED — D-S066-13=1 / D-S066-close=1; #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; #988 Done; promote deferred; active_session=null"
   decisions:
     D-S065-close: "1 — recorded on archived S065; PR #987 MERGED → stage @ 340b3cf6; open S066/EV-056"
     D-S066-route: "1 — Lean as drafted"
     D-S066-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
     D-S066-board: "1 — #988 → In progress"
+    D-S066-pr: "1 — PR #989 opened/merged → stage @ b4a63ab8"
+    D-S066-13: "1 — Approve 13-deploy-smoke; Staging CD 31545833142 success; H0c–H5 PASS; promote deferred"
+    D-S066-close: "1 — Close S066/EV-056; #989 → stage @ b4a63ab8; #988 Done; docs #990; active_session=null"
   context_briefs: []
-  note: "IN PROGRESS — D-S066-route=1 / ui-preview=1 / board=1; Lean approved; local UI preview http://127.0.0.1:18000/; 16-evolve Phase 0–1; next 01-requirements; base stage@340b3cf6; branch evolve/EV-056-quality-metrics-diff-page (not pushed); #988; [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]"
-
-sessions:
-
+  note: "CLOSED — D-S066-13=1 / D-S066-close=1 — #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; #988 Done; promote deferred; docs PR #990; [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]"
 
 - id: S065-quality-metrics-diff-long-line
   type: hotfix
@@ -37951,7 +37987,7 @@ retrospective_cycles:
 evolve_cycles:
 - id: EV-056
   title: "F7.q Quality metrics detail page + collapsible diffs (#988)"
-  status: in_progress
+  status: completed
   cycle_type: feature
   session_id: S066-quality-metrics-diff-page
   feature_ids: []
@@ -37966,16 +38002,35 @@ evolve_cycles:
   branch_base: stage@340b3cf6
   branch_base_sha: 340b3cf6
   branch_base_sha_full: 340b3cf66388b18da4381955f3721c3f04b1ea7d
-  branch_status: ACTIVE
+  branch_status: merged
   branch_exists: true
-  branch_pushed: false
-  branch_note: "local evolve/EV-056-quality-metrics-diff-page @ stage@340b3cf6 (not pushed yet)"
-  tip_sha:
-  tip_sha_full:
-  tip_sha_pushed: false
-  current_stage: 16-evolve
-  current_stage_status: in_progress
-  current_stage_note: "16-evolve in_progress — Lean approved; local UI preview; next child 01-requirements"
+  branch_pushed: true
+  branch_note: "CLOSED — D-S066-13=1 / D-S066-close=1; #989 → stage @ b4a63ab8; Staging CD 31545833142 success; promote deferred"
+  tip_sha: "b4a63ab8"
+  tip_sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+  tip_sha_pushed: true
+  tip_sha_note: "COMPLETE D-S066-13=1 / D-S066-close=1; #989@b4a63ab8 Staging CD 31545833142 success; H0c–H5 PASS; closed on stage (no promote)"
+  pr_number: 989
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989
+  pr_status: merged
+  pr_base: stage
+  merge_sha: b4a63ab8
+  merge_sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+  merge_at: '2026-08-11T23:16:21Z'
+  followup_pr_number: 990
+  followup_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/990
+  followup_pr_status: open
+  followup_pr_note: "docs closeout PR #990 open → stage; product tip remains #989@b4a63ab8"
+  tip_ci_run: '31545833142'
+  tip_ci_status: success
+  tip_ci_note: "Staging CD 31545833142 success; H0c–H5 PASS; D-S066-13=1"
+  board_note: "#988 Done"
+  completed: '2026-08-11'
+  completed_at: '2026-08-11'
+  close_decision_id: D-S066-close
+  current_stage: 13-deploy-smoke
+  current_stage_status: completed
+  current_stage_note: "CLOSED — D-S066-13=1 / D-S066-close=1; #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; promote deferred"
   started: "2026-08-11"
   started_at: "2026-08-11"
   preset: Lean
@@ -38000,17 +38055,20 @@ evolve_cycles:
   - 11-verify-impl
   - 12-verify-deploy
   scope_summary: "Dedicated Quality metrics detail route + GitHub-style collapsible unified XML diffs; keep C14N equality; follow-up from S065 / #988; base stage@340b3cf6"
-  decisions_locked: false
+  decisions_locked: true
   decisions:
     D-S065-close: "1 — prior session closed; #987@340b3cf6; open EV-056/S066"
     D-S066-route: "1 — Lean as drafted"
     D-S066-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
     D-S066-board: "1 — #988 → In progress"
+    D-S066-pr: "1 — PR #989 opened/merged → stage @ b4a63ab8"
+    D-S066-13: "1 — Approve 13-deploy-smoke; Staging CD 31545833142 success; H0c–H5 PASS; promote deferred"
+    D-S066-close: "1 — Close S066/EV-056; #989 → stage @ b4a63ab8; #988 Done; docs #990"
   artifacts:
   - docs/sessions/S066-quality-metrics-diff-page/
   prior_session: S065-quality-metrics-diff-long-line
   prior_evolve_note: "Follow-up from S065 hotfix #987 (pretty-print); page+hunks deferred to EV-056 / #988"
-  note: "IN PROGRESS — D-S066-route=1 / ui-preview=1; Plan orchestrator Phase 0–1; next 01-requirements; [Corpus: product §F7.q] [Corpus: tests §UJ-056] [Corpus: journeys §UJ-056]"
+  note: "CLOSED — D-S066-13=1 / D-S066-close=1; #989 → stage @ b4a63ab8; Staging CD 31545833142 success; H0c–H5 PASS; #988 Done; promote deferred; session_id S066; [Corpus: product §F7.q]"
 - id: EV-055
   title: "Quality metrics 2025-2 follow-ups (#982/#980/#979)"
   status: completed
@@ -51679,6 +51737,25 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: "b4a63ab8"
+    sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+    message: "Merge pull request #989 from EMPIRIC2/evolve/EV-056-quality-metrics-diff-page"
+    branch: stage
+    stage: 13-deploy-smoke
+    session_id: S066-quality-metrics-diff-page
+    evolve_cycle_id: EV-056
+    timestamp: "2026-08-11"
+    pushed: true
+    tip_sha: b4a63ab8
+    tip_sha_full: b4a63ab8ec09f47d8ea95a50008c698fa37b7734
+    tip_ci_run: '31545833142'
+    tip_ci_status: success
+    pr_number: 989
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/989
+    pr_status: merged
+    pr_base: stage
+    merge_at: '2026-08-11T23:16:21Z'
+    note: "CLOSED D-S066-13=1 / D-S066-close=1 — #989 → stage @ b4a63ab8; Staging CD 31545833142 success"
   - sha: "f065d808"
     sha_full: f065d808b015612a876dc4a10687e33a5f192629
     message: "docs: open S066/EV-056 Quality metrics detail page session"


### PR DESCRIPTION
## Summary
- Record 13-deploy-smoke evidence for EV-056 / S066 after #989 merge to `stage`
- Staging Deploy + Staging smoke green; H0c–H5 PASS on staging hosts

## Test plan
- [x] CI Deploy (stage) + Staging smoke on `b4a63ab8`
- [x] Local `verify_connectivity.sh` H0c/H4/H5 against staging
- [x] Quality metrics API + `/quality` FE probes


Made with [Cursor](https://cursor.com)