### PR TITLE
[EV-058] Quality metrics: side-by-side vs inline XML diff (#983)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI/CD](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/ci-cd.yml)
 [![E2E](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/EMPIRIC2/TAC-to-IWXXM/actions/workflows/e2e-tests.yml)
-[![E2E tests](https://img.shields.io/badge/E2E_tests-87-blue)](apps/e2e)
+[![E2E tests](https://img.shields.io/badge/E2E_tests-88-blue)](apps/e2e)
 [![Unit coverage gate](https://img.shields.io/badge/unit_coverage-%E2%89%A595%25-success)](docs/test-plan.md)
 
 Convert aviation TAC (METAR, SPECI, TAF, SIGMET family, and related products) to WMO IWXXM

--- a/apps/e2e/uj056-quality-metrics.e2e.spec.ts
+++ b/apps/e2e/uj056-quality-metrics.e2e.spec.ts
@@ -149,4 +149,35 @@ test.describe('UJ-056 Quality metrics tab (TC-EV054-007 / TC-EV055-007 / TC-EV05
     );
     await expect(page.getByTestId('quality-metrics-detail-close')).toBeVisible();
   });
+
+  test('TC-EV058-005: switch Inline ↔ Side-by-side and persist preference', async ({
+    page,
+  }) => {
+    await page.goto(`/quality/${PASSER_STEM}`);
+    await dismissPrivacyNoticeIfPresent(page);
+
+    await expect(page.getByTestId('quality-metrics-detail')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('quality-metrics-diff-layout')).toBeVisible();
+    await expect(
+      page.getByTestId('quality-metrics-diff-layout-unified'),
+    ).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByTestId('quality-metrics-diff-layout-side-by-side').click();
+    await expect(
+      page.getByTestId('quality-metrics-diff-layout-side-by-side'),
+    ).toHaveAttribute('aria-checked', 'true');
+    // Equal passer still shows empty diff in both layouts.
+    await expect(page.getByTestId('quality-metrics-diff-empty')).toBeVisible();
+
+    await page.reload();
+    await dismissPrivacyNoticeIfPresent(page);
+    await expect(page.getByTestId('quality-metrics-detail')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByTestId('quality-metrics-diff-layout-side-by-side'),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
 });

--- a/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
@@ -2,7 +2,7 @@
  * TC-EV055-001 / AC6 — C14N panes, raw override, validate disposition chips.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -307,5 +307,53 @@ describe('QualityMetricsDetail C14N panes (TC-EV055-001)', () => {
     expect(screen.getByTestId('quality-metrics-pane-validate')).toHaveTextContent(
       '[object Object]',
     );
+  });
+});
+
+describe('QualityMetricsDetail diff layout (TC-EV058)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to unified and switches to side-by-side without reload', async () => {
+    const user = userEvent.setup();
+    render(<QualityMetricsDetail detail={SEMANTIC_DIFF} />);
+
+    expect(screen.getByTestId('quality-metrics-diff-layout-unified')).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByTestId('quality-metrics-diff-body')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('quality-metrics-diff-layout-side-by-side'));
+
+    expect(
+      screen.getByTestId('quality-metrics-diff-layout-side-by-side'),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('quality-metrics-diff-side-by-side')).toBeInTheDocument();
+    expect(screen.getByTestId('quality-metrics-diff-side-left')).toHaveTextContent(
+      '<v>1</v>',
+    );
+    expect(screen.getByTestId('quality-metrics-diff-side-right')).toHaveTextContent(
+      '<v>2</v>',
+    );
+    expect(screen.queryByTestId('quality-metrics-diff-body')).not.toBeInTheDocument();
+  });
+
+  it('persists layout preference in localStorage across remount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<QualityMetricsDetail detail={SEMANTIC_DIFF} />);
+    await user.click(screen.getByTestId('quality-metrics-diff-layout-side-by-side'));
+    unmount();
+
+    render(<QualityMetricsDetail detail={SEMANTIC_DIFF} />);
+    expect(
+      screen.getByTestId('quality-metrics-diff-layout-side-by-side'),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('quality-metrics-diff-side-by-side')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
@@ -356,4 +356,39 @@ describe('QualityMetricsDetail diff layout (TC-EV058)', () => {
     ).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByTestId('quality-metrics-diff-side-by-side')).toBeInTheDocument();
   });
+
+  it('renders unpaired add/remove rows and best-effort syncs side-by-side scroll', async () => {
+    const user = userEvent.setup();
+    const detail: QualityMetricsDetailResponse = {
+      ...FORMATTING_ONLY,
+      stem: 'metar-unpaired',
+      match_status: 'unequal',
+      official_xml: '<root xmlns="urn:x"><a/><b/></root>',
+      converted_xml: '<root xmlns="urn:x"><a/><c/><d/></root>',
+    };
+    render(<QualityMetricsDetail detail={detail} />);
+    await user.click(screen.getByTestId('quality-metrics-diff-layout-side-by-side'));
+
+    const left = screen.getByTestId('quality-metrics-diff-side-left');
+    const right = screen.getByTestId('quality-metrics-diff-side-right');
+    expect(left.querySelectorAll('[data-op="empty"]').length).toBeGreaterThan(0);
+    expect(right.querySelectorAll('[data-op="add"]').length).toBeGreaterThan(0);
+    expect(left.querySelectorAll('[data-op="remove"]').length).toBeGreaterThan(0);
+
+    // Best-effort sync — fire both scroll handlers without asserting DOM scrollTop
+    // (jsdom scroll assignment is unreliable).
+    left.dispatchEvent(new Event('scroll'));
+    right.dispatchEvent(new Event('scroll'));
+  });
+
+  it('switches back to unified layout from side-by-side', async () => {
+    const user = userEvent.setup();
+    render(<QualityMetricsDetail detail={SEMANTIC_DIFF} />);
+    await user.click(screen.getByTestId('quality-metrics-diff-layout-side-by-side'));
+    await user.click(screen.getByTestId('quality-metrics-diff-layout-unified'));
+    expect(screen.getByTestId('quality-metrics-diff-body')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('quality-metrics-diff-side-by-side'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/components/QualityMetricsDetail.tsx
+++ b/apps/frontend/src/app/components/QualityMetricsDetail.tsx
@@ -1,17 +1,25 @@
 /**
- * Per-stem Quality metrics detail — TAC/XML panes, diagnostics, unified diff.
+ * Per-stem Quality metrics detail — TAC/XML panes, diagnostics, XML diff.
  *
  * F7.q / EV-054 M4 + EV-055 M4 (AC1/AC6 — C14N panes + validate chips) +
- * EV-056 collapsible equal-context hunks (`D-S066-context-n=1`).
+ * EV-056 collapsible equal-context hunks (`D-S066-context-n=1`) +
+ * EV-058 selectable Inline vs Side-by-side (`D-S068-01-control=3a`).
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type Ref } from 'react';
 import type { QualityMetricsDetailResponse } from '@/utils/openapiTypes';
 import {
   collapseEqualContext,
   DEFAULT_DIFF_CONTEXT,
   type CollapsedDiffSegment,
 } from '@/utils/collapseEqualContext';
+import {
+  readDiffLayoutPreference,
+  sideBySideFromUnified,
+  writeDiffLayoutPreference,
+  type QualityMetricsDiffLayout,
+  type SideBySideDiffRow,
+} from '@/utils/qualityMetricsDiffLayout';
 import { qualityMetricsDisplayXml } from '@/utils/qualityMetricsDisplayXml';
 import {
   isUnifiedDiffEmpty,
@@ -35,6 +43,10 @@ export const QUALITY_METRICS_DIFF_EXPAND_ALL = 'Show all unchanged lines';
 export const QUALITY_METRICS_DIFF_COLLAPSE_ALL = 'Hide distant unchanged lines';
 export const QUALITY_METRICS_BACK_TO_LIST = 'Back to list';
 export const QUALITY_METRICS_DIFF_HEADING = 'Line-by-line XML differences';
+export const QUALITY_METRICS_DIFF_LAYOUT_INLINE = 'Inline (unified)';
+export const QUALITY_METRICS_DIFF_LAYOUT_SIDE_BY_SIDE = 'Side-by-side';
+export const QUALITY_METRICS_DIFF_LAYOUT_LEGEND =
+  'Choose how to compare official vs converted XML. The default is a single inline (unified) diff.';
 export const QUALITY_METRICS_RESIDUALS_HELP =
   'TAC tokens left over after conversion (should usually be empty).';
 export const QUALITY_METRICS_LINT_HELP =
@@ -52,7 +64,7 @@ interface QualityMetricsDetailProps {
 }
 
 /**
- * Render inspectable TAC/XML panes, match status, diagnostics, and unified diff.
+ * Render inspectable TAC/XML panes, match status, diagnostics, and XML diff.
  *
  * @param props.detail - Stem detail response
  * @param props.onClose - Optional close handler
@@ -68,6 +80,16 @@ export function QualityMetricsDetail({
   const [expandedCollapseKeys, setExpandedCollapseKeys] = useState<Set<string>>(
     () => new Set(),
   );
+  const [diffLayout, setDiffLayout] = useState<QualityMetricsDiffLayout>(() =>
+    readDiffLayoutPreference(),
+  );
+  const sideBySideLeftRef = useRef<HTMLPreElement | null>(null);
+  const sideBySideRightRef = useRef<HTMLPreElement | null>(null);
+  const syncingScroll = useRef(false);
+
+  useEffect(() => {
+    writeDiffLayoutPreference(diffLayout);
+  }, [diffLayout]);
 
   const officialC14n = useMemo(
     () => qualityMetricsDisplayXml(detail.official_xml ?? ''),
@@ -92,6 +114,8 @@ export function QualityMetricsDetail({
     [diffLines],
   );
 
+  const sideBySideRows = useMemo(() => sideBySideFromUnified(diffLines), [diffLines]);
+
   const dispositionChips = useMemo(
     () => validateDispositionChips(detail.validate_issues ?? []),
     [detail.validate_issues],
@@ -111,6 +135,26 @@ export function QualityMetricsDetail({
         next.add(key);
       }
       return next;
+    });
+  };
+
+  /** Best-effort synced scroll between side-by-side panes (`D-S068-01-ac=2b`). */
+  const onSideBySideScroll = (source: 'left' | 'right') => {
+    if (syncingScroll.current) {
+      return;
+    }
+    const from =
+      source === 'left' ? sideBySideLeftRef.current : sideBySideRightRef.current;
+    const to =
+      source === 'left' ? sideBySideRightRef.current : sideBySideLeftRef.current;
+    if (!from || !to) {
+      return;
+    }
+    syncingScroll.current = true;
+    to.scrollTop = from.scrollTop;
+    to.scrollLeft = from.scrollLeft;
+    requestAnimationFrame(() => {
+      syncingScroll.current = false;
     });
   };
 
@@ -224,24 +268,64 @@ export function QualityMetricsDetail({
           <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
             {QUALITY_METRICS_DIFF_HEADING}
           </h3>
-          {!diffEmpty && hasCollapseSegments ? (
-            <button
-              type="button"
-              className="rounded-md border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
-              data-testid="quality-metrics-diff-expand-all"
-              onClick={() => {
-                setExpandAll((prev) => !prev);
-                if (expandAll) {
-                  setExpandedCollapseKeys(new Set());
-                }
-              }}
+          <div className="flex flex-wrap items-center gap-2">
+            <div
+              className="inline-flex rounded-md border border-gray-300 dark:border-gray-600"
+              role="radiogroup"
+              aria-label="XML diff layout"
+              data-testid="quality-metrics-diff-layout"
             >
-              {expandAll
-                ? QUALITY_METRICS_DIFF_COLLAPSE_ALL
-                : QUALITY_METRICS_DIFF_EXPAND_ALL}
-            </button>
-          ) : null}
+              <button
+                type="button"
+                role="radio"
+                aria-checked={diffLayout === 'unified'}
+                className={
+                  diffLayout === 'unified'
+                    ? 'bg-gray-800 px-2 py-1 text-xs text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'px-2 py-1 text-xs text-gray-700 dark:text-gray-300'
+                }
+                data-testid="quality-metrics-diff-layout-unified"
+                onClick={() => setDiffLayout('unified')}
+              >
+                {QUALITY_METRICS_DIFF_LAYOUT_INLINE}
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={diffLayout === 'side-by-side'}
+                className={
+                  diffLayout === 'side-by-side'
+                    ? 'bg-gray-800 px-2 py-1 text-xs text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'px-2 py-1 text-xs text-gray-700 dark:text-gray-300'
+                }
+                data-testid="quality-metrics-diff-layout-side-by-side"
+                onClick={() => setDiffLayout('side-by-side')}
+              >
+                {QUALITY_METRICS_DIFF_LAYOUT_SIDE_BY_SIDE}
+              </button>
+            </div>
+            {diffLayout === 'unified' && !diffEmpty && hasCollapseSegments ? (
+              <button
+                type="button"
+                className="rounded-md border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
+                data-testid="quality-metrics-diff-expand-all"
+                onClick={() => {
+                  setExpandAll((prev) => !prev);
+                  if (expandAll) {
+                    setExpandedCollapseKeys(new Set());
+                  }
+                }}
+              >
+                {expandAll
+                  ? QUALITY_METRICS_DIFF_COLLAPSE_ALL
+                  : QUALITY_METRICS_DIFF_EXPAND_ALL}
+              </button>
+            ) : null}
+          </div>
         </div>
+        <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+          {QUALITY_METRICS_DIFF_LAYOUT_LEGEND}
+        </p>
         {diffEmpty ? (
           <p
             className="text-sm text-gray-500 dark:text-gray-400"
@@ -249,6 +333,14 @@ export function QualityMetricsDetail({
           >
             {QUALITY_METRICS_DIFF_EMPTY_LABEL}
           </p>
+        ) : diffLayout === 'side-by-side' ? (
+          <SideBySideDiff
+            rows={sideBySideRows}
+            leftRef={sideBySideLeftRef}
+            rightRef={sideBySideRightRef}
+            onScrollLeft={() => onSideBySideScroll('left')}
+            onScrollRight={() => onSideBySideScroll('right')}
+          />
         ) : (
           <pre
             className="max-h-96 overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100 dark:border-gray-700"
@@ -390,6 +482,97 @@ function DiffLineRow({ line }: { line: UnifiedDiffLine }) {
     <div className={`${color} whitespace-pre-wrap break-all`}>
       {prefix}
       {line.text}
+    </div>
+  );
+}
+
+function SideBySideDiff({
+  rows,
+  leftRef,
+  rightRef,
+  onScrollLeft,
+  onScrollRight,
+}: {
+  rows: SideBySideDiffRow[];
+  leftRef: Ref<HTMLPreElement>;
+  rightRef: Ref<HTMLPreElement>;
+  onScrollLeft: () => void;
+  onScrollRight: () => void;
+}) {
+  return (
+    <div
+      className="grid max-h-96 grid-cols-2 gap-2"
+      data-testid="quality-metrics-diff-side-by-side"
+    >
+      <div>
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Official
+        </p>
+        <pre
+          ref={leftRef}
+          className="max-h-80 overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100 dark:border-gray-700"
+          data-testid="quality-metrics-diff-side-left"
+          onScroll={onScrollLeft}
+        >
+          {rows.map((row, index) => (
+            <SideBySideCell
+              key={`L-${index}`}
+              text={row.left}
+              op={row.leftOp}
+              side="left"
+            />
+          ))}
+        </pre>
+      </div>
+      <div>
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Converted
+        </p>
+        <pre
+          ref={rightRef}
+          className="max-h-80 overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100 dark:border-gray-700"
+          data-testid="quality-metrics-diff-side-right"
+          onScroll={onScrollRight}
+        >
+          {rows.map((row, index) => (
+            <SideBySideCell
+              key={`R-${index}`}
+              text={row.right}
+              op={row.rightOp}
+              side="right"
+            />
+          ))}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function SideBySideCell({
+  text,
+  op,
+  side,
+}: {
+  text: string | null;
+  op: SideBySideDiffRow['leftOp'] | SideBySideDiffRow['rightOp'];
+  side: 'left' | 'right';
+}) {
+  const color =
+    op === 'add'
+      ? 'text-green-400'
+      : op === 'remove'
+        ? 'text-red-400'
+        : op === 'empty'
+          ? 'text-gray-600'
+          : 'text-gray-300';
+  const display = text === null ? ' ' : text;
+  return (
+    <div
+      className={`${color} whitespace-pre-wrap break-all`}
+      data-op={op}
+      data-side={side}
+    >
+      {display}
     </div>
   );
 }

--- a/apps/frontend/src/utils/qualityMetricsDiffLayout.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsDiffLayout.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for Quality metrics diff layout helpers (TC-EV058).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { unifiedLineDiff } from './unifiedLineDiff';
+import {
+  QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY,
+  parseDiffLayout,
+  readDiffLayoutPreference,
+  sideBySideFromUnified,
+  writeDiffLayoutPreference,
+} from './qualityMetricsDiffLayout';
+
+describe('qualityMetricsDiffLayout (TC-EV058)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('parseDiffLayout defaults unknown to unified', () => {
+    expect(parseDiffLayout(null)).toBe('unified');
+    expect(parseDiffLayout('')).toBe('unified');
+    expect(parseDiffLayout('side-by-side')).toBe('side-by-side');
+    expect(parseDiffLayout('inline')).toBe('unified');
+  });
+
+  it('persists preference in localStorage', () => {
+    expect(readDiffLayoutPreference()).toBe('unified');
+    writeDiffLayoutPreference('side-by-side');
+    expect(window.localStorage.getItem(QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY)).toBe(
+      'side-by-side',
+    );
+    expect(readDiffLayoutPreference()).toBe('side-by-side');
+    writeDiffLayoutPreference('unified');
+    expect(readDiffLayoutPreference()).toBe('unified');
+  });
+
+  it('sideBySideFromUnified pairs remove+add and keeps equals', () => {
+    const lines = unifiedLineDiff('a\nb\nc', 'a\nx\nc');
+    const rows = sideBySideFromUnified(lines);
+    expect(rows).toEqual([
+      { left: 'a', right: 'a', leftOp: 'equal', rightOp: 'equal' },
+      { left: 'b', right: 'x', leftOp: 'remove', rightOp: 'add' },
+      { left: 'c', right: 'c', leftOp: 'equal', rightOp: 'equal' },
+    ]);
+  });
+
+  it('sideBySideFromUnified handles unpaired add/remove', () => {
+    const onlyRemove = sideBySideFromUnified(unifiedLineDiff('a\nb', 'a'));
+    expect(onlyRemove.some((r) => r.leftOp === 'remove' && r.right === null)).toBe(
+      true,
+    );
+    const onlyAdd = sideBySideFromUnified(unifiedLineDiff('a', 'a\nb'));
+    expect(onlyAdd.some((r) => r.rightOp === 'add' && r.left === null)).toBe(true);
+  });
+});

--- a/apps/frontend/src/utils/qualityMetricsDiffLayout.test.ts
+++ b/apps/frontend/src/utils/qualityMetricsDiffLayout.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for Quality metrics diff layout helpers (TC-EV058).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { unifiedLineDiff } from './unifiedLineDiff';
 import {
   QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY,
@@ -56,5 +56,33 @@ describe('qualityMetricsDiffLayout (TC-EV058)', () => {
     );
     const onlyAdd = sideBySideFromUnified(unifiedLineDiff('a', 'a\nb'));
     expect(onlyAdd.some((r) => r.rightOp === 'add' && r.left === null)).toBe(true);
+  });
+
+  it('readDiffLayoutPreference falls back when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(readDiffLayoutPreference()).toBe('unified');
+  });
+
+  it('writeDiffLayoutPreference swallows setItem errors', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => writeDiffLayoutPreference('side-by-side')).not.toThrow();
+  });
+
+  it('read/write tolerate missing localStorage', () => {
+    const original = window.localStorage;
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: undefined,
+    });
+    expect(readDiffLayoutPreference()).toBe('unified');
+    expect(() => writeDiffLayoutPreference('unified')).not.toThrow();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: original,
+    });
   });
 });

--- a/apps/frontend/src/utils/qualityMetricsDiffLayout.ts
+++ b/apps/frontend/src/utils/qualityMetricsDiffLayout.ts
@@ -1,0 +1,128 @@
+/**
+ * Quality metrics XML diff layout preference (F7.q / EV-058 / #983).
+ *
+ * Persist Inline (unified) vs Side-by-side in localStorage; derive side-by-side
+ * rows from {@link unifiedLineDiff} without a new npm diff package.
+ */
+
+import type { UnifiedDiffLine } from './unifiedLineDiff';
+
+/** localStorage key for diff layout preference (`D-S068-01-ac=2b`). */
+export const QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY =
+  'tac-to-iwxxm.quality-metrics.diff-layout';
+
+/** Diff layout modes on `/quality/:stem`. */
+export type QualityMetricsDiffLayout = 'unified' | 'side-by-side';
+
+/** One aligned row for side-by-side rendering. */
+export type SideBySideDiffRow = {
+  /** Left (official) line text, or null when only converted added a line. */
+  left: string | null;
+  /** Right (converted) line text, or null when only official removed a line. */
+  right: string | null;
+  /** Left gutter highlight. */
+  leftOp: 'equal' | 'remove' | 'empty';
+  /** Right gutter highlight. */
+  rightOp: 'equal' | 'add' | 'empty';
+};
+
+/**
+ * Parse a stored layout value; unknown values fall back to unified.
+ *
+ * @param raw - Raw localStorage string
+ * @returns Valid layout mode
+ */
+export function parseDiffLayout(
+  raw: string | null | undefined,
+): QualityMetricsDiffLayout {
+  return raw === 'side-by-side' ? 'side-by-side' : 'unified';
+}
+
+/**
+ * Read preferred layout from localStorage (SSR-safe).
+ *
+ * @returns Stored preference or unified default
+ */
+export function readDiffLayoutPreference(): QualityMetricsDiffLayout {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return 'unified';
+  }
+  try {
+    return parseDiffLayout(
+      window.localStorage.getItem(QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY),
+    );
+  } catch {
+    return 'unified';
+  }
+}
+
+/**
+ * Persist layout preference to localStorage (best-effort).
+ *
+ * @param layout - Selected layout
+ */
+export function writeDiffLayoutPreference(layout: QualityMetricsDiffLayout): void {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(QUALITY_METRICS_DIFF_LAYOUT_STORAGE_KEY, layout);
+  } catch {
+    // Quota / private mode — preference is session-only.
+  }
+}
+
+/**
+ * Build side-by-side rows from a unified line diff (same LCS source as inline).
+ *
+ * @param lines - Output of {@link unifiedLineDiff}
+ * @returns Aligned left/right rows
+ */
+export function sideBySideFromUnified(lines: UnifiedDiffLine[]): SideBySideDiffRow[] {
+  const rows: SideBySideDiffRow[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (line.op === 'equal') {
+      rows.push({
+        left: line.text,
+        right: line.text,
+        leftOp: 'equal',
+        rightOp: 'equal',
+      });
+      i += 1;
+      continue;
+    }
+    // Pair consecutive remove+add as a changed line when both present.
+    if (line.op === 'remove') {
+      const next = lines[i + 1];
+      if (next?.op === 'add') {
+        rows.push({
+          left: line.text,
+          right: next.text,
+          leftOp: 'remove',
+          rightOp: 'add',
+        });
+        i += 2;
+        continue;
+      }
+      rows.push({
+        left: line.text,
+        right: null,
+        leftOp: 'remove',
+        rightOp: 'empty',
+      });
+      i += 1;
+      continue;
+    }
+    // add without preceding remove
+    rows.push({
+      left: null,
+      right: line.text,
+      leftOp: 'empty',
+      rightOp: 'add',
+    });
+    i += 1;
+  }
+  return rows;
+}

--- a/docs/decisions/evolve-decisions.md
+++ b/docs/decisions/evolve-decisions.md
@@ -3,6 +3,47 @@
 > Standing log of approved evolve-cycle scope and product decisions.
 > Cycle metadata also recorded in `workflow-state.yaml` §`evolve_cycles`.
 
+## Cycle EV-058 — Quality metrics side-by-side vs inline XML diff (#983) (S068)
+
+**Session**: S068-quality-metrics-diff-layout  
+**Features**: deepen **F7.q** only  
+**Started**: 2026-08-17  
+**Branch**: `evolve/EV-058-quality-metrics-diff-layout` (base `stage@c2ca9a3f`)  
+**Status**: **in_progress** — Spec-development; Spec→Build gate **closed**  
+**Issue**: [#983](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/983) — board **In progress**  
+**Predecessor**: S066 / EV-056 / #988 (unified + collapsible on stage)  
+**Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]
+[Corpus: decisions §EV-058]
+
+### Scope (Phase 0 — locked 2026-08-17)
+
+| ID | Decision |
+|----|----------|
+| D-S068-e0 | **1a/2b/3a/4a/5a** — evolve #983; persist + synced-scroll AC; stage; proceed |
+| D-S068-route | **1a/2a/3a** — Lean `00→16→01→02→10→13`; Spec→Build closed |
+| D-S068-ui-preview | **1** — http://127.0.0.1:18000/ |
+| D-S068-board | **1** — #983 → In progress |
+| D-S068-ev-confirm | **1a** — EV0–EV9 carry-forward |
+| D-S068-01-ac | **2b** — AC1–AC5; synced scroll **best-effort** (not blocking) |
+| D-S068-01-control | **3a** — segmented Inline \| Side-by-side |
+| D-S068-01-uj | **4a** — deepen UJ-056 + TC-EV058-001..005 |
+
+### Acceptance (approved `D-S068-01-ac=2b`)
+
+1. Switch Inline ↔ Side-by-side without reload.
+2. Default remains unified.
+3. Side-by-side via existing line-diff util; no new npm `diff`.
+4. Preference in localStorage.
+5. TAC/diagnostics/collapse kept; Vitest + Playwright both modes; H4–H5 via 13.
+   Synced scroll is best-effort polish only.
+
+### Out of scope
+
+- API/backend; new npm `diff`; C14N/`match_status`; #982 whitespace; promote to main;
+  non–Quality-metrics UI
+
+---
+
 ## Cycle EV-057 — M0 Ready: apex redirect + accumulate ZIP + validate IWXXM (#948 / #903 / #838) (S067)
 
 **Session**: S067-m0-ready-apex-accumulate-validate  

--- a/docs/decisions/requirements-decisions.md
+++ b/docs/decisions/requirements-decisions.md
@@ -1,6 +1,25 @@
 # Requirements Decisions Log
 
-> Stage: 01-requirements | Last updated: 2026-08-15 (S067 / EV-057)
+> Stage: 01-requirements | Last updated: 2026-08-17 (S068 / EV-058)
+
+## EV-058 / S068 — Quality metrics side-by-side vs inline XML diff (#983) (`D-S068-01-ac=2b`)
+
+| Topic | Decision | Notes | Status |
+|-------|----------|-------|--------|
+| EV-058 / Fn | Deepen **F7.q** only | No new top-level Fn | confirmed |
+| EV-058 / journey | Deepen **UJ-056** | + TC-EV058-001..005 (`D-S068-01-uj=4a`) | confirmed |
+| EV-058 / control | Segmented Inline \| Side-by-side | `D-S068-01-control=3a` | confirmed |
+| EV-058 / default | Unified / inline | UJ-056 compatible | confirmed |
+| EV-058 / persist | localStorage | Preference across visits | confirmed |
+| EV-058 / sync scroll | Best-effort | Not blocking AC (`D-S068-01-ac=2b`) | confirmed |
+| EV-058 / deps | Reuse line-diff helpers | No new npm `diff` | confirmed |
+| EV-058 / C14N | Unchanged | No `match_status` / fixture regen | confirmed |
+| EV-058 / AC | AC1–AC5 | See feature-list §F7.q EV-058 | confirmed |
+| EV-058 / docs | Delta manifest | feature-list + journeys + test-plan + decisions; skip api/deploy | confirmed |
+| EV-058 / UI preview | Local :18000 | `D-S068-ui-preview=1` | confirmed |
+| EV-058 / route | Lean | PR → stage; promote held | confirmed |
+
+[Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests] [Corpus: decisions §EV-058]
 
 ## EV-057 / S067 — M0 Ready: #948 / #903 / #838 (`D-S067-01-ac=1`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -14,7 +14,7 @@
 | F4 | IWXXM version handling | Implemented | Product | docs/domain/iwxxm/IWXXM_VERSION_SWITCHING.md; **deepen** S046 / EV-038 release-line SoT/UX (#851–#855) |
 | F5 | User METAR work history | Implemented | Product | S038 / EV-031 / F31 hybrid: guest IndexedDB + logged-in DO Postgres |
 | F6 | General TAC→IWXXM (`tac2iwxxm`) | Implemented | Product | S008, ADR-013/014/019; bulletin split; **deepen** S055 / EV-046 #889; **deepen** S059 / EV-050 #959 annex3 vs iwxxm_us membership compare |
-| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S063–S066 **F7.q**; **deepen** S067 / EV-057 **F7.r** accumulate ZIP (#903) + **F7.s** validate-only IWXXM (#838) |
+| F7 | Multi-product TAC operator UI / sessions | Planned | Product | S011; F7.g #780; F7.h IndexedDB; **F31** hybrid; **deepen** S063–S066 **F7.q**; **deepen** S068 / EV-058 **F7.q** side-by-side vs inline diff (#983); **deepen** S067 / EV-057 **F7.r** accumulate ZIP (#903) + **F7.s** validate-only IWXXM (#838) |
 | F8 | Near-realtime TAC ingest → IWXXM gate | Implemented | Product | S008 ADR-018; **F30** writers → DO Postgres (not Supabase DB) |
 | F9 | Value-aware live decode + plain-language summary | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723) |
 | F10 | Workbench preview clarity (IWXXM pane + lint UX) | Done | Product | S013 / EV-009; shipped 2026-07-17 (#723); **deepen** S048 / EV-040 full lint console lines + preserve input on convert |
@@ -309,7 +309,7 @@
   | F7.g | #780 | Pre-loaded golden examples (convert + validate) — S021 / EV-016 |
   | F7.h | #783 | IndexedDB local sessions (all products); drop JWT session APIs — S023 / EV-017 |
   | F7.i | #842 / F31 | Hybrid: guest IndexedDB + logged-in DO Postgres; auto-upload on login — S038 / EV-031 |
-  | F7.q | #836 / #982 / #988 | Quality metrics tab — official WMO corpus; W3C C14N match/diff (S063 / EV-054; S064 / EV-055); dedicated detail route + collapsible diffs (S066 / EV-056) |
+  | F7.q | #836 / #982 / #988 / #983 | Quality metrics tab — official WMO corpus; W3C C14N match/diff (S063 / EV-054; S064 / EV-055); dedicated detail route + collapsible diffs (S066 / EV-056); selectable side-by-side vs inline XML diff (S068 / EV-058) |
   | F7.r | #903 | Accumulate back-to-back conversions → one ZIP (S067 / EV-057) |
   | F7.s | #838 | Validate existing IWXXM (paste / single `.xml` upload; no TAC) (S067 / EV-057) |
 - **Inputs**: TAC text/files (`.txt` / `.metar` / `.tac`); `product` / `profile` /
@@ -438,6 +438,21 @@
   3. Diff shows collapsible equal-context hunks (default 3 lines; expand N / expand all).
   4. Unequal SIGMET stems remain navigable and readable on staging.
   5. UJ-056 / TC-EV056 updated; FE unit + Playwright smoke (H4–H5 via 13).
+- **S068 / EV-058 deepen (F7.q / #983 — side-by-side vs inline XML diff)**: On
+  `/quality/:stem`, add a **segmented control** — **Inline (unified)** | **Side-by-side** —
+  so operators can switch layouts without reload (`D-S068-01-control=3a`). Default remains
+  **unified** (UJ-056 backward compatible). Side-by-side uses existing `unifiedLineDiff` /
+  line-diff helpers (no new npm `diff` unless Gate B re-approved). Preference persists in
+  **localStorage**. Synced scroll between side-by-side panes is **best-effort** (not a
+  blocking AC — `D-S068-01-ac=2b`). Keep raw TAC / diagnostics / collapse-equal-context.
+  C14N / `match_status` unchanged; FE-only. Does **not** flip F7 → Implemented.
+- **Acceptance (EV-058 / #983 — F7.q)** — **approved** (`D-S068-01-ac=2b`):
+  1. Operator switches Inline (unified) ↔ Side-by-side without reload.
+  2. Default layout is unified (compatible with prior UJ-056 assertions unless updated).
+  3. Side-by-side highlights changed lines via existing line-diff util; no new npm `diff`.
+  4. Layout preference persists in localStorage across visits.
+  5. Raw TAC / diagnostics / collapsible unified equal-context remain; Vitest + Playwright
+     cover both modes; H4–H5 via 13. Synced scroll is best-effort polish, not required to pass.
 - **S067 / EV-057 deepen (F7.r / #903 — accumulate conversions → one ZIP)**: Successful
   converts **append** to the current result set instead of wiping prior successes so operators
   can convert A→B→C and **Download all** as one ZIP. Default archive basename when custom

--- a/docs/sessions/S068-quality-metrics-diff-layout/evolve-plan-card.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/evolve-plan-card.md
@@ -1,0 +1,58 @@
+# Evolve Plan Card
+
+> Cycle: EV-058 | Session: S068-quality-metrics-diff-layout | Updated: 2026-08-17
+
+## Goal
+
+Selectable **inline (unified)** vs **side-by-side** XML diff on F7.q `/quality/:stem`, with preference persistence and synced-scroll polish; ship to stage; promote held.
+
+## Features
+
+- F7.q — side-by-side vs inline XML diff layout — [Corpus: product §F7.q]
+- UJ-056 deepen — both layout modes — [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]
+
+## In / out of scope
+
+- In: layout toggle without reload; default unified; reuse `unifiedLineDiff`; localStorage/sessionStorage preference; optional synced scroll; Vitest + Playwright; PR → stage
+- Out: API/backend; new npm `diff`; C14N/`match_status` semantics; #982 whitespace; promote to main; non–Quality-metrics UI
+
+## Phase split
+
+- Active phase: **Build**
+- Spec→Build gate: **open** (`D-S068-spec-build=1a`)
+- Preset: **Lean** (`D-S068-route=1a`)
+- Gate A: **PASS** (`D-S068-gateA=1`)
+
+## Spec-development band (00–06)
+
+- Stages (ordered): `00 → 16 → 01 → 02`
+- Dual-mode Spec skills: none
+- Skip: `03`, `04`, `05`, `06`
+
+## Build band (07–13) — blocked until gate
+
+- Stages (ordered): `10 → 13`
+- Dual-mode Build skills: none
+- Deploy intent: **staging** (promote held)
+- Skip: `07`, `08`, `09`, `11`, `12` (Lean — 16 Agent implements after Gate A)
+
+## Next child stage
+
+**13-deploy-smoke** — after commit + PR → `stage` (CI green)
+
+## Locked intake
+
+| ID | Decision |
+|----|----------|
+| D-S068-ev-confirm | **1a** — EV0–EV9 carry-forward from E0–E8 |
+| D-S068-route | **1a/2a/3a** — Lean bands; Spec→Build closed |
+| D-S068-ui-preview | **1** — http://127.0.0.1:18000/ |
+| D-S068-board | **1** — #983 In progress |
+| D-S068-01-ac | **2b** — AC1–AC5; synced scroll best-effort |
+| D-S068-01-control | **3a** — segmented Inline \| Side-by-side |
+| D-S068-01-uj | **4a** — deepen UJ-056 + TC-EV058-* |
+
+## Risks / open decisions
+
+- Synced-scroll “if feasible” — confirm in 01 whether required or best-effort
+- UJ-056: extend assertions vs new UJ id — prefer deepen UJ-056 (`D-S068-e1e2`)

--- a/docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
@@ -1,0 +1,47 @@
+# 01-requirements — EV-058 / S068 (delta)
+
+**Mode**: delta (deepen F7.q — #983)  
+**Status**: **completed** (`D-S068-01-ac=2b`)  
+**Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests] [Corpus: decisions]
+
+## Document manifest (approved)
+
+| Doc | Action |
+|-----|--------|
+| `docs/feature-list.md` | F7 / F7.q EV-058 deepen + AC1–AC5 |
+| `docs/user-journeys.md` | UJ-056 deepen (layout toggle + persist) |
+| `docs/test-plan.md` | TC-EV058-001..005; UJ-056 map |
+| `docs/decisions/requirements-decisions.md` | §EV-058 |
+| `docs/decisions/evolve-decisions.md` | §EV-058 |
+| api-contract / config / system-spec / deploy | **skip** — FE-only; no API/`match_status` change |
+
+## Acceptance (approved `D-S068-01-ac=2b`)
+
+| ID | Criterion |
+|----|-----------|
+| AC1 | Switch Inline ↔ Side-by-side without reload |
+| AC2 | Default = unified |
+| AC3 | Side-by-side via existing line-diff util; no new npm `diff` |
+| AC4 | Preference in localStorage |
+| AC5 | TAC/diagnostics/collapse kept; Vitest + Playwright both modes; H4–H5 via 13; synced scroll **best-effort** |
+
+## Phase 0 / 01 locked
+
+| ID | Choice |
+|----|--------|
+| D-S068-01-start | 1a — delta F7.q #983 |
+| D-S068-01-ac | 2b — AC1–AC5; synced scroll best-effort |
+| D-S068-01-control | 3a — segmented Inline \| Side-by-side |
+| D-S068-01-uj | 4a — deepen UJ-056 + TC-EV058-* |
+| D-S068-ui-preview | 1 — http://127.0.0.1:18000/ |
+
+## Out of scope
+
+- API / backend / C14N / `match_status` / corpus regen
+- New npm diff library
+- Promote to main
+- Synced scroll as hard AC (best-effort only)
+
+## Next
+
+**02-verify-plan** — Gate A on this delta.

--- a/docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
@@ -1,0 +1,52 @@
+# 02-verify-plan — Gate A (S068 / EV-058)
+
+**Date**: 2026-08-17  
+**Mode**: delta — F7.q side-by-side vs inline XML diff (#983)  
+**Status**: Gate A PASS — `D-S068-gateA=1`  
+**01**: completed (`D-S068-01-ac=2b`)  
+**Spec→Build**: **open** (`D-S068-spec-build=1a`)
+
+## Inventory (touched)
+
+| # | Document | Delta | Status |
+|---|----------|-------|--------|
+| 1 | feature-list.md | F7.q EV-058 AC1–AC5 | audited |
+| 2 | user-journeys.md | UJ-056 deepen | audited |
+| 3 | test-plan.md | TC-EV058-001..005 | audited |
+| 4 | evolve-decisions / requirements-decisions | EV-058 locks | reference |
+| — | api-contract / config / deploy | skipped — FE-only | OK |
+
+## Consistency checklist
+
+| Check | Result |
+|-------|--------|
+| Feature ↔ Journey | **PASS** — UJ-056 EV-058 |
+| Journey ↔ Test | **PASS** — TC-EV058-001..005 |
+| Feature ↔ Test | **PASS** — AC1–AC5 ↔ TC-EV058-* |
+| Feature ↔ API | **PASS** — no contract change |
+| Connectivity H4–H5 | **PASS** — UJ-056 via **13** |
+| C14N / match_status | **PASS** — explicitly unchanged |
+| Synced scroll | **PASS** — best-effort only (`D-S068-01-ac=2b`) |
+
+## Statements (high — auto-approved)
+
+| ID | Statement | Verdict |
+|----|-----------|---------|
+| S1.1 | Segmented Inline \| Side-by-side | auto-approved (`D-S068-01-control=3a`) |
+| S1.2 | Default unified | auto-approved |
+| S1.3 | localStorage preference | auto-approved |
+| S1.4 | Reuse `unifiedLineDiff` / no new npm `diff` | auto-approved |
+| S1.5 | Deepen UJ-056 + TC-EV058 | auto-approved (`D-S068-01-uj=4a`) |
+| S1.6 | Lean path; PR → stage | auto-approved (`D-S068-route=1a`) |
+
+## Medium / low
+
+None blocking.
+
+## Gate A / Spec→Build (`D-S068-gateA=1` / `D-S068-spec-build=1a`)
+
+User: **1a / 2a** → PASS; open Build; implement FE (Lean — no 04/07).
+
+## Next
+
+Implement layout toggle on `QualityMetricsDetail` → FE unit → **10-e2e** → PR → **13**.

--- a/docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
@@ -1,0 +1,26 @@
+# 10-e2e — EV-058 / S068 (delta)
+
+**Date**: 2026-08-17  
+**Mode**: delta — F7.q side-by-side vs inline (#983)  
+**Status**: **PASS** (local)  
+**Env**: Playwright webServer / `PLAYWRIGHT_BASE_URL` (non-deployed)  
+**Corpus**: [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056] [Corpus: product §F7.q]
+
+## Results
+
+| Suite | Result |
+|-------|--------|
+| Vitest `qualityMetricsDiffLayout.test.ts` + `QualityMetricsDetail.test.tsx` | **20/20 PASS** |
+| Playwright `uj056-quality-metrics.e2e.spec.ts` (4 tests) | **4/4 PASS** |
+
+Includes new **TC-EV058-005**: switch Inline ↔ Side-by-side + localStorage persist across reload.
+
+## Notes
+
+- Default remains unified (prior UJ-056 assertions intact).
+- Equal passer still shows empty diff in both layouts.
+- H4–H5 live staging deferred to **13** after PR → `stage`.
+
+## Next
+
+Commit + push + PR → `stage` → **13-deploy-smoke**.

--- a/docs/sessions/S068-quality-metrics-diff-layout/routing-plan.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/routing-plan.md
@@ -1,0 +1,64 @@
+# Routing plan — S068 / EV-058
+
+**Status:** **approved** (`D-S068-route=1a/2a/3a`)  
+**Preset:** **Lean** (user-approved; pure UI / small blast radius — not Auto-Lean skip of intake)  
+**PR target:** `stage`  
+**Branch:** `evolve/EV-058-quality-metrics-diff-layout` @ `stage@c2ca9a3f`  
+**UI preview:** **Yes** — non-deployed local (`D-S068-ui-preview=1`) → http://127.0.0.1:18000/  
+**Spec→Build gate:** **open** (`D-S068-spec-build=1a`)
+**Gate A:** **PASS** (`D-S068-gateA=1`)
+
+## Spec-development band
+
+| Stage | Include? | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 00-context | yes | session | **completed** | Open S068; #983 In progress; Lean routing approved |
+| 16-evolve | yes | orchestrate | **in_progress** | Build open; FE implement → 10 → 13 |
+| 01-requirements | yes | delta | **completed** | `D-S068-01-ac=2b`; AC1–AC5; UJ-056 + TC-EV058 |
+| 02-verify-plan | yes | delta | **completed** | Gate A PASS `D-S068-gateA=1` |
+| 03-plan-tooling | no | — | skipped | No new Cursor rules expected |
+| 04-tech-plan | no | — | skipped | Lean — FE layout toggle only |
+| 05-verify-tech | no | — | skipped | Lean |
+| 06-tech-tooling | no | — | skipped | No new deps unless AskQuestion |
+
+## Build band
+
+| Stage | Include? | Mode | Status | Notes |
+|-------|----------|------|--------|-------|
+| 07-build | no | — | skipped | Lean: 16 Agent implements after Gate A |
+| 08-verify-build | no | — | skipped | Lean |
+| 09-qa | no | — | skipped | Lean |
+| 10-e2e | yes | delta | **completed** | UJ-056 4/4 PASS local; H4–H5 via 13 |
+| 11-verify-impl | no | — | skipped | Lean |
+| 12-verify-deploy | no | — | skipped | Lean (PR path via 13) |
+| 13-deploy-smoke | yes | delta | pending | Stage smoke after merge |
+
+## Recommended ordered stages
+
+`00 → 16 → 01 → 02 → 10 → 13`
+
+## Skip rationale
+
+- **Lean (user):** FE-only layout choice on existing `/quality/:stem`; C14N unchanged; reuse `unifiedLineDiff`.
+- **Skip 03/04/05/06/07/08/09/11/12:** no new guardrails/stack/Standard milestones; 16 orchestrates implementation after 01/02 Gate A.
+- **Include 10 + 13:** operator UI + staging H4–H5 / smoke for UJ-056 layout modes.
+
+## Board / velocity
+
+- WIP: #983 **In progress** (1 ≤ 2)
+- Ready: refill after this pull as needed (3–5 target)
+
+## Locked / pending decisions
+
+| ID | Decision |
+|----|----------|
+| D-S068-e0 | **1a/2b/3a/4a/5a** — goal/scope/success/constraints/proceed |
+| D-S068-e1e2 | **recommended** — feature; #983; operator; F7.q+UJ-056 |
+| D-S068-e3e4 | **1a–4a** — docs; no CORPUS gap; Lean Spec; FE Build intent |
+| D-S068-e5e6 | **1a–4a** — out-of-scope fence; H4–H5; local preview |
+| D-S068-route | **1a/2a/3a** — Lean bands; Spec→Build closed; open Spec |
+| D-S068-ui-preview | **1** — http://127.0.0.1:18000/ |
+| D-S068-board | **1** — #983 → In progress |
+| D-S068-01-ac | **2b** — AC1–AC5; synced scroll best-effort |
+| D-S068-01-control | **3a** — segmented Inline \| Side-by-side |
+| D-S068-01-uj | **4a** — deepen UJ-056 + TC-EV058-001..005 |

--- a/docs/sessions/S068-quality-metrics-diff-layout/session-brief.md
+++ b/docs/sessions/S068-quality-metrics-diff-layout/session-brief.md
@@ -1,0 +1,77 @@
+---
+session_id: S068-quality-metrics-diff-layout
+type: feature
+status: active
+branch: evolve/EV-058-quality-metrics-diff-layout
+orchestrator: 16-evolve
+evolve_cycle_id: EV-058
+github_issues: [983]
+prior_session: S067-m0-ready-apex-accumulate-validate
+opened: 2026-08-17
+---
+
+# Session brief — S068-quality-metrics-diff-layout
+
+> **Cycle**: EV-058 · **Type**: feature · **Opened**: 2026-08-17  
+> **Branch**: `evolve/EV-058-quality-metrics-diff-layout` @ `stage@c2ca9a3f`  
+> **Orchestrator**: **16-evolve** · **Preset**: Lean  
+> **Issue**: [#983](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/983) → **In progress**  
+> **Corpus**: [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]
+
+## Goal
+
+Add a user-selectable **inline (unified)** vs **side-by-side** XML diff layout on the F7.q Quality metrics detail page (`/quality/:stem`), with preference persistence and synced-scroll polish, without changing C14N match semantics.
+
+## Intent
+
+Natural follow-on to [S066 / EV-056 / #988](../S066-quality-metrics-diff-page/session-brief.md) (unified + collapsible context on stage). Operators reviewing noisy/large peers need an explicit layout choice; smaller blast radius than multi-issue M0 packs.
+
+| Decision | Choice |
+|----------|--------|
+| D-S068-e0 | **1a/2b/3a/4a/5a** — evolve #983; persist preference + synced-scroll as AC; stage only; no blockers; proceed |
+| D-S068-e1e2 | **recommended** — feature/16-evolve; #983 normal; operator pain; F7.q + UJ-056 fence |
+| D-S068-e3e4 | **1a–4a** — product/journeys/tests/evolve-decisions; no CORPUS gap; Lean Spec; FE-only Build intent |
+| D-S068-e5e6 | **1a–4a** — UI-only out-of-scope fence; compatible; H4–H5; local preview yes |
+| D-S068-route | **1a/2a/3a** — Lean Spec `00→16→01→02`; Lean Build `10→13` blocked; open Spec-only |
+| D-S068-ui-preview | **1** — non-deployed local UI at http://127.0.0.1:18000/ |
+| D-S068-board | **1** — #983 → In progress |
+
+## Out of scope
+
+- API / backend contract changes
+- New npm `diff` package (reuse `unifiedLineDiff` / existing helpers)
+- C14N / `match_status` / fixture generator semantics
+- Whitespace-normalize (#982) and non–Quality-metrics UI
+- Promote `stage` → `main` unless separately approved
+
+## Features
+
+- Deepen **F7.q** — selectable side-by-side vs inline XML diff on detail page  
+  ([Corpus: product §F7.q])
+- Journey / tests: deepen **UJ-056** for both layout modes  
+  ([Corpus: journeys §UJ-056] [Corpus: tests §UJ-056])
+
+## Acceptance (seed — refine in 01)
+
+| ID | Criterion |
+|----|-----------|
+| AC1 | Operator can switch Inline (unified) ↔ Side-by-side without reload |
+| AC2 | Default remains unified (UJ-056 backward compatible unless journey updated) |
+| AC3 | Side-by-side uses existing line-diff util; optional synced scroll; no new npm `diff` |
+| AC4 | Layout preference persists (sessionStorage or localStorage) |
+| AC5 | Raw TAC / diagnostics / collapse-equal-context remain; Vitest + Playwright cover both modes |
+
+## Implementation notes
+
+- Primary surface: `apps/frontend` `QualityMetricsDetail.tsx` + `unifiedLineDiff` / `collapseEqualContext`
+- Operator copy: no internal doc refs (EV-048)
+- PR target: `stage`; promote held
+
+## Board
+
+- Project [#7 TAC-to-IWXXM](https://github.com/orgs/EMPIRIC2/projects/7)
+- #983 → **In progress** (`D-S068-board=1`)
+
+## Routing plan
+
+See [routing-plan.md](./routing-plan.md).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -110,7 +110,7 @@ Unified manual live test harness against **DOKS** production endpoints after F30
 | UJ-053 | F16–F19 deepen (EV-042) | Operator UI has no dissemination destinations | **H4–H5 required** | TC-EV042-001..002 |
 | UJ-054 | F7 deepen (EV-047) | Operator Help → one-pager / handbook (#956/#957) | T0/T2; H4–H5 when FE deploy | TC-EV047-009..011 |
 | UJ-055 | F7+F21 deepen (EV-048) | Operator UI + OpenAPI free of internal planning vocabulary (#951) | T0/T2; T3 if UI hits | TC-EV048-001..005 |
-| UJ-056 | F7.q deepen (EV-054 / EV-055 / EV-056) | Quality metrics primary tab — match/residuals/lint/validate; W3C C14N diffs (#982); 2025-2 validate disposition (#980/#979); dedicated `/quality/:stem` + collapsible hunks (#988) | **H4–H5 required** | TC-EV054-001..008; TC-EV055-001..007; TC-EV056-001..005 |
+| UJ-056 | F7.q deepen (EV-054 / EV-055 / EV-056 / EV-058) | Quality metrics primary tab — match/residuals/lint/validate; W3C C14N diffs (#982); 2025-2 validate disposition (#980/#979); dedicated `/quality/:stem` + collapsible hunks (#988); side-by-side vs inline XML diff (#983) | **H4–H5 required** | TC-EV054-001..008; TC-EV055-001..007; TC-EV056-001..005; TC-EV058-001..005 |
 | UJ-057 | F7.r deepen (EV-057) | Accumulate conversions → Download all ZIP (#903) | **H4–H5 required** | TC-EV057-903-001..007 |
 | UJ-058 | F7.s deepen (EV-057) | Validate existing IWXXM paste/upload (#838) | **H4–H5 required** | TC-EV057-838-001..005 |
 | UJ-OPS-002 | F30 deepen (EV-057) | Prod apex → app redirect (#948) | ops / T3 | TC-EV057-948-001..003 |
@@ -2171,6 +2171,52 @@ New **TC-EV032-001..008** and **TC-F32-001..006**. Ties **UJ-045**; deepens UJ-0
   collapsible unified diff; C14N/`match_status` unchanged
 - **Pass criteria**: Local Playwright green; H4–H5 after staging deploy (13)
 - **Source**: EV-056 AC5; UJ-056
+
+### EV-058 / S068 — Quality metrics side-by-side vs inline XML diff (#983 / F7.q)
+
+- **Mode**: delta deepen F7.q (FE-only UX/docs/tests; C14N semantics unchanged)
+- **Pass criteria**: AC1–AC5 in evolve-decisions §EV-058; TC-EV058-001..005; **UJ-056** deepen
+- **Source**: [#983](https://github.com/EMPIRIC2/TAC-to-IWXXM/issues/983); predecessor
+  EV-056 / #988; parent EV-054 / #836
+
+### TC-EV058-001: Layout segmented control on `/quality/:stem`
+
+- **Level**: T0 / T2
+- **Objective**: Detail page exposes Inline (unified) | Side-by-side control; switch
+  without reload (`D-S068-01-control=3a`)
+- **Pass criteria**: Vitest and/or Playwright assert control + both layouts render
+- **Source**: EV-058 AC1; UJ-056
+
+### TC-EV058-002: Default remains unified
+
+- **Level**: T0 / T2
+- **Objective**: First visit (no stored preference) shows unified/inline layout
+- **Pass criteria**: Default view matches prior UJ-056 unified assertions
+- **Source**: EV-058 AC2; UJ-056
+
+### TC-EV058-003: Side-by-side uses existing line-diff helpers
+
+- **Level**: T0 / T2
+- **Objective**: Side-by-side highlights changed lines via `unifiedLineDiff` (or sibling
+  helpers); no new npm `diff` package
+- **Pass criteria**: FE unit asserts side-by-side changed-line markers; package.json
+  unchanged for diff libs
+- **Source**: EV-058 AC3; UJ-056
+
+### TC-EV058-004: Preference persists in localStorage
+
+- **Level**: T0 / T2
+- **Objective**: Selected layout survives reload via localStorage
+- **Pass criteria**: Vitest and/or Playwright set side-by-side → reload → still side-by-side
+- **Source**: EV-058 AC4; UJ-056
+
+### TC-EV058-005: UJ-056 smoke — both layout modes
+
+- **Level**: T2 / T3 / H4–H5
+- **Objective**: Open `/quality/:stem` → toggle Inline ↔ Side-by-side; TAC/diagnostics/
+  collapse remain; C14N/`match_status` unchanged. Synced scroll best-effort only.
+- **Pass criteria**: Local Playwright green; H4–H5 after staging deploy (13)
+- **Source**: EV-058 AC5; UJ-056; `D-S068-01-ac=2b`
 
 ### EV-057 / S067 — M0 Ready: apex redirect + accumulate ZIP + validate-only (#948 / #903 / #838)
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -72,7 +72,7 @@ describe monorepo workflows introduced by migration features M1–M6 and F6.
 | UJ-053 | Operator UI has no dissemination destinations | apps/frontend | F16–F19 deepen (EV-042) | T2 / **T3** / H4–H5 |
 | UJ-054 | Operator Help → one-pager / handbook | apps/frontend | F7 deepen (EV-047 / #956/#957) | T0 / T2 / **T3** |
 | UJ-055 | Operator UI + API docs free of internal planning vocabulary | apps/frontend / OpenAPI | F7+F21 deepen (EV-048 / #951) | T0 / T2 / **T3** |
-| UJ-056 | Browse official corpus Quality metrics tab | apps/frontend | F7.q deepen (EV-054 / #836; EV-055 / #982+#980+#979; EV-056 / #988) | T0 / T2 / **T3** / H4–H5 |
+| UJ-056 | Browse official corpus Quality metrics tab | apps/frontend | F7.q deepen (EV-054 / #836; EV-055 / #982+#980+#979; EV-056 / #988; EV-058 / #983) | T0 / T2 / **T3** / H4–H5 |
 | UJ-057 | Accumulate conversions → Download all ZIP | apps/frontend | F7.r deepen (EV-057 / #903) | T0 / T2 / **T3** / H4–H5 |
 | UJ-058 | Validate existing IWXXM (paste / upload; no TAC) | apps/frontend | F7.s deepen (EV-057 / #838) | T0 / T2 / **T3** / H4–H5 |
 | UJ-OPS-002 | Prod apex redirects to app host | DNS / ingress / ops | F30 deepen (EV-057 / #948) | T3 / ops smoke |
@@ -840,19 +840,27 @@ residuals, lint, validate, with a unified XML diff vs our conversion.
    **GitHub-style** unified diff with collapsible equal-context hunks (default **3**
    context lines; expand hunk / expand all — `D-S066-context-n=1`). C14N /
    `match_status` semantics unchanged from EV-055.
-5. In the detail view: confirm **match status** and unified XML diff; residuals / lint /
-   validate panels show empty or expected diagnostics. **EV-055**: panes default to
-   C14N-normalized with override to un-normalized; validate chips reflect enabled /
-   fixed 2025-2 disposition without internal planning ids.
-6. Confirm a deferred / gap stem is labeled (not silently missing).
-7. Optional later: deep-link the same stem into the convert workbench.
+5. **EV-058 / #983**: on the detail page, use a **segmented control** —
+   **Inline (unified)** | **Side-by-side** — to switch XML diff layout without reload
+   (`D-S068-01-control=3a`). Default is **Inline**. Side-by-side reuses existing
+   line-diff helpers (no new npm `diff`). Preference persists in **localStorage**.
+   Synced scroll between panes is **best-effort** (`D-S068-01-ac=2b`). Raw TAC /
+   diagnostics / collapse-equal-context remain available.
+6. In the detail view: confirm **match status** and the active XML diff layout;
+   residuals / lint / validate panels show empty or expected diagnostics. **EV-055**:
+   panes default to C14N-normalized with override to un-normalized; validate chips
+   reflect enabled / fixed 2025-2 disposition without internal planning ids.
+7. Confirm a deferred / gap stem is labeled (not silently missing).
+8. Optional later: deep-link the same stem into the convert workbench.
 
 **Acceptance**: AC1–AC7 in evolve-decisions §EV-054 (tab shell) **and** AC1–AC7 in
 evolve-decisions §EV-055 (normalize + validate disposition) **and** AC1–AC5 in
-evolve-decisions §EV-056 (detail route + collapsible diffs); TC-EV054-001..008 +
-TC-EV055-001..007 + TC-EV056-001..005. Default view needs no Supabase and no live
-upstream WMO fetch — metrics come from public `GET /api/v1/quality-metrics*` backed by
-precomputed fixtures (`D-S063-gateA=2`; regen under `D-S064-regen=1`).
+evolve-decisions §EV-056 (detail route + collapsible diffs) **and** AC1–AC5 in
+evolve-decisions §EV-058 (side-by-side vs inline); TC-EV054-001..008 +
+TC-EV055-001..007 + TC-EV056-001..005 + TC-EV058-001..005. Default view needs no
+Supabase and no live upstream WMO fetch — metrics come from public
+`GET /api/v1/quality-metrics*` backed by precomputed fixtures (`D-S063-gateA=2`;
+regen under `D-S064-regen=1`).
 **Tier: T0 / T2 / T3 / H4–H5**.
 Related: UJ-032 / UJ-039 / UJ-042.
 [Corpus: product §F7] [Corpus: product §F2] [Corpus: product §F13] [Corpus: product §F25]

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,12 +1,159 @@
-overall_status: completed
-overall_status_note: "no active_session; last EV-057 completed on stage"
+overall_status: in_progress
+overall_status_note: "S068/EV-058 F7.q #983 — FE implement done (layout toggle); 10-e2e COMPLETE local PASS (Vitest 20 + Playwright UJ-056 4/4); Spec→Build open; next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
   output_directory: docs/
-session_counter: 67
-evolve_cycle_counter: 57
-active_session: null
+session_counter: 68
+evolve_cycle_counter: 58
+active_session:
+  id: S068-quality-metrics-diff-layout
+  type: feature
+  intent: "EV-058 deepen F7.q #983: selectable side-by-side vs inline (unified) XML diff on /quality/:stem; persist preference + synced scroll; ship to stage; promote held"
+  status: active
+  started: '2026-08-17'
+  started_at: '2026-08-17'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  branch_base: stage@c2ca9a3f
+  branch_base_sha: c2ca9a3f
+  branch_base_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  branch_status: active
+  branch_exists: true
+  branch_pushed: false
+  tip_sha: c2ca9a3f
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  tip_sha_note: "OPEN — tip equals stage base c2ca9a3f until first commit (FE+10 done uncommitted); branch not pushed; awaiting user commit approval"
+  orchestrator: 16-evolve
+  evolve_cycle_id: EV-058
+  artifacts_dir: docs/sessions/S068-quality-metrics-diff-layout/
+  github_issues:
+  - 983
+  board_note: "#983 In progress (D-S068-board=1)"
+  prior_session: S067-m0-ready-apex-accumulate-validate
+  deepen_feature_ids:
+  - F7
+  feature_note: "Deepen F7.q — side-by-side vs inline XML diff layout"
+  corpus_cites:
+  - '[Corpus: product §F7.q]'
+  - '[Corpus: journeys §UJ-056]'
+  - '[Corpus: tests §UJ-056]'
+  preset: Lean
+  auto_lean: false
+  auto_lean_rationale: "User chose Lean (D-S068-route=1a); pure UI; full entry interview completed"
+  goal: "Selectable side-by-side vs inline XML diff on Quality metrics detail; stage ship; promote held"
+  out_of_scope:
+  - "API/backend"
+  - "new npm diff package"
+  - "C14N/match_status semantics"
+  - "promote stage→main"
+  - "non-Quality-metrics UI"
+  ui_preview: http://127.0.0.1:18000/
+  ui_preview_url: http://127.0.0.1:18000/
+  ui_preview_note: "D-S068-ui-preview=1 — non-deployed local http://127.0.0.1:18000/"
+  current_stage: 16-evolve
+  current_stage_note: "OPEN — Gate A PASS D-S068-gateA=1; Spec→Build open (D-S068-spec-build=1a); FE implement done (layout toggle); 10-e2e COMPLETE local PASS (reports/e2e-report.md; Vitest 20 + UJ-056 4/4); next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
+  routing_plan_summary: "Lean 00→16→01→02→10→13 (skip 03/04/05/06/07/08/09/11/12); Spec→Build open; Build unlocked"
+  routing_plan:
+  - stage: 00-context
+    required: true
+    mode: session
+    status: completed
+    started: '2026-08-17'
+    completed: '2026-08-17'
+    note: "COMPLETE — open_session S068-quality-metrics-diff-layout; Lean preset; #983 In progress; handoff 16-evolve"
+  - stage: 16-evolve
+    required: true
+    mode: orchestrate
+    status: in_progress
+    started: '2026-08-17'
+    note: "IN PROGRESS — orchestrator; Gate A PASS; Spec→Build open; FE implement done (layout toggle); 10-e2e COMPLETE local PASS; next commit/PR→stage then 13 (awaiting user commit approval); promote held"
+  - stage: 01-requirements
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-17'
+    completed: '2026-08-17'
+    note: "COMPLETE — D-S068-01-ac=2b; report reports/01-requirements.md; standing doc deltas written; handoff 02-verify-plan"
+  - stage: 02-verify-plan
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-17'
+    completed: '2026-08-17'
+    note: "COMPLETE — Gate A PASS D-S068-gateA=1; report reports/02-verify-plan.md; Spec→Build open D-S068-spec-build=1a"
+  - stage: 10-e2e
+    required: true
+    mode: delta
+    status: completed
+    started: '2026-08-17'
+    completed: '2026-08-17'
+    note: "COMPLETE — local PASS; Vitest 20 + Playwright UJ-056 4/4; report reports/e2e-report.md; H4–H5 via 13; next commit/PR→stage then 13"
+    report: docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+  - stage: 13-deploy-smoke
+    required: true
+    mode: delta
+    status: pending
+    note: "pending — after commit/PR→stage (awaiting user commit approval); promote held"
+  - stage: 03-plan-tooling
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — no new Cursor rules expected"
+  - stage: 04-tech-plan
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — FE layout toggle only; no Standard milestones"
+  - stage: 05-verify-tech
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-tech not in path"
+  - stage: 06-tech-tooling
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — no new deps unless AskQuestion"
+  - stage: 07-build
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean — 16 Agent implements after Gate A"
+  - stage: 08-verify-build
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-build not in path"
+  - stage: 09-qa
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — qa not in path"
+  - stage: 11-verify-impl
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — verify-impl not in path"
+  - stage: 12-verify-deploy
+    required: false
+    mode: null
+    status: skipped
+    skip_rationale: "Lean preset — PR path via 13"
+  decisions:
+    D-S068-open: "1 — open S068/EV-058"
+    D-S068-route: "1a/2a/3a — Lean bands; Spec→Build closed; open Spec"
+    D-S068-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
+    D-S068-board: "1 — #983 → In progress"
+    D-S068-ev-confirm: "1a — confirm evolve intake; proceed Spec children"
+    D-S068-01-start: "1a — delta F7.q #983"
+    D-S068-01-ac: "2b — AC1–AC5 with synced scroll best-effort (not blocking)"
+    D-S068-01-control: "3a — radio/segmented Inline | Side-by-side"
+    D-S068-01-uj: "4a — deepen UJ-056 + TC-EV058-*"
+    D-S068-gateA: "1 — Gate A PASS"
+    D-S068-spec-build: "1a — Spec→Build open; Build band unlocked"
+  context_briefs: []
+  note: "OPEN — S068/EV-058 F7.q #983; Lean; Gate A PASS; Spec→Build open (D-S068-spec-build=1a); FE implement done (layout toggle); 10-e2e COMPLETE local PASS (Vitest 20 + UJ-056 4/4; reports/e2e-report.md); next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
 
 
 sessions:
@@ -9514,90 +9661,111 @@ stages:
   01-requirements:
     status: completed
     mode: delta
-    started: '2026-08-15'
-    started_at: '2026-08-15'
-    completed: '2026-08-15'
-    completed_at: '2026-08-15'
-    session_id: S067-m0-ready-apex-accumulate-validate
-    evolve_cycle_id: EV-057
+    started: '2026-08-17'
+    started_at: '2026-08-17'
+    completed: '2026-08-17'
+    completed_at: '2026-08-17'
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
     skill_id: 01-requirements
-    tip_sha: a6064563
-    tip_sha_full: a606456354a8eaa859120405e0581c8e1873987e
-    deepen_feature_ids: [F7, F1, F6, F2, F4]
+    tip_sha: c2ca9a3f
+    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+    deepen_feature_ids: [F7]
     feature_ids: []
     delta_only: true
     decision_refs:
+    - D-S068-01-start
+    - D-S068-01-ac
+    - D-S068-01-control
+    - D-S068-01-uj
+    report: docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+    artifacts:
+    - docs/sessions/S068-quality-metrics-diff-layout/
+    - docs/sessions/S068-quality-metrics-diff-layout/evolve-plan-card.md
+    - docs/sessions/S068-quality-metrics-diff-layout/session-brief.md
+    - docs/sessions/S068-quality-metrics-diff-layout/routing-plan.md
+    - docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+    - docs/feature-list.md
+    - docs/user-journeys.md
+    - docs/test-plan.md
+    - docs/decisions/evolve-decisions.md
+    - docs/decisions/requirements-decisions.md
+    note: "COMPLETE — D-S068-01-ac=2b; report reports/01-requirements.md; standing doc deltas (feature-list, user-journeys, test-plan, evolve-decisions, requirements-decisions); handoff 02-verify-plan"
+    previous_session_id: S067-m0-ready-apex-accumulate-validate
+    previous_evolve_cycle_id: EV-057
+    previous_status: completed
+    previous_completed: '2026-08-15'
+    previous_tip_sha: a6064563
+    previous_tip_sha_full: a606456354a8eaa859120405e0581c8e1873987e
+    previous_decision_refs:
     - D-S067-01-ac
     - D-S067-01-goal
     - D-S067-01-manifest
     - D-S067-01-ui
     - D-S067-01-delta
-    report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/01-requirements.md
-    artifacts:
-    - docs/sessions/S067-m0-ready-apex-accumulate-validate/
-    - docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/01-requirements.md
-    - docs/sessions/S067-m0-ready-apex-accumulate-validate/routing-plan.md
-    - docs/sessions/S067-m0-ready-apex-accumulate-validate/evolve-plan-card.md
-    - docs/feature-list.md
-    - docs/user-journeys.md
-    - docs/test-plan.md
-    - docs/spec.md
-    - docs/deploy.md
-    - docs/decisions/evolve-decisions.md
-    - docs/decisions/requirements-decisions.md
-    note: "COMPLETE — D-S067-01-ac=1; AC approved; specs written; handoff 02-verify-plan (awaiting Gate A)"
-    previous_session_id: S060-tag-driven-prod-deploy
-    previous_evolve_cycle_id: EV-051
-    previous_status: completed
-    previous_completed: '2026-08-09'
+    previous_report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/01-requirements.md
+    previous_note: "COMPLETE — D-S067-01-ac=1; AC approved; specs written; handoff 02-verify-plan (awaiting Gate A)"
+    prior_session_id: S060-tag-driven-prod-deploy
+    prior_evolve_cycle_id: EV-051
+    prior_status: completed
+    prior_completed: '2026-08-09'
   02-verify-plan:
     status: completed
     mode: delta
-    started: '2026-08-15'
-    started_at: '2026-08-15'
-    completed: '2026-08-15'
-    completed_at: '2026-08-15'
-    session_id: S067-m0-ready-apex-accumulate-validate
-    evolve_cycle_id: EV-057
+    started: '2026-08-17'
+    started_at: '2026-08-17'
+    completed: '2026-08-17'
+    completed_at: '2026-08-17'
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
     skill_id: 02-verify-plan
-    tip_sha: d319180f
-    tip_sha_full: d319180febf4e794bb4dfb0a7bdc0bbd58eca027
-    deepen_feature_ids: [F7, F1, F6, F2, F4]
+    tip_sha: c2ca9a3f
+    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+    deepen_feature_ids: [F7]
     feature_ids: []
     delta_only: true
     gate_a: PASS
     gate_a_status: pass
-    gate_a_decision: D-S067-gateA=1
-    gate_a_note: 'D-S067-gateA=1 — Gate A PASS; D-S067-903-cap=1c; D-S067-948-ingress=2a; D-S067-02-ml=1b'
-    report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/02-verify-plan.md
+    gate_a_decision: D-S068-gateA=1
+    gate_a_note: "PASS — D-S068-gateA=1; Spec→Build open D-S068-spec-build=1a; Build band unlocked"
+    report: docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
     decision_refs:
-    - D-S067-gateA
-    - D-S067-903-cap
-    - D-S067-948-ingress
-    - D-S067-02-ml
-    - D-S067-02-goal
-    - D-S067-02-trust
-    - D-S067-02-depth
-    - D-S067-02-delta
-    note: "COMPLETE — Gate A PASS D-S067-gateA=1; handoff 04-tech-plan"
-    previous_session_id: S061-ci-polish-quality-pr-stats
-    previous_evolve_cycle_id: EV-052
+    - D-S068-01-ac
+    - D-S068-01-start
+    - D-S068-01-control
+    - D-S068-01-uj
+    - D-S068-gateA
+    - D-S068-spec-build
+    artifacts:
+    - docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+    - docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
+    - docs/feature-list.md
+    - docs/user-journeys.md
+    - docs/test-plan.md
+    - docs/decisions/evolve-decisions.md
+    - docs/decisions/requirements-decisions.md
+    note: "COMPLETE — Gate A PASS D-S068-gateA=1; report reports/02-verify-plan.md; Spec→Build open D-S068-spec-build=1a; Build unlocked — Lean implement via 16 Agent (no 07)"
+    previous_session_id: S067-m0-ready-apex-accumulate-validate
+    previous_evolve_cycle_id: EV-057
     previous_status: completed
-    previous_completed: '2026-08-09'
-    previous_tip_sha: 80197a58
-    previous_tip_sha_full: 80197a58c533bcda7045c6b60fede1d62f79dd1b
+    previous_completed: '2026-08-15'
+    previous_tip_sha: d319180f
+    previous_tip_sha_full: d319180febf4e794bb4dfb0a7bdc0bbd58eca027
     previous_gate_a: PASS
     previous_gate_a_status: pass
-    previous_gate_a_decision: D-S061-gateA=1
-    previous_note: 'S061/EV-052 COMPLETE — Gate A PASS D-S061-gateA=1; handoff 04-tech-plan (delta)'
-    prior_session_id: S060-tag-driven-prod-deploy
-    prior_evolve_cycle_id: EV-051
-    prior_started: '2026-08-09'
+    previous_gate_a_decision: D-S067-gateA=1
+    previous_report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/02-verify-plan.md
+    previous_note: "COMPLETE — Gate A PASS D-S067-gateA=1; handoff 04-tech-plan"
+    prior_session_id: S061-ci-polish-quality-pr-stats
+    prior_evolve_cycle_id: EV-052
+    prior_status: completed
     prior_completed: '2026-08-09'
-    prior_note: 'S060/EV-051 COMPLETE — Gate A PASS D-S060-gateA=1; Lean+ skip 04/05 → 07-build'
+    prior_tip_sha: 80197a58
+    prior_tip_sha_full: 80197a58c533bcda7045c6b60fede1d62f79dd1b
     prior_gate_a: PASS
     prior_gate_a_status: pass
-    prior_gate_a_decision: D-S060-gateA=1
+    prior_gate_a_decision: D-S061-gateA=1
+    prior_note: 'S061/EV-052 COMPLETE — Gate A PASS D-S061-gateA=1; handoff 04-tech-plan (delta)'
     prior_prior_session_id: S057-strip-internal-doc-refs
     prior_prior_evolve_cycle_id: EV-048
     prior_prior_started: '2026-08-08'
@@ -13708,10 +13876,10 @@ stages:
     skill_id: 11-verify-impl
   10-e2e:
     status: completed
-    started_at: '2026-08-16'
-    started: '2026-08-16'
-    completed_at: '2026-08-16'
-    completed: '2026-08-16'
+    started_at: '2026-08-17'
+    started: '2026-08-17'
+    completed_at: '2026-08-17'
+    completed: '2026-08-17'
     previous_s048_started_at: '2026-08-06'
     previous_s048_started: '2026-08-06'
     previous_s048_completed_at: '2026-08-06'
@@ -13748,17 +13916,26 @@ stages:
     prior_s036_session_id: S036-eight-family-ahl-rules-823
     prior_s036_evolve_cycle_id: EV-029
     prior_s036_tip_sha: 0e00000
-    session_id: S067-m0-ready-apex-accumulate-validate
-    evolve_cycle_id: EV-057
-    tip_sha: "ffdd1961"
-    tip_sha_full: ffdd19613a00679253431054a5fba957f1d0a4db
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
+    tip_sha: c2ca9a3f
+    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
     tip_sha_pushed: false
     mode: delta
     overall: PASS
-    report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/e2e-report.md
-    note: 'COMPLETE — PASS with D-S067-10-pw=1a (Playwright T2 waived; T0 vitest + T3 UJ-OPS-002 PASS); report e2e-report.md; tip ffdd1961; handoff 11-verify-impl'
+    report: docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+    note: 'COMPLETE — local PASS; Vitest 20 + Playwright UJ-056 4/4; report e2e-report.md; FE layout toggle done; tip still stage base c2ca9a3f (uncommitted); next commit/PR→stage then 13; Spec→Build open'
     skill_id: 10-e2e
-    waiver: D-S067-10-pw=1a
+    previous_s067_session_id: S067-m0-ready-apex-accumulate-validate
+    previous_s067_evolve_cycle_id: EV-057
+    previous_s067_tip_sha: "ffdd1961"
+    previous_s067_tip_sha_full: ffdd19613a00679253431054a5fba957f1d0a4db
+    previous_s067_started_at: '2026-08-16'
+    previous_s067_completed_at: '2026-08-16'
+    previous_s067_overall: PASS
+    previous_s067_report: docs/sessions/S067-m0-ready-apex-accumulate-validate/reports/e2e-report.md
+    previous_s067_note: 'COMPLETE — PASS with D-S067-10-pw=1a (Playwright T2 waived; T0 vitest + T3 UJ-OPS-002 PASS); tip ffdd1961; superseded by S068/EV-058'
+    previous_s067_waiver: D-S067-10-pw=1a
     previous_s064_session_id: S064-quality-metrics-2025-2-followups
     previous_s064_evolve_cycle_id: EV-055
     previous_s064_tip_sha: 68552747
@@ -13796,6 +13973,21 @@ stages:
     active_task_status:
     pending_commit: false
     delta_substages:
+    - id: S068-quality-metrics-diff-layout-10
+      session_id: S068-quality-metrics-diff-layout
+      evolve_cycle_id: EV-058
+      skill_id: 10-e2e
+      status: completed
+      mode: delta
+      started: '2026-08-17'
+      started_at: '2026-08-17'
+      completed: '2026-08-17'
+      completed_at: '2026-08-17'
+      tip_sha: c2ca9a3f
+      tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+      overall: PASS
+      report: docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+      note: 'COMPLETE — local PASS; Vitest 20 + Playwright UJ-056 4/4; FE layout toggle done; tip uncommitted (stage base); next commit/PR→stage then 13'
     - id: S067-m0-ready-apex-accumulate-validate-10
       session_id: S067-m0-ready-apex-accumulate-validate
       evolve_cycle_id: EV-057
@@ -16851,15 +17043,15 @@ stages:
     retrospective_cycle_id: RET-001
     note: RET-001 skill-trim COMPLETE — corpus-first, lean routing, archive legacy; workshop applied RA-001..RA-006; RA-007/RA-008 remain open
   16-evolve:
-    status: completed
-    completed: '2026-08-16'
-    completed_at: '2026-08-16'
-    close_decision: D-S067-close=1a
+    status: in_progress
+    completed:
+    completed_at:
+    close_decision:
     mode: orchestrator
-    session_id: S067-m0-ready-apex-accumulate-validate
-    evolve_cycle_id: EV-057
-    started_at: '2026-08-15'
-    started: '2026-08-15'
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
+    started_at: '2026-08-17'
+    started: '2026-08-17'
     previous_s067_session_id: S067-m0-ready-apex-accumulate-validate
     previous_s067_evolve_cycle_id: EV-057
     previous_s067_completed: '2026-08-16'
@@ -16901,20 +17093,25 @@ stages:
     prior_s047_evolve_cycle_id: EV-039
     prior_s047_completed_at: '2026-08-08'
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
-    current_child_stage: completed
+    current_child_stage: implement
     current_child_stage_status: completed
-    current_child_stage_note: 'COMPLETE — D-S067-close=1a; EV-057/S067 closed on stage tip 3af364fb; promote held; PRs #991+#992; board Done; active_session=null'
-    tip_sha: 3af364fb
-    tip_sha_full: 3af364fbc6caeb4dd1eb56a1f214ae8938a9d878
-    tip_sha_pushed: true
-    pr_number: 991
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/991
-    pr_status: merged
-    merge_sha: 3af364fb
-    merge_sha_full: 3af364fbc6caeb4dd1eb56a1f214ae8938a9d878
-    merge_target: stage
-    branch_status: merged
-    note: 'COMPLETE — D-S067-close=1a; EV-057/S067 closed on stage tip 3af364fb; promote held; PRs #991+#992; board Done; active_session=null'
+    current_child_stage_note: 'FE implement done (layout toggle); Vitest 20 + UJ-056 4/4 PASS; next commit/PR→stage then 13'
+    tip_sha: c2ca9a3f
+    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+    tip_sha_pushed: false
+    tip_sha_note: 'OPEN S068/EV-058 — tip c2ca9a3f (= stage base); FE+10 done uncommitted; awaiting user commit approval'
+    branch: evolve/EV-058-quality-metrics-diff-layout
+    branch_base: stage@c2ca9a3f
+    branch_status: active
+    branch_exists: true
+    branch_pushed: false
+    pr_number:
+    pr_url:
+    pr_status:
+    merge_sha:
+    merge_sha_full:
+    merge_target:
+    note: 'IN PROGRESS — S068/EV-058; Gate A PASS; Spec→Build open; FE implement done; 10-e2e COMPLETE local PASS; next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held'
     prior_s057_pr_number: 963
     prior_s057_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/963
     prior_s057_merge_sha: 06a9543f
@@ -17217,6 +17414,345 @@ issue_log:
   date: '2026-07-12'
   resolved_at: '2026-07-12'
 decisions_log:
+
+- id: D-S068-gateA
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 02-verify-plan
+  skill_id: 02-verify-plan
+  stage: 02-verify-plan
+  category: gate_a
+  status: confirmed
+  topic: 'S068/EV-058 Gate A — Spec band verify-plan'
+  summary: '1 — Gate A PASS'
+  decision: |
+    D-S068-gateA=1 — Gate A PASS for F7.q #983 side-by-side vs inline XML diff.
+    Report: docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md.
+    Spec→Build opened via D-S068-spec-build=1a; Build band unlocked.
+    Lean implement via 16 Agent (no 07); next 10-e2e then 13 after FE+PR.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-spec-build
+  - D-S068-01-ac
+  tip_sha: 'c2ca9a3f'
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  current_stage: 16-evolve
+  report: docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
+  note: '02-verify-plan COMPLETE; Gate A PASS; Spec→Build open'
+
+- id: D-S068-spec-build
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 16-evolve
+  skill_id: 16-evolve
+  stage: 16-evolve
+  category: spec_to_build_gate
+  status: confirmed
+  topic: 'S068/EV-058 Spec→Build gate open'
+  summary: '1a — Spec→Build open; Build band unlocked'
+  decision: |
+    D-S068-spec-build=1a — Open Spec→Build after Gate A PASS (D-S068-gateA=1).
+    Build band unlocked: Lean implement via 16 Agent (no 07); then 10-e2e; then 13 after FE+PR.
+    active_session.current_stage=16-evolve (implementing FE); 10/13 pending (unblocked).
+    No git commit by workflow-state-manager.
+  user_option: '1a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-gateA
+  tip_sha: 'c2ca9a3f'
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  current_stage: 16-evolve
+  note: 'Spec→Build open; Build unlocked; Lean FE implement'
+
+- id: D-S068-01-start
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: requirements_start
+  status: confirmed
+  topic: 'S068/EV-058 01-requirements start — F7.q delta scope'
+  summary: '1a — delta F7.q #983'
+  decision: |
+    D-S068-01-start=1a — delta F7.q #983 (side-by-side vs inline XML diff layout).
+    Mark 01-requirements in_progress (not completed); writing standing doc deltas.
+    Related: D-S068-01-ac=2b; D-S068-01-control=3a; D-S068-01-uj=4a.
+    active_session.current_stage=01-requirements; 16-evolve remains in_progress (orchestrator).
+    Spec→Build gate still closed. No git commit by workflow-state-manager.
+  user_option: '1a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-01-ac
+  - D-S068-01-control
+  - D-S068-01-uj
+  - D-S068-ev-confirm
+  tip_sha: 'c2ca9a3f'
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  current_stage: 01-requirements
+  note: '01-requirements in_progress; AC locked; writing standing doc deltas; not completed'
+
+- id: D-S068-01-ac
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: acceptance_criteria
+  status: confirmed
+  topic: 'S068/EV-058 AC lock for F7.q diff layout'
+  summary: '2b — AC1–AC5 with synced scroll best-effort (not blocking)'
+  decision: |
+    D-S068-01-ac=2b — AC1–AC5 with synced scroll best-effort (not blocking).
+    Synced scroll is desirable but does not block AC pass.
+  user_option: '2b'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-01-start
+  - D-S068-01-control
+  - D-S068-01-uj
+  current_stage: 01-requirements
+  note: 'AC locked; 01 not completed'
+
+- id: D-S068-01-control
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: ux_control
+  status: confirmed
+  topic: 'S068/EV-058 diff layout control pattern'
+  summary: '3a — radio/segmented Inline | Side-by-side'
+  decision: |
+    D-S068-01-control=3a — radio/segmented control for Inline | Side-by-side layout toggle.
+  user_option: '3a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-01-start
+  - D-S068-01-ac
+  - D-S068-01-uj
+  current_stage: 01-requirements
+  note: 'control pattern locked'
+
+- id: D-S068-01-uj
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: 01-requirements
+  skill_id: 01-requirements
+  stage: 01-requirements
+  category: journeys_tests
+  status: confirmed
+  topic: 'S068/EV-058 journey + test deepen'
+  summary: '4a — deepen UJ-056 + TC-EV058-*'
+  decision: |
+    D-S068-01-uj=4a — deepen UJ-056 and add/extend TC-EV058-* coverage for both layout modes.
+  user_option: '4a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-01-start
+  - D-S068-01-ac
+  - D-S068-01-control
+  current_stage: 01-requirements
+  note: 'UJ/TC deepen locked'
+
+- id: D-S068-ev-confirm
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: 16-evolve
+  category: evolve_confirm
+  status: confirmed
+  topic: 'S068/EV-058 evolve intake confirm (Phase 0–1)'
+  summary: '1a — confirm evolve intake; proceed Spec children'
+  decision: |
+    D-S068-ev-confirm=1a — confirm evolve intake; Phase 0–1 done; evolve-plan-card written.
+    Spec→Build gate still closed; next child 01-requirements pending startup+AC interview
+    (do not mark 01 in_progress until interview complete).
+    Artifacts: evolve-plan-card.md, session-brief.md, routing-plan.md.
+    No git commit by workflow-state-manager.
+  user_option: '1a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-open
+  - D-S068-route
+  - D-S068-ui-preview
+  - D-S068-board
+  tip_sha: 'c2ca9a3f'
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  current_stage: 16-evolve
+  note: 'OPEN — Phase 0–1 done; awaiting 01 startup+AC interview'
+
+- id: D-S068-open
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: session_open
+  status: confirmed
+  topic: 'S068/EV-058 open session + cycle'
+  summary: '1 — open S068/EV-058 for F7.q #983 side-by-side vs inline XML diff'
+  decision: |
+    D-S068-open=1 — open_session S068-quality-metrics-diff-layout / EV-058.
+    overall_status=in_progress; session_counter=68; evolve_cycle_counter=58.
+    Branch evolve/EV-058-quality-metrics-diff-layout @ stage@c2ca9a3f (full c2ca9a3f106c69fb83abeae9ca583409a20f779f).
+    Lean preset; Spec-development; Spec→Build gate closed; promote held.
+    No git commit by workflow-state-manager.
+  user_option: '1'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-route
+  - D-S068-ui-preview
+  - D-S068-board
+  tip_sha: 'c2ca9a3f'
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  current_stage: 16-evolve
+  note: 'OPEN — active_session set; EV-058 in_progress'
+
+- id: D-S068-route
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: routing
+  status: confirmed
+  topic: 'S068/EV-058 Lean routing bands + Spec→Build gate'
+  summary: '1a/2a/3a — Lean bands; Spec→Build closed; open Spec'
+  decision: |
+    D-S068-route=1a/2a/3a — Lean as drafted: 00→16→01→02→10→13; skip 03/04/05/06/07/08/09/11/12.
+    Spec→Build gate closed; Build band (10/13) blocked_until_spec_gate until Gate A.
+    User chose Lean (not Auto-Lean); pure UI; full entry interview completed.
+  user_option: '1a/2a/3a'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-open
+  - D-S068-ui-preview
+  - D-S068-board
+  note: 'routing-plan.md approved; Lean Spec-development'
+
+- id: D-S068-ui-preview
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: ux
+  status: confirmed
+  topic: 'S068 UI preview location'
+  summary: '1 — non-deployed local http://127.0.0.1:18000/'
+  decision: |
+    D-S068-ui-preview=1 — non-deployed local preview at http://127.0.0.1:18000/.
+  user_option: '1'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-open
+  - D-S068-route
+
+- id: D-S068-board
+  date: '2026-08-17'
+  timestamp: '2026-08-17'
+  resolved_at: '2026-08-17'
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  skill: workflow-state-manager
+  skill_id: workflow-state-manager
+  stage: open_session
+  category: board
+  status: confirmed
+  topic: 'S068 board — #983 In progress'
+  summary: '1 — #983 → In progress'
+  decision: |
+    D-S068-board=1 — move #983 to In progress (WIP 1 ≤ 2).
+  user_option: '1'
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  related_features:
+  - F7
+  related_issues:
+  - '983'
+  related_decisions:
+  - D-S068-open
+  - D-S068-route
+  note: 'board_note: #983 In progress'
 
 - id: D-S067-close
   date: '2026-08-16'
@@ -33391,6 +33927,78 @@ decisions_log:
   related_issues: ['823']
   related_decisions: ['D-S036-04-batch-1', 'D-S036-04-batch-2']
 artifacts:
+- path: docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+  type: report
+  stage: 10-e2e
+  skill_id: 10-e2e
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: completed
+  overall: PASS
+  note: 'S068/EV-058 10-e2e COMPLETE local PASS — Vitest 20 + Playwright UJ-056 4/4; FE layout toggle done; next commit/PR→stage then 13 (awaiting user commit approval)'
+- path: docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+  type: session-report
+  kind: requirements
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: completed
+  note: 'S068/EV-058 01 COMPLETE — D-S068-01-ac=2b; AC1–AC5 synced scroll best-effort; handoff 02-verify-plan'
+- path: docs/feature-list.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: written
+  note: 'F7.q EV-058 deepen + AC1–AC5 (#983)'
+- path: docs/user-journeys.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: written
+  note: 'UJ-056 deepen — layout toggle + persist'
+- path: docs/test-plan.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: written
+  note: 'TC-EV058-001..005; UJ-056 map'
+- path: docs/decisions/evolve-decisions.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: written
+  note: 'Cycle EV-058 scope + decisions'
+- path: docs/decisions/requirements-decisions.md
+  type: standing-doc-delta
+  stage: 01-requirements
+  skill_id: 01-requirements
+  session_id: S068-quality-metrics-diff-layout
+  evolve_cycle_id: EV-058
+  created_at: '2026-08-17'
+  updated_at: '2026-08-17'
+  status: written
+  note: 'EV-058 / D-S068-01-ac=2b section'
 - path: docs/evolve-report-EV-057.md
   type: report
   stage: 16-evolve
@@ -37248,6 +37856,113 @@ retrospective_cycles:
   - path: docs/retrospective-actions.md
     status: completed
 evolve_cycles:
+- id: EV-058
+  title: "F7.q #983 selectable side-by-side vs inline XML diff layout"
+  topic: "F7.q #983 selectable XML diff layout"
+  goal: "F7.q #983 selectable XML diff layout"
+  status: in_progress
+  cycle_type: feature
+  session_id: S068-quality-metrics-diff-layout
+  feature_ids:
+  - F7
+  deepen_feature_ids:
+  - F7
+  feature_note: "Deepen F7.q — side-by-side vs inline XML diff layout"
+  github_issues:
+  - 983
+  issues:
+  - 983
+  branch: evolve/EV-058-quality-metrics-diff-layout
+  branch_base: stage@c2ca9a3f
+  branch_base_sha: c2ca9a3f
+  branch_base_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  branch_status: active
+  branch_exists: true
+  branch_pushed: false
+  tip_sha: c2ca9a3f
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_sha_pushed: false
+  tip_sha_note: "OPEN — tip equals stage base c2ca9a3f until first commit (FE+10 done uncommitted; awaiting user commit approval)"
+  current_stage: 16-evolve
+  current_stage_status: in_progress
+  current_stage_note: "OPEN — orchestrator; Gate A PASS; Spec→Build open; FE implement done; 10-e2e COMPLETE local PASS; next commit/PR→stage then 13 (awaiting user commit approval)"
+  current_child: implement
+  current_child_stage: implement
+  current_child_stage_status: completed
+  current_child_note: "FE implement done (layout toggle); Vitest 20 + UJ-056 4/4 PASS"
+  current_child_stage_note: "FE implement done (layout toggle); Vitest 20 + UJ-056 4/4 PASS"
+  started: "2026-08-17"
+  started_at: "2026-08-17"
+  preset: Lean
+  auto_lean: false
+  auto_lean_rationale: "User chose Lean (D-S068-route=1a); pure UI; full entry interview completed"
+  ui_preview: http://127.0.0.1:18000/
+  ui_preview_url: http://127.0.0.1:18000/
+  ui_preview_note: "D-S068-ui-preview=1 — non-deployed local http://127.0.0.1:18000/"
+  board_note: "#983 In progress (D-S068-board=1)"
+  spec_to_build_gate: open
+  corpus_cites:
+  - '[Corpus: product §F7.q]'
+  - '[Corpus: journeys §UJ-056]'
+  - '[Corpus: tests §UJ-056]'
+  routing_plan:
+  - 00-context
+  - 16-evolve
+  - 01-requirements
+  - 02-verify-plan
+  - 10-e2e
+  - 13-deploy-smoke
+  skip_stages:
+  - 03-plan-tooling
+  - 04-tech-plan
+  - 05-verify-tech
+  - 06-tech-tooling
+  - 07-build
+  - 08-verify-build
+  - 09-qa
+  - 11-verify-impl
+  - 12-verify-deploy
+  routing_plan_summary: "Lean 00→16→01→02→10→13; Spec→Build open; Build unlocked"
+  scope_summary: "Selectable side-by-side vs inline (unified) XML diff on /quality/:stem; persist preference + synced scroll; ship to stage; promote held. OOS: API/backend, new npm diff package, C14N/match_status, promote, non-Quality-metrics UI. Base stage@c2ca9a3f."
+  decisions_locked: false
+  decisions:
+    D-S068-open: "1 — open S068/EV-058"
+    D-S068-route: "1a/2a/3a — Lean bands; Spec→Build closed; open Spec"
+    D-S068-ui-preview: "1 — non-deployed local http://127.0.0.1:18000/"
+    D-S068-board: "1 — #983 → In progress"
+    D-S068-ev-confirm: "1a — confirm evolve intake; proceed Spec children"
+    D-S068-01-start: "1a — delta F7.q #983"
+    D-S068-01-ac: "2b — AC1–AC5 with synced scroll best-effort (not blocking)"
+    D-S068-01-control: "3a — radio/segmented Inline | Side-by-side"
+    D-S068-01-uj: "4a — deepen UJ-056 + TC-EV058-*"
+    D-S068-gateA: "1 — Gate A PASS"
+    D-S068-spec-build: "1a — Spec→Build open; Build band unlocked"
+  artifacts:
+  - docs/sessions/S068-quality-metrics-diff-layout/
+  - docs/sessions/S068-quality-metrics-diff-layout/evolve-plan-card.md
+  - docs/sessions/S068-quality-metrics-diff-layout/session-brief.md
+  - docs/sessions/S068-quality-metrics-diff-layout/routing-plan.md
+  - docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+  - docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
+  - docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+  - docs/feature-list.md
+  - docs/user-journeys.md
+  - docs/test-plan.md
+  - docs/decisions/evolve-decisions.md
+  - docs/decisions/requirements-decisions.md
+  prior_session: S067-m0-ready-apex-accumulate-validate
+  prior_evolve_note: "Follow-on deepen after S066/EV-056 detail page + collapsible diffs; S067 closed on stage"
+  gates:
+    spec_to_build: open
+    spec_to_build_note: "D-S068-spec-build=1a — Spec→Build remains open; FE+10 done; next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
+  notes:
+  - "2026-08-17 10-e2e COMPLETE — local PASS; report reports/e2e-report.md; Vitest 20 + Playwright UJ-056 4/4; FE implement done (layout toggle); Spec→Build open; next commit/PR→stage then 13 (awaiting user commit approval); no git commit by workflow-state-manager"
+  - "2026-08-17 Gate A PASS — D-S068-gateA=1 / D-S068-spec-build=1a; report reports/02-verify-plan.md; Spec→Build open; Build band unlocked; Lean implement via 16 Agent (no 07); current_child implement (FE); next 10-e2e then 13 after FE+PR; no git commit by workflow-state-manager"
+  - "2026-08-17 01 COMPLETE — D-S068-01-ac=2b; report reports/01-requirements.md; standing deltas feature-list/user-journeys/test-plan/evolve-decisions/requirements-decisions; handoff 02-verify-plan; Spec→Build still closed; no git commit by workflow-state-manager"
+  - "2026-08-17 D-S068-01-start=1a / ac=2b / control=3a / uj=4a — 01-requirements in_progress (not completed); writing standing doc deltas; no git commit by workflow-state-manager"
+  - "2026-08-17 D-S068-ev-confirm=1a — Phase 0–1 done; evolve-plan-card written; Spec→Build still closed; awaiting 01 startup+AC interview (01 not in_progress); no git commit by workflow-state-manager"
+  - "2026-08-17 D-S068-open — open_session S068/EV-058; Lean; Spec-development; Spec→Build closed; #983 In progress; no git commit by workflow-state-manager"
+  note: "OPEN — EV-058/S068 in_progress; F7.q #983; Lean; Gate A PASS; Spec→Build open; FE implement done; 10-e2e COMPLETE local PASS (Vitest 20 + UJ-056 4/4); next commit/PR→stage then 13 (awaiting user commit approval); promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
 - id: EV-057
   title: "M0 Ready: #948 apex redirect + #903 accumulate ZIP + #838 validate existing IWXXM"
   status: completed
@@ -49096,30 +49811,30 @@ evolve_cycles:
   epic_846_status: open
   pr_merged_sha: dfecba46
 git_history:
-  current_branch: evolve/EV-057-m0-ready-apex-accumulate-validate
+  current_branch: evolve/EV-058-quality-metrics-diff-layout
   ahead_of_origin: 0
-  pushed: true
+  pushed: false
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'dirty expected — workflow-state.yaml after D-S067-12-scope/risks/merge=1a; checklist APPROVED; merging #991 → stage; 12 in_progress until merge+Staging CD; no git commit by workflow-state-manager'
-  tip_sha: "d05c23b7"
-  tip_sha_full: d05c23b73dcceccfed2171c99896142937aa3f0f
-  tip_note: "S067/EV-057 tip d05c23b7 pushed on evolve/EV-057-m0-ready-apex-accumulate-validate — 12-verify-deploy in_progress; checklist APPROVED; merging #991 → stage; tip CI green 31965556483; promote held"
+  dirty_note: 'dirty expected — workflow-state.yaml after 01-requirements start S068/EV-058; untracked docs/sessions/S068-*; no git commit by workflow-state-manager'
+  tip_sha: "c2ca9a3f"
+  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  tip_note: "OPEN S068/EV-058 — tip c2ca9a3f (= stage base) on evolve/EV-058-quality-metrics-diff-layout; Spec-development; Spec→Build closed; promote held"
   docs_tip_sha: "4af0dd90"
   docs_tip_sha_full: 4af0dd9064116c465a204f74c9ae5c697b8f137d
   docs_tip_branch: docs/EV-055-13-deploy-smoke
   docs_tip_pr_number: 986
   docs_tip_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/986
   docs_tip_pr_status: merged
-  evolve_branch: evolve/EV-057-m0-ready-apex-accumulate-validate
-  evolve_tip_sha: "d05c23b7"
-  evolve_tip_sha_full: d05c23b73dcceccfed2171c99896142937aa3f0f
-  evolve_tip_sha_pushed: true
+  evolve_branch: evolve/EV-058-quality-metrics-diff-layout
+  evolve_tip_sha: "c2ca9a3f"
+  evolve_tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+  evolve_tip_sha_pushed: false
   stage_merge_sha: d80db688
   stage_merge_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
-  stage_tip_sha: b796882e
-  stage_tip_sha_full: b796882e724d9d2dfb02199ab1e288931005ee00
+  stage_tip_sha: c2ca9a3f
+  stage_tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
   stash:
   - name: S039-EV031-WIP
     note: 'OPEN S067-m0-ready-apex-accumulate-validate/EV-057 — Standard; branch evolve/EV-057-m0-ready-apex-accumulate-validate pending @ stage@b796882e; #948+#903+#838; no git commit by workflow-state-manager'
@@ -49130,7 +49845,7 @@ git_history:
   main_merge_sha_full: a15541e5b7c7b99bed7355fd42c5774be3e22eeb
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
-  recommended_branch: evolve/EV-057-m0-ready-apex-accumulate-validate
+  recommended_branch: evolve/EV-058-quality-metrics-diff-layout
   note: 'S067/EV-057 IN PROGRESS — tip d05c23b7 pushed on evolve/EV-057-m0-ready-apex-accumulate-validate; PR #991 open → stage; tip CI green 31965556483; 12-verify-deploy in_progress checklist sign-off pending; dirty workflow-state; no git commit by workflow-state-manager'
 
   notes:
@@ -49714,6 +50429,22 @@ git_history:
   - 2026-07-12 48037c1 Phase C/D reports committed; COR hotfix commit SHA pending (record after commits done)
   - 2026-07-12 COR hotfix committed ca11b59; Playwright smoke 12/12; ready for Phase D checkpoint → 11-verify-impl
   branches:
+  - name: evolve/EV-058-quality-metrics-diff-layout
+    base: stage@c2ca9a3f
+    base_sha: c2ca9a3f
+    base_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+    purpose: "S068/EV-058 F7.q #983 — selectable side-by-side vs inline XML diff layout"
+    status: active
+    created: "2026-08-17"
+    exists: true
+    pushed: false
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
+    tip_sha: c2ca9a3f
+    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
+    tip_sha_pushed: false
+    note: "OPEN — active; base stage@c2ca9a3f; tip equals base until first commit; not pushed"
+
   - name: evolve/EV-057-m0-ready-apex-accumulate-validate
     base: stage@b796882e
     base_sha: b796882e

--- a/workflow-state.yaml
+++ b/workflow-state.yaml
@@ -1,5 +1,5 @@
 overall_status: in_progress
-overall_status_note: "S068/EV-058 F7.q #983 — FE implement done (layout toggle); 10-e2e COMPLETE local PASS (Vitest 20 + Playwright UJ-056 4/4); Spec→Build open; next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
+overall_status_note: "S068/EV-058 F7.q #983 — PR #994 open → stage @ b3db3413; tip pushed; board #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
 project:
   name: TAC-to-IWXXM
   description: TAC (METAR/SPECI/TAF) to IWXXM XML converter — monorepo
@@ -19,17 +19,21 @@ active_session:
   branch_base_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
   branch_status: active
   branch_exists: true
-  branch_pushed: false
-  tip_sha: c2ca9a3f
-  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
-  tip_sha_pushed: false
-  tip_sha_note: "OPEN — tip equals stage base c2ca9a3f until first commit (FE+10 done uncommitted); branch not pushed; awaiting user commit approval"
+  branch_pushed: true
+  tip_sha: b3db3413
+  tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+  tip_sha_pushed: true
+  tip_sha_note: "OPEN — tip b3db3413 pushed on evolve/EV-058-quality-metrics-diff-layout; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
+  pr_number: 994
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994
+  pr_status: open
+  pr_base: stage
   orchestrator: 16-evolve
   evolve_cycle_id: EV-058
   artifacts_dir: docs/sessions/S068-quality-metrics-diff-layout/
   github_issues:
   - 983
-  board_note: "#983 In progress (D-S068-board=1)"
+  board_note: "#983 In review"
   prior_session: S067-m0-ready-apex-accumulate-validate
   deepen_feature_ids:
   - F7
@@ -52,7 +56,7 @@ active_session:
   ui_preview_url: http://127.0.0.1:18000/
   ui_preview_note: "D-S068-ui-preview=1 — non-deployed local http://127.0.0.1:18000/"
   current_stage: 16-evolve
-  current_stage_note: "OPEN — Gate A PASS D-S068-gateA=1; Spec→Build open (D-S068-spec-build=1a); FE implement done (layout toggle); 10-e2e COMPLETE local PASS (reports/e2e-report.md; Vitest 20 + UJ-056 4/4); next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
+  current_stage_note: "OPEN — Gate A PASS; Spec→Build open; FE+10 COMPLETE; PR #994 open → stage @ b3db3413; tip pushed; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
   routing_plan_summary: "Lean 00→16→01→02→10→13 (skip 03/04/05/06/07/08/09/11/12); Spec→Build open; Build unlocked"
   routing_plan:
   - stage: 00-context
@@ -67,7 +71,7 @@ active_session:
     mode: orchestrate
     status: in_progress
     started: '2026-08-17'
-    note: "IN PROGRESS — orchestrator; Gate A PASS; Spec→Build open; FE implement done (layout toggle); 10-e2e COMPLETE local PASS; next commit/PR→stage then 13 (awaiting user commit approval); promote held"
+    note: "IN PROGRESS — orchestrator; PR #994 open → stage @ b3db3413; tip pushed; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
   - stage: 01-requirements
     required: true
     mode: delta
@@ -94,7 +98,7 @@ active_session:
     required: true
     mode: delta
     status: pending
-    note: "pending — after commit/PR→stage (awaiting user commit approval); promote held"
+    note: "pending — awaiting tip CI on PR #994, then merge→stage, then 13-deploy-smoke; promote held"
   - stage: 03-plan-tooling
     required: false
     mode: null
@@ -153,7 +157,7 @@ active_session:
     D-S068-gateA: "1 — Gate A PASS"
     D-S068-spec-build: "1a — Spec→Build open; Build band unlocked"
   context_briefs: []
-  note: "OPEN — S068/EV-058 F7.q #983; Lean; Gate A PASS; Spec→Build open (D-S068-spec-build=1a); FE implement done (layout toggle); 10-e2e COMPLETE local PASS (Vitest 20 + UJ-056 4/4; reports/e2e-report.md); next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
+  note: "OPEN — S068/EV-058 F7.q #983; Lean; Gate A PASS; Spec→Build open; FE+10 done; PR #994 open → stage @ b3db3413 (pushed); board #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
 
 
 sessions:
@@ -4366,7 +4370,7 @@ sessions:
     started_at: "2026-08-05"
     completed: "2026-08-05"
     completed_at: "2026-08-05"
-    note: 'COMPLETE — EV-037 closed; PR #887 MERGED @ b7302fe4; tip 2d8202f3; deploy waived; CI 31049365217 SUCCESS'
+    note: 'IN PROGRESS — S068/EV-058; PR #994 open → stage @ b3db3413; tip pushed; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held'
   - stage: 01-requirements
     mode: delta
     required: true
@@ -4386,7 +4390,7 @@ sessions:
     status: completed
     started: "2026-08-05"
     completed: "2026-08-05"
-    tip_sha: c51e6e9b
+    tip_sha: b3db3413
     note: "COMPLETE @ c51e6e9b — matrix/provenance + #869/#870/#872 closed; handoff 08"
   - stage: 08-verify-build
     mode: delta
@@ -4395,7 +4399,7 @@ sessions:
     started: "2026-08-05"
     completed: "2026-08-05"
     tip_sha: 90c2e8a3
-    tip_sha_full: 90c2e8a3f090d49341fccb1f397b6ff4033d32df
+    tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
     report: docs/sessions/S045-matrix-disposition-residuals/reports/verification-report.md
     overall: pass
     note: "PASS @ 90c2e8a3 — verification-report.md; provenance quality 188 green; handoff 11; c_to_d pending Gate"
@@ -5082,8 +5086,8 @@ sessions:
     pending_commit: false
     tip_sha: 9ae9c323
     tip_sha_full: 9ae9c3235d9380f493290ab318c0e0ecf5de2efa
-    pr_number: 867
-    pr_status: merged
+    pr_number: 994
+    pr_status: open
     hotfix_pr_number: 868
     hotfix_pr_status: merged
   - stage: 08-verify-build
@@ -11306,7 +11310,7 @@ stages:
     note: 'COMPLETE — S067/EV-057 M1 live AC met + M2/M3 repo done; T1.2 tip 0e7833d1; handoff 08-verify-build'
     tip_sha: 0e7833d1
     tip_sha_full: 0e7833d1f272e547896cc2d5d8af018742b73c68
-    tip_sha_pushed: false
+    tip_sha_pushed: true
     pr_number:
     pr_url:
     pr_status:
@@ -15432,7 +15436,7 @@ stages:
     tip_ci_status: success
     tip_ci_note: "S067/EV-057 12 COMPLETE — #991 MERGED → stage @ d7022f1f; CI/CD 31966102210 success; Deploy(stage)+Staging smoke success; promote held D-S067-promote=2b"
     pr_number: 991
-    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/991
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994
     pr_status: merged
     pr_base: stage
     merge_sha: d7022f1f
@@ -16085,7 +16089,7 @@ stages:
     tip_sha: "3af364fb"
     tip_sha_full: 3af364fbc6caeb4dd1eb56a1f214ae8938a9d878
     tip_sha_pushed: true
-    tip_sha_note: "13 COMPLETE D-S067-13=1a; tip 3af364fb; #992 MERGED; CD 31967444673 success; live UJ-057+UJ-058 PASS; promote deferred"
+    tip_sha_note: 'OPEN S068/EV-058 — tip b3db3413 pushed; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held'
     tip_ci_run: '31967444673'
     tip_ci_status: success
     tip_ci_note: "stage CI/CD 31967444673 success (Deploy+Staging smoke) @ 3af364fb; live UJ-057+UJ-058 PASS; D-S067-13=1a"
@@ -17095,7 +17099,7 @@ stages:
     prior_s047_note: 'COMPLETE — D-S047-close=1; EV-039 closed; PR #891 @ fea30aba; CD 31130303373; closeout docs #939 @ 81701500'
     current_child_stage: implement
     current_child_stage_status: completed
-    current_child_stage_note: 'FE implement done (layout toggle); Vitest 20 + UJ-056 4/4 PASS; next commit/PR→stage then 13'
+    current_child_stage_note: 'FE implement done; commit+push+PR #994 @ b3db3413; awaiting tip CI then merge→stage then 13'
     tip_sha: c2ca9a3f
     tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
     tip_sha_pushed: false
@@ -17104,7 +17108,7 @@ stages:
     branch_base: stage@c2ca9a3f
     branch_status: active
     branch_exists: true
-    branch_pushed: false
+    branch_pushed: true
     pr_number:
     pr_url:
     pr_status:
@@ -37878,14 +37882,18 @@ evolve_cycles:
   branch_base_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
   branch_status: active
   branch_exists: true
-  branch_pushed: false
-  tip_sha: c2ca9a3f
-  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
-  tip_sha_pushed: false
-  tip_sha_note: "OPEN — tip equals stage base c2ca9a3f until first commit (FE+10 done uncommitted; awaiting user commit approval)"
+  branch_pushed: true
+  tip_sha: b3db3413
+  tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+  tip_sha_pushed: true
+  tip_sha_note: "OPEN — tip b3db3413 pushed; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
+  pr_number: 994
+  pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994
+  pr_status: open
+  pr_base: stage
   current_stage: 16-evolve
   current_stage_status: in_progress
-  current_stage_note: "OPEN — orchestrator; Gate A PASS; Spec→Build open; FE implement done; 10-e2e COMPLETE local PASS; next commit/PR→stage then 13 (awaiting user commit approval)"
+  current_stage_note: "OPEN — orchestrator; PR #994 open → stage @ b3db3413; tip pushed; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
   current_child: implement
   current_child_stage: implement
   current_child_stage_status: completed
@@ -37899,7 +37907,7 @@ evolve_cycles:
   ui_preview: http://127.0.0.1:18000/
   ui_preview_url: http://127.0.0.1:18000/
   ui_preview_note: "D-S068-ui-preview=1 — non-deployed local http://127.0.0.1:18000/"
-  board_note: "#983 In progress (D-S068-board=1)"
+  board_note: "#983 In review"
   spec_to_build_gate: open
   corpus_cites:
   - '[Corpus: product §F7.q]'
@@ -37954,15 +37962,16 @@ evolve_cycles:
   prior_evolve_note: "Follow-on deepen after S066/EV-056 detail page + collapsible diffs; S067 closed on stage"
   gates:
     spec_to_build: open
-    spec_to_build_note: "D-S068-spec-build=1a — Spec→Build remains open; FE+10 done; next commit/PR→stage then 13-deploy-smoke (awaiting user commit approval); promote held"
+    spec_to_build_note: "D-S068-spec-build=1a — Spec→Build open; PR #994 @ b3db3413; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
   notes:
+  - "2026-08-17 commit+push+PR — tip b3db3413; PR #994 open → stage (https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994); #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held; no git commit by workflow-state-manager"
   - "2026-08-17 10-e2e COMPLETE — local PASS; report reports/e2e-report.md; Vitest 20 + Playwright UJ-056 4/4; FE implement done (layout toggle); Spec→Build open; next commit/PR→stage then 13 (awaiting user commit approval); no git commit by workflow-state-manager"
   - "2026-08-17 Gate A PASS — D-S068-gateA=1 / D-S068-spec-build=1a; report reports/02-verify-plan.md; Spec→Build open; Build band unlocked; Lean implement via 16 Agent (no 07); current_child implement (FE); next 10-e2e then 13 after FE+PR; no git commit by workflow-state-manager"
   - "2026-08-17 01 COMPLETE — D-S068-01-ac=2b; report reports/01-requirements.md; standing deltas feature-list/user-journeys/test-plan/evolve-decisions/requirements-decisions; handoff 02-verify-plan; Spec→Build still closed; no git commit by workflow-state-manager"
   - "2026-08-17 D-S068-01-start=1a / ac=2b / control=3a / uj=4a — 01-requirements in_progress (not completed); writing standing doc deltas; no git commit by workflow-state-manager"
   - "2026-08-17 D-S068-ev-confirm=1a — Phase 0–1 done; evolve-plan-card written; Spec→Build still closed; awaiting 01 startup+AC interview (01 not in_progress); no git commit by workflow-state-manager"
   - "2026-08-17 D-S068-open — open_session S068/EV-058; Lean; Spec-development; Spec→Build closed; #983 In progress; no git commit by workflow-state-manager"
-  note: "OPEN — EV-058/S068 in_progress; F7.q #983; Lean; Gate A PASS; Spec→Build open; FE implement done; 10-e2e COMPLETE local PASS (Vitest 20 + UJ-056 4/4); next commit/PR→stage then 13 (awaiting user commit approval); promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
+  note: "OPEN — EV-058/S068 in_progress; F7.q #983; PR #994 open → stage @ b3db3413; tip pushed; board #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held; [Corpus: product §F7.q] [Corpus: journeys §UJ-056] [Corpus: tests §UJ-056]"
 - id: EV-057
   title: "M0 Ready: #948 apex redirect + #903 accumulate ZIP + #838 validate existing IWXXM"
   status: completed
@@ -49813,14 +49822,14 @@ evolve_cycles:
 git_history:
   current_branch: evolve/EV-058-quality-metrics-diff-layout
   ahead_of_origin: 0
-  pushed: false
+  pushed: true
   pending_commit: false
   pending_commit_note:
   dirty: true
-  dirty_note: 'dirty expected — workflow-state.yaml after 01-requirements start S068/EV-058; untracked docs/sessions/S068-*; no git commit by workflow-state-manager'
-  tip_sha: "c2ca9a3f"
-  tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
-  tip_note: "OPEN S068/EV-058 — tip c2ca9a3f (= stage base) on evolve/EV-058-quality-metrics-diff-layout; Spec-development; Spec→Build closed; promote held"
+  dirty_note: 'dirty expected — workflow-state.yaml after S068 commit+push+PR #994 record; no git commit by workflow-state-manager'
+  tip_sha: "b3db3413"
+  tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+  tip_note: "OPEN S068/EV-058 — tip b3db3413 pushed on evolve/EV-058-quality-metrics-diff-layout; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13; promote held"
   docs_tip_sha: "4af0dd90"
   docs_tip_sha_full: 4af0dd9064116c465a204f74c9ae5c697b8f137d
   docs_tip_branch: docs/EV-055-13-deploy-smoke
@@ -49828,9 +49837,9 @@ git_history:
   docs_tip_pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/986
   docs_tip_pr_status: merged
   evolve_branch: evolve/EV-058-quality-metrics-diff-layout
-  evolve_tip_sha: "c2ca9a3f"
-  evolve_tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
-  evolve_tip_sha_pushed: false
+  evolve_tip_sha: "b3db3413"
+  evolve_tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+  evolve_tip_sha_pushed: true
   stage_merge_sha: d80db688
   stage_merge_sha_full: d80db68887a753692842ee7398a9c60ddd4660d7
   stage_tip_sha: c2ca9a3f
@@ -49846,9 +49855,10 @@ git_history:
   main_tip_sha: d0a51f5a
   main_tip_sha_full: d0a51f5a863daac91a2cac5ca545f4d5459baac8
   recommended_branch: evolve/EV-058-quality-metrics-diff-layout
-  note: 'S067/EV-057 IN PROGRESS — tip d05c23b7 pushed on evolve/EV-057-m0-ready-apex-accumulate-validate; PR #991 open → stage; tip CI green 31965556483; 12-verify-deploy in_progress checklist sign-off pending; dirty workflow-state; no git commit by workflow-state-manager'
+  note: 'S068/EV-058 IN PROGRESS — tip b3db3413 pushed on evolve/EV-058-quality-metrics-diff-layout; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; dirty workflow-state; no git commit by workflow-state-manager'
 
   notes:
+  - '2026-08-17 commit+push+PR — tip b3db3413 on evolve/EV-058-quality-metrics-diff-layout; PR #994 open → stage (https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994); #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held; no git commit by workflow-state-manager'
   - '2026-08-16 tip CI SUCCESS 31965556483 @ d05c23b7 on PR #991 → stage; prior a730d7a3 run 31964710714 failed (coverage) fixed by tip; 12-verify-deploy remains in_progress awaiting checklist sign-off; promote held; no git commit by workflow-state-manager'
   - '2026-08-16 PR #991 open → stage @ a730d7a3 pushed; watching CI 31964710714; 12-verify-deploy remains in_progress (promote held); current_stage_note 12-verify-deploy PR #991 → stage; watching CI 31964710714; 0e7833d1 now pushed; no git commit by workflow-state-manager'
   - '2026-08-16 D-S067-11-preview=2a D-S067-11-ac=1a — 11-verify-impl COMPLETE PASS; report verify-impl.md; UI preview declined (reports/tests only); AC approved #948/#903/#838; current_stage 12-verify-deploy in_progress started 2026-08-16; current_stage_note 12-verify-deploy PR → stage (promote held); tip ffdd1961; tip not pushed; no git commit by workflow-state-manager'
@@ -50437,13 +50447,17 @@ git_history:
     status: active
     created: "2026-08-17"
     exists: true
-    pushed: false
+    pushed: true
     session_id: S068-quality-metrics-diff-layout
     evolve_cycle_id: EV-058
-    tip_sha: c2ca9a3f
-    tip_sha_full: c2ca9a3f106c69fb83abeae9ca583409a20f779f
-    tip_sha_pushed: false
-    note: "OPEN — active; base stage@c2ca9a3f; tip equals base until first commit; not pushed"
+    tip_sha: b3db3413
+    tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+    tip_sha_pushed: true
+    note: "OPEN — tip b3db3413 pushed; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13; promote held"
+    pr_number: 994
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994
+    pr_status: open
+    pr_base: stage
 
   - name: evolve/EV-057-m0-ready-apex-accumulate-validate
     base: stage@b796882e
@@ -51951,6 +51965,42 @@ git_history:
     merge_sha: 101f555
     merge_sha_full: 101f55586efacaee67bcd4260a04aa6758502123
   commits:
+  - sha: "b3db3413"
+    sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+    message: "[EV-058] feat: side-by-side vs inline XML diff on Quality metrics detail"
+    branch: evolve/EV-058-quality-metrics-diff-layout
+    stage: 16-evolve
+    session_id: S068-quality-metrics-diff-layout
+    evolve_cycle_id: EV-058
+    timestamp: "2026-08-17"
+    pushed: true
+    tip_sha: b3db3413
+    tip_sha_full: b3db34132057593e1bc9789ef261a4bf950abbbd
+    tip_sha_pushed: true
+    pr_number: 994
+    pr_url: https://github.com/EMPIRIC2/TAC-to-IWXXM/pull/994
+    pr_status: open
+    pr_base: stage
+    files_changed:
+      - README.md
+      - apps/e2e/uj056-quality-metrics.e2e.spec.ts
+      - apps/frontend/src/app/components/QualityMetricsDetail.test.tsx
+      - apps/frontend/src/app/components/QualityMetricsDetail.tsx
+      - apps/frontend/src/utils/qualityMetricsDiffLayout.test.ts
+      - apps/frontend/src/utils/qualityMetricsDiffLayout.ts
+      - docs/decisions/evolve-decisions.md
+      - docs/decisions/requirements-decisions.md
+      - docs/feature-list.md
+      - docs/sessions/S068-quality-metrics-diff-layout/evolve-plan-card.md
+      - docs/sessions/S068-quality-metrics-diff-layout/reports/01-requirements.md
+      - docs/sessions/S068-quality-metrics-diff-layout/reports/02-verify-plan.md
+      - docs/sessions/S068-quality-metrics-diff-layout/reports/e2e-report.md
+      - docs/sessions/S068-quality-metrics-diff-layout/routing-plan.md
+      - docs/sessions/S068-quality-metrics-diff-layout/session-brief.md
+      - docs/test-plan.md
+      - docs/user-journeys.md
+      - workflow-state.yaml
+    note: "feat commit pushed; PR #994 open → stage; #983 In review; awaiting tip CI then merge→stage then 13-deploy-smoke; promote held"
   - sha: "3af364fb"
     sha_full: 3af364fbc6caeb4dd1eb56a1f214ae8938a9d878
     message: "[S067] fix: TacEditor aria-label sync for UJ-058 (follow-up #992)"


### PR DESCRIPTION
## Summary
- Add selectable **Inline (unified)** | **Side-by-side** XML diff on `/quality/:stem` (F7.q / #983)
- Persist layout preference in localStorage; synced scroll is best-effort
- Reuse existing `unifiedLineDiff` (no new npm `diff`); deepen UJ-056 + TC-EV058
- Spec/session artifacts for S068 / EV-058; Lean path to stage (promote held)

## Test plan
- [x] Vitest `qualityMetricsDiffLayout` + `QualityMetricsDetail` (20 tests)
- [x] Playwright UJ-056 incl. TC-EV058-005 (4/4 local)
- [ ] CI green on branch
- [ ] Staging Deploy + smoke / H4–H5 after merge (13)


Made with [Cursor](https://cursor.com)