### PR TITLE
[EV-057] fix: TacEditor aria-label sync for Validate IWXXM (UJ-058)

### DIFF
--- a/apps/frontend/src/app/components/TacEditor.test.tsx
+++ b/apps/frontend/src/app/components/TacEditor.test.tsx
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
 
 vi.mock('codemirror', () => {
   class FakeEditorView {
@@ -13,9 +14,13 @@ vi.mock('codemirror', () => {
     static contentAttributes = { of: () => ({}) };
     static theme = () => ({});
     state = { doc: { toString: () => '', length: 0 } };
-    contentDOM = { contentEditable: 'true' };
-    constructor() {
-      /* no-op for unit smoke */
+    contentDOM: HTMLElement;
+    constructor(config?: { parent?: HTMLElement | null }) {
+      this.contentDOM = document.createElement('div');
+      this.contentDOM.contentEditable = 'true';
+      this.contentDOM.setAttribute('aria-label', 'Enter TAC data manually');
+      this.contentDOM.id = 'manual-input';
+      config?.parent?.appendChild(this.contentDOM);
     }
     dispatch() {
       /* no-op */
@@ -69,5 +74,24 @@ describe('TacEditor', () => {
       'data-issue-span-count',
       '1',
     );
+  });
+
+  it('syncs contentDOM aria-label when the prop changes (UJ-058 / EV-057)', () => {
+    function Harness() {
+      const [label, setLabel] = useState('Enter METAR data manually');
+      return (
+        <div>
+          <button type="button" onClick={() => setLabel('Enter IWXXM XML manually')}>
+            switch-validate
+          </button>
+          <TacEditor value="<root/>" onChange={() => undefined} aria-label={label} />
+        </div>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByLabelText('Enter METAR data manually')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'switch-validate' }));
+    expect(screen.getByLabelText('Enter IWXXM XML manually')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/components/TacEditor.tsx
+++ b/apps/frontend/src/app/components/TacEditor.tsx
@@ -138,6 +138,17 @@ export function TacEditor({
     view.contentDOM.contentEditable = readOnly ? 'false' : 'true';
   }, [readOnly]);
 
+  // Mount-once CodeMirror keeps initial contentAttributes; sync a11y label when
+  // FileConverter switches modes (e.g. TAC → Validate IWXXM / UJ-058 live).
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) {
+      return;
+    }
+    view.contentDOM.setAttribute('aria-label', ariaLabel);
+    view.contentDOM.id = id;
+  }, [ariaLabel, id]);
+
   useEffect(() => {
     const view = viewRef.current;
     if (!view) {


### PR DESCRIPTION
## Summary
- Sync CodeMirror `contentDOM` `aria-label` when FileConverter switches input modes (TAC → Validate IWXXM).
- Fixes live UJ-058 on staging after EV-057 merge (#991): Playwright `getByLabel(/Enter IWXXM XML manually/i)` no longer times out.
- Unit regression in `TacEditor.test.tsx`.

## Test plan
- [x] `vitest` TacEditor tests
- [x] `make validate-ci` + `make ci-prepush`
- [ ] Tip CI green on PR
- [ ] Merge → stage Deploy + Staging smoke
- [ ] Re-run live UJ-058 against staging


Made with [Cursor](https://cursor.com)